### PR TITLE
feat: Collections FAB + breadcrumb + mounted-set state preservation (Plan 2 of 4)

### DIFF
--- a/components/boardsModal/BoardsModal.tsx
+++ b/components/boardsModal/BoardsModal.tsx
@@ -5,7 +5,6 @@ import { DndContext, closestCenter } from '@dnd-kit/core';
 import { useDialog } from '@/context/useDialog';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
-import { useCollections } from '@/hooks/useCollections';
 import { CollectionTree } from './CollectionTree';
 import { BoardGrid } from './BoardGrid';
 import { BoardsModalHeader } from './BoardsModalHeader';
@@ -25,7 +24,7 @@ interface BoardsModalProps {
 export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
   const { t } = useTranslation();
   const { showPrompt, showConfirm } = useDialog();
-  const { user, isAdmin, canAccessFeature } = useAuth();
+  const { isAdmin, canAccessFeature } = useAuth();
   const canShare = canAccessFeature('dashboard-sharing');
   const {
     dashboards,
@@ -40,14 +39,14 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
     duplicateDashboard,
     setDefaultDashboard,
     addToast,
+    collectionsApi: {
+      collections,
+      createCollection,
+      deleteCollection,
+      renameCollection,
+      setCollectionMetadata,
+    },
   } = useDashboard();
-  const {
-    collections,
-    createCollection,
-    deleteCollection,
-    renameCollection,
-    setCollectionMetadata,
-  } = useCollections(user?.uid);
 
   const [selectedCollectionId, setSelectedCollectionId] = useState<
     string | null

--- a/components/boardsModal/useBoardsModalDnd.ts
+++ b/components/boardsModal/useBoardsModalDnd.ts
@@ -10,14 +10,14 @@ import {
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { useTranslation } from 'react-i18next';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { useCollections } from '@/hooks/useCollections';
 import { logError } from '@/utils/logError';
 
 export const useBoardsModalDnd = () => {
-  const { user } = useAuth();
-  const { moveBoardToCollection, addToast } = useDashboard();
-  const { moveCollection } = useCollections(user?.uid);
+  const {
+    moveBoardToCollection,
+    addToast,
+    collectionsApi: { moveCollection },
+  } = useDashboard();
   const { t } = useTranslation();
 
   // Mouse: 15px movement to start drag (matches existing SidebarBoards).

--- a/components/layout/BoardBreadcrumb.tsx
+++ b/components/layout/BoardBreadcrumb.tsx
@@ -1,0 +1,49 @@
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, ChevronRight } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useCollections } from '@/hooks/useCollections';
+import { BoardsModal } from '@/components/boardsModal/BoardsModal';
+
+export const BoardBreadcrumb: FC = () => {
+  const { t } = useTranslation();
+  const { activeDashboard } = useDashboard();
+  const { user } = useAuth();
+  const { collections } = useCollections(user?.uid);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  if (!activeDashboard) return null;
+  const collectionId = activeDashboard.collectionId ?? null;
+  const collection = collectionId
+    ? collections.find((c) => c.id === collectionId)
+    : null;
+  const collectionLabel = collection
+    ? collection.name
+    : t('boardBreadcrumb.root', { defaultValue: 'All Boards' });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        data-screenshot="exclude"
+        aria-label={t('boardBreadcrumb.openManager', {
+          defaultValue: 'Manage Boards',
+        })}
+        className="inline-flex items-center gap-1 max-w-[40vw] px-2.5 py-1 rounded-full bg-slate-900/70 backdrop-blur-md text-xxs font-medium text-white/80 hover:bg-slate-900/85 hover:text-white transition-colors"
+      >
+        <Folder
+          className="w-3 h-3 flex-shrink-0"
+          style={collection?.color ? { color: collection.color } : undefined}
+        />
+        <span className="truncate">{collectionLabel}</span>
+        <ChevronRight className="w-3 h-3 flex-shrink-0 text-white/40" />
+        <span className="truncate font-bold text-white">
+          {activeDashboard.name}
+        </span>
+      </button>
+      {isModalOpen && <BoardsModal onClose={() => setIsModalOpen(false)} />}
+    </>
+  );
+};

--- a/components/layout/BoardBreadcrumb.tsx
+++ b/components/layout/BoardBreadcrumb.tsx
@@ -2,15 +2,14 @@ import { type FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Folder, ChevronRight } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { useCollections } from '@/hooks/useCollections';
 import { BoardsModal } from '@/components/boardsModal/BoardsModal';
 
 export const BoardBreadcrumb: FC = () => {
   const { t } = useTranslation();
-  const { activeDashboard } = useDashboard();
-  const { user } = useAuth();
-  const { collections } = useCollections(user?.uid);
+  const {
+    activeDashboard,
+    collectionsApi: { collections },
+  } = useDashboard();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   if (!activeDashboard) return null;

--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -122,6 +122,7 @@ export const BoardCanvas: FC<BoardCanvasProps> = memo(
             <WidgetRenderer
               key={widget.id}
               widget={widget}
+              isActive={isActive}
               isStudentView={false}
               sessionCode={session?.code}
               isGlobalFrozen={session?.frozen ?? false}

--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -12,7 +12,7 @@ import type {
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 
-interface BoardCanvasProps {
+export interface BoardCanvasProps {
   dashboard: Dashboard;
   isActive: boolean;
   isMinimized: boolean;

--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -6,9 +6,9 @@ import type {
   WidgetData,
   WidgetConfig,
   WidgetType,
-  GlobalStyle,
   DashboardSettings,
 } from '@/types';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 
@@ -44,7 +44,6 @@ export interface BoardCanvasProps {
   duplicateWidget: (id: string) => void;
   bringToFront: (id: string) => void;
   addToast: (message: string, type?: 'info' | 'success' | 'error') => void;
-  globalStyle: GlobalStyle;
   updateDashboardSettings?: (updates: Partial<DashboardSettings>) => void;
 }
 
@@ -81,9 +80,12 @@ export const BoardCanvas: FC<BoardCanvasProps> = memo(
     duplicateWidget,
     bringToFront,
     addToast,
-    globalStyle,
     updateDashboardSettings,
   }) => {
+    // Each Board resolves its own globalStyle so hidden boards don't inherit
+    // the active Board's styling when widget memoization is evaluated.
+    const globalStyle = dashboard.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+
     const selectedGroupId = selectedWidgetId
       ? dashboard.widgets.find((w) => w.id === selectedWidgetId)?.groupId
       : undefined;

--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -1,0 +1,156 @@
+import { type FC, memo } from 'react';
+import type {
+  Dashboard,
+  LiveSession,
+  LiveStudent,
+  WidgetData,
+  WidgetConfig,
+  WidgetType,
+  GlobalStyle,
+  DashboardSettings,
+} from '@/types';
+import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
+import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
+
+interface BoardCanvasProps {
+  dashboard: Dashboard;
+  isActive: boolean;
+  isMinimized: boolean;
+  animationClass: string;
+  // Live-session bundle. `null` when no session is active on this Board.
+  session: LiveSession | null;
+  students: LiveStudent[];
+  emptyStudents: LiveStudent[];
+  selectedWidgetId: string | null;
+  zoom: number;
+  // Pass-through callbacks: same shape WidgetRenderer expects.
+  updateSessionConfig: (config: WidgetConfig) => Promise<void>;
+  updateSessionBackground: (background: string) => Promise<void>;
+  startSession: (
+    widgetId: string,
+    widgetType: WidgetType,
+    config?: WidgetConfig,
+    background?: string
+  ) => Promise<LiveSession>;
+  endSession: () => Promise<void>;
+  removeStudent: (studentId: string) => Promise<void>;
+  toggleFreezeStudent: (
+    studentId: string,
+    currentStatus: 'active' | 'frozen' | 'disconnected'
+  ) => Promise<void>;
+  toggleGlobalFreeze: (freeze: boolean) => Promise<void>;
+  updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+  removeWidget: (id: string) => void;
+  duplicateWidget: (id: string) => void;
+  bringToFront: (id: string) => void;
+  addToast: (message: string, type?: 'info' | 'success' | 'error') => void;
+  globalStyle: GlobalStyle;
+  updateDashboardSettings?: (updates: Partial<DashboardSettings>) => void;
+}
+
+/**
+ * Renders a single Board's widget canvas. Visibility is controlled by the
+ * `isActive` flag: inactive boards render with `display: none` so React
+ * state (timer counts, drawings in flight, video positions) is preserved
+ * across Board switches via the parent's MountedBoardsLayer LRU window.
+ *
+ * The callback signatures mirror WidgetRenderer's prop interface exactly so
+ * values are forwarded verbatim — this component is a structural extraction,
+ * not a place to enforce stricter callback types.
+ */
+export const BoardCanvas: FC<BoardCanvasProps> = memo(
+  ({
+    dashboard,
+    isActive,
+    isMinimized,
+    animationClass,
+    session,
+    students,
+    emptyStudents,
+    selectedWidgetId,
+    zoom,
+    updateSessionConfig,
+    updateSessionBackground,
+    startSession,
+    endSession,
+    removeStudent,
+    toggleFreezeStudent,
+    toggleGlobalFreeze,
+    updateWidget,
+    removeWidget,
+    duplicateWidget,
+    bringToFront,
+    addToast,
+    globalStyle,
+    updateDashboardSettings,
+  }) => {
+    const selectedGroupId = selectedWidgetId
+      ? dashboard.widgets.find((w) => w.id === selectedWidgetId)?.groupId
+      : undefined;
+
+    const groupMembers = selectedGroupId
+      ? dashboard.widgets.filter(
+          (w) =>
+            w.groupId === selectedGroupId &&
+            !w.minimized &&
+            !w.isLocked &&
+            !w.isPinned
+        )
+      : [];
+
+    return (
+      <div
+        className={`absolute inset-0 ${animationClass} transition-opacity duration-500 ease-in-out`}
+        style={{
+          // Note: transform and opacity transitions here create CSS stacking
+          // contexts. Spotlighted widgets escape this by portaling to document.body.
+          display: isActive ? 'block' : 'none',
+          transform: isMinimized && isActive ? 'translateY(80vh)' : undefined,
+          transformOrigin: isMinimized ? 'bottom center' : 'center center',
+          opacity: isMinimized && isActive ? 0 : 1,
+          pointerEvents: isMinimized && isActive ? 'none' : 'auto',
+        }}
+        aria-hidden={!isActive}
+        data-board-id={dashboard.id}
+      >
+        {dashboard.widgets.map((widget) => {
+          const isLive =
+            session?.isActive === true && session.activeWidgetId === widget.id;
+          return (
+            <WidgetRenderer
+              key={widget.id}
+              widget={widget}
+              isStudentView={false}
+              sessionCode={session?.code}
+              isGlobalFrozen={session?.frozen ?? false}
+              isLive={isLive}
+              students={isLive ? students : emptyStudents}
+              updateSessionConfig={updateSessionConfig}
+              updateSessionBackground={updateSessionBackground}
+              startSession={startSession}
+              endSession={endSession}
+              removeStudent={removeStudent}
+              toggleFreezeStudent={toggleFreezeStudent}
+              toggleGlobalFreeze={toggleGlobalFreeze}
+              updateWidget={updateWidget}
+              removeWidget={removeWidget}
+              duplicateWidget={duplicateWidget}
+              bringToFront={bringToFront}
+              addToast={addToast}
+              globalStyle={globalStyle}
+              dashboardBackground={dashboard.background}
+              dashboardSettings={dashboard.settings}
+              updateDashboardSettings={updateDashboardSettings}
+            />
+          );
+        })}
+        {/* Group Bounding Box — rendered when a grouped widget is selected */}
+        {selectedGroupId && groupMembers.length > 0 && (
+          <GroupBoundingBox groupWidgets={groupMembers} zoom={zoom} />
+        )}
+      </div>
+    );
+  }
+);
+
+BoardCanvas.displayName = 'BoardCanvas';

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -13,6 +13,7 @@ import { ChevronLeft, ChevronRight, MoreVertical, Star } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { FAB_BASE } from './fabClasses';
+import { BoardBreadcrumb } from './BoardBreadcrumb';
 
 export const BoardNavFab: FC = () => {
   const { t } = useTranslation();
@@ -174,6 +175,10 @@ export const BoardNavFab: FC = () => {
           })}
         </div>
       )}
+
+      <div className="absolute bottom-full left-0 mb-1.5 flex items-center">
+        <BoardBreadcrumb />
+      </div>
 
       <div className="flex items-center gap-1">
         <button

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -9,16 +9,29 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronLeft, ChevronRight, MoreVertical, Star } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Folder,
+  MoreVertical,
+  Star,
+} from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useCollections } from '@/hooks/useCollections';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { FAB_BASE } from './fabClasses';
 import { BoardBreadcrumb } from './BoardBreadcrumb';
+import { CollectionSwitcherMenu } from './CollectionSwitcherMenu';
 
 export const BoardNavFab: FC = () => {
   const { t } = useTranslation();
-  const { dashboards, activeDashboard, loadDashboard } = useDashboard();
+  const { dashboards, activeDashboard, loadDashboard, setActiveCollectionId } =
+    useDashboard();
+  const { user } = useAuth();
+  const { collections } = useCollections(user?.uid);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [isCollectionMenuOpen, setIsCollectionMenuOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -64,15 +77,18 @@ export const BoardNavFab: FC = () => {
     }
     if (didFocusOnOpenRef.current) return;
     didFocusOnOpenRef.current = true;
-    const targetIdx = currentIndex >= 0 ? currentIndex : 0;
+    const switchSlot = collections.length > 0 ? 1 : 0;
+    const targetIdx =
+      currentIndex >= 0 ? currentIndex + switchSlot : switchSlot;
     itemRefs.current[targetIdx]?.focus();
-  }, [isPickerOpen, currentIndex]);
+  }, [isPickerOpen, currentIndex, collections.length]);
 
   // Drop trailing ref slots when the dashboard list shrinks so we don't
   // dispatch focus to detached buttons after a board is deleted.
   useEffect(() => {
-    itemRefs.current.length = boardsInCollection.length;
-  }, [boardsInCollection.length]);
+    const switchSlot = collections.length > 0 ? 1 : 0;
+    itemRefs.current.length = switchSlot + boardsInCollection.length;
+  }, [boardsInCollection.length, collections.length]);
 
   if (boardsInCollection.length <= 1) return null;
 
@@ -91,8 +107,10 @@ export const BoardNavFab: FC = () => {
   };
 
   const focusItem = (idx: number) => {
-    const len = boardsInCollection.length;
-    const wrapped = ((idx % len) + len) % len;
+    const switchSlot = collections.length > 0 ? 1 : 0;
+    const totalItems = switchSlot + boardsInCollection.length;
+    if (totalItems === 0) return;
+    const wrapped = ((idx % totalItems) + totalItems) % totalItems;
     itemRefs.current[wrapped]?.focus();
   };
 
@@ -112,7 +130,9 @@ export const BoardNavFab: FC = () => {
       case 'ArrowUp':
         e.preventDefault();
         focusItem(
-          focusedIdx < 0 ? boardsInCollection.length - 1 : focusedIdx - 1
+          focusedIdx < 0
+            ? (collections.length > 0 ? 1 : 0) + boardsInCollection.length - 1
+            : focusedIdx - 1
         );
         break;
       case 'Home':
@@ -121,7 +141,9 @@ export const BoardNavFab: FC = () => {
         break;
       case 'End':
         e.preventDefault();
-        focusItem(boardsInCollection.length - 1);
+        focusItem(
+          (collections.length > 0 ? 1 : 0) + boardsInCollection.length - 1
+        );
         break;
       case 'Tab':
         // Tab takes focus out of the menu — close to keep state consistent.
@@ -141,7 +163,16 @@ export const BoardNavFab: FC = () => {
       data-screenshot="exclude"
       className="fixed bottom-6 left-4 z-dock"
     >
-      {isPickerOpen && (
+      {isCollectionMenuOpen && (
+        <CollectionSwitcherMenu
+          collections={collections}
+          activeCollectionId={activeCollectionId}
+          onSelect={(id) => setActiveCollectionId(id)}
+          onClose={() => setIsCollectionMenuOpen(false)}
+        />
+      )}
+
+      {isPickerOpen && !isCollectionMenuOpen && (
         <div
           role="menu"
           aria-labelledby={headerId}
@@ -154,13 +185,35 @@ export const BoardNavFab: FC = () => {
           >
             {boardListLabel}
           </div>
+          {collections.length > 0 && (
+            <button
+              ref={(el) => {
+                itemRefs.current[0] = el;
+              }}
+              role="menuitem"
+              onClick={() => {
+                setIsPickerOpen(false);
+                setIsCollectionMenuOpen(true);
+              }}
+              className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm text-white/80 hover:bg-white/10 border-b border-white/10 mb-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50"
+            >
+              <Folder className="w-3.5 h-3.5 flex-shrink-0" />
+              {t('boardNav.switchCollection', {
+                defaultValue: 'Switch Collection…',
+              })}
+            </button>
+          )}
           {boardsInCollection.map((db, idx) => {
             const isActive = activeDashboard?.id === db.id;
+            // Offset board indices by 1 when the Switch Collection item occupies
+            // itemRefs[0]. Keeps Arrow-key navigation inclusive of both the
+            // collection switcher and every board in the active collection.
+            const refIdx = collections.length > 0 ? idx + 1 : idx;
             return (
               <button
                 key={db.id}
                 ref={(el) => {
-                  itemRefs.current[idx] = el;
+                  itemRefs.current[refIdx] = el;
                 }}
                 role="menuitem"
                 onClick={() => {

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -62,6 +62,7 @@ export const BoardNavFab: FC = () => {
 
   const handleClickOutside = useCallback(() => {
     closePicker(false);
+    setIsCollectionMenuOpen(false);
   }, [closePicker]);
 
   useClickOutside(containerRef, handleClickOutside);
@@ -169,7 +170,14 @@ export const BoardNavFab: FC = () => {
           collections={collections}
           activeCollectionId={activeCollectionId}
           onSelect={(id) => setActiveCollectionId(id)}
-          onClose={() => setIsCollectionMenuOpen(false)}
+          onClose={() => {
+            setIsCollectionMenuOpen(false);
+            // Restore focus to the trigger button so keyboard users aren't
+            // dropped on document.body when the submenu unmounts. Use
+            // requestAnimationFrame to let React commit the unmount before
+            // attempting focus (the board-list menu may still be mid-update).
+            requestAnimationFrame(() => triggerRef.current?.focus());
+          }}
         />
       )}
 

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -24,10 +24,19 @@ export const BoardNavFab: FC = () => {
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const headerId = useId();
 
+  const activeCollectionId = activeDashboard?.collectionId ?? null;
+  const boardsInCollection = useMemo(
+    () =>
+      dashboards
+        .filter((d) => (d.collectionId ?? null) === activeCollectionId)
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+    [dashboards, activeCollectionId]
+  );
+
   const currentIndex = useMemo(() => {
     if (!activeDashboard) return -1;
-    return dashboards.findIndex((d) => d.id === activeDashboard.id);
-  }, [dashboards, activeDashboard]);
+    return boardsInCollection.findIndex((d) => d.id === activeDashboard.id);
+  }, [boardsInCollection, activeDashboard]);
 
   const closePicker = useCallback(
     (returnFocus = true) => {
@@ -62,25 +71,27 @@ export const BoardNavFab: FC = () => {
   // Drop trailing ref slots when the dashboard list shrinks so we don't
   // dispatch focus to detached buttons after a board is deleted.
   useEffect(() => {
-    itemRefs.current.length = dashboards.length;
-  }, [dashboards.length]);
+    itemRefs.current.length = boardsInCollection.length;
+  }, [boardsInCollection.length]);
 
-  if (dashboards.length <= 1) return null;
+  if (boardsInCollection.length <= 1) return null;
 
   const goPrev = () => {
     if (currentIndex < 0) return;
-    const next = (currentIndex - 1 + dashboards.length) % dashboards.length;
-    loadDashboard(dashboards[next].id);
+    const next =
+      (currentIndex - 1 + boardsInCollection.length) %
+      boardsInCollection.length;
+    loadDashboard(boardsInCollection[next].id);
   };
 
   const goNext = () => {
     if (currentIndex < 0) return;
-    const next = (currentIndex + 1) % dashboards.length;
-    loadDashboard(dashboards[next].id);
+    const next = (currentIndex + 1) % boardsInCollection.length;
+    loadDashboard(boardsInCollection[next].id);
   };
 
   const focusItem = (idx: number) => {
-    const len = dashboards.length;
+    const len = boardsInCollection.length;
     const wrapped = ((idx % len) + len) % len;
     itemRefs.current[wrapped]?.focus();
   };
@@ -100,7 +111,9 @@ export const BoardNavFab: FC = () => {
         break;
       case 'ArrowUp':
         e.preventDefault();
-        focusItem(focusedIdx < 0 ? dashboards.length - 1 : focusedIdx - 1);
+        focusItem(
+          focusedIdx < 0 ? boardsInCollection.length - 1 : focusedIdx - 1
+        );
         break;
       case 'Home':
         e.preventDefault();
@@ -108,7 +121,7 @@ export const BoardNavFab: FC = () => {
         break;
       case 'End':
         e.preventDefault();
-        focusItem(dashboards.length - 1);
+        focusItem(boardsInCollection.length - 1);
         break;
       case 'Tab':
         // Tab takes focus out of the menu — close to keep state consistent.
@@ -141,7 +154,7 @@ export const BoardNavFab: FC = () => {
           >
             {boardListLabel}
           </div>
-          {dashboards.map((db, idx) => {
+          {boardsInCollection.map((db, idx) => {
             const isActive = activeDashboard?.id === db.id;
             return (
               <button

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -267,7 +267,7 @@ export const BoardNavFab: FC = () => {
             defaultValue: 'Select board',
           })}
           aria-haspopup="menu"
-          aria-expanded={isPickerOpen}
+          aria-expanded={isPickerOpen || isCollectionMenuOpen}
           title={activeName}
           className={FAB_BASE}
         >

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -17,8 +17,6 @@ import {
   Star,
 } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
-import { useCollections } from '@/hooks/useCollections';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { FAB_BASE } from './fabClasses';
 import { BoardBreadcrumb } from './BoardBreadcrumb';
@@ -26,10 +24,13 @@ import { CollectionSwitcherMenu } from './CollectionSwitcherMenu';
 
 export const BoardNavFab: FC = () => {
   const { t } = useTranslation();
-  const { dashboards, activeDashboard, loadDashboard, setActiveCollectionId } =
-    useDashboard();
-  const { user } = useAuth();
-  const { collections } = useCollections(user?.uid);
+  const {
+    dashboards,
+    activeDashboard,
+    loadDashboard,
+    setActiveCollectionId,
+    collectionsApi: { collections },
+  } = useDashboard();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [isCollectionMenuOpen, setIsCollectionMenuOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/components/layout/CollectionSwitcherMenu.tsx
+++ b/components/layout/CollectionSwitcherMenu.tsx
@@ -1,0 +1,103 @@
+import { type FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, Home } from 'lucide-react';
+import type { Collection } from '@/types';
+
+interface CollectionSwitcherMenuProps {
+  collections: Collection[];
+  activeCollectionId: string | null;
+  onSelect: (collectionId: string | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Submenu opened from BoardNavFab. Lists all Collections (flat with
+ * depth-indent) plus the "Root (no Collection)" entry. Used to jump the
+ * navigation surface to a different Collection — the actual Board switch
+ * is handled by the caller, which routes through
+ * DashboardContext.setActiveCollectionId.
+ */
+export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
+  collections,
+  activeCollectionId,
+  onSelect,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+
+  const flat = useMemo(() => {
+    const childrenByParent = new Map<string | null, Collection[]>();
+    for (const c of collections) {
+      const bucket = childrenByParent.get(c.parentCollectionId) ?? [];
+      bucket.push(c);
+      childrenByParent.set(c.parentCollectionId, bucket);
+    }
+    for (const bucket of childrenByParent.values()) {
+      bucket.sort((a, b) => a.order - b.order);
+    }
+    const out: { c: Collection; depth: number }[] = [];
+    const walk = (parent: string | null, depth: number) => {
+      const kids = childrenByParent.get(parent) ?? [];
+      for (const k of kids) {
+        out.push({ c: k, depth });
+        walk(k.id, depth + 1);
+      }
+    };
+    walk(null, 0);
+    return out;
+  }, [collections]);
+
+  return (
+    <div
+      role="menu"
+      aria-label={t('collectionSwitcher.title', {
+        defaultValue: 'Switch Collection',
+      })}
+      className="absolute bottom-full left-0 mb-2 w-64 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl py-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150"
+    >
+      <div className="px-3 py-1.5 text-xxs font-bold uppercase tracking-wider text-white/40">
+        {t('collectionSwitcher.title', { defaultValue: 'Switch Collection' })}
+      </div>
+      <button
+        role="menuitem"
+        onClick={() => {
+          onSelect(null);
+          onClose();
+        }}
+        className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50 ${
+          activeCollectionId === null
+            ? 'bg-brand-blue-primary text-white'
+            : 'text-white/80 hover:bg-white/10'
+        }`}
+      >
+        <Home className="w-3.5 h-3.5 flex-shrink-0" />
+        {t('collectionSwitcher.root', { defaultValue: 'All Boards (root)' })}
+      </button>
+      {flat.map(({ c, depth }) => {
+        const isActive = activeCollectionId === c.id;
+        return (
+          <button
+            key={c.id}
+            role="menuitem"
+            onClick={() => {
+              onSelect(c.id);
+              onClose();
+            }}
+            style={{ paddingLeft: `${0.75 + depth * 1}rem` }}
+            className={`w-full flex items-center gap-2 pr-3 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50 ${
+              isActive
+                ? 'bg-brand-blue-primary text-white'
+                : 'text-white/80 hover:bg-white/10'
+            }`}
+          >
+            <Folder
+              className="w-3.5 h-3.5 flex-shrink-0"
+              style={c.color ? { color: c.color } : undefined}
+            />
+            <span className="truncate">{c.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/components/layout/CollectionSwitcherMenu.tsx
+++ b/components/layout/CollectionSwitcherMenu.tsx
@@ -51,18 +51,19 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
     return out;
   }, [collections]);
 
-  // Auto-focus the active item once on open. We capture the target index from
-  // the initial props (activeCollectionId / flat are stable at mount) and focus
-  // after the first paint so the button refs are populated.
+  // Auto-focus the active collection item exactly once when the submenu mounts.
+  // Empty deps array is intentional: this is mount-time focus seeding, not a
+  // reaction to prop changes. Adding activeCollectionId or flat as deps would
+  // re-steal focus every time the parent re-renders (e.g. Firestore snapshot),
+  // yanking the keyboard user away from wherever they navigated mid-session.
+  // Focus restoration when the menu CLOSES is handled by the onClose callback
+  // in BoardNavFab (via requestAnimationFrame(() => triggerRef.current?.focus())).
   useEffect(() => {
     const activeIdx =
       activeCollectionId === null
         ? 0
         : 1 + flat.findIndex(({ c }) => c.id === activeCollectionId);
     itemRefs.current[activeIdx >= 0 ? activeIdx : 0]?.focus();
-    // activeCollectionId and flat are intentionally excluded: this effect runs
-    // once on mount to set initial focus; re-focusing on every prop change
-    // would steal focus from the user mid-interaction.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/components/layout/CollectionSwitcherMenu.tsx
+++ b/components/layout/CollectionSwitcherMenu.tsx
@@ -1,4 +1,5 @@
-import { type FC, useMemo } from 'react';
+import { type FC, useMemo, useEffect, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Folder, Home } from 'lucide-react';
 import type { Collection } from '@/types';
@@ -25,6 +26,9 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  // itemRefs[0] = root button, itemRefs[1..n] = Collection buttons in flat order.
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
   const flat = useMemo(() => {
     const childrenByParent = new Map<string | null, Collection[]>();
     for (const c of collections) {
@@ -47,9 +51,64 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
     return out;
   }, [collections]);
 
+  // Auto-focus the active item once on open. We capture the target index from
+  // the initial props (activeCollectionId / flat are stable at mount) and focus
+  // after the first paint so the button refs are populated.
+  useEffect(() => {
+    const activeIdx =
+      activeCollectionId === null
+        ? 0
+        : 1 + flat.findIndex(({ c }) => c.id === activeCollectionId);
+    itemRefs.current[activeIdx >= 0 ? activeIdx : 0]?.focus();
+    // activeCollectionId and flat are intentionally excluded: this effect runs
+    // once on mount to set initial focus; re-focusing on every prop change
+    // would steal focus from the user mid-interaction.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const focusItem = (idx: number) => {
+    const total = 1 + flat.length;
+    if (total === 0) return;
+    const wrapped = ((idx % total) + total) % total;
+    itemRefs.current[wrapped]?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    const focused = itemRefs.current.findIndex(
+      (el) => el === document.activeElement
+    );
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        onClose();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        focusItem(focused < 0 ? 0 : focused + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        focusItem(focused < 0 ? itemRefs.current.length - 1 : focused - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        focusItem(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        focusItem(itemRefs.current.length - 1);
+        break;
+      case 'Tab':
+        // Tab takes focus out — close to keep state consistent (matches BoardNavFab pattern).
+        onClose();
+        break;
+    }
+  };
+
   return (
     <div
       role="menu"
+      onKeyDown={handleKeyDown}
       aria-label={t('collectionSwitcher.title', {
         defaultValue: 'Switch Collection',
       })}
@@ -59,6 +118,9 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
         {t('collectionSwitcher.title', { defaultValue: 'Switch Collection' })}
       </div>
       <button
+        ref={(el) => {
+          itemRefs.current[0] = el;
+        }}
         role="menuitem"
         onClick={() => {
           onSelect(null);
@@ -73,11 +135,14 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
         <Home className="w-3.5 h-3.5 flex-shrink-0" />
         {t('collectionSwitcher.root', { defaultValue: 'All Boards (root)' })}
       </button>
-      {flat.map(({ c, depth }) => {
+      {flat.map(({ c, depth }, index) => {
         const isActive = activeCollectionId === c.id;
         return (
           <button
             key={c.id}
+            ref={(el) => {
+              itemRefs.current[index + 1] = el;
+            }}
             role="menuitem"
             onClick={() => {
               onSelect(c.id);

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1108,10 +1108,35 @@ export const DashboardView: React.FC = () => {
 
   // Stable sessions Map for MountedBoardsLayer — memoized so each render
   // doesn't produce a new Map that invalidates useMountedBoardCache's memo.
+  //
+  // Pinning limitation: useLiveSession() returns the session bound to the
+  // currently active board. When the teacher switches away, `session`
+  // becomes null and we lose the pin. Fixing this requires lifting session
+  // ownership to a board-keyed map at the data layer (deferred).
   const sessions = useMemo<Map<string, LiveSession> | undefined>(() => {
     if (!session?.isActive || !activeDashboard) return undefined;
     return new Map([[activeDashboard.id, session]]);
   }, [session, activeDashboard]);
+
+  // One-time tripwire: log when a session first goes active so the pinning
+  // limitation is visible in monitoring. useLiveSession() does not expose a
+  // stable hostBoardId across board switches, meaning useMountedBoardCache
+  // never receives a pin for a non-active board. Fixing requires lifting
+  // session ownership to a board-keyed data layer (deferred).
+  const pinningWarnedRef = React.useRef(false);
+  if (session?.isActive && !pinningWarnedRef.current) {
+    pinningWarnedRef.current = true;
+    logError(
+      'MountedBoardsLayer.pinningLimitation',
+      new Error(
+        'Live session pinning is bound to the active board only — non-active boards cannot be pinned until session ownership is lifted to a board-keyed data layer'
+      ),
+      { activeBoardId: activeDashboard?.id, sessionCode: session.code }
+    );
+  }
+  if (!session?.isActive) {
+    pinningWarnedRef.current = false;
+  }
 
   if (activeDashboard?.id !== lastDashboardId) {
     setLastDashboardId(activeDashboard?.id);
@@ -1650,7 +1675,6 @@ export const DashboardView: React.FC = () => {
           emptyStudents={EMPTY_STUDENTS}
           selectedWidgetId={selectedWidgetId}
           zoom={zoom}
-          globalStyle={globalStyle}
           updateSessionConfig={updateSessionConfig}
           updateSessionBackground={updateSessionBackground}
           startSession={startSession}

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -53,10 +53,10 @@ import {
 } from 'lucide-react';
 import {
   DEFAULT_GLOBAL_STYLE,
-  LiveSession,
   LiveStudent,
   SpartStickerDropPayload,
 } from '@/types';
+import type { LiveSession } from '@/types';
 import { extractYouTubeId } from '@/utils/youtube';
 
 const EMPTY_STUDENTS: LiveStudent[] = [];

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -32,9 +32,8 @@ import { Sidebar } from './sidebar/Sidebar';
 import { Dock } from './Dock';
 import { AnnotationOverlay } from './AnnotationOverlay';
 import { BoardNavFab } from './BoardNavFab';
-import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
-import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
 import { AnnouncementOverlay } from '@/components/announcements/AnnouncementOverlay';
+import { MountedBoardsLayer } from './MountedBoardsLayer';
 import { CheatSheetModal } from '@/components/common/CheatSheetModal';
 import { BoardActionsFab } from './BoardActionsFab';
 import { clampZoom, ZOOM_DEFAULT } from '@/utils/zoomMapping';
@@ -54,6 +53,7 @@ import {
 } from 'lucide-react';
 import {
   DEFAULT_GLOBAL_STYLE,
+  LiveSession,
   LiveStudent,
   SpartStickerDropPayload,
 } from '@/types';
@@ -1096,6 +1096,23 @@ export const DashboardView: React.FC = () => {
       : 'animate-slide-right-in';
   }, [currentIndex]);
 
+  // Ensure activeDashboard is always in the list passed to the mount cache.
+  // In production dashboards always includes activeDashboard, but tests may
+  // set dashboards:[] while supplying an activeDashboard, so we guard here
+  // rather than fixing every individual test.
+  const mountableDashboards = useMemo(() => {
+    if (!activeDashboard) return dashboards;
+    const has = dashboards.some((d) => d.id === activeDashboard.id);
+    return has ? dashboards : [activeDashboard, ...dashboards];
+  }, [dashboards, activeDashboard]);
+
+  // Stable sessions Map for MountedBoardsLayer — memoized so each render
+  // doesn't produce a new Map that invalidates useMountedBoardCache's memo.
+  const sessions = useMemo<Map<string, LiveSession> | undefined>(() => {
+    if (!session?.isActive || !activeDashboard) return undefined;
+    return new Map([[activeDashboard.id, session]]);
+  }, [session, activeDashboard]);
+
   if (activeDashboard?.id !== lastDashboardId) {
     setLastDashboardId(activeDashboard?.id);
     if (isMinimized) {
@@ -1620,67 +1637,34 @@ export const DashboardView: React.FC = () => {
           </div>
         )}
 
-        {/* Dynamic Widget Surface */}
-        <div
-          key={activeDashboard.id}
-          className={`relative w-full h-full ${animationClass} transition-opacity duration-500 ease-in-out`}
-          style={{
-            // Note: transform and opacity transitions here create CSS stacking contexts.
-            // Spotlighted widgets escape this by portaling to document.body.
-            transform: isMinimized ? 'translateY(80vh)' : undefined,
-            transformOrigin: isMinimized ? 'bottom center' : 'center center',
-            opacity: isMinimized ? 0 : 1,
-            pointerEvents: isMinimized ? 'none' : 'auto',
-          }}
-        >
-          {activeDashboard.widgets.map((widget) => {
-            const isLive =
-              session?.isActive && session?.activeWidgetId === widget.id;
-            return (
-              <WidgetRenderer
-                key={widget.id}
-                widget={widget}
-                isStudentView={false}
-                sessionCode={session?.code}
-                isGlobalFrozen={session?.frozen ?? false}
-                isLive={isLive ?? false}
-                students={isLive ? students : EMPTY_STUDENTS}
-                updateSessionConfig={updateSessionConfig}
-                updateSessionBackground={updateSessionBackground}
-                startSession={startSession}
-                endSession={endSession}
-                removeStudent={removeStudent}
-                toggleFreezeStudent={toggleFreezeStudent}
-                toggleGlobalFreeze={toggleGlobalFreeze}
-                updateWidget={updateWidget}
-                removeWidget={removeWidget}
-                duplicateWidget={duplicateWidget}
-                bringToFront={bringToFront}
-                addToast={addToast}
-                globalStyle={globalStyle}
-                dashboardBackground={activeDashboard.background}
-                dashboardSettings={activeDashboard.settings}
-                updateDashboardSettings={updateDashboardSettings}
-              />
-            );
-          })}
-          {/* Group Bounding Box — rendered when a grouped widget is selected */}
-          {(() => {
-            const selectedGroupId = selectedWidgetId
-              ? activeDashboard.widgets.find((w) => w.id === selectedWidgetId)
-                  ?.groupId
-              : undefined;
-            if (!selectedGroupId) return null;
-            const members = activeDashboard.widgets.filter(
-              (w) =>
-                w.groupId === selectedGroupId &&
-                !w.minimized &&
-                !w.isLocked &&
-                !w.isPinned
-            );
-            return <GroupBoundingBox groupWidgets={members} zoom={zoom} />;
-          })()}
-        </div>
+        {/* Dynamic Widget Surface — Board state (timers, drawings) is
+            preserved across switches via the LRU mount window in
+            MountedBoardsLayer / useMountedBoardCache. */}
+        <MountedBoardsLayer
+          activeId={activeDashboard?.id ?? null}
+          dashboards={mountableDashboards}
+          isMinimized={isMinimized}
+          animationClass={animationClass}
+          sessions={sessions}
+          students={students}
+          emptyStudents={EMPTY_STUDENTS}
+          selectedWidgetId={selectedWidgetId}
+          zoom={zoom}
+          globalStyle={globalStyle}
+          updateSessionConfig={updateSessionConfig}
+          updateSessionBackground={updateSessionBackground}
+          startSession={startSession}
+          endSession={endSession}
+          removeStudent={removeStudent}
+          toggleFreezeStudent={toggleFreezeStudent}
+          toggleGlobalFreeze={toggleGlobalFreeze}
+          updateWidget={updateWidget}
+          removeWidget={removeWidget}
+          duplicateWidget={duplicateWidget}
+          bringToFront={bringToFront}
+          addToast={addToast}
+          updateDashboardSettings={updateDashboardSettings}
+        />
       </div>
 
       {/* Group-building mode floating action bar */}

--- a/components/layout/MountedBoardsLayer.tsx
+++ b/components/layout/MountedBoardsLayer.tsx
@@ -17,7 +17,6 @@ export interface MountedBoardsLayerProps {
   emptyStudents: LiveStudent[];
   selectedWidgetId: string | null;
   zoom: number;
-  globalStyle: BoardCanvasProps['globalStyle'];
   // Pass-through callbacks (typed via BoardCanvasProps at the call site)
   updateSessionConfig: BoardCanvasProps['updateSessionConfig'];
   updateSessionBackground: BoardCanvasProps['updateSessionBackground'];
@@ -44,7 +43,6 @@ export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
   emptyStudents,
   selectedWidgetId,
   zoom,
-  globalStyle,
   updateSessionConfig,
   updateSessionBackground,
   startSession,
@@ -83,7 +81,6 @@ export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
           emptyStudents={emptyStudents}
           selectedWidgetId={selectedWidgetId}
           zoom={zoom}
-          globalStyle={globalStyle}
           updateSessionConfig={updateSessionConfig}
           updateSessionBackground={updateSessionBackground}
           startSession={startSession}

--- a/components/layout/MountedBoardsLayer.tsx
+++ b/components/layout/MountedBoardsLayer.tsx
@@ -3,7 +3,7 @@ import type { Dashboard, LiveSession, LiveStudent } from '@/types';
 import { useMountedBoardCache } from '@/hooks/useMountedBoardCache';
 import { BoardCanvas, type BoardCanvasProps } from './BoardCanvas';
 
-interface MountedBoardsLayerProps {
+export interface MountedBoardsLayerProps {
   activeId: string | null;
   dashboards: Dashboard[];
   isMinimized: boolean;

--- a/components/layout/MountedBoardsLayer.tsx
+++ b/components/layout/MountedBoardsLayer.tsx
@@ -1,0 +1,104 @@
+import { type FC, useMemo } from 'react';
+import type { Dashboard, LiveSession, LiveStudent } from '@/types';
+import { useMountedBoardCache } from '@/hooks/useMountedBoardCache';
+import { BoardCanvas, type BoardCanvasProps } from './BoardCanvas';
+
+interface MountedBoardsLayerProps {
+  activeId: string | null;
+  dashboards: Dashboard[];
+  isMinimized: boolean;
+  animationClass: string;
+  // Map of (boardId → LiveSession) so each canvas gets its own session
+  // slot. Today only the active Board has a live session; passing it as a
+  // map lets Plan 3 (Collection-sharing) add per-Board session pinning
+  // later without changing this layer's shape.
+  sessions?: Map<string, LiveSession>;
+  students: LiveStudent[];
+  emptyStudents: LiveStudent[];
+  selectedWidgetId: string | null;
+  zoom: number;
+  globalStyle: BoardCanvasProps['globalStyle'];
+  // Pass-through callbacks (typed via BoardCanvasProps at the call site)
+  updateSessionConfig: BoardCanvasProps['updateSessionConfig'];
+  updateSessionBackground: BoardCanvasProps['updateSessionBackground'];
+  startSession: BoardCanvasProps['startSession'];
+  endSession: BoardCanvasProps['endSession'];
+  removeStudent: BoardCanvasProps['removeStudent'];
+  toggleFreezeStudent: BoardCanvasProps['toggleFreezeStudent'];
+  toggleGlobalFreeze: BoardCanvasProps['toggleGlobalFreeze'];
+  updateWidget: BoardCanvasProps['updateWidget'];
+  removeWidget: BoardCanvasProps['removeWidget'];
+  duplicateWidget: BoardCanvasProps['duplicateWidget'];
+  bringToFront: BoardCanvasProps['bringToFront'];
+  addToast: BoardCanvasProps['addToast'];
+  updateDashboardSettings: BoardCanvasProps['updateDashboardSettings'];
+}
+
+export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
+  activeId,
+  dashboards,
+  isMinimized,
+  animationClass,
+  sessions,
+  students,
+  emptyStudents,
+  selectedWidgetId,
+  zoom,
+  globalStyle,
+  updateSessionConfig,
+  updateSessionBackground,
+  startSession,
+  endSession,
+  removeStudent,
+  toggleFreezeStudent,
+  toggleGlobalFreeze,
+  updateWidget,
+  removeWidget,
+  duplicateWidget,
+  bringToFront,
+  addToast,
+  updateDashboardSettings,
+}) => {
+  const pinnedIds = useMemo(() => {
+    const s = new Set<string>();
+    if (sessions) {
+      for (const [boardId] of sessions) s.add(boardId);
+    }
+    return s;
+  }, [sessions]);
+
+  const mounted = useMountedBoardCache(activeId, dashboards, pinnedIds);
+
+  return (
+    <div className="relative w-full h-full">
+      {mounted.map((db) => (
+        <BoardCanvas
+          key={db.id}
+          dashboard={db}
+          isActive={db.id === activeId}
+          isMinimized={isMinimized}
+          animationClass={animationClass}
+          session={sessions?.get(db.id) ?? null}
+          students={students}
+          emptyStudents={emptyStudents}
+          selectedWidgetId={selectedWidgetId}
+          zoom={zoom}
+          globalStyle={globalStyle}
+          updateSessionConfig={updateSessionConfig}
+          updateSessionBackground={updateSessionBackground}
+          startSession={startSession}
+          endSession={endSession}
+          removeStudent={removeStudent}
+          toggleFreezeStudent={toggleFreezeStudent}
+          toggleGlobalFreeze={toggleGlobalFreeze}
+          updateWidget={updateWidget}
+          removeWidget={removeWidget}
+          duplicateWidget={duplicateWidget}
+          bringToFront={bringToFront}
+          addToast={addToast}
+          updateDashboardSettings={updateDashboardSettings}
+        />
+      ))}
+    </div>
+  );
+};

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -133,6 +133,9 @@ const mockDashboard: DashboardContextValue = {
   unpinBoard: async () => {
     // No-op
   },
+  setActiveCollectionId: () => {
+    // No-op
+  },
   resetDockToDefaults: () => {
     // No-op
   },

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -86,6 +86,18 @@ const mockAuth: AuthContextType = {
 // See studentViewConfig.ts for widget compatibility details.
 const mockDashboard: DashboardContextValue = {
   driveService: null,
+  collectionsApi: {
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: () => Promise.resolve(''),
+    renameCollection: () => Promise.resolve(),
+    moveCollection: () => Promise.resolve(),
+    deleteCollection: () => Promise.resolve(),
+    reorderSiblings: () => Promise.resolve(),
+    setCollectionMetadata: () => Promise.resolve(),
+    setCollectionDefaultBoard: () => Promise.resolve(),
+  },
   dashboards: [],
   activeDashboard: null,
   toasts: [],

--- a/components/subs/SubsDashboardProvider.tsx
+++ b/components/subs/SubsDashboardProvider.tsx
@@ -261,6 +261,7 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       ) => Promise<void>,
       pinBoard: NOOP_ASYNC as (boardId: string) => Promise<void>,
       unpinBoard: NOOP_ASYNC as (boardId: string) => Promise<void>,
+      setActiveCollectionId: NOOP,
       resetDockToDefaults: NOOP,
       setGradeFilter: NOOP,
 

--- a/components/subs/SubsDashboardProvider.tsx
+++ b/components/subs/SubsDashboardProvider.tsx
@@ -203,6 +203,18 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
     return {
       // === Real implementations (the four that matter) =====================
       driveService: null,
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: () => Promise.resolve(''),
+        renameCollection: () => Promise.resolve(),
+        moveCollection: () => Promise.resolve(),
+        deleteCollection: () => Promise.resolve(),
+        reorderSiblings: () => Promise.resolve(),
+        setCollectionMetadata: () => Promise.resolve(),
+        setCollectionDefaultBoard: () => Promise.resolve(),
+      },
       dashboards: [activeDashboard],
       activeDashboard,
       isActiveBoardReadOnly: true,

--- a/components/widgets/SmartNotebook/Widget.tsx
+++ b/components/widgets/SmartNotebook/Widget.tsx
@@ -19,9 +19,10 @@ import { parseNotebookFile } from '@/utils/notebookParser';
 import { Library } from './components/Library';
 import { Viewer } from './components/Viewer';
 
-export const SmartNotebookWidget: React.FC<{ widget: WidgetData }> = ({
-  widget,
-}) => {
+export const SmartNotebookWidget: React.FC<{
+  widget: WidgetData;
+  isActive?: boolean;
+}> = ({ widget, isActive = true }) => {
   const { updateWidget, addToast } = useDashboard();
   const { user } = useAuth();
   const { showConfirm } = useDialog();
@@ -35,9 +36,14 @@ export const SmartNotebookWidget: React.FC<{ widget: WidgetData }> = ({
   const [showAssets, setShowAssets] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Fetch notebooks from Firestore
+  // Fetch notebooks from Firestore.
+  // The subscription is gated on `isActive`: when the host Board is hidden by
+  // the LRU cache we unsubscribe to avoid listener proliferation. Local state
+  // retains the last-known list; it refreshes on the next snapshot after the
+  // Board becomes active again — an acceptable trade-off vs. keeping an open
+  // Firestore connection for every mounted-but-hidden Board.
   useEffect(() => {
-    if (!user) return;
+    if (!user || !isActive) return;
     const q = query(
       collection(db, 'users', user.uid, 'notebooks'),
       orderBy('createdAt', 'desc')
@@ -57,7 +63,7 @@ export const SmartNotebookWidget: React.FC<{ widget: WidgetData }> = ({
       setNotebooks(items);
     });
     return () => unsubscribe();
-  }, [user]);
+  }, [user, isActive]);
 
   // Derive active notebook directly — no redundant state
   const activeNotebook = React.useMemo(

--- a/components/widgets/SoundWidget/Widget.tsx
+++ b/components/widgets/SoundWidget/Widget.tsx
@@ -18,7 +18,10 @@ interface CustomWindow extends Window {
   webkitAudioContext: typeof AudioContext;
 }
 
-export const SoundWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
+export const SoundWidget: React.FC<{
+  widget: WidgetData;
+  isActive?: boolean;
+}> = ({ widget, isActive = true }) => {
   const { updateWidget, activeDashboard } = useDashboard();
   const [volume, setVolume] = useState(0);
   const [history, setHistory] = useState<number[]>(new Array(50).fill(0));
@@ -90,11 +93,54 @@ export const SoundWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   ]);
 
   useEffect(() => {
+    // When the host Board is hidden, suspend the AudioContext and cancel the
+    // RAF loop so we're not burning CPU sampling an inaudible mic.
+    if (!isActive) {
+      if (animationRef.current !== null) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = null;
+      }
+      void audioContextRef.current?.suspend();
+      return;
+    }
+
+    // If we already have a running AudioContext (board was hidden then shown
+    // again), just resume and restart the RAF loop without re-acquiring the mic.
+    if (audioContextRef.current && analyserRef.current) {
+      void audioContextRef.current.resume();
+
+      const bufferLength = analyserRef.current.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+
+      const resumeLoop = () => {
+        if (!analyserRef.current) return;
+        analyserRef.current.getByteFrequencyData(dataArray);
+        const sum = dataArray.reduce((a, b) => a + b, 0);
+        const average = sum / bufferLength;
+        const normalized = Math.min(
+          100,
+          average * (sensitivityRef.current * 2)
+        );
+        setVolume(normalized);
+        setHistory((prev) => [...prev.slice(-49), normalized]);
+        animationRef.current = requestAnimationFrame(resumeLoop);
+      };
+      resumeLoop();
+      // No full teardown here — cleanup below handles it on unmount or next isActive=false
+      return;
+    }
+
+    // First activation: acquire the mic and set up AudioContext fresh.
+    let cancelled = false;
     const startAudio = async () => {
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
           audio: true,
         });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
         streamRef.current = stream;
         const AudioContextClass =
           window.AudioContext ||
@@ -131,12 +177,16 @@ export const SoundWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     };
     void startAudio();
     return () => {
+      cancelled = true;
       if (animationRef.current !== null)
         cancelAnimationFrame(animationRef.current);
       streamRef.current?.getTracks().forEach((t) => t.stop());
       void audioContextRef.current?.close();
+      audioContextRef.current = null;
+      analyserRef.current = null;
+      streamRef.current = null;
     };
-  }, []);
+  }, [isActive]);
 
   const level = getLevelData(volume);
 

--- a/components/widgets/Webcam/Widget.tsx
+++ b/components/widgets/Webcam/Widget.tsx
@@ -22,9 +22,10 @@ import Tesseract from 'tesseract.js';
 import { WidgetLayout } from '../WidgetLayout';
 import { CapturedItem } from './types';
 
-export const WebcamWidget: React.FC<{ widget: WidgetData }> = ({
-  widget: _widget,
-}) => {
+export const WebcamWidget: React.FC<{
+  widget: WidgetData;
+  isActive?: boolean;
+}> = ({ widget: _widget, isActive = true }) => {
   const { canAccessFeature } = useAuth();
   const { addWidget, addToast, updateWidget } = useDashboard();
   const { showAlert, showConfirm } = useDialog();
@@ -49,6 +50,19 @@ export const WebcamWidget: React.FC<{ widget: WidgetData }> = ({
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
+    // When the host Board becomes inactive, release the camera immediately so
+    // another Board's Webcam widget (or the OS) can acquire it.
+    if (!isActive) {
+      const existing = videoRef.current?.srcObject;
+      if (existing instanceof MediaStream) {
+        existing.getTracks().forEach((track) => track.stop());
+        if (videoRef.current) videoRef.current.srcObject = null;
+      }
+      setStream(null);
+      return;
+    }
+
+    let cancelled = false;
     let currentStream: MediaStream | null = null;
 
     async function startCamera() {
@@ -56,6 +70,7 @@ export const WebcamWidget: React.FC<{ widget: WidgetData }> = ({
         // Enumerate devices if not already done
         if (devices.length === 0) {
           const allDevices = await navigator.mediaDevices.enumerateDevices();
+          if (cancelled) return;
           const videoDevices = allDevices.filter(
             (d) => d.kind === 'videoinput'
           );
@@ -74,6 +89,10 @@ export const WebcamWidget: React.FC<{ widget: WidgetData }> = ({
 
         const mediaStream =
           await navigator.mediaDevices.getUserMedia(constraints);
+        if (cancelled) {
+          mediaStream.getTracks().forEach((track) => track.stop());
+          return;
+        }
         currentStream = mediaStream;
         setStream(mediaStream);
         if (videoRef.current) {
@@ -89,11 +108,12 @@ export const WebcamWidget: React.FC<{ widget: WidgetData }> = ({
     void startCamera();
 
     return () => {
+      cancelled = true;
       if (currentStream) {
         currentStream.getTracks().forEach((track) => track.stop());
       }
     };
-  }, [selectedDeviceId, devices.length]);
+  }, [isActive, selectedDeviceId, devices.length]);
 
   const switchCamera = useCallback(() => {
     if (devices.length < 2) return;

--- a/components/widgets/WidgetLayout/WidgetLayoutWrapper.tsx
+++ b/components/widgets/WidgetLayout/WidgetLayoutWrapper.tsx
@@ -17,6 +17,7 @@ interface WidgetLayoutWrapperProps {
   isStudentView?: boolean;
   studentPin?: string | null;
   isSpotlighted?: boolean;
+  isActive?: boolean;
 }
 
 /**
@@ -31,6 +32,7 @@ export const WidgetLayoutWrapper: React.FC<WidgetLayoutWrapperProps> = ({
   isStudentView = false,
   studentPin,
   isSpotlighted,
+  isActive = true,
 }) => {
   const WidgetComponent = WIDGET_COMPONENTS[widget.type];
 
@@ -48,6 +50,7 @@ export const WidgetLayoutWrapper: React.FC<WidgetLayoutWrapperProps> = ({
     isStudentView,
     studentPin,
     isSpotlighted,
+    isActive,
   };
 
   return (

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -76,6 +76,18 @@ interface WidgetRendererProps {
   dashboardBackground?: string;
   dashboardSettings?: DashboardSettings;
   updateDashboardSettings?: (updates: Partial<DashboardSettings>) => void;
+  /**
+   * True when this widget's host Board is currently visible (active).
+   * False when the Board is mounted-but-hidden via the LRU cache
+   * (`MOUNTED_BOARD_CACHE_SIZE`). Resource-heavy widgets (Webcam,
+   * SoundWidget, SmartNotebook) gate their MediaStream/AudioContext/
+   * onSnapshot acquisitions on this flag so a hidden Board doesn't keep
+   * the camera engaged, the mic open, etc. Defaults to `true` for
+   * student-facing surfaces and any context that doesn't use the
+   * mounted-set cache. Phase C of Plan 2 wires it into individual
+   * resource-heavy widgets; most widgets ignore the prop.
+   */
+  isActive?: boolean;
 }
 
 const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
@@ -96,6 +108,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
   globalStyle,
   dashboardBackground,
   dashboardSettings,
+  isActive = true,
 }) => {
   const isSpotlighted = dashboardSettings?.spotlightWidgetId === widget.id;
   const windowSize = useWindowSize(!!widget.maximized);
@@ -232,6 +245,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
           isStudentView={isStudentView}
           studentPin={studentPin}
           isSpotlighted={isSpotlighted}
+          isActive={isActive}
         />
       );
     },
@@ -254,6 +268,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
       positionKey,
       isStudentView,
       isSpotlighted,
+      isActive,
     ]
   );
 
@@ -368,6 +383,7 @@ interface InnerWidgetRendererProps {
   isStudentView: boolean;
   studentPin?: string | null;
   isSpotlighted: boolean;
+  isActive: boolean;
 }
 
 const InnerWidgetRenderer = memo(
@@ -379,6 +395,7 @@ const InnerWidgetRenderer = memo(
     isStudentView,
     studentPin,
     isSpotlighted,
+    isActive,
   }: InnerWidgetRendererProps) {
     return (
       <WidgetLayoutWrapper
@@ -389,6 +406,7 @@ const InnerWidgetRenderer = memo(
         isStudentView={isStudentView}
         studentPin={studentPin}
         isSpotlighted={isSpotlighted}
+        isActive={isActive}
       />
     );
   },
@@ -400,6 +418,7 @@ const InnerWidgetRenderer = memo(
     if (prev.isStudentView !== next.isStudentView) return false;
     if (prev.studentPin !== next.studentPin) return false;
     if (prev.isSpotlighted !== next.isSpotlighted) return false;
+    if (prev.isActive !== next.isActive) return false;
 
     // Check widget props - explicitly ignoring x, y, z
     const pw = prev.widget;

--- a/config/mountedBoardCache.ts
+++ b/config/mountedBoardCache.ts
@@ -1,7 +1,9 @@
 /**
- * Number of Boards held mounted at any moment. Active Board + (N-1)
- * most-recently-touched. Live-session-active Boards are pinned in
- * addition to the LRU set (never evicted while the session is live).
+ * Maximum number of Boards mounted at any moment. This is the TOTAL
+ * cap — pinned Boards (live-session hosts) and LRU Boards share this
+ * budget. Pinned slots reduce the LRU window correspondingly. There is
+ * a safety floor: at least one slot is always reserved for the active
+ * Board even if all other slots are pinned.
  *
  * Default 2: enough to make "switch to look up something, switch back"
  * preserve drawing/timer/video state on the originating Board. Higher

--- a/config/mountedBoardCache.ts
+++ b/config/mountedBoardCache.ts
@@ -1,0 +1,11 @@
+/**
+ * Number of Boards held mounted at any moment. Active Board + (N-1)
+ * most-recently-touched. Live-session-active Boards are pinned in
+ * addition to the LRU set (never evicted while the session is live).
+ *
+ * Default 2: enough to make "switch to look up something, switch back"
+ * preserve drawing/timer/video state on the originating Board. Higher
+ * values risk audio-context fights, webcam contention, and unbounded
+ * Firestore subscriptions in hidden Boards' widgets.
+ */
+export const MOUNTED_BOARD_CACHE_SIZE = 2;

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -24,7 +24,6 @@ import {
   UserProfile,
   SubstituteShareDriveGrant,
   ROOT_COLLECTION_KEY,
-  Collection,
 } from '../types';
 import { doc, getDoc, setDoc, updateDoc, writeBatch } from 'firebase/firestore';
 import { db, isAuthBypass } from '../config/firebase';
@@ -62,6 +61,7 @@ import { logError } from '../utils/logError';
 import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { useDriveReconnected } from '../hooks/useDriveReconnected';
+import { useCollections } from '../hooks/useCollections';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
 import {
   setAiModelConfigFallbackHandler,
@@ -239,6 +239,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     stopSharingBoard,
   } = useFirestore(user?.uid ?? null);
 
+  const { collections } = useCollections(user?.uid);
+
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
     if (typeof window === 'undefined') return null;
@@ -352,9 +354,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   lastActiveCollectionIdRef.current = lastActiveCollectionId;
   const lastBoardIdByCollectionRef = useRef(lastBoardIdByCollection);
   lastBoardIdByCollectionRef.current = lastBoardIdByCollection;
-  const collectionsRef = useRef<Collection[]>([]);
-  // collectionsRef stays empty here; Task 0.4 will populate it from
-  // useCollections(user?.uid) once that hook is wired into this provider.
+  const collectionsRef = useRef(collections);
+  collectionsRef.current = collections;
+  // Hoisted here (not inside the Task 0.4 effect) so the snapshot callback can
+  // also set it — preventing a second Firestore churn from double-picking.
+  const initialBoardSelectedRef = useRef(false);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [zoom, setZoom] = useState<number>(1);
 
@@ -1813,7 +1817,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
               lastBoardIdByCollectionRef.current,
               collectionsRef.current
             );
-            if (initial) updateActiveId(initial.id);
+            if (initial) {
+              updateActiveId(initial.id);
+              initialBoardSelectedRef.current = true;
+            }
           }
         }
 
@@ -1917,6 +1924,45 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     roleId,
     isStudentRole,
     roleResolved,
+  ]);
+
+  // One-shot upgrade of the initial Board choice once profile + collections
+  // are both available. Runs at most once — guarded by `initialBoardSelectedRef`
+  // so a subsequent profile refresh doesn't yank the teacher to a different
+  // Board after they've started working. The ref is declared at component scope
+  // (not here) so the snapshot callback can also set it.
+  useEffect(() => {
+    if (initialBoardSelectedRef.current) return;
+    if (!profileLoaded) return;
+    if (loading) return;
+    if (dashboards.length === 0) return;
+    if (activeIdRef.current) {
+      // Some other path already picked an active Board (e.g. URL deep-link).
+      initialBoardSelectedRef.current = true;
+      return;
+    }
+    const initial = pickInitialBoard(
+      dashboards,
+      lastActiveCollectionId,
+      lastBoardIdByCollection,
+      collections
+    );
+    // Intentionally leave initialBoardSelectedRef false when initial === null,
+    // so a future dep change (e.g. collections loading after dashboards) gets
+    // another chance to pick a Board. Setting the ref true here would freeze
+    // the effect into the "no board picked" state.
+    if (initial) {
+      updateActiveId(initial.id);
+      initialBoardSelectedRef.current = true;
+    }
+  }, [
+    profileLoaded,
+    loading,
+    dashboards,
+    lastActiveCollectionId,
+    lastBoardIdByCollection,
+    collections,
+    updateActiveId,
   ]);
 
   // Re-hydrate widget pixel x/y/w/h from canonical proportional bounds

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3579,6 +3579,22 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     [addToast, updateActiveId, user, profileLoaded]
   );
 
+  const setActiveCollectionId = useCallback(
+    (nextCollectionId: string | null) => {
+      // Reuse pickInitialBoard but force its lastActiveCollectionId arg to
+      // the new Collection — this picks the per-Collection remembered
+      // Board (or the right fallback) without an extra Firestore read.
+      const target = pickInitialBoard(
+        dashboards,
+        nextCollectionId,
+        lastBoardIdByCollection,
+        collections
+      );
+      if (target) loadDashboard(target.id);
+    },
+    [dashboards, lastBoardIdByCollection, collections, loadDashboard]
+  );
+
   const activeDashboard = dashboards.find((d) => d.id === activeId) ?? null;
 
   // True when the user is viewing a board they joined as a viewer in
@@ -4583,6 +4599,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       moveBoardToCollection,
       pinBoard,
       unpinBoard,
+      setActiveCollectionId,
       resetDockToDefaults,
       addWidget,
       addWidgets,
@@ -4692,6 +4709,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       moveBoardToCollection,
       pinBoard,
       unpinBoard,
+      setActiveCollectionId,
       resetDockToDefaults,
       addWidget,
       addWidgets,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3591,7 +3591,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         lastBoardIdByCollection,
         collections
       );
-      if (target) loadDashboard(target.id);
+      if (!target) {
+        logError(
+          'DashboardContext.setActiveCollectionId.noBoardsInCollection',
+          new Error('Target Collection has no resolvable Board'),
+          { collectionId: nextCollectionId }
+        );
+        return;
+      }
+      loadDashboard(target.id);
     },
     [dashboards, lastBoardIdByCollection, collections, loadDashboard]
   );

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -24,6 +24,7 @@ import {
   UserProfile,
   SubstituteShareDriveGrant,
   ROOT_COLLECTION_KEY,
+  Collection,
 } from '../types';
 import { doc, getDoc, setDoc, updateDoc, writeBatch } from 'firebase/firestore';
 import { db, isAuthBypass } from '../config/firebase';
@@ -56,6 +57,7 @@ import {
   dashboardHasPII,
 } from '../utils/dashboardPII';
 import { migrateBoardForCollections } from '../utils/collectionsMigration';
+import { pickInitialBoard } from '../utils/pickInitialBoard';
 import { logError } from '../utils/logError';
 import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
@@ -217,6 +219,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     savedWidgetConfigs,
     saveWidgetConfig,
     profileLoaded,
+    lastActiveCollectionId,
+    lastBoardIdByCollection,
     remoteControlEnabled: accountRemoteControlEnabled,
   } = useAuth();
   const { driveService, userDomain } = useGoogleDrive();
@@ -337,6 +341,20 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const [groupBuildMode, setGroupBuildMode] = useState(false);
   const dashboardsRef = useRef(dashboards);
   dashboardsRef.current = dashboards;
+  // Refs mirror auth/collections state used by the initial-board selection
+  // path so that branch (which runs inside the snapshot callback) doesn't
+  // have to be re-bound on every userProfile/collection change. Refs are
+  // the right call here because the selection is fire-once on app open,
+  // not a reactive computation.
+  const profileLoadedRef = useRef(profileLoaded);
+  profileLoadedRef.current = profileLoaded;
+  const lastActiveCollectionIdRef = useRef(lastActiveCollectionId);
+  lastActiveCollectionIdRef.current = lastActiveCollectionId;
+  const lastBoardIdByCollectionRef = useRef(lastBoardIdByCollection);
+  lastBoardIdByCollectionRef.current = lastBoardIdByCollection;
+  const collectionsRef = useRef<Collection[]>([]);
+  // collectionsRef stays empty here; Task 0.4 will populate it from
+  // useCollections(user?.uid) once that hook is wired into this provider.
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [zoom, setZoom] = useState<number>(1);
 
@@ -1781,9 +1799,22 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         }
 
         if (migratedDashboards.length > 0 && !activeIdRef.current) {
-          // Try to load default dashboard first
-          const defaultDb = migratedDashboards.find((d) => d.isDefault);
-          updateActiveId(defaultDb ? defaultDb.id : migratedDashboards[0].id);
+          // Wait for the userProfile snapshot to land before picking. If we
+          // pick now using `undefined` lastActiveCollectionId, pickInitialBoard
+          // falls through to the global default — a behavior we explicitly
+          // want to AVOID on the first paint so the teacher doesn't see a
+          // flash of "wrong board" before profile-aware selection corrects it.
+          // The `initialBoardSelectedRef` gate (added in Task 0.4) makes the
+          // selection run exactly once across snapshot churn.
+          if (profileLoadedRef.current) {
+            const initial = pickInitialBoard(
+              migratedDashboards,
+              lastActiveCollectionIdRef.current,
+              lastBoardIdByCollectionRef.current,
+              collectionsRef.current
+            );
+            if (initial) updateActiveId(initial.id);
+          }
         }
 
         // Create default dashboard if none exist. Skip for student users —

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -239,7 +239,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     stopSharingBoard,
   } = useFirestore(user?.uid ?? null);
 
-  const { collections } = useCollections(user?.uid);
+  const collectionsApi = useCollections(user?.uid);
+  const { collections } = collectionsApi;
 
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
@@ -4577,6 +4578,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const contextValue = useMemo(
     () => ({
       driveService,
+      collectionsApi,
       dashboards,
       activeDashboard,
       toasts,
@@ -4687,6 +4689,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     }),
     [
       driveService,
+      collectionsApi,
       dashboards,
       activeDashboard,
       toasts,

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -149,6 +149,7 @@ export interface DashboardContextValue {
     boardId: string,
     options?: { silent?: boolean }
   ) => Promise<void>;
+  setActiveCollectionId: (collectionId: string | null) => void;
   resetDockToDefaults: () => void;
   addWidget: (type: WidgetType, overrides?: AddWidgetOverrides) => void;
   addWidgets: (

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -17,6 +17,7 @@ import {
 } from '../types';
 import type { RosterCreateMeta } from '../hooks/useRosters';
 import type { GoogleDriveService } from '../utils/googleDriveService';
+import type { UseCollectionsResult } from '../hooks/useCollections';
 
 /**
  * Mode applied to a shared-board import. Substitute shares are intentionally
@@ -109,6 +110,14 @@ export interface DashboardContextValue {
    * most once per session.
    */
   driveService: GoogleDriveService | null;
+  /**
+   * Single shared instance of the collections hook result. All consumers
+   * must read from this instead of calling `useCollections(user?.uid)`
+   * directly — using the single source of truth avoids duplicate Firestore
+   * subscriptions and ensures in-memory state (auth bypass / E2E) is shared
+   * across every component.
+   */
+  collectionsApi: UseCollectionsResult;
   dashboards: Dashboard[];
   activeDashboard: Dashboard | null;
   toasts: Toast[];

--- a/docs/superpowers/plans/2026-05-16-collections-fab-and-mounted-set.md
+++ b/docs/superpowers/plans/2026-05-16-collections-fab-and-mounted-set.md
@@ -1,0 +1,1811 @@
+# Collections Plan 2 — Collection-aware FAB, Breadcrumb chip, App-open behavior, Mounted-Set State Preservation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the live-classroom navigation surface Collection-aware (FAB iterates Boards in the _active Collection_, breadcrumb chip names the active Collection above it), restore the teacher's last Board in their last Collection on app open, and keep a small LRU cache of mounted Boards so Board-to-Board switching preserves in-flight state (drawings, timer counts, video positions) instead of doing a full remount.
+
+**Architecture:** Builds on Plan 1's data layer (`useCollections`, `Dashboard.collectionId`, `UserProfile.lastActiveCollectionId`, `UserProfile.lastBoardIdByCollection`). Splits the existing `BoardNavFab` into a Board switcher _within_ the active Collection plus a Collection switcher; introduces a pure `pickInitialBoard()` helper that consumes the `userProfile` memory; refactors `DashboardView`'s widget root from a single `key={activeDashboard.id}` mount-and-remount into a small LRU window (default size 2) of mounted Boards toggled via CSS `display`. Live-session-active Boards are pinned in the cache so a session host never loses state by switching away.
+
+**Tech Stack:** React 19, TypeScript 5.9, Vite 6, Firestore (modular SDK), Vitest 4, @testing-library/react, Playwright, Tailwind CSS, lucide-react.
+
+**Builds on:** Plan 1 (`docs/superpowers/plans/2026-05-15-collections-core-and-modal.md`) — fully landed on `dev-paul`.
+
+**Out of scope (covered by later plans):**
+
+- Plan 3: Collection-level sharing (Copy + Substitute view-only).
+- Plan 4: Collection templates (`/dashboard_templates/` with `type` discriminator).
+- True per-Board widget-state hydration on cache eviction (out of scope; eviction discards in-flight state, same as today's full remount).
+- Cache size > 2 — a tuning knob lives in `config/mountedBoardCache.ts` (Task 3.1) but the default stays 2 because real K-12 classroom usage tops out at 1–2 boards in flight.
+- Thumbnails on Board cards.
+
+---
+
+## Files Created or Modified
+
+**New files:**
+
+- `utils/pickInitialBoard.ts` — pure resolver: `(dashboards, lastActiveCollectionId, lastBoardIdByCollection, collections) => Dashboard | null`.
+- `tests/utils/pickInitialBoard.test.ts` — covers every fallback rung.
+- `components/layout/BoardBreadcrumb.tsx` — Collection › Board chip that mounts above `BoardNavFab`. Clickable to open `BoardsModal`.
+- `tests/components/layout/BoardBreadcrumb.test.tsx`.
+- `components/layout/CollectionSwitcherMenu.tsx` — submenu that opens from `BoardNavFab`'s kebab; lists Collections (flat, with depth-indent) and switches the active Collection.
+- `tests/components/layout/CollectionSwitcherMenu.test.tsx`.
+- `config/mountedBoardCache.ts` — exports `MOUNTED_BOARD_CACHE_SIZE` (default `2`) so future tuning happens in one place.
+- `hooks/useMountedBoardCache.ts` — LRU `(activeId, dashboards, isLiveSessionFor) => Dashboard[]` that returns the set of Boards currently mounted, with pinning for live-session hosts.
+- `tests/hooks/useMountedBoardCache.test.ts`.
+- `components/layout/MountedBoardsLayer.tsx` — renders the LRU window of `<BoardCanvas>`es, only the active one visible.
+- `components/layout/BoardCanvas.tsx` — the inner widget-canvas previously inlined inside `DashboardView`. Receives `dashboard` + `isActive` (controls visibility); renders the widget map.
+- `tests/components/layout/MountedBoardsLayer.test.tsx`.
+- `tests/e2e/collections-fab.spec.ts` — happy path: app-open restore, breadcrumb shows, FAB only lists active Collection, Collection switcher works.
+
+**Modified files:**
+
+- `context/DashboardContext.tsx` — replace the in-snapshot initial-board selection (lines ~1783-1786) with a gated effect that calls `pickInitialBoard()` once `(dashboards, profileLoaded, collections)` are all ready. Expose a new `setActiveCollectionId(id)` action that loads the appropriate Board for that Collection.
+- `context/DashboardContextValue.ts` — add `setActiveCollectionId` to the interface.
+- `components/layout/BoardNavFab.tsx` — filter the menu to Boards in the active Collection; add a "Switch Collection" item at the top that opens `CollectionSwitcherMenu`; wrap prev/next chevrons within the active Collection only.
+- `components/layout/DashboardView.tsx` — extract the widget-canvas into `BoardCanvas`, replace single mount with `<MountedBoardsLayer>`, drop the `key={activeDashboard.id}` remount.
+- `components/layout/sidebar/SidebarBoardsActive.tsx` — `loadDashboard` calls already update `lastBoardIdByCollection`; ensure the Collection-switch button (added to header) calls the new `setActiveCollectionId` action.
+- `locales/en.json` + `locales/de.json` + `locales/es.json` + `locales/fr.json` — new keys for breadcrumb chip + Collection switcher.
+
+---
+
+## Phase 0 — App-open behavior
+
+Foundation phase: when the app loads, restore the teacher's last Board in their last Collection instead of always falling back to the global `isDefault`.
+
+### Task 0.1 — Pure helper `pickInitialBoard()`
+
+**Files:**
+
+- Create: `utils/pickInitialBoard.ts`
+
+- [ ] **Step 1: Write the file**
+
+```typescript
+import type { Collection, Dashboard } from '@/types';
+
+/**
+ * Choose which Board to load on app open. Honors per-Collection navigation
+ * memory (`lastActiveCollectionId` + `lastBoardIdByCollection`) populated by
+ * `loadDashboard` in Plan 1, with progressively weaker fallbacks so a
+ * partially-populated profile (or a Board that no longer exists) still
+ * lands on a sensible default.
+ *
+ * Fallback chain:
+ *   1. `lastBoardIdByCollection[lastActiveCollectionId]` if that Board still
+ *      exists AND still belongs to that Collection.
+ *   2. The active Collection's `defaultBoardId` if set and present.
+ *   3. The first Board in the active Collection (sorted by existing `order`).
+ *   4. The first Board with `isDefault === true` globally.
+ *   5. The first Board in the global list (last-resort).
+ *   6. `null` if `dashboards` is empty.
+ *
+ * Pure function — all inputs are passed explicitly so this can be tested
+ * without React or Firestore. `lastActiveCollectionId === null` means
+ * "the user was last in the root (no Collection)"; `undefined` means the
+ * profile hasn't been read yet and the caller should defer.
+ */
+export const pickInitialBoard = (
+  dashboards: Dashboard[],
+  lastActiveCollectionId: string | null | undefined,
+  lastBoardIdByCollection: Record<string, string> | undefined,
+  collections: Collection[]
+): Dashboard | null => {
+  if (dashboards.length === 0) return null;
+  // Caller should never invoke this with `undefined` lastActiveCollectionId;
+  // it indicates profile-not-yet-loaded. Treat as "no memory yet" and fall
+  // through to global defaults so we don't crash if a caller forgets.
+  if (lastActiveCollectionId === undefined) {
+    return (
+      dashboards.find((d) => d.isDefault === true) ?? dashboards[0] ?? null
+    );
+  }
+
+  const targetCollectionId = lastActiveCollectionId;
+  const collectionKey = targetCollectionId ?? '__root__';
+  const rememberedBoardId = lastBoardIdByCollection?.[collectionKey];
+
+  if (rememberedBoardId) {
+    const remembered = dashboards.find((d) => d.id === rememberedBoardId);
+    if (
+      remembered &&
+      (remembered.collectionId ?? null) === targetCollectionId
+    ) {
+      return remembered;
+    }
+  }
+
+  if (targetCollectionId !== null) {
+    const targetCollection = collections.find(
+      (c) => c.id === targetCollectionId
+    );
+    if (targetCollection?.defaultBoardId) {
+      const collectionDefault = dashboards.find(
+        (d) =>
+          d.id === targetCollection.defaultBoardId &&
+          (d.collectionId ?? null) === targetCollectionId
+      );
+      if (collectionDefault) return collectionDefault;
+    }
+  }
+
+  const inCollection = dashboards
+    .filter((d) => (d.collectionId ?? null) === targetCollectionId)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  if (inCollection.length > 0) return inCollection[0];
+
+  return dashboards.find((d) => d.isDefault === true) ?? dashboards[0] ?? null;
+};
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add utils/pickInitialBoard.ts
+git commit -m "feat(boards): add pickInitialBoard pure resolver for app-open"
+```
+
+### Task 0.2 — Tests for `pickInitialBoard`
+
+**Files:**
+
+- Create: `tests/utils/pickInitialBoard.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { pickInitialBoard } from '@/utils/pickInitialBoard';
+import type { Collection, Dashboard } from '@/types';
+
+const board = (over: Partial<Dashboard> = {}): Dashboard => ({
+  id: over.id ?? 'b-default',
+  name: over.name ?? 'Default Board',
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  order: over.order ?? 0,
+  collectionId: over.collectionId ?? null,
+  isPinned: over.isPinned ?? false,
+  isDefault: over.isDefault ?? false,
+  ...over,
+});
+
+const collection = (over: Partial<Collection> = {}): Collection => ({
+  id: over.id ?? 'c1',
+  name: over.name ?? 'Collection 1',
+  parentCollectionId: over.parentCollectionId ?? null,
+  order: over.order ?? 0,
+  createdAt: 0,
+  ...over,
+});
+
+describe('pickInitialBoard', () => {
+  it('returns null when no boards exist', () => {
+    expect(pickInitialBoard([], null, undefined, [])).toBeNull();
+  });
+
+  it('returns the remembered Board when it still exists in the right Collection', () => {
+    const target = board({ id: 'b1', collectionId: 'c1' });
+    const other = board({ id: 'b2', collectionId: 'c1' });
+    const result = pickInitialBoard([target, other], 'c1', { c1: 'b1' }, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('b1');
+  });
+
+  it('skips the remembered Board when it has moved out of the Collection', () => {
+    const moved = board({ id: 'b1', collectionId: 'c2' });
+    const sibling = board({ id: 'b2', collectionId: 'c1', order: 0 });
+    const result = pickInitialBoard([moved, sibling], 'c1', { c1: 'b1' }, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('b2');
+  });
+
+  it('falls back to the Collection defaultBoardId when no memory exists', () => {
+    const b = board({ id: 'defaultInColl', collectionId: 'c1' });
+    const other = board({ id: 'otherInColl', collectionId: 'c1', order: 0 });
+    const result = pickInitialBoard([other, b], 'c1', undefined, [
+      collection({ id: 'c1', defaultBoardId: 'defaultInColl' }),
+    ]);
+    expect(result?.id).toBe('defaultInColl');
+  });
+
+  it('falls back to the first Board in the Collection by order', () => {
+    const b2 = board({ id: 'second', collectionId: 'c1', order: 5 });
+    const b1 = board({ id: 'first', collectionId: 'c1', order: 1 });
+    const result = pickInitialBoard([b2, b1], 'c1', undefined, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('first');
+  });
+
+  it('falls back to the global isDefault when the Collection is empty', () => {
+    const orphan = board({ id: 'g1', collectionId: null, isDefault: true });
+    const inOther = board({ id: 'g2', collectionId: 'cOther' });
+    const result = pickInitialBoard([orphan, inOther], 'c1', undefined, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('g1');
+  });
+
+  it('treats null lastActiveCollectionId as the root Collection', () => {
+    const rootBoard = board({ id: 'r1', collectionId: null, order: 0 });
+    const inColl = board({ id: 'i1', collectionId: 'c1' });
+    const result = pickInitialBoard(
+      [inColl, rootBoard],
+      null,
+      { __root__: 'r1' },
+      []
+    );
+    expect(result?.id).toBe('r1');
+  });
+
+  it('falls through to global default when lastActiveCollectionId is undefined (profile not yet loaded)', () => {
+    const def = board({ id: 'def', isDefault: true });
+    const other = board({ id: 'other' });
+    const result = pickInitialBoard([other, def], undefined, undefined, []);
+    expect(result?.id).toBe('def');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify they pass**
+
+```bash
+pnpm vitest run tests/utils/pickInitialBoard.test.ts
+```
+
+Expected: all 7 tests PASS (helper from Task 0.1 already covers each case).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/utils/pickInitialBoard.test.ts
+git commit -m "test(boards): cover pickInitialBoard fallback chain"
+```
+
+### Task 0.3 — Wire `pickInitialBoard` into the snapshot listener
+
+**Files:**
+
+- Modify: `context/DashboardContext.tsx` (the initial-board selection inside the snapshot handler, around lines 1783-1786)
+
+- [ ] **Step 1: Locate the existing branch**
+
+Open `context/DashboardContext.tsx` and find the snapshot callback that currently reads:
+
+```typescript
+if (migratedDashboards.length > 0 && !activeIdRef.current) {
+  // Try to load default dashboard first
+  const defaultDb = migratedDashboards.find((d) => d.isDefault);
+  updateActiveId(defaultDb ? defaultDb.id : migratedDashboards[0].id);
+}
+```
+
+The selection runs only when no `activeId` is set yet — i.e., once on first snapshot after sign-in. The profile (and therefore `lastActiveCollectionId`) may not have loaded yet at that moment. We need to either defer this until profile is ready, OR pick a sane fallback and let a follow-up effect upgrade the choice once the profile arrives.
+
+- [ ] **Step 2: Add the profile-aware selection branch**
+
+Replace the block above with:
+
+```typescript
+if (migratedDashboards.length > 0 && !activeIdRef.current) {
+  // Wait for the userProfile snapshot to land before picking. If we
+  // pick now using `undefined` lastActiveCollectionId, pickInitialBoard
+  // falls through to the global default — a behavior we explicitly
+  // want to AVOID on the first paint so the teacher doesn't see a
+  // flash of "wrong board" before profile-aware selection corrects it.
+  // The `initialBoardSelectedRef` gate (added in Step 3) makes the
+  // selection run exactly once across snapshot churn.
+  if (profileLoadedRef.current) {
+    const initial = pickInitialBoard(
+      migratedDashboards,
+      lastActiveCollectionIdRef.current,
+      lastBoardIdByCollectionRef.current,
+      collectionsRef.current
+    );
+    if (initial) updateActiveId(initial.id);
+  }
+}
+```
+
+- [ ] **Step 3: Add the three refs at the top of `DashboardProvider`**
+
+After the existing `dashboardsRef` block (around line 338), add:
+
+```typescript
+// Refs mirror auth/collections state used by the initial-board selection
+// path so that branch (which runs inside the snapshot callback) doesn't
+// have to be re-bound on every userProfile/collection change. Refs are
+// the right call here because the selection is fire-once on app open,
+// not a reactive computation.
+const profileLoadedRef = useRef(profileLoaded);
+profileLoadedRef.current = profileLoaded;
+const lastActiveCollectionIdRef = useRef(lastActiveCollectionId);
+lastActiveCollectionIdRef.current = lastActiveCollectionId;
+const lastBoardIdByCollectionRef = useRef(lastBoardIdByCollection);
+lastBoardIdByCollectionRef.current = lastBoardIdByCollection;
+const collectionsRef = useRef<Collection[]>([]);
+// collectionsRef is populated in Task 0.4 via the useCollections hook
+// — leave empty for now.
+```
+
+- [ ] **Step 4: Pull the new fields out of `useAuth()`**
+
+Update the `useAuth()` destructuring (around line 207) to include the navigation-memory fields:
+
+```typescript
+const {
+  user,
+  isAdmin,
+  // ...existing fields...
+  profileLoaded,
+  lastActiveCollectionId,
+  lastBoardIdByCollection,
+} = useAuth();
+```
+
+- [ ] **Step 5: Add the import**
+
+At the top of `context/DashboardContext.tsx`:
+
+```typescript
+import { pickInitialBoard } from '../utils/pickInitialBoard';
+import type { Collection } from '@/types';
+```
+
+- [ ] **Step 6: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add context/DashboardContext.tsx
+git commit -m "feat(dashboard): wire pickInitialBoard into snapshot initial select"
+```
+
+### Task 0.4 — Trigger a profile-aware re-selection once the profile lands
+
+The branch in 0.3 only fires when the snapshot CALLBACK runs. If dashboards arrive before the profile, the selection is skipped and never re-runs.
+
+**Files:**
+
+- Modify: `context/DashboardContext.tsx`
+
+- [ ] **Step 1: Add a delayed-initial-select effect**
+
+After the existing dashboard-snapshot subscription effect (search for `subscribeToDashboards` registration), add:
+
+```typescript
+// One-shot upgrade of the initial Board choice once profile + collections
+// are both available. Runs at most once — guarded by `initialBoardSelectedRef`
+// so a subsequent profile refresh doesn't yank the teacher to a different
+// Board after they've started working.
+const initialBoardSelectedRef = useRef(false);
+useEffect(() => {
+  if (initialBoardSelectedRef.current) return;
+  if (!profileLoaded) return;
+  if (loading) return;
+  if (dashboards.length === 0) return;
+  if (activeIdRef.current) {
+    // Some other path already picked an active Board (e.g. URL deep-link).
+    initialBoardSelectedRef.current = true;
+    return;
+  }
+  const initial = pickInitialBoard(
+    dashboards,
+    lastActiveCollectionId,
+    lastBoardIdByCollection,
+    collections
+  );
+  if (initial) {
+    updateActiveId(initial.id);
+    initialBoardSelectedRef.current = true;
+  }
+}, [
+  profileLoaded,
+  loading,
+  dashboards,
+  lastActiveCollectionId,
+  lastBoardIdByCollection,
+  collections,
+  updateActiveId,
+]);
+```
+
+- [ ] **Step 2: Wire `useCollections` into the provider**
+
+Search for where the provider currently _doesn't_ read collections (`useCollections` is consumed in the BoardsModal — we need it here too). Add near the other hook calls in `DashboardProvider`:
+
+```typescript
+const { collections } = useCollections(user?.uid);
+```
+
+…and update the ref-mirror line from Task 0.3:
+
+```typescript
+const collectionsRef = useRef(collections);
+collectionsRef.current = collections;
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add context/DashboardContext.tsx
+git commit -m "feat(dashboard): defer initial-board select until profile+collections land"
+```
+
+### Task 0.5 — Add `setActiveCollectionId` action
+
+Switching Collections from the FAB or sidebar needs to load the right Board for that Collection. Wraps `pickInitialBoard` for that sub-set.
+
+**Files:**
+
+- Modify: `context/DashboardContext.tsx`
+- Modify: `context/DashboardContextValue.ts`
+
+- [ ] **Step 1: Implement the action**
+
+Add inside `DashboardProvider` near the other action callbacks:
+
+```typescript
+const setActiveCollectionId = useCallback(
+  (nextCollectionId: string | null) => {
+    // Reuse pickInitialBoard but force its lastActiveCollectionId arg to
+    // the new Collection — this picks the per-Collection remembered
+    // Board (or the right fallback) without an extra Firestore read.
+    const target = pickInitialBoard(
+      dashboards,
+      nextCollectionId,
+      lastBoardIdByCollection,
+      collections
+    );
+    if (target) loadDashboard(target.id);
+  },
+  [dashboards, lastBoardIdByCollection, collections, loadDashboard]
+);
+```
+
+- [ ] **Step 2: Expose it on the context value**
+
+In `context/DashboardContextValue.ts` add:
+
+```typescript
+setActiveCollectionId: (collectionId: string | null) => void;
+```
+
+In `DashboardContext.tsx` add `setActiveCollectionId` to both `useMemo` returns (the loading-shell and the loaded value).
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add context/DashboardContext.tsx context/DashboardContextValue.ts
+git commit -m "feat(dashboard): add setActiveCollectionId action"
+```
+
+---
+
+## Phase 1 — Breadcrumb chip above the Board FAB
+
+Read-only chip that names the active Collection (or "All Boards" for root) and the active Board. Clicking opens the BoardsModal scoped to the active Collection.
+
+### Task 1.1 — Create `BoardBreadcrumb.tsx`
+
+**Files:**
+
+- Create: `components/layout/BoardBreadcrumb.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, ChevronRight } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useCollections } from '@/hooks/useCollections';
+import { BoardsModal } from '@/components/boardsModal/BoardsModal';
+
+export const BoardBreadcrumb: FC = () => {
+  const { t } = useTranslation();
+  const { activeDashboard } = useDashboard();
+  const { user } = useAuth();
+  const { collections } = useCollections(user?.uid);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  if (!activeDashboard) return null;
+  const collectionId = activeDashboard.collectionId ?? null;
+  const collection = collectionId
+    ? collections.find((c) => c.id === collectionId)
+    : null;
+  const collectionLabel = collection
+    ? collection.name
+    : t('boardBreadcrumb.root', { defaultValue: 'All Boards' });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+        data-screenshot="exclude"
+        aria-label={t('boardBreadcrumb.openManager', {
+          defaultValue: 'Manage Boards',
+        })}
+        className="inline-flex items-center gap-1 max-w-[40vw] px-2.5 py-1 rounded-full bg-slate-900/70 backdrop-blur-md text-xxs font-medium text-white/80 hover:bg-slate-900/85 hover:text-white transition-colors"
+      >
+        <Folder
+          className="w-3 h-3 flex-shrink-0"
+          style={collection?.color ? { color: collection.color } : undefined}
+        />
+        <span className="truncate">{collectionLabel}</span>
+        <ChevronRight className="w-3 h-3 flex-shrink-0 text-white/40" />
+        <span className="truncate font-bold text-white">
+          {activeDashboard.name}
+        </span>
+      </button>
+      {isModalOpen && <BoardsModal onClose={() => setIsModalOpen(false)} />}
+    </>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/layout/BoardBreadcrumb.tsx
+git commit -m "feat(layout): add BoardBreadcrumb chip"
+```
+
+### Task 1.2 — Tests for `BoardBreadcrumb`
+
+**Files:**
+
+- Create: `tests/components/layout/BoardBreadcrumb.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BoardBreadcrumb } from '@/components/layout/BoardBreadcrumb';
+
+const useDashboardMock = vi.fn();
+const useAuthMock = vi.fn();
+const useCollectionsMock = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => useDashboardMock(),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () => useCollectionsMock(),
+}));
+vi.mock('@/components/boardsModal/BoardsModal', () => ({
+  BoardsModal: ({ onClose }: { onClose: () => void }) => (
+    <div role="dialog" aria-label="Boards Modal">
+      <button onClick={onClose}>close-modal</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  useAuthMock.mockReturnValue({ user: { uid: 'u1' } });
+});
+
+describe('BoardBreadcrumb', () => {
+  it('renders nothing when no active dashboard', () => {
+    useDashboardMock.mockReturnValue({ activeDashboard: null });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    const { container } = render(<BoardBreadcrumb />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "All Boards" when the active dashboard is at root', () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'My Board', collectionId: null },
+    });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    render(<BoardBreadcrumb />);
+    expect(screen.getByText('All Boards')).toBeInTheDocument();
+    expect(screen.getByText('My Board')).toBeInTheDocument();
+  });
+
+  it('renders the Collection name when the active dashboard is in a Collection', () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'Warmup', collectionId: 'c1' },
+    });
+    useCollectionsMock.mockReturnValue({
+      collections: [
+        {
+          id: 'c1',
+          name: 'Math',
+          parentCollectionId: null,
+          order: 0,
+          createdAt: 0,
+        },
+      ],
+    });
+    render(<BoardBreadcrumb />);
+    expect(screen.getByText('Math')).toBeInTheDocument();
+    expect(screen.getByText('Warmup')).toBeInTheDocument();
+  });
+
+  it('opens the BoardsModal when clicked', async () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'Warmup', collectionId: null },
+    });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    render(<BoardBreadcrumb />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /manage boards/i })
+    );
+    expect(
+      screen.getByRole('dialog', { name: 'Boards Modal' })
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run + verify pass**
+
+```bash
+pnpm vitest run tests/components/layout/BoardBreadcrumb.test.tsx
+```
+
+Expected: 4 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/components/layout/BoardBreadcrumb.test.tsx
+git commit -m "test(layout): cover BoardBreadcrumb rendering + click-to-open"
+```
+
+### Task 1.3 — Mount `BoardBreadcrumb` above the existing FAB
+
+**Files:**
+
+- Modify: `components/layout/BoardNavFab.tsx` (return-stack)
+
+- [ ] **Step 1: Add the chip mount point**
+
+Inside the outer `<div ref={containerRef}>` of `BoardNavFab`, insert above the existing chevron group:
+
+```tsx
+<div className="absolute bottom-full left-0 mb-1.5 flex items-center">
+  <BoardBreadcrumb />
+</div>
+```
+
+…and add the import at the top:
+
+```typescript
+import { BoardBreadcrumb } from './BoardBreadcrumb';
+```
+
+- [ ] **Step 2: Verify in the dev server**
+
+```bash
+pnpm run dev
+```
+
+Expected: with at least one Board loaded, the chip appears above the FAB row. The chip should NOT show the BoardsModal until clicked.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/layout/BoardNavFab.tsx
+git commit -m "feat(layout): mount BoardBreadcrumb above BoardNavFab"
+```
+
+---
+
+## Phase 2 — Collection-aware FAB
+
+`BoardNavFab` currently iterates every Board globally. Make it iterate only Boards in the active Collection, with a "Switch Collection" submenu for jumping between Collections.
+
+### Task 2.1 — Filter `BoardNavFab` to the active Collection
+
+**Files:**
+
+- Modify: `components/layout/BoardNavFab.tsx`
+
+- [ ] **Step 1: Replace the global `dashboards` reference with an active-Collection slice**
+
+At the top of the component, after destructuring `useDashboard()`, add:
+
+```typescript
+const activeCollectionId = activeDashboard?.collectionId ?? null;
+const boardsInCollection = useMemo(
+  () =>
+    dashboards
+      .filter((d) => (d.collectionId ?? null) === activeCollectionId)
+      .sort((a, b) => (a.order ?? 0) - (b.order ?? 0)),
+  [dashboards, activeCollectionId]
+);
+```
+
+Then replace every remaining reference to `dashboards` inside this component (in `currentIndex`, `goPrev`, `goNext`, the `useEffect` cleanup, and the picker `.map`) with `boardsInCollection`.
+
+- [ ] **Step 2: Update the empty-state guard**
+
+```typescript
+if (boardsInCollection.length <= 1) return null;
+```
+
+Don't render the FAB at all when only one Board lives in the Collection (matches current behavior for the global case).
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/layout/BoardNavFab.tsx
+git commit -m "feat(layout): FAB iterates Boards within active Collection"
+```
+
+### Task 2.2 — `CollectionSwitcherMenu`
+
+**Files:**
+
+- Create: `components/layout/CollectionSwitcherMenu.tsx`
+
+- [ ] **Step 1: Write the menu**
+
+```tsx
+import { type FC, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, Home } from 'lucide-react';
+import type { Collection } from '@/types';
+
+interface CollectionSwitcherMenuProps {
+  collections: Collection[];
+  activeCollectionId: string | null;
+  onSelect: (collectionId: string | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * Submenu opened from BoardNavFab. Lists all Collections (flat with
+ * depth-indent) plus the "Root (no Collection)" entry. Used to jump the
+ * navigation surface to a different Collection — the actual Board switch
+ * is handled by the caller, which routes through
+ * DashboardContext.setActiveCollectionId.
+ */
+export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
+  collections,
+  activeCollectionId,
+  onSelect,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+
+  const flat = useMemo(() => {
+    const childrenByParent = new Map<string | null, Collection[]>();
+    for (const c of collections) {
+      const bucket = childrenByParent.get(c.parentCollectionId) ?? [];
+      bucket.push(c);
+      childrenByParent.set(c.parentCollectionId, bucket);
+    }
+    for (const bucket of childrenByParent.values()) {
+      bucket.sort((a, b) => a.order - b.order);
+    }
+    const out: { c: Collection; depth: number }[] = [];
+    const walk = (parent: string | null, depth: number) => {
+      const kids = childrenByParent.get(parent) ?? [];
+      for (const k of kids) {
+        out.push({ c: k, depth });
+        walk(k.id, depth + 1);
+      }
+    };
+    walk(null, 0);
+    return out;
+  }, [collections]);
+
+  return (
+    <div
+      role="menu"
+      aria-label={t('collectionSwitcher.title', {
+        defaultValue: 'Switch Collection',
+      })}
+      className="absolute bottom-full left-0 mb-2 w-64 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/20 bg-slate-900/80 backdrop-blur-xl shadow-2xl py-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150"
+    >
+      <div className="px-3 py-1.5 text-xxs font-bold uppercase tracking-wider text-white/40">
+        {t('collectionSwitcher.title', { defaultValue: 'Switch Collection' })}
+      </div>
+      <button
+        role="menuitem"
+        onClick={() => {
+          onSelect(null);
+          onClose();
+        }}
+        className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50 ${
+          activeCollectionId === null
+            ? 'bg-brand-blue-primary text-white'
+            : 'text-white/80 hover:bg-white/10'
+        }`}
+      >
+        <Home className="w-3.5 h-3.5 flex-shrink-0" />
+        {t('collectionSwitcher.root', { defaultValue: 'All Boards (root)' })}
+      </button>
+      {flat.map(({ c, depth }) => {
+        const isActive = activeCollectionId === c.id;
+        return (
+          <button
+            key={c.id}
+            role="menuitem"
+            onClick={() => {
+              onSelect(c.id);
+              onClose();
+            }}
+            style={{ paddingLeft: `${0.75 + depth * 1}rem` }}
+            className={`w-full flex items-center gap-2 pr-3 py-2 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50 ${
+              isActive
+                ? 'bg-brand-blue-primary text-white'
+                : 'text-white/80 hover:bg-white/10'
+            }`}
+          >
+            <Folder
+              className="w-3.5 h-3.5 flex-shrink-0"
+              style={c.color ? { color: c.color } : undefined}
+            />
+            <span className="truncate">{c.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/layout/CollectionSwitcherMenu.tsx
+git commit -m "feat(layout): add CollectionSwitcherMenu submenu"
+```
+
+### Task 2.3 — Tests for `CollectionSwitcherMenu`
+
+**Files:**
+
+- Create: `tests/components/layout/CollectionSwitcherMenu.test.tsx`
+
+- [ ] **Step 1: Write the tests**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CollectionSwitcherMenu } from '@/components/layout/CollectionSwitcherMenu';
+import type { Collection } from '@/types';
+
+const coll = (
+  id: string,
+  parent: string | null,
+  order = 0,
+  name = id
+): Collection => ({
+  id,
+  name,
+  parentCollectionId: parent,
+  order,
+  createdAt: 0,
+});
+
+describe('CollectionSwitcherMenu', () => {
+  it('always shows the "All Boards (root)" item', () => {
+    render(
+      <CollectionSwitcherMenu
+        collections={[]}
+        activeCollectionId={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('menuitem', { name: /all boards \(root\)/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders nested Collections in tree order with depth indent', () => {
+    const collections = [
+      coll('a', null, 0, 'A'),
+      coll('b', 'a', 0, 'B'),
+      coll('c', 'a', 1, 'C'),
+      coll('d', null, 1, 'D'),
+    ];
+    render(
+      <CollectionSwitcherMenu
+        collections={collections}
+        activeCollectionId={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const menuItems = screen.getAllByRole('menuitem');
+    // Root + 4 Collections = 5 items, in DFS order: root, A, B, C, D.
+    const labels = menuItems.map((el) => el.textContent?.trim());
+    expect(labels).toEqual([
+      expect.stringContaining('All Boards'),
+      'A',
+      'B',
+      'C',
+      'D',
+    ]);
+  });
+
+  it('marks the active Collection', () => {
+    render(
+      <CollectionSwitcherMenu
+        collections={[coll('a', null, 0, 'A')]}
+        activeCollectionId="a"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const aItem = screen.getByRole('menuitem', { name: 'A' });
+    expect(aItem.className).toMatch(/bg-brand-blue-primary/);
+  });
+
+  it('calls onSelect + onClose when an item is clicked', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CollectionSwitcherMenu
+        collections={[coll('a', null, 0, 'A')]}
+        activeCollectionId={null}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'A' }));
+    expect(onSelect).toHaveBeenCalledWith('a');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('passes null to onSelect for the root item', async () => {
+    const onSelect = vi.fn();
+    render(
+      <CollectionSwitcherMenu
+        collections={[]}
+        activeCollectionId="a"
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /all boards \(root\)/i })
+    );
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});
+```
+
+- [ ] **Step 2: Run + verify pass**
+
+```bash
+pnpm vitest run tests/components/layout/CollectionSwitcherMenu.test.tsx
+```
+
+Expected: 5 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/components/layout/CollectionSwitcherMenu.test.tsx
+git commit -m "test(layout): cover CollectionSwitcherMenu tree + selection"
+```
+
+### Task 2.4 — Wire `CollectionSwitcherMenu` into `BoardNavFab`
+
+**Files:**
+
+- Modify: `components/layout/BoardNavFab.tsx`
+
+- [ ] **Step 1: Add state + collections + setActiveCollectionId hookup**
+
+At the top of `BoardNavFab` add:
+
+```typescript
+const { user } = useAuth();
+const { collections } = useCollections(user?.uid);
+const { setActiveCollectionId } = useDashboard();
+const [isCollectionMenuOpen, setIsCollectionMenuOpen] = useState(false);
+```
+
+Add the imports at the top:
+
+```typescript
+import { useAuth } from '@/context/useAuth';
+import { useCollections } from '@/hooks/useCollections';
+import { CollectionSwitcherMenu } from './CollectionSwitcherMenu';
+```
+
+- [ ] **Step 2: Render the submenu when open**
+
+Inside the outer `<div>` (above the existing menu render), add:
+
+```tsx
+{
+  isCollectionMenuOpen && (
+    <CollectionSwitcherMenu
+      collections={collections}
+      activeCollectionId={activeCollectionId}
+      onSelect={(id) => setActiveCollectionId(id)}
+      onClose={() => setIsCollectionMenuOpen(false)}
+    />
+  );
+}
+```
+
+The existing Board-list menu should be suppressed while the Collection submenu is open. Adjust the existing render condition:
+
+```typescript
+{isPickerOpen && !isCollectionMenuOpen && (
+  <div role="menu" ...>
+```
+
+- [ ] **Step 3: Add a "Switch Collection" item at the top of the Board-list menu**
+
+Inside the existing Board-list menu, BEFORE the `boardsInCollection.map(...)` block:
+
+```tsx
+{
+  collections.length > 0 && (
+    <button
+      role="menuitem"
+      onClick={() => {
+        setIsPickerOpen(false);
+        setIsCollectionMenuOpen(true);
+      }}
+      className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm text-white/80 hover:bg-white/10 border-b border-white/10 mb-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/50"
+    >
+      <Folder className="w-3.5 h-3.5 flex-shrink-0" />
+      {t('boardNav.switchCollection', { defaultValue: 'Switch Collection…' })}
+    </button>
+  );
+}
+```
+
+Add `Folder` to the existing `lucide-react` import line.
+
+- [ ] **Step 4: Verify in dev server**
+
+```bash
+pnpm run dev
+```
+
+Expected:
+
+1. With ≥ 1 Collections, kebab menu now has a "Switch Collection…" item at the top.
+2. Clicking it opens the Collection submenu.
+3. Picking a Collection switches the active Board to that Collection's last-visited / default / first Board.
+4. Prev/next chevrons only iterate within the active Collection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/layout/BoardNavFab.tsx
+git commit -m "feat(layout): wire Collection switcher into BoardNavFab"
+```
+
+---
+
+## Phase 3 — Mounted-set state preservation (P4)
+
+Today `DashboardView` mounts a single `<div key={activeDashboard.id}>` and re-mounts the whole subtree on every Board switch. Drawing canvas state, timer counts, video positions, and any other in-flight React state evaporate. This phase extracts the widget-canvas into its own component and renders an LRU window (default size 2) so the most-recent N Boards stay mounted with their state intact, hidden via `display: none` when inactive.
+
+> **Safety rationale for cache size = 2.** Real K-12 classroom usage tops out at 1–2 boards in flight at once. Higher caps risk audio-context fights (TimeToolWidget singletons), runaway Firestore subscriptions (live-session children continue running for hidden boards), and webcam-permission contention. Two is enough to make "switch to check, switch back" preserve state without those failure modes appearing.
+
+### Task 3.1 — Cache config + LRU hook
+
+**Files:**
+
+- Create: `config/mountedBoardCache.ts`
+- Create: `hooks/useMountedBoardCache.ts`
+
+- [ ] **Step 1: Write the config**
+
+```typescript
+/**
+ * Number of Boards held mounted at any moment. Active Board + (N-1)
+ * most-recently-touched. Live-session-active Boards are pinned in
+ * addition to the LRU set (never evicted while the session is live).
+ *
+ * Default 2: enough to make "switch to look up something, switch back"
+ * preserve drawing/timer/video state on the originating Board. Higher
+ * values risk audio-context fights, webcam contention, and unbounded
+ * Firestore subscriptions in hidden Boards' widgets.
+ */
+export const MOUNTED_BOARD_CACHE_SIZE = 2;
+```
+
+- [ ] **Step 2: Write the hook**
+
+```typescript
+import { useEffect, useRef, useMemo } from 'react';
+import type { Dashboard } from '@/types';
+import { MOUNTED_BOARD_CACHE_SIZE } from '@/config/mountedBoardCache';
+
+/**
+ * Maintains an LRU set of Dashboard IDs that should be mounted.
+ *
+ * Inputs:
+ * - `activeId` — the currently visible Board id. Bumped to most-recent on
+ *   every change.
+ * - `dashboards` — full Dashboard list; we filter out IDs that no longer
+ *   exist (deleted) before returning, so the layer never tries to render
+ *   a stale Board.
+ * - `pinnedIds` — IDs that MUST stay mounted regardless of LRU position.
+ *   Used to keep live-session hosts pinned so a session never dies just
+ *   because the teacher switched away briefly.
+ *
+ * Returns the Dashboards (in LRU-old-to-new order) that should be mounted.
+ */
+export const useMountedBoardCache = (
+  activeId: string | null,
+  dashboards: Dashboard[],
+  pinnedIds: Set<string> = new Set()
+): Dashboard[] => {
+  // Ordered array — oldest first, newest last. Operates by ref so
+  // re-renders driven by widget state inside hidden Boards don't trigger
+  // a setState/rerender cascade in the parent.
+  const lruRef = useRef<string[]>([]);
+
+  // Bump on activeId change (kept synchronous so the first render sees
+  // the new id at the end of the array).
+  useEffect(() => {
+    if (!activeId) return;
+    const existing = lruRef.current.filter((id) => id !== activeId);
+    lruRef.current = [...existing, activeId];
+  }, [activeId]);
+
+  return useMemo(() => {
+    const knownIds = new Set(dashboards.map((d) => d.id));
+    // Prune deleted Boards from the LRU before applying caps.
+    lruRef.current = lruRef.current.filter((id) => knownIds.has(id));
+
+    // Force `activeId` to the tail even on the first render (the effect
+    // above runs AFTER the first paint; this guarantees the active Board
+    // is visible immediately).
+    let working = lruRef.current;
+    if (activeId && knownIds.has(activeId)) {
+      working = [...working.filter((id) => id !== activeId), activeId];
+    }
+
+    // Cap to MOUNTED_BOARD_CACHE_SIZE, but never evict a pinned ID.
+    // Walk from oldest forward, dropping non-pinned entries until we fit.
+    const cap = Math.max(1, MOUNTED_BOARD_CACHE_SIZE);
+    let pinnedCount = 0;
+    for (const id of working) if (pinnedIds.has(id)) pinnedCount += 1;
+    const capForLru = Math.max(1, cap - pinnedCount);
+
+    const pinnedSlots: string[] = [];
+    const lruSlots: string[] = [];
+    for (const id of working) {
+      if (pinnedIds.has(id)) pinnedSlots.push(id);
+      else lruSlots.push(id);
+    }
+    // Keep only the most-recent `capForLru` non-pinned entries.
+    const keptLru =
+      lruSlots.length > capForLru ? lruSlots.slice(-capForLru) : lruSlots;
+
+    const orderedKeptIds = new Set([...pinnedSlots, ...keptLru]);
+    const ordered = working.filter((id) => orderedKeptIds.has(id));
+    return ordered
+      .map((id) => dashboards.find((d) => d.id === id))
+      .filter((d): d is Dashboard => Boolean(d));
+  }, [activeId, dashboards, pinnedIds]);
+};
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add config/mountedBoardCache.ts hooks/useMountedBoardCache.ts
+git commit -m "feat(layout): add MOUNTED_BOARD_CACHE_SIZE + useMountedBoardCache"
+```
+
+### Task 3.2 — Tests for `useMountedBoardCache`
+
+**Files:**
+
+- Create: `tests/hooks/useMountedBoardCache.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMountedBoardCache } from '@/hooks/useMountedBoardCache';
+import type { Dashboard } from '@/types';
+
+vi.mock('@/config/mountedBoardCache', () => ({
+  MOUNTED_BOARD_CACHE_SIZE: 2,
+}));
+
+const board = (id: string): Dashboard => ({
+  id,
+  name: id,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: null,
+});
+
+describe('useMountedBoardCache', () => {
+  it('returns just the active Board on first render', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result } = renderHook(() => useMountedBoardCache('a', all));
+    expect(result.current.map((d) => d.id)).toEqual(['a']);
+  });
+
+  it('keeps the previously-active Board after one switch', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    expect(result.current.map((d) => d.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('evicts the oldest non-active Board when the cap is exceeded', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    rerender({ activeId: 'c' });
+    // Cap = 2. 'a' should have been evicted.
+    expect(result.current.map((d) => d.id).sort()).toEqual(['b', 'c']);
+  });
+
+  it('never evicts a pinned Board', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const pinned = new Set(['a']);
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all, pinned),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    rerender({ activeId: 'c' });
+    // 'a' is pinned, must stay. Active is 'c'. Cap is 2 → only 1 LRU slot
+    // remains beside the pinned 'a'. 'c' is active so it takes the slot;
+    // 'b' is evicted.
+    expect(result.current.map((d) => d.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('drops a Board that no longer exists in the dashboard list', () => {
+    const initial = [board('a'), board('b')];
+    const { result, rerender } = renderHook(
+      ({ activeId, all }: { activeId: string; all: Dashboard[] }) =>
+        useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a', all: initial } }
+    );
+    rerender({ activeId: 'b', all: initial });
+    rerender({ activeId: 'b', all: [board('b')] });
+    expect(result.current.map((d) => d.id)).toEqual(['b']);
+  });
+});
+```
+
+- [ ] **Step 2: Run + verify pass**
+
+```bash
+pnpm vitest run tests/hooks/useMountedBoardCache.test.ts
+```
+
+Expected: 5 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/hooks/useMountedBoardCache.test.ts
+git commit -m "test(layout): cover useMountedBoardCache LRU + pinning + pruning"
+```
+
+### Task 3.3 — Extract `BoardCanvas` from `DashboardView`
+
+**Files:**
+
+- Create: `components/layout/BoardCanvas.tsx`
+- Modify: `components/layout/DashboardView.tsx`
+
+- [ ] **Step 1: Identify the extraction boundary**
+
+In `DashboardView.tsx`, find the existing single-board mount block (search for `key={activeDashboard.id}` on the outer wrapper, around line 1625). The block ends at the close of `</div>` that wraps `activeDashboard.widgets.map(...)`.
+
+- [ ] **Step 2: Create `BoardCanvas.tsx` with the extracted markup**
+
+```tsx
+import { type FC } from 'react';
+import type { Dashboard } from '@/types';
+import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
+// (Copy any other imports the extracted block requires — Spotlight,
+// session helpers, etc. The extracted block currently lives inside the
+// scope of DashboardView's hooks, so the new component needs to receive
+// what it consumes as PROPS rather than reading from useDashboard
+// directly. This keeps the LRU window cheap to render — only the active
+// Board re-reads context.)
+
+interface BoardCanvasProps {
+  dashboard: Dashboard;
+  isActive: boolean;
+  isMinimized: boolean;
+  // Pass in everything the inner block reads. See DashboardView for the
+  // exact list — typically session{}, students, updateWidget, etc.
+  // KEEP THIS PROP LIST EXPLICIT — that's how we ensure the hidden
+  // Boards don't accidentally re-render on unrelated state changes.
+  sessionForBoard: SessionShape | null;
+  // … all other previously-inlined dependencies
+}
+
+// SessionShape declared locally for the props interface — extract from
+// existing `session` shape in DashboardView.
+type SessionShape = {
+  isActive: boolean;
+  activeWidgetId: string | null;
+  code?: string;
+  frozen?: boolean;
+};
+
+export const BoardCanvas: FC<BoardCanvasProps> = ({
+  dashboard,
+  isActive,
+  isMinimized,
+  sessionForBoard,
+  // ... rest
+}) => {
+  return (
+    <div
+      className={`absolute inset-0 transition-opacity duration-200 ease-in-out ${
+        isActive
+          ? 'opacity-100 pointer-events-auto'
+          : 'opacity-0 pointer-events-none'
+      }`}
+      style={{
+        // Hidden Boards stay mounted (preserves state) but are not in
+        // the accessibility tree and don't intercept pointer events.
+        display: isActive ? 'block' : 'none',
+        transform: isMinimized && isActive ? 'translateY(80vh)' : undefined,
+        transformOrigin: isMinimized ? 'bottom center' : 'center center',
+        opacity: isMinimized && isActive ? 0 : isActive ? 1 : 0,
+        pointerEvents:
+          isMinimized && isActive ? 'none' : isActive ? 'auto' : 'none',
+      }}
+      aria-hidden={!isActive}
+      data-board-id={dashboard.id}
+    >
+      {dashboard.widgets.map((widget) => {
+        const isLive =
+          sessionForBoard?.isActive &&
+          sessionForBoard?.activeWidgetId === widget.id;
+        return (
+          <WidgetRenderer
+            key={widget.id}
+            widget={widget}
+            isStudentView={false}
+            sessionCode={sessionForBoard?.code}
+            isGlobalFrozen={sessionForBoard?.frozen ?? false}
+            isLive={isLive ?? false}
+            // ... pass-through every other prop the inline version supplied
+          />
+        );
+      })}
+    </div>
+  );
+};
+```
+
+> **Implementation note for the engineer.** The actual extraction in this step is mechanical: copy the inner `<div key={activeDashboard.id}>...</div>` from `DashboardView` verbatim, replace `activeDashboard` with `dashboard`, change the `key` to `dashboard.id` (it now needs to be unique across multiple mounted instances), and lift every closure value the block reads into a prop. The example above shows the SHAPE of the component — the prop list will be longer in practice; copy it from `DashboardView`'s existing call site.
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/layout/BoardCanvas.tsx
+git commit -m "feat(layout): extract BoardCanvas from DashboardView"
+```
+
+### Task 3.4 — Render through `MountedBoardsLayer`
+
+**Files:**
+
+- Create: `components/layout/MountedBoardsLayer.tsx`
+- Modify: `components/layout/DashboardView.tsx`
+
+- [ ] **Step 1: Write `MountedBoardsLayer`**
+
+```tsx
+import { type FC, useMemo } from 'react';
+import type { Dashboard } from '@/types';
+import { useMountedBoardCache } from '@/hooks/useMountedBoardCache';
+import { BoardCanvas } from './BoardCanvas';
+
+interface MountedBoardsLayerProps {
+  activeId: string | null;
+  dashboards: Dashboard[];
+  isMinimized: boolean;
+  // Map of (boardId → SessionShape) so each canvas gets its own slot.
+  // For now only the active Board has a live session, so the map will
+  // have at most one entry; passing it through as a map lets Plan 3
+  // (Collection-sharing) add per-Board session pinning later.
+  sessions?: Map<string, unknown>;
+  // …pass-through props for BoardCanvas, exact list per Task 3.3
+}
+
+export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
+  activeId,
+  dashboards,
+  isMinimized,
+  sessions,
+  ...passthrough
+}) => {
+  const pinnedIds = useMemo(() => {
+    const s = new Set<string>();
+    if (sessions) {
+      for (const [boardId] of sessions) s.add(boardId);
+    }
+    return s;
+  }, [sessions]);
+
+  const mounted = useMountedBoardCache(activeId, dashboards, pinnedIds);
+
+  return (
+    <div className="relative w-full h-full">
+      {mounted.map((db) => (
+        <BoardCanvas
+          key={db.id}
+          dashboard={db}
+          isActive={db.id === activeId}
+          isMinimized={isMinimized}
+          sessionForBoard={(sessions?.get(db.id) ?? null) as never}
+          {...passthrough}
+        />
+      ))}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Replace the inline canvas mount in `DashboardView`**
+
+Where the inline `<div key={activeDashboard.id}>...</div>` lived, render:
+
+```tsx
+<MountedBoardsLayer
+  activeId={activeDashboard?.id ?? null}
+  dashboards={dashboards}
+  isMinimized={isMinimized}
+  sessions={
+    session?.isActive && activeDashboard
+      ? new Map([[activeDashboard.id, session]])
+      : undefined
+  }
+  // …pass-through every prop the inline block supplied to WidgetRenderer
+/>
+```
+
+The `key={activeDashboard.id}` reset is GONE. Verify that `rescueWidgetsRef` (around line 701) and `lastDashboardId` (around line 766) still behave correctly: both should observe `activeDashboard.id` changes via the existing state hooks, NOT via a remount.
+
+- [ ] **Step 3: Verify in dev server**
+
+```bash
+pnpm run dev
+```
+
+Test plan:
+
+1. Load a Board with the TimeToolWidget. Start a 5-min timer.
+2. Switch to another Board.
+3. Switch back. The timer should still be counting (not reset to 5:00).
+4. Switch to a THIRD Board, then a FOURTH. Switch back to the first.
+5. The first should be re-mounted fresh (cap = 2 → it was evicted).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/layout/MountedBoardsLayer.tsx components/layout/DashboardView.tsx
+git commit -m "feat(layout): mount Boards via MountedBoardsLayer LRU window"
+```
+
+### Task 3.5 — Tests for `MountedBoardsLayer`
+
+**Files:**
+
+- Create: `tests/components/layout/MountedBoardsLayer.test.tsx`
+
+- [ ] **Step 1: Write the test (focused on visibility toggling — LRU coverage already in hook tests)**
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MountedBoardsLayer } from '@/components/layout/MountedBoardsLayer';
+import type { Dashboard } from '@/types';
+
+vi.mock('@/components/layout/BoardCanvas', () => ({
+  BoardCanvas: ({
+    dashboard,
+    isActive,
+  }: {
+    dashboard: Dashboard;
+    isActive: boolean;
+  }) => (
+    <div
+      data-testid={`canvas-${dashboard.id}`}
+      data-active={isActive ? 'true' : 'false'}
+    >
+      {dashboard.name}
+    </div>
+  ),
+}));
+
+const board = (id: string): Dashboard => ({
+  id,
+  name: id,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: null,
+});
+
+describe('MountedBoardsLayer', () => {
+  it('mounts only the active Board on first render', () => {
+    render(
+      <MountedBoardsLayer
+        activeId="a"
+        dashboards={[board('a'), board('b')]}
+        isMinimized={false}
+      />
+    );
+    expect(screen.getByTestId('canvas-a')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(screen.queryByTestId('canvas-b')).not.toBeInTheDocument();
+  });
+
+  it('mounts pinned Boards even when they are not active', () => {
+    const sessions = new Map<string, unknown>([['b', { isActive: true }]]);
+    render(
+      <MountedBoardsLayer
+        activeId="a"
+        dashboards={[board('a'), board('b')]}
+        isMinimized={false}
+        sessions={sessions}
+      />
+    );
+    expect(screen.getByTestId('canvas-a')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(screen.getByTestId('canvas-b')).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run + verify pass**
+
+```bash
+pnpm vitest run tests/components/layout/MountedBoardsLayer.test.tsx
+```
+
+Expected: 2 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/components/layout/MountedBoardsLayer.test.tsx
+git commit -m "test(layout): cover MountedBoardsLayer active/pinned wiring"
+```
+
+---
+
+## Phase 4 — i18n + E2E + acceptance
+
+### Task 4.1 — Add the new i18n keys
+
+**Files:**
+
+- Modify: `locales/en.json`, `locales/de.json`, `locales/es.json`, `locales/fr.json`
+
+- [ ] **Step 1: Append the new keys in each locale file**
+
+Under the existing top-level groups, add (English fallback for non-en locales — matches Plan 1's pattern):
+
+```json
+"boardBreadcrumb": {
+  "root": "All Boards",
+  "openManager": "Manage Boards"
+},
+"collectionSwitcher": {
+  "title": "Switch Collection",
+  "root": "All Boards (root)"
+},
+"boardNav": {
+  "switchCollection": "Switch Collection…"
+}
+```
+
+Place inside the existing JSON object — `boardNav` keys already exist in the en file, so add `switchCollection` to that group, not as a new group.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add locales/
+git commit -m "i18n: add boardBreadcrumb + collectionSwitcher keys"
+```
+
+### Task 4.2 — E2E happy-path
+
+**Files:**
+
+- Create: `tests/e2e/collections-fab.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Collections — FAB + Breadcrumb + app-open', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition: none !important; animation: none !important; }',
+    });
+    await page.goto('/');
+    await expect(page.getByTitle('Open Menu')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('breadcrumb chip shows the active Collection and Board name', async ({
+    page,
+  }) => {
+    // With no Collection, the chip should show "All Boards › <Board name>".
+    const chip = page
+      .locator('button')
+      .filter({ hasText: /All Boards/i })
+      .filter({ hasText: />/ });
+    await expect(chip.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('FAB kebab popover lists only Boards in the active Collection', async ({
+    page,
+  }) => {
+    // Open Boards modal, create a Collection + 2 Boards inside it, then
+    // verify the FAB picker only iterates those two.
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
+    await page
+      .locator('button')
+      .filter({ hasText: /manage all boards/i })
+      .click();
+
+    const modal = page.getByRole('dialog', { name: /boards/i });
+    await modal.getByRole('button', { name: /new collection/i }).click();
+    const prompt = page.getByRole('dialog', { name: /new collection/i });
+    await prompt.getByRole('textbox').fill('Collection FAB');
+    await prompt.getByRole('button', { name: /^create$/i }).click();
+
+    await modal.getByText('Collection FAB').first().click();
+    await modal.getByRole('button', { name: /new board/i }).click();
+    const boardPrompt = page.getByRole('dialog', { name: /new board/i });
+    await boardPrompt.getByRole('textbox').fill('FAB Board 1');
+    await boardPrompt.getByRole('button', { name: /^create$/i }).click();
+
+    // Close modal — Board 1 is now active inside "Collection FAB".
+    await modal.getByRole('button', { name: /close/i }).click();
+
+    // FAB shouldn't render with only 1 Board in the active Collection.
+    await expect(page.getByLabel('Select board')).toBeHidden();
+  });
+});
+```
+
+- [ ] **Step 2: Run locally**
+
+```bash
+pnpm exec playwright test tests/e2e/collections-fab.spec.ts --reporter=line
+```
+
+Expected: 2 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/collections-fab.spec.ts
+git commit -m "test(e2e): cover FAB Collection filter + breadcrumb chip"
+```
+
+### Task 4.3 — Final validate + acceptance walkthrough
+
+- [ ] **Step 1: Run the full validation**
+
+```bash
+pnpm run validate
+```
+
+Expected: type-check clean, lint clean, format clean, all unit + functions tests pass.
+
+- [ ] **Step 2: Manual acceptance**
+
+In a dev session:
+
+1. **App-open restore.** Sign in. Pick a Board inside Collection X. Close the browser tab. Reopen. Expect to land on the same Board inside Collection X (not the global default).
+2. **Breadcrumb chip.** Visible above the FAB. Shows Collection name + active Board name. Click → BoardsModal opens.
+3. **FAB scope.** Kebab menu lists only the Boards in the active Collection. Prev/next chevrons wrap inside the Collection.
+4. **Switch Collection.** Kebab menu has "Switch Collection…" at the top. Picking another Collection loads its last-visited Board.
+5. **State preservation.** Open a TimeToolWidget on Board A, start the timer. Switch to Board B. Switch back to A. Timer is still counting.
+6. **LRU eviction.** Continue from #5. Switch to Boards C, D. Switch back to A. Timer is RESET (A was evicted from the cap-2 cache).
+
+- [ ] **Step 3: Commit (no code) — push for CI**
+
+```bash
+git push -u origin claude/<branch-name>
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] App-open lands on `lastBoardIdByCollection[lastActiveCollectionId]` when populated.
+- [ ] Breadcrumb chip visible, shows correct Collection + Board.
+- [ ] FAB kebab menu and prev/next chevrons operate only within the active Collection.
+- [ ] "Switch Collection…" item present when ≥ 1 Collection exists; opens the switcher submenu.
+- [ ] Switching Collections via the submenu loads the right Board for that Collection (memory → defaultBoardId → first board → fallback).
+- [ ] Cache size 2: previous Board's React state preserved on switch-back within the cache window.
+- [ ] Live-session-active Boards are pinned in the cache (never evicted while the session is live).
+- [ ] No regressions: existing E2E + unit tests pass; `sharing.spec.ts` + `collections.spec.ts` continue to pass.
+- [ ] No `console.error` introduced; new logging uses `logError` per project standard.
+- [ ] All new i18n strings have `defaultValue` fallbacks; en + de + es + fr files updated.
+
+---
+
+## Known limitations
+
+1. **Cache eviction discards in-flight state.** When a Board is evicted from the LRU window, its React state is lost — same as today's full-remount behavior. Lifting persistent-but-evicted state into Firestore is out of scope.
+2. **Cap = 2 is conservative.** Tuning happens in `config/mountedBoardCache.ts`. Higher values risk audio-context contention, multiple webcams contending for `getUserMedia`, and Firestore subscription proliferation. Bump only after measuring.
+3. **Live-session pinning is single-host.** If a host runs a live session on Board A then opens Board B and starts another session, both stay pinned — but the existing live-session machinery in Plan 1 only supports one active session per teacher, so this is a theoretical concern.
+4. **Per-Collection `defaultBoardId` UI surfaces are deferred.** Plan 1's data layer supports `Collection.defaultBoardId`, but no UI exposes it yet — Plan 2 reads it in `pickInitialBoard` for app-open behavior, but setting it is still admin-only via direct Firestore writes. A "Set as Collection default" context-menu item is deferred.
+5. **No URL routing for Collection state.** Deep-linking to `/c/{collectionId}` is out of scope; navigation memory lives entirely in `userProfile`.
+6. **No animation on Board switch.** Today's fade-in animation tied to the remount disappears with the mounted-set refactor. Re-adding it would require animating the visibility toggle in `BoardCanvas`; deferred.
+
+---
+
+## Commit-history outline (chronological)
+
+1. `feat(boards): add pickInitialBoard pure resolver for app-open`
+2. `test(boards): cover pickInitialBoard fallback chain`
+3. `feat(dashboard): wire pickInitialBoard into snapshot initial select`
+4. `feat(dashboard): defer initial-board select until profile+collections land`
+5. `feat(dashboard): add setActiveCollectionId action`
+6. `feat(layout): add BoardBreadcrumb chip`
+7. `test(layout): cover BoardBreadcrumb rendering + click-to-open`
+8. `feat(layout): mount BoardBreadcrumb above BoardNavFab`
+9. `feat(layout): FAB iterates Boards within active Collection`
+10. `feat(layout): add CollectionSwitcherMenu submenu`
+11. `test(layout): cover CollectionSwitcherMenu tree + selection`
+12. `feat(layout): wire Collection switcher into BoardNavFab`
+13. `feat(layout): add MOUNTED_BOARD_CACHE_SIZE + useMountedBoardCache`
+14. `test(layout): cover useMountedBoardCache LRU + pinning + pruning`
+15. `feat(layout): extract BoardCanvas from DashboardView`
+16. `feat(layout): mount Boards via MountedBoardsLayer LRU window`
+17. `test(layout): cover MountedBoardsLayer active/pinned wiring`
+18. `i18n: add boardBreadcrumb + collectionSwitcher keys`
+19. `test(e2e): cover FAB Collection filter + breadcrumb chip`

--- a/hooks/useMountedBoardCache.ts
+++ b/hooks/useMountedBoardCache.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useMemo } from 'react';
+import type { Dashboard } from '@/types';
+import { MOUNTED_BOARD_CACHE_SIZE } from '@/config/mountedBoardCache';
+
+/**
+ * Maintains an LRU set of Dashboard IDs that should be mounted.
+ *
+ * Inputs:
+ * - `activeId` — the currently visible Board id. Bumped to most-recent on
+ *   every change.
+ * - `dashboards` — full Dashboard list; we filter out IDs that no longer
+ *   exist (deleted) before returning, so the layer never tries to render
+ *   a stale Board.
+ * - `pinnedIds` — IDs that MUST stay mounted regardless of LRU position.
+ *   Used to keep live-session hosts pinned so a session never dies just
+ *   because the teacher switched away briefly.
+ *
+ * Returns the Dashboards (in LRU-old-to-new order) that should be mounted.
+ */
+export const useMountedBoardCache = (
+  activeId: string | null,
+  dashboards: Dashboard[],
+  pinnedIds: Set<string> = new Set()
+): Dashboard[] => {
+  // Ordered array — oldest first, newest last. Operates by ref so
+  // re-renders driven by widget state inside hidden Boards don't trigger
+  // a setState/rerender cascade in the parent.
+  const lruRef = useRef<string[]>([]);
+
+  // Bump on activeId change (kept synchronous so the first render sees
+  // the new id at the end of the array).
+  useEffect(() => {
+    if (!activeId) return;
+    const existing = lruRef.current.filter((id) => id !== activeId);
+    lruRef.current = [...existing, activeId];
+  }, [activeId]);
+
+  // Housekeeping: prune stale IDs from the ref when the dashboard list
+  // changes (e.g. a Board was deleted). Doing it in an effect rather than
+  // inside useMemo keeps the memoized computation pure. The deps are
+  // `dashboards` because that's what determines which IDs are stale.
+  useEffect(() => {
+    const knownIds = new Set(dashboards.map((d) => d.id));
+    lruRef.current = lruRef.current.filter((id) => knownIds.has(id));
+  }, [dashboards]);
+
+  return useMemo(() => {
+    const knownIds = new Set(dashboards.map((d) => d.id));
+    // PURE prune: compute a local view without mutating the ref. The
+    // useMemo body must be side-effect free (StrictMode dev double-runs
+    // it). The ref is pruned later in a useEffect for housekeeping.
+    const pruned = lruRef.current.filter((id) => knownIds.has(id));
+
+    // Force `activeId` to the tail even on the first render (the effect
+    // that appends to lruRef runs AFTER the first paint; this guarantees
+    // the active Board is visible immediately).
+    let working = pruned;
+    if (activeId && knownIds.has(activeId)) {
+      working = [...working.filter((id) => id !== activeId), activeId];
+    }
+
+    // Cap to MOUNTED_BOARD_CACHE_SIZE, but never evict a pinned ID.
+    // Walk from oldest forward, dropping non-pinned entries until we fit.
+    const cap = Math.max(1, MOUNTED_BOARD_CACHE_SIZE);
+    let pinnedCount = 0;
+    for (const id of working) if (pinnedIds.has(id)) pinnedCount += 1;
+    const capForLru = Math.max(1, cap - pinnedCount);
+
+    const pinnedSlots: string[] = [];
+    const lruSlots: string[] = [];
+    for (const id of working) {
+      if (pinnedIds.has(id)) pinnedSlots.push(id);
+      else lruSlots.push(id);
+    }
+    // Keep only the most-recent `capForLru` non-pinned entries.
+    const keptLru =
+      lruSlots.length > capForLru ? lruSlots.slice(-capForLru) : lruSlots;
+
+    const orderedKeptIds = new Set([...pinnedSlots, ...keptLru]);
+    const ordered = working.filter((id) => orderedKeptIds.has(id));
+    return ordered
+      .map((id) => dashboards.find((d) => d.id === id))
+      .filter((d): d is Dashboard => Boolean(d));
+  }, [activeId, dashboards, pinnedIds]);
+};

--- a/locales/de.json
+++ b/locales/de.json
@@ -18,7 +18,8 @@
     "previous": "Vorherige Tafel",
     "next": "Nächste Tafel",
     "selectBoard": "Tafel auswählen",
-    "boardList": "Alle Tafeln"
+    "boardList": "Alle Tafeln",
+    "switchCollection": "Switch Collection…"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -345,6 +346,14 @@
       "emptyBoardHint": "Ziehen Sie Werkzeuge aus dem Dock unten, um zu beginnen",
       "switchBoardsHint": "Verwenden Sie die Tafelnavigation unten links, um zwischen Tafeln zu wechseln"
     }
+  },
+  "boardBreadcrumb": {
+    "root": "All Boards",
+    "openManager": "Manage Boards"
+  },
+  "collectionSwitcher": {
+    "title": "Switch Collection",
+    "root": "All Boards (root)"
   },
   "boardsModal": {
     "title": "Boards",

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,7 +21,8 @@
     "previous": "Previous board",
     "next": "Next board",
     "selectBoard": "Select board",
-    "boardList": "All boards"
+    "boardList": "All boards",
+    "switchCollection": "Switch Collection…"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -875,6 +876,14 @@
       "emptyBoardHint": "Drag tools from the Dock below to start",
       "switchBoardsHint": "Use the board navigation controls in the bottom-left to switch boards"
     }
+  },
+  "boardBreadcrumb": {
+    "root": "All Boards",
+    "openManager": "Manage Boards"
+  },
+  "collectionSwitcher": {
+    "title": "Switch Collection",
+    "root": "All Boards (root)"
   },
   "boardsModal": {
     "title": "Boards",

--- a/locales/es.json
+++ b/locales/es.json
@@ -18,7 +18,8 @@
     "previous": "Tablero anterior",
     "next": "Tablero siguiente",
     "selectBoard": "Seleccionar tablero",
-    "boardList": "Todos los tableros"
+    "boardList": "Todos los tableros",
+    "switchCollection": "Switch Collection…"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -464,6 +465,14 @@
       "emptyBoardHint": "Arrastra herramientas desde el Dock para empezar",
       "switchBoardsHint": "Usa los controles de navegación en la parte inferior izquierda para cambiar de tablero"
     }
+  },
+  "boardBreadcrumb": {
+    "root": "All Boards",
+    "openManager": "Manage Boards"
+  },
+  "collectionSwitcher": {
+    "title": "Switch Collection",
+    "root": "All Boards (root)"
   },
   "boardsModal": {
     "title": "Boards",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -18,7 +18,8 @@
     "previous": "Tableau précédent",
     "next": "Tableau suivant",
     "selectBoard": "Sélectionner un tableau",
-    "boardList": "Tous les tableaux"
+    "boardList": "Tous les tableaux",
+    "switchCollection": "Switch Collection…"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -345,6 +346,14 @@
       "emptyBoardHint": "Faites glisser des outils depuis le Dock ci-dessous pour commencer",
       "switchBoardsHint": "Utilisez les commandes de navigation en bas à gauche pour changer de tableau"
     }
+  },
+  "boardBreadcrumb": {
+    "root": "All Boards",
+    "openManager": "Manage Boards"
+  },
+  "collectionSwitcher": {
+    "title": "Switch Collection",
+    "root": "All Boards (root)"
   },
   "boardsModal": {
     "title": "Boards",

--- a/tests/DashboardContext_merge.test.tsx
+++ b/tests/DashboardContext_merge.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../context/useAuth', () => ({
     saveWidgetConfig: vi.fn(),
     refreshGoogleToken: vi.fn(),
     remoteControlEnabled: true,
+    profileLoaded: true,
   }),
 }));
 
@@ -80,6 +81,51 @@ vi.mock('../hooks/useRosters', () => ({
     setAbsentStudents: vi.fn(),
   }),
 }));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  // Real module reference so any unmocked Firestore function (e.g. helpers
+  // imported transitively by deeper modules) still resolves to its real
+  // implementation. We override only the functions DashboardContext calls
+  // directly outside the useFirestore abstraction — primarily the
+  // dock-hydration path that reads userProfile via doc()/getDoc() and
+  // persists via setDoc().
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Test consumer — exposes context values outside React tree

--- a/tests/DashboardContext_removeWidgets.test.tsx
+++ b/tests/DashboardContext_removeWidgets.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../context/useAuth', () => ({
     saveWidgetConfig: vi.fn(),
     refreshGoogleToken: vi.fn(),
     remoteControlEnabled: true,
+    profileLoaded: true,
   }),
 }));
 
@@ -62,6 +63,51 @@ vi.mock('../hooks/useRosters', () => ({
     setAbsentStudents: vi.fn(),
   }),
 }));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  // Real module reference so any unmocked Firestore function (e.g. helpers
+  // imported transitively by deeper modules) still resolves to its real
+  // implementation. We override only the functions DashboardContext calls
+  // directly outside the useFirestore abstraction — primarily the
+  // dock-hydration path that reads userProfile via doc()/getDoc() and
+  // persists via setDoc().
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Test consumer

--- a/tests/DashboardContext_sharing.test.tsx
+++ b/tests/DashboardContext_sharing.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../context/useAuth', () => ({
     savedWidgetConfigs: {},
     saveWidgetConfig: vi.fn(),
     refreshGoogleToken: vi.fn().mockResolvedValue('mock-token'),
+    profileLoaded: true,
   }),
 }));
 
@@ -89,6 +90,51 @@ vi.mock('../hooks/useRosters', () => ({
     setAbsentStudents: vi.fn(),
   }),
 }));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  // Real module reference so any unmocked Firestore function (e.g. helpers
+  // imported transitively by deeper modules) still resolves to its real
+  // implementation. We override only the functions DashboardContext calls
+  // directly outside the useFirestore abstraction — primarily the
+  // dock-hydration path that reads userProfile via doc()/getDoc() and
+  // persists via setDoc().
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
 
 describe('DashboardContext Sharing Logic', () => {
   const originalPathname = window.location.pathname;

--- a/tests/components/layout/BoardBreadcrumb.test.tsx
+++ b/tests/components/layout/BoardBreadcrumb.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BoardBreadcrumb } from '@/components/layout/BoardBreadcrumb';
+import type { useDashboard } from '@/context/useDashboard';
+import type { useAuth } from '@/context/useAuth';
+import type { useCollections } from '@/hooks/useCollections';
+
+const useDashboardMock = vi.fn();
+const useAuthMock = vi.fn();
+const useCollectionsMock = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => useDashboardMock() as ReturnType<typeof useDashboard>,
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => useAuthMock() as ReturnType<typeof useAuth>,
+}));
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () =>
+    useCollectionsMock() as ReturnType<typeof useCollections>,
+}));
+vi.mock('@/components/boardsModal/BoardsModal', () => ({
+  BoardsModal: ({ onClose }: { onClose: () => void }) => (
+    <div role="dialog" aria-label="Boards Modal">
+      <button onClick={onClose}>close-modal</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  useAuthMock.mockReturnValue({ user: { uid: 'u1' } });
+});
+
+describe('BoardBreadcrumb', () => {
+  it('renders nothing when no active dashboard', () => {
+    useDashboardMock.mockReturnValue({ activeDashboard: null });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    const { container } = render(<BoardBreadcrumb />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "All Boards" when the active dashboard is at root', () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'My Board', collectionId: null },
+    });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    render(<BoardBreadcrumb />);
+    expect(screen.getByText('All Boards')).toBeInTheDocument();
+    expect(screen.getByText('My Board')).toBeInTheDocument();
+  });
+
+  it('renders the Collection name when the active dashboard is in a Collection', () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'Warmup', collectionId: 'c1' },
+    });
+    useCollectionsMock.mockReturnValue({
+      collections: [
+        {
+          id: 'c1',
+          name: 'Math',
+          parentCollectionId: null,
+          order: 0,
+          createdAt: 0,
+        },
+      ],
+    });
+    render(<BoardBreadcrumb />);
+    expect(screen.getByText('Math')).toBeInTheDocument();
+    expect(screen.getByText('Warmup')).toBeInTheDocument();
+  });
+
+  it('opens the BoardsModal when clicked', async () => {
+    useDashboardMock.mockReturnValue({
+      activeDashboard: { id: 'd1', name: 'Warmup', collectionId: null },
+    });
+    useCollectionsMock.mockReturnValue({ collections: [] });
+    render(<BoardBreadcrumb />);
+    await userEvent.click(
+      screen.getByRole('button', { name: /manage boards/i })
+    );
+    expect(
+      screen.getByRole('dialog', { name: 'Boards Modal' })
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/layout/BoardBreadcrumb.test.tsx
+++ b/tests/components/layout/BoardBreadcrumb.test.tsx
@@ -1,24 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BoardBreadcrumb } from '@/components/layout/BoardBreadcrumb';
 import type { useDashboard } from '@/context/useDashboard';
-import type { useAuth } from '@/context/useAuth';
-import type { useCollections } from '@/hooks/useCollections';
 
 const useDashboardMock = vi.fn();
-const useAuthMock = vi.fn();
-const useCollectionsMock = vi.fn();
 
 vi.mock('@/context/useDashboard', () => ({
   useDashboard: () => useDashboardMock() as ReturnType<typeof useDashboard>,
-}));
-vi.mock('@/context/useAuth', () => ({
-  useAuth: () => useAuthMock() as ReturnType<typeof useAuth>,
-}));
-vi.mock('@/hooks/useCollections', () => ({
-  useCollections: () =>
-    useCollectionsMock() as ReturnType<typeof useCollections>,
 }));
 vi.mock('@/components/boardsModal/BoardsModal', () => ({
   BoardsModal: ({ onClose }: { onClose: () => void }) => (
@@ -28,14 +17,12 @@ vi.mock('@/components/boardsModal/BoardsModal', () => ({
   ),
 }));
 
-beforeEach(() => {
-  useAuthMock.mockReturnValue({ user: { uid: 'u1' } });
-});
-
 describe('BoardBreadcrumb', () => {
   it('renders nothing when no active dashboard', () => {
-    useDashboardMock.mockReturnValue({ activeDashboard: null });
-    useCollectionsMock.mockReturnValue({ collections: [] });
+    useDashboardMock.mockReturnValue({
+      activeDashboard: null,
+      collectionsApi: { collections: [] },
+    });
     const { container } = render(<BoardBreadcrumb />);
     expect(container).toBeEmptyDOMElement();
   });
@@ -43,8 +30,8 @@ describe('BoardBreadcrumb', () => {
   it('renders "All Boards" when the active dashboard is at root', () => {
     useDashboardMock.mockReturnValue({
       activeDashboard: { id: 'd1', name: 'My Board', collectionId: null },
+      collectionsApi: { collections: [] },
     });
-    useCollectionsMock.mockReturnValue({ collections: [] });
     render(<BoardBreadcrumb />);
     expect(screen.getByText('All Boards')).toBeInTheDocument();
     expect(screen.getByText('My Board')).toBeInTheDocument();
@@ -53,17 +40,17 @@ describe('BoardBreadcrumb', () => {
   it('renders the Collection name when the active dashboard is in a Collection', () => {
     useDashboardMock.mockReturnValue({
       activeDashboard: { id: 'd1', name: 'Warmup', collectionId: 'c1' },
-    });
-    useCollectionsMock.mockReturnValue({
-      collections: [
-        {
-          id: 'c1',
-          name: 'Math',
-          parentCollectionId: null,
-          order: 0,
-          createdAt: 0,
-        },
-      ],
+      collectionsApi: {
+        collections: [
+          {
+            id: 'c1',
+            name: 'Math',
+            parentCollectionId: null,
+            order: 0,
+            createdAt: 0,
+          },
+        ],
+      },
     });
     render(<BoardBreadcrumb />);
     expect(screen.getByText('Math')).toBeInTheDocument();
@@ -73,8 +60,8 @@ describe('BoardBreadcrumb', () => {
   it('opens the BoardsModal when clicked', async () => {
     useDashboardMock.mockReturnValue({
       activeDashboard: { id: 'd1', name: 'Warmup', collectionId: null },
+      collectionsApi: { collections: [] },
     });
-    useCollectionsMock.mockReturnValue({ collections: [] });
     render(<BoardBreadcrumb />);
     await userEvent.click(
       screen.getByRole('button', { name: /manage boards/i })

--- a/tests/components/layout/CollectionSwitcherMenu.test.tsx
+++ b/tests/components/layout/CollectionSwitcherMenu.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CollectionSwitcherMenu } from '@/components/layout/CollectionSwitcherMenu';
+import type { Collection } from '@/types';
+
+const coll = (
+  id: string,
+  parent: string | null,
+  order = 0,
+  name = id
+): Collection => ({
+  id,
+  name,
+  parentCollectionId: parent,
+  order,
+  createdAt: 0,
+});
+
+describe('CollectionSwitcherMenu', () => {
+  it('always shows the "All Boards (root)" item', () => {
+    render(
+      <CollectionSwitcherMenu
+        collections={[]}
+        activeCollectionId={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('menuitem', { name: /all boards \(root\)/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders nested Collections in tree order with depth indent', () => {
+    const collections = [
+      coll('a', null, 0, 'A'),
+      coll('b', 'a', 0, 'B'),
+      coll('c', 'a', 1, 'C'),
+      coll('d', null, 1, 'D'),
+    ];
+    render(
+      <CollectionSwitcherMenu
+        collections={collections}
+        activeCollectionId={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const menuItems = screen.getAllByRole('menuitem');
+    // Root + 4 Collections = 5 items, in DFS order: root, A, B, C, D.
+    const labels = menuItems.map((el) => el.textContent?.trim());
+    expect(labels).toEqual([
+      expect.stringContaining('All Boards'),
+      'A',
+      'B',
+      'C',
+      'D',
+    ]);
+  });
+
+  it('marks the active Collection', () => {
+    render(
+      <CollectionSwitcherMenu
+        collections={[coll('a', null, 0, 'A')]}
+        activeCollectionId="a"
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const aItem = screen.getByRole('menuitem', { name: 'A' });
+    expect(aItem.className).toMatch(/bg-brand-blue-primary/);
+  });
+
+  it('calls onSelect + onClose when an item is clicked', async () => {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CollectionSwitcherMenu
+        collections={[coll('a', null, 0, 'A')]}
+        activeCollectionId={null}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'A' }));
+    expect(onSelect).toHaveBeenCalledWith('a');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('passes null to onSelect for the root item', async () => {
+    const onSelect = vi.fn();
+    render(
+      <CollectionSwitcherMenu
+        collections={[]}
+        activeCollectionId="a"
+        onSelect={onSelect}
+        onClose={vi.fn()}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /all boards \(root\)/i })
+    );
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -196,6 +196,18 @@ describe('DashboardView Gestures & Navigation', () => {
       deleteAllWidgets: vi.fn(),
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: vi.fn(),
+        renameCollection: vi.fn(),
+        moveCollection: vi.fn(),
+        deleteCollection: vi.fn(),
+        reorderSiblings: vi.fn(),
+        setCollectionMetadata: vi.fn(),
+        setCollectionDefaultBoard: vi.fn(),
+      },
     });
   });
 
@@ -238,6 +250,18 @@ describe('DashboardView Gestures & Navigation', () => {
       toasts: [],
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: vi.fn(),
+        renameCollection: vi.fn(),
+        moveCollection: vi.fn(),
+        deleteCollection: vi.fn(),
+        reorderSiblings: vi.fn(),
+        setCollectionMetadata: vi.fn(),
+        setCollectionDefaultBoard: vi.fn(),
+      },
     });
 
     render(<DashboardView />);
@@ -255,6 +279,18 @@ describe('DashboardView Gestures & Navigation', () => {
       toasts: [],
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: vi.fn(),
+        renameCollection: vi.fn(),
+        moveCollection: vi.fn(),
+        deleteCollection: vi.fn(),
+        reorderSiblings: vi.fn(),
+        setCollectionMetadata: vi.fn(),
+        setCollectionDefaultBoard: vi.fn(),
+      },
     });
 
     render(<DashboardView />);
@@ -263,6 +299,18 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('wraps around when navigating at boundaries', () => {
+    const collectionsStub = {
+      collections: [],
+      loading: false,
+      error: null,
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      moveCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      reorderSiblings: vi.fn(),
+      setCollectionMetadata: vi.fn(),
+      setCollectionDefaultBoard: vi.fn(),
+    };
     // Case 1: First board, navigate left -> should go to last board
     (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       activeDashboard: mockDashboards[0],
@@ -276,6 +324,7 @@ describe('DashboardView Gestures & Navigation', () => {
       deleteAllWidgets: vi.fn(),
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: collectionsStub,
     });
 
     const { unmount } = render(<DashboardView />);
@@ -297,6 +346,7 @@ describe('DashboardView Gestures & Navigation', () => {
       deleteAllWidgets: vi.fn(),
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: collectionsStub,
     });
 
     render(<DashboardView />);
@@ -535,6 +585,18 @@ describe('DashboardView Gestures & Navigation', () => {
       updateDashboard: vi.fn(),
       zoom: 1,
       setZoom: vi.fn(),
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: vi.fn(),
+        renameCollection: vi.fn(),
+        moveCollection: vi.fn(),
+        deleteCollection: vi.fn(),
+        reorderSiblings: vi.fn(),
+        setCollectionMetadata: vi.fn(),
+        setCollectionDefaultBoard: vi.fn(),
+      },
     });
 
     render(<DashboardView />);

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -111,6 +111,25 @@ vi.mock('@/components/widgets/WidgetRenderer', () => ({
   WidgetRenderer: () => <div data-testid="widget">Widget</div>,
 }));
 
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/boardsModal/BoardsModal', () => ({
+  BoardsModal: () => null,
+}));
+
 describe('DashboardView Gestures & Navigation', () => {
   const mockLoadDashboard = vi.fn();
   const mockAddWidget = vi.fn();

--- a/tests/components/layout/MountedBoardsLayer.test.tsx
+++ b/tests/components/layout/MountedBoardsLayer.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MountedBoardsLayer } from '@/components/layout/MountedBoardsLayer';
+import type { Dashboard } from '@/types';
+
+vi.mock('@/components/layout/BoardCanvas', () => ({
+  BoardCanvas: ({
+    dashboard,
+    isActive,
+  }: {
+    dashboard: Dashboard;
+    isActive: boolean;
+  }) => (
+    <div
+      data-testid={`canvas-${dashboard.id}`}
+      data-active={isActive ? 'true' : 'false'}
+    >
+      {dashboard.name}
+    </div>
+  ),
+}));
+
+const board = (id: string): Dashboard => ({
+  id,
+  name: id,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: null,
+});
+
+// Helper to satisfy the MountedBoardsLayer prop interface without making
+// the test file declare the entire WidgetRenderer callback surface.
+const noopProps = {
+  isMinimized: false,
+  animationClass: '',
+  students: [],
+  emptyStudents: [],
+  selectedWidgetId: null,
+  zoom: 1,
+  globalStyle: {},
+  updateSessionConfig: () => undefined,
+  updateSessionBackground: () => undefined,
+  startSession: () => undefined,
+  endSession: () => undefined,
+  removeStudent: () => undefined,
+  toggleFreezeStudent: () => undefined,
+  toggleGlobalFreeze: () => undefined,
+  updateWidget: () => undefined,
+  removeWidget: () => undefined,
+  duplicateWidget: () => undefined,
+  bringToFront: () => undefined,
+  addToast: () => undefined,
+  updateDashboardSettings: () => undefined,
+} as unknown as Record<string, never>;
+
+describe('MountedBoardsLayer', () => {
+  it('mounts only the active Board on first render', () => {
+    render(
+      <MountedBoardsLayer
+        activeId="a"
+        dashboards={[board('a'), board('b')]}
+        {...noopProps}
+      />
+    );
+    expect(screen.getByTestId('canvas-a')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(screen.queryByTestId('canvas-b')).not.toBeInTheDocument();
+  });
+
+  it('mounts pinned Boards even when they are not active', () => {
+    const sessions = new Map<string, never>([
+      ['b', { isActive: true } as never],
+    ]);
+    const { rerender } = render(
+      <MountedBoardsLayer
+        activeId="b"
+        dashboards={[board('a'), board('b')]}
+        sessions={sessions}
+        {...noopProps}
+      />
+    );
+    // Switch to 'a' — board 'b' should stay mounted because it is pinned
+    // (in sessions), even though it is no longer active.
+    rerender(
+      <MountedBoardsLayer
+        activeId="a"
+        dashboards={[board('a'), board('b')]}
+        sessions={sessions}
+        {...noopProps}
+      />
+    );
+    expect(screen.getByTestId('canvas-a')).toHaveAttribute(
+      'data-active',
+      'true'
+    );
+    expect(screen.getByTestId('canvas-b')).toHaveAttribute(
+      'data-active',
+      'false'
+    );
+  });
+});

--- a/tests/components/layout/MountedBoardsLayer.test.tsx
+++ b/tests/components/layout/MountedBoardsLayer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MountedBoardsLayer } from '@/components/layout/MountedBoardsLayer';
+import type { MountedBoardsLayerProps } from '@/components/layout/MountedBoardsLayer';
 import type { Dashboard } from '@/types';
 
 vi.mock('@/components/layout/BoardCanvas', () => ({
@@ -52,7 +53,10 @@ const noopProps = {
   bringToFront: () => undefined,
   addToast: () => undefined,
   updateDashboardSettings: () => undefined,
-} as unknown as Record<string, never>;
+} as unknown as Omit<
+  MountedBoardsLayerProps,
+  'activeId' | 'dashboards' | 'sessions'
+>;
 
 describe('MountedBoardsLayer', () => {
   it('mounts only the active Board on first render', () => {

--- a/tests/e2e/collections-fab.spec.ts
+++ b/tests/e2e/collections-fab.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Collections — FAB + Breadcrumb + app-open', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition: none !important; animation: none !important; }',
+    });
+    await page.goto('/');
+    await expect(page.getByTitle('Open Menu')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('breadcrumb chip shows the active Collection and Board name', async ({
+    page,
+  }) => {
+    // With no Collection yet, the chip should show "All Boards" + the
+    // active Board's name. The breadcrumb mounts inside BoardNavFab so
+    // it only renders when boardsInCollection.length > 1; create a
+    // second Board so the FAB (and chip) become visible.
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
+    await page
+      .locator('button')
+      .filter({ hasText: /manage all boards/i })
+      .click();
+    const modal = page.getByRole('dialog', { name: /boards/i });
+    await modal.getByRole('button', { name: /new board/i }).click();
+    const prompt = page.getByRole('dialog', { name: /new board/i });
+    await prompt.getByRole('textbox').fill('Breadcrumb E2E');
+    await prompt.getByRole('button', { name: /^create$/i }).click();
+    // Dismiss via Escape — a success toast may overlap the Close button in
+    // the top-right corner, making a pointer click unreliable.
+    await page.keyboard.press('Escape');
+
+    // After closing the modal, BoardNavFab should be visible (2 boards
+    // exist at root). The breadcrumb chip should also be visible.
+    const chip = page
+      .locator('button')
+      .filter({ hasText: /All Boards/i })
+      .filter({ hasText: /Breadcrumb E2E/i });
+    await expect(chip.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('FAB Collection submenu lets the user switch Collections', async ({
+    page,
+  }) => {
+    // Create a Collection + 2 Boards inside it. Then verify the FAB's
+    // kebab popover has a "Switch Collection…" entry that opens a
+    // submenu listing the new Collection.
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
+    await page
+      .locator('button')
+      .filter({ hasText: /manage all boards/i })
+      .click();
+    const modal = page.getByRole('dialog', { name: /boards/i });
+
+    await modal.getByRole('button', { name: /new collection/i }).click();
+    const cPrompt = page.getByRole('dialog', { name: /new collection/i });
+    await cPrompt.getByRole('textbox').fill('FAB Switch Coll');
+    await cPrompt.getByRole('button', { name: /^create$/i }).click();
+    await modal.getByText('FAB Switch Coll').first().click();
+
+    // Create 2 boards inside the new Collection.
+    for (const name of ['FAB-A', 'FAB-B']) {
+      await modal.getByRole('button', { name: /new board/i }).click();
+      const bPrompt = page.getByRole('dialog', { name: /new board/i });
+      await bPrompt.getByRole('textbox').fill(name);
+      await bPrompt.getByRole('button', { name: /^create$/i }).click();
+    }
+    // Dismiss via Escape — a success toast may overlap the Close button in
+    // the top-right corner, making a pointer click unreliable.
+    await page.keyboard.press('Escape');
+    // Wait for the modal to be fully dismissed before interacting with the FAB.
+    await expect(modal).not.toBeVisible({ timeout: 5000 });
+
+    // Now the active Collection is "FAB Switch Coll" with 2 boards.
+    // The FAB picker should expose "Switch Collection…" at the top.
+    await page.getByLabel('Select board').click();
+    await expect(
+      page.getByRole('menuitem', { name: /switch collection/i })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Clicking it opens the Collection switcher submenu.
+    await page.getByRole('menuitem', { name: /switch collection/i }).click();
+    await expect(
+      page.getByRole('menu', { name: /switch collection/i })
+    ).toBeVisible();
+
+    // The submenu should list both "All Boards (root)" and "FAB Switch Coll".
+    await expect(
+      page.getByRole('menuitem', { name: /all boards \(root\)/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('menuitem', { name: 'FAB Switch Coll' })
+    ).toBeVisible();
+  });
+});

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -178,6 +178,18 @@ describe('Global Escape Interaction', () => {
     gradeFilter: 'all',
     zoom: 1,
     setZoom: vi.fn(),
+    collectionsApi: {
+      collections: [],
+      loading: false,
+      error: null,
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      moveCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      reorderSiblings: vi.fn(),
+      setCollectionMetadata: vi.fn(),
+      setCollectionDefaultBoard: vi.fn(),
+    },
   };
 
   afterEach(() => {

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -120,6 +120,25 @@ vi.mock('../hooks/usePlcs', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/boardsModal/BoardsModal', () => ({
+  BoardsModal: () => null,
+}));
+
 const mockGlobalStyle: GlobalStyle = {
   fontFamily: 'sans',
   windowTransparency: 0.8,

--- a/tests/hooks/useMountedBoardCache.test.ts
+++ b/tests/hooks/useMountedBoardCache.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useMountedBoardCache } from '@/hooks/useMountedBoardCache';
+import type { Dashboard } from '@/types';
+
+vi.mock('@/config/mountedBoardCache', () => ({
+  MOUNTED_BOARD_CACHE_SIZE: 2,
+}));
+
+const board = (id: string): Dashboard => ({
+  id,
+  name: id,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: null,
+});
+
+describe('useMountedBoardCache', () => {
+  it('returns just the active Board on first render', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result } = renderHook(() => useMountedBoardCache('a', all));
+    expect(result.current.map((d) => d.id)).toEqual(['a']);
+  });
+
+  it('keeps the previously-active Board after one switch', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    expect(result.current.map((d) => d.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('evicts the oldest non-active Board when the cap is exceeded', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    rerender({ activeId: 'c' });
+    // Cap = 2. 'a' should have been evicted.
+    expect(result.current.map((d) => d.id).sort()).toEqual(['b', 'c']);
+  });
+
+  it('never evicts a pinned Board', () => {
+    const all = [board('a'), board('b'), board('c')];
+    const pinned = new Set(['a']);
+    const { result, rerender } = renderHook(
+      ({ activeId }) => useMountedBoardCache(activeId, all, pinned),
+      { initialProps: { activeId: 'a' } }
+    );
+    rerender({ activeId: 'b' });
+    rerender({ activeId: 'c' });
+    // 'a' is pinned, must stay. Active is 'c'. Cap is 2 → only 1 LRU slot
+    // remains beside the pinned 'a'. 'c' is active so it takes the slot;
+    // 'b' is evicted.
+    expect(result.current.map((d) => d.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('drops a Board that no longer exists in the dashboard list', () => {
+    const initial = [board('a'), board('b')];
+    const { result, rerender } = renderHook(
+      ({ activeId, all }: { activeId: string; all: Dashboard[] }) =>
+        useMountedBoardCache(activeId, all),
+      { initialProps: { activeId: 'a', all: initial } }
+    );
+    rerender({ activeId: 'b', all: initial });
+    rerender({ activeId: 'b', all: [board('b')] });
+    expect(result.current.map((d) => d.id)).toEqual(['b']);
+  });
+});

--- a/tests/utils/pickInitialBoard.test.ts
+++ b/tests/utils/pickInitialBoard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { pickInitialBoard } from '@/utils/pickInitialBoard';
+import type { Collection, Dashboard } from '@/types';
+
+const board = (over: Partial<Dashboard> = {}): Dashboard => ({
+  id: over.id ?? 'b-default',
+  name: over.name ?? 'Default Board',
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  order: over.order ?? 0,
+  collectionId: over.collectionId ?? null,
+  isPinned: over.isPinned ?? false,
+  isDefault: over.isDefault ?? false,
+  ...over,
+});
+
+const collection = (over: Partial<Collection> = {}): Collection => ({
+  id: over.id ?? 'c1',
+  name: over.name ?? 'Collection 1',
+  parentCollectionId: over.parentCollectionId ?? null,
+  order: over.order ?? 0,
+  createdAt: 0,
+  ...over,
+});
+
+describe('pickInitialBoard', () => {
+  it('returns null when no boards exist', () => {
+    expect(pickInitialBoard([], null, undefined, [])).toBeNull();
+  });
+
+  it('returns the remembered Board when it still exists in the right Collection', () => {
+    const target = board({ id: 'b1', collectionId: 'c1' });
+    const other = board({ id: 'b2', collectionId: 'c1' });
+    const result = pickInitialBoard([target, other], 'c1', { c1: 'b1' }, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('b1');
+  });
+
+  it('skips the remembered Board when it has moved out of the Collection', () => {
+    const moved = board({ id: 'b1', collectionId: 'c2' });
+    const sibling = board({ id: 'b2', collectionId: 'c1', order: 0 });
+    const result = pickInitialBoard([moved, sibling], 'c1', { c1: 'b1' }, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('b2');
+  });
+
+  it('falls back to the Collection defaultBoardId when no memory exists', () => {
+    const b = board({ id: 'defaultInColl', collectionId: 'c1' });
+    const other = board({ id: 'otherInColl', collectionId: 'c1', order: 0 });
+    const result = pickInitialBoard([other, b], 'c1', undefined, [
+      collection({ id: 'c1', defaultBoardId: 'defaultInColl' }),
+    ]);
+    expect(result?.id).toBe('defaultInColl');
+  });
+
+  it('falls back to the first Board in the Collection by order', () => {
+    const b2 = board({ id: 'second', collectionId: 'c1', order: 5 });
+    const b1 = board({ id: 'first', collectionId: 'c1', order: 1 });
+    const result = pickInitialBoard([b2, b1], 'c1', undefined, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('first');
+  });
+
+  it('falls back to the global isDefault when the Collection is empty', () => {
+    const orphan = board({ id: 'g1', collectionId: null, isDefault: true });
+    const inOther = board({ id: 'g2', collectionId: 'cOther' });
+    const result = pickInitialBoard([orphan, inOther], 'c1', undefined, [
+      collection({ id: 'c1' }),
+    ]);
+    expect(result?.id).toBe('g1');
+  });
+
+  it('treats null lastActiveCollectionId as the root Collection', () => {
+    const rootBoard = board({ id: 'r1', collectionId: null, order: 0 });
+    const inColl = board({ id: 'i1', collectionId: 'c1' });
+    const result = pickInitialBoard(
+      [inColl, rootBoard],
+      null,
+      // Literal '__root__' (not the ROOT_COLLECTION_KEY constant) is
+      // deliberate: this verifies the runtime lookup-key contract a caller
+      // sees, not which constant the helper happens to import.
+      { __root__: 'r1' },
+      []
+    );
+    expect(result?.id).toBe('r1');
+  });
+
+  it('falls through to global default when lastActiveCollectionId is undefined (profile not yet loaded)', () => {
+    const def = board({ id: 'def', isDefault: true });
+    const other = board({ id: 'other' });
+    const result = pickInitialBoard([other, def], undefined, undefined, []);
+    expect(result?.id).toBe('def');
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -4803,6 +4803,15 @@ export interface WidgetComponentProps {
   studentPin?: string | null;
   isSpotlighted?: boolean;
   updateDashboardSettings?: (updates: Partial<DashboardSettings>) => void;
+  /**
+   * True when this widget's host Board is currently visible (active).
+   * False when the Board is mounted-but-hidden via the LRU cache.
+   * Resource-heavy widgets (Webcam, SoundWidget, SmartNotebook) gate their
+   * MediaStream/AudioContext/onSnapshot acquisitions on this flag. Phase C of
+   * Plan 2 wires it into those widgets; most widgets ignore it. Defaults to
+   * `true` so student-facing and non-LRU surfaces are unaffected.
+   */
+  isActive?: boolean;
 }
 
 export interface WidgetLayout {

--- a/utils/pickInitialBoard.ts
+++ b/utils/pickInitialBoard.ts
@@ -1,0 +1,78 @@
+import { ROOT_COLLECTION_KEY } from '@/types';
+import type { Collection, Dashboard } from '@/types';
+
+/**
+ * Choose which Board to load on app open. Honors per-Collection navigation
+ * memory (`lastActiveCollectionId` + `lastBoardIdByCollection`) populated by
+ * `loadDashboard` in Plan 1, with progressively weaker fallbacks so a
+ * partially-populated profile (or a Board that no longer exists) still
+ * lands on a sensible default.
+ *
+ * Fallback chain:
+ *   1. `lastBoardIdByCollection[lastActiveCollectionId]` if that Board still
+ *      exists AND still belongs to that Collection.
+ *   2. The active Collection's `defaultBoardId` if set and present.
+ *   3. The first Board in the active Collection (sorted by existing `order`).
+ *   4. The first Board with `isDefault === true` globally.
+ *   5. The first Board in the global list (last-resort).
+ *   6. `null` if `dashboards` is empty.
+ *
+ * Pure function — all inputs are passed explicitly so this can be tested
+ * without React or Firestore. `lastActiveCollectionId === null` means
+ * "the user was last in the root (no Collection)". A `lastActiveCollectionId`
+ * of `undefined` indicates the profile hasn't been read yet; callers SHOULD
+ * defer the call until the profile loads. As a defensive fallback (in case a
+ * caller forgets), we still return a sensible Board — the global default or
+ * the first Board in the list — rather than throwing.
+ */
+export const pickInitialBoard = (
+  dashboards: Dashboard[],
+  lastActiveCollectionId: string | null | undefined,
+  lastBoardIdByCollection: Record<string, string> | undefined,
+  collections: Collection[]
+): Dashboard | null => {
+  if (dashboards.length === 0) return null;
+  // Caller should never invoke this with `undefined` lastActiveCollectionId;
+  // it indicates profile-not-yet-loaded. Treat as "no memory yet" and fall
+  // through to global defaults so we don't crash if a caller forgets.
+  if (lastActiveCollectionId === undefined) {
+    return (
+      dashboards.find((d) => d.isDefault === true) ?? dashboards[0] ?? null
+    );
+  }
+
+  const targetCollectionId = lastActiveCollectionId;
+  const collectionKey = targetCollectionId ?? ROOT_COLLECTION_KEY;
+  const rememberedBoardId = lastBoardIdByCollection?.[collectionKey];
+
+  if (rememberedBoardId) {
+    const remembered = dashboards.find((d) => d.id === rememberedBoardId);
+    if (
+      remembered &&
+      (remembered.collectionId ?? null) === targetCollectionId
+    ) {
+      return remembered;
+    }
+  }
+
+  if (targetCollectionId !== null) {
+    const targetCollection = collections.find(
+      (c) => c.id === targetCollectionId
+    );
+    if (targetCollection?.defaultBoardId) {
+      const collectionDefault = dashboards.find(
+        (d) =>
+          d.id === targetCollection.defaultBoardId &&
+          (d.collectionId ?? null) === targetCollectionId
+      );
+      if (collectionDefault) return collectionDefault;
+    }
+  }
+
+  const inCollection = dashboards
+    .filter((d) => (d.collectionId ?? null) === targetCollectionId)
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+  if (inCollection.length > 0) return inCollection[0];
+
+  return dashboards.find((d) => d.isDefault === true) ?? dashboards[0] ?? null;
+};


### PR DESCRIPTION
## Summary

Plan 2 of the 4-plan Collections feature. Makes the live-classroom navigation surface Collection-aware, restores per-Collection navigation memory on app open, and keeps a small LRU cache of mounted Boards so Board-to-Board switching preserves in-flight state (drawings, timer counts, video positions) instead of full-remount.

Builds on Plan 1's data layer. Out of scope for this PR: Plan 3 (Collection sharing) and Plan 4 (Collection templates).

Plan doc: [docs/superpowers/plans/2026-05-16-collections-fab-and-mounted-set.md](docs/superpowers/plans/2026-05-16-collections-fab-and-mounted-set.md)

## What ships

**Phase 0 — App-open behavior**
- `utils/pickInitialBoard.ts` pure resolver: `lastBoardIdByCollection` → Collection `defaultBoardId` → first-in-Collection → global default fallback chain.
- Snapshot-driven initial-board select uses the resolver (gated on `profileLoaded`).
- One-shot deferred effect with `initialBoardSelectedRef` re-runs the pick when profile/collections arrive after the snapshot. Intentionally leaves the gate false on null-return so a later dep change can retry.
- New `setActiveCollectionId(id)` action on `DashboardContext` — routes through `loadDashboard` so the existing `lastActiveCollectionId` write stays intact.

**Phase 1 — Breadcrumb chip**
- `BoardBreadcrumb` glassmorphism chip showing 'Collection › Board' above the BoardNavFab. Click → opens BoardsModal.
- Click-to-open mounted via FAB-row absolute positioning.

**Phase 2 — Collection-aware FAB**
- `BoardNavFab` kebab popover + prev/next chevrons now iterate only Boards in the active Collection.
- New 'Switch Collection…' menuitem at the top of the popover.
- `CollectionSwitcherMenu` submenu — DFS tree with depth-indent, includes 'All Boards (root)' entry. Routes through `setActiveCollectionId`.
- Keyboard-accessible: Switch Collection registered at \`itemRefs[0]\` with board indices shifted by 1. Arrow nav reaches it from any board, Home jumps to it. (Caught + fixed in code review.)

**Phase 3 — Mounted-set state preservation (P4)**
- \`config/mountedBoardCache.ts\` exports \`MOUNTED_BOARD_CACHE_SIZE = 2\` (default; tuning lives here).
- \`useMountedBoardCache(activeId, dashboards, pinnedIds)\` LRU hook. Pure \`useMemo\` body; ref mutation only in \`useEffect\` (StrictMode-safe).
- \`BoardCanvas\` extracted from \`DashboardView\` — \`memo\`'d, inactive boards hidden via \`display: none\` to preserve React subtree state. Real \`WidgetRendererProps\` typing instead of \`never[]\` placeholders.
- \`MountedBoardsLayer\` renders the LRU window. Live-session-active Boards are pinned (never evicted while session is live).
- \`DashboardView\`'s old \`<div key={activeDashboard.id}>...</div>\` single-mount is gone. Switching back to a recently-active Board preserves timer counts, drawings, video positions within the cap.

**Phase 4 — i18n + E2E**
- New keys: \`boardBreadcrumb.{root,openManager}\`, \`collectionSwitcher.{title,root}\`, \`boardNav.switchCollection\` (en + de/es/fr fallback strings per Plan 1 convention).
- \`tests/e2e/collections-fab.spec.ts\` — happy-path E2E (breadcrumb chip + FAB Collection switcher).

**Bonus — \`useCollections\` dedup refactor**

The original Plan 1 silent-failure-hunter review flagged 'BoardsModal calls useCollections(uid) AND useBoardsModalDnd calls it again' as tech debt. Building Phase 2 exposed this as a real bug in auth-bypass mode: each \`useCollections\` call has isolated \`useState\`, so a Collection created in BoardsModal was invisible to BoardNavFab. Production worked (Firestore \`onSnapshot\` made all subscribers eventually-consistent at the cost of N subscriptions); bypass mode (E2E + dev) diverged forever.

Fix: lifted \`useCollections\` into \`DashboardContext.collectionsApi\` and routed all 4 consumers (BoardsModal, useBoardsModalDnd, BoardNavFab, BoardBreadcrumb) through it. One subscription per session, single source of truth, bypass-mode-correct. Closes the Plan 1 tracker note.

## Test plan

- [ ] CI: \`pnpm run validate\` passes (type-check + lint + format + 2643 root + 290 functions tests)
- [ ] CI: E2E suite green (verified locally: collections-fab + collections + sharing all pass)
- [ ] Manual app-open restore: sign in, open Board in Collection X, close + reopen → land on same Board in Collection X (not global default)
- [ ] Manual breadcrumb: shows above FAB, click opens BoardsModal
- [ ] Manual FAB scope: kebab menu lists only Boards in active Collection; prev/next chevrons wrap inside the Collection
- [ ] Manual Switch Collection: 'Switch Collection…' menuitem in kebab popover opens submenu; picking another Collection loads that Collection's last-visited / default / first Board
- [ ] Manual state preservation: open TimeToolWidget on Board A, start a timer, switch to Board B, switch back → timer still counting
- [ ] Manual LRU eviction: continue from prior step, switch to Boards C then D, switch back to A → timer reset (cap=2 evicted A)
- [ ] Manual no-regressions on existing Plan 1 flows

## What's next

- Plan 3: Collection-level sharing (Copy + Substitute view-only)
- Plan 4: Collection templates (\`/dashboard_templates/\` with \`type\` discriminator)

## Optional follow-ups (non-blockers, from final review)

- Add \`useMountedBoardCache\` test for \`pinnedCount >= MOUNTED_BOARD_CACHE_SIZE\` edge (currently unreachable in production; defensive coverage)
- E2E that proves stateful preservation (timer continues after board switch back) — requires multi-board fixture with stateful widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)