### PR TITLE
feat: Collection-level sharing (Copy + Substitute view-only) (Plan 3 of 4)

### DIFF
--- a/components/boardsModal/BoardsModal.tsx
+++ b/components/boardsModal/BoardsModal.tsx
@@ -13,9 +13,10 @@ import { BoardContextMenu } from './BoardContextMenu';
 import { CollectionContextMenu } from './CollectionContextMenu';
 import { MoveToCollectionMenu } from './MoveToCollectionMenu';
 import { ShareLinkCreatorModal } from '@/components/share/ShareLinkCreatorModal';
+import { ShareCollectionLinkCreatorModal } from '@/components/share/ShareCollectionLinkCreatorModal';
 import { SaveAsTemplateModal } from '@/components/admin/SaveAsTemplateModal';
 import { useBoardsModalDnd } from './useBoardsModalDnd';
-import type { Dashboard } from '@/types';
+import type { Collection, Dashboard } from '@/types';
 
 interface BoardsModalProps {
   onClose: () => void;
@@ -60,6 +61,8 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
     position: { x: number; y: number };
   } | null>(null);
   const [shareTarget, setShareTarget] = useState<Dashboard | null>(null);
+  const [shareCollectionTarget, setShareCollectionTarget] =
+    useState<Collection | null>(null);
   const [saveAsTemplateTarget, setSaveAsTemplateTarget] =
     useState<Dashboard | null>(null);
   const [moveMenuOpen, setMoveMenuOpen] = useState(false);
@@ -498,6 +501,8 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
               position={contextMenu.position}
               onClose={() => setContextMenu(null)}
               onOpen={() => setSelectedCollectionId(c.id)}
+              canShare={canShare}
+              onShare={() => setShareCollectionTarget(c)}
               onRename={async () => {
                 const next = await showPrompt('Rename Collection', {
                   title: 'Rename',
@@ -568,6 +573,16 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
         dashboard={shareTarget}
         onClose={() => setShareTarget(null)}
       />
+      {shareCollectionTarget && (
+        <ShareCollectionLinkCreatorModal
+          isOpen
+          collection={shareCollectionTarget}
+          boards={dashboards.filter(
+            (d) => (d.collectionId ?? null) === shareCollectionTarget.id
+          )}
+          onClose={() => setShareCollectionTarget(null)}
+        />
+      )}
       <SaveAsTemplateModal
         isOpen={!!saveAsTemplateTarget}
         currentDashboard={saveAsTemplateTarget}

--- a/components/boardsModal/CollectionContextMenu.tsx
+++ b/components/boardsModal/CollectionContextMenu.tsx
@@ -5,6 +5,7 @@ import {
   Pencil,
   FolderInput,
   Palette,
+  Share2,
   Trash2,
 } from 'lucide-react';
 
@@ -15,6 +16,8 @@ interface CollectionContextMenuProps {
   onRename: () => void;
   onMove: () => void;
   onColor: () => void;
+  canShare: boolean;
+  onShare: () => void;
   onDelete: () => void;
 }
 
@@ -25,6 +28,8 @@ export const CollectionContextMenu: React.FC<CollectionContextMenuProps> = ({
   onRename,
   onMove,
   onColor,
+  canShare,
+  onShare,
   onDelete,
 }) => {
   const { t } = useTranslation();
@@ -67,13 +72,22 @@ export const CollectionContextMenu: React.FC<CollectionContextMenuProps> = ({
       icon: Palette,
       action: onColor,
     },
-    {
-      label: t('boardsModal.menu.delete', { defaultValue: 'Delete' }),
-      icon: Trash2,
-      action: onDelete,
-      danger: true,
-    },
   ];
+
+  if (canShare) {
+    items.push({
+      label: t('collectionMenu.share', { defaultValue: 'Share Collection…' }),
+      icon: Share2,
+      action: onShare,
+    });
+  }
+
+  items.push({
+    label: t('boardsModal.menu.delete', { defaultValue: 'Delete' }),
+    icon: Trash2,
+    action: onDelete,
+    danger: true,
+  });
 
   return (
     <div

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -20,6 +20,7 @@ import { useVideoActivity } from '@/hooks/useVideoActivity';
 import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
 import { QuizAssignmentImportModeModal } from '@/components/widgets/QuizWidget/components/QuizAssignmentImportModeModal';
 import { ImportShareModePicker } from '@/components/share/ImportShareModePicker';
+import { ImportSharedCollectionModal } from '@/components/share/ImportSharedCollectionModal';
 import { ShareStatusBanner } from '@/components/share/ShareStatusBanner';
 import { logError } from '@/utils/logError';
 import {
@@ -168,6 +169,8 @@ export const DashboardView: React.FC = () => {
     clearPendingAssignmentShare,
     pendingVideoActivityShareId,
     clearPendingVideoActivityShare,
+    pendingSharedCollectionId,
+    clearPendingSharedCollection,
     setPendingAssignmentSetup,
     // Widget grouping
     groupWidgets,
@@ -1741,6 +1744,18 @@ export const DashboardView: React.FC = () => {
       <AnnouncementOverlay />
       <ShareStatusBanner />
       <ImportShareModePicker />
+      {pendingSharedCollectionId && (
+        <ImportSharedCollectionModal
+          shareId={pendingSharedCollectionId}
+          onClose={clearPendingSharedCollection}
+          onImported={(newCollectionId) => {
+            const firstBoard = dashboards.find(
+              (d) => (d.collectionId ?? null) === newCollectionId
+            );
+            if (firstBoard) loadDashboard(firstBoard.id);
+          }}
+        />
+      )}
       <BoardActionsFab onOpenCheatSheet={() => setIsCheatSheetOpen(true)} />
 
       {importModePrompt && (

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1748,11 +1748,11 @@ export const DashboardView: React.FC = () => {
         <ImportSharedCollectionModal
           shareId={pendingSharedCollectionId}
           onClose={clearPendingSharedCollection}
-          onImported={(newCollectionId) => {
-            const firstBoard = dashboards.find(
-              (d) => (d.collectionId ?? null) === newCollectionId
-            );
-            if (firstBoard) loadDashboard(firstBoard.id);
+          onImported={(result) => {
+            // Use firstBoardId returned directly from importSharedCollection
+            // rather than searching dashboards — the Firestore snapshot may not
+            // have updated yet when this callback fires.
+            if (result.firstBoardId) loadDashboard(result.firstBoardId);
           }}
         />
       )}

--- a/components/share/ImportSharedCollectionModal.tsx
+++ b/components/share/ImportSharedCollectionModal.tsx
@@ -39,8 +39,16 @@ export const ImportSharedCollectionModal: FC<
   const handleImport = async () => {
     if (!meta) return;
     setBusy(true);
-    const result = await importSharedCollection(shareId);
-    setBusy(false);
+    // Guard `setBusy(false)` in a finally so a thrown rejection from
+    // `importSharedCollection` (network failure, rules denial, etc.)
+    // can't leave the Import button permanently disabled/spinning for
+    // the rest of the session.
+    let result: Awaited<ReturnType<typeof importSharedCollection>>;
+    try {
+      result = await importSharedCollection(shareId);
+    } finally {
+      setBusy(false);
+    }
     if (result) {
       onImported(result);
       onClose();

--- a/components/share/ImportSharedCollectionModal.tsx
+++ b/components/share/ImportSharedCollectionModal.tsx
@@ -93,7 +93,15 @@ export const ImportSharedCollectionModal: FC<
               })}
             </p>
           )}
-          {!loading && meta && (
+          {!loading && meta && meta.intendedMode === 'substitute' && (
+            <p className="text-sm text-amber-600">
+              {t('importSharedCollection.substituteOnly', {
+                defaultValue:
+                  'This is a substitute (view-only) share. Open it in /subs.',
+              })}
+            </p>
+          )}
+          {!loading && meta && meta.intendedMode === 'copy' && (
             <>
               <p className="text-sm text-slate-800">
                 <span className="font-bold">{meta.collection.name}</span>{' '}
@@ -127,7 +135,9 @@ export const ImportSharedCollectionModal: FC<
             <button
               type="button"
               onClick={() => void handleImport()}
-              disabled={busy || loading || !meta}
+              disabled={
+                busy || loading || !meta || meta.intendedMode === 'substitute'
+              }
               className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark disabled:opacity-50"
             >
               {busy

--- a/components/share/ImportSharedCollectionModal.tsx
+++ b/components/share/ImportSharedCollectionModal.tsx
@@ -1,0 +1,135 @@
+import { type FC, useState, useEffect, useId } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import type { SharedCollection } from '@/types';
+
+interface ImportSharedCollectionModalProps {
+  shareId: string;
+  onClose: () => void;
+  onImported: (collectionId: string) => void;
+}
+
+export const ImportSharedCollectionModal: FC<
+  ImportSharedCollectionModalProps
+> = ({ shareId, onClose, onImported }) => {
+  const { t } = useTranslation();
+  const { loadSharedCollection, importSharedCollection } = useDashboard();
+  const [meta, setMeta] = useState<SharedCollection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const headingId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadSharedCollection(shareId).then((result) => {
+      if (!cancelled) {
+        setMeta(result);
+        setLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId, loadSharedCollection]);
+
+  const handleImport = async () => {
+    if (!meta) return;
+    setBusy(true);
+    const result = await importSharedCollection(shareId);
+    setBusy(false);
+    if (result) {
+      onImported(result.collectionId);
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md">
+        <div className="p-5 border-b border-slate-100 flex items-center gap-2">
+          <Folder
+            className="w-5 h-5 flex-shrink-0"
+            style={
+              meta?.collection.color
+                ? { color: meta.collection.color }
+                : undefined
+            }
+          />
+          <h2 id={headingId} className="text-lg font-bold text-slate-800">
+            {t('importSharedCollection.title', {
+              defaultValue: 'Import shared Collection',
+            })}
+          </h2>
+        </div>
+        <div className="p-5 space-y-3">
+          {loading && (
+            <p className="text-sm text-slate-500">
+              {t('importSharedCollection.loading', {
+                defaultValue: 'Loading shared Collection…',
+              })}
+            </p>
+          )}
+          {!loading && !meta && (
+            <p className="text-sm text-red-600">
+              {t('importSharedCollection.notFound', {
+                defaultValue: 'Shared Collection not found or expired.',
+              })}
+            </p>
+          )}
+          {!loading && meta && (
+            <>
+              <p className="text-sm text-slate-800">
+                <span className="font-bold">{meta.collection.name}</span>{' '}
+                <span className="text-slate-500">
+                  (
+                  {t('importSharedCollection.boardCount', {
+                    count: meta.boardIds.length,
+                    defaultValue: '{{count}} board(s)',
+                  })}
+                  )
+                </span>
+              </p>
+              {meta.hostDisplayName && (
+                <p className="text-xs text-slate-500">
+                  {t('importSharedCollection.shared', {
+                    name: meta.hostDisplayName,
+                    defaultValue: 'Shared by {{name}}',
+                  })}
+                </p>
+              )}
+            </>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 rounded"
+            >
+              {t('common.cancel', { defaultValue: 'Cancel' })}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleImport()}
+              disabled={busy || loading || !meta}
+              className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark disabled:opacity-50"
+            >
+              {busy
+                ? t('importSharedCollection.importing', {
+                    defaultValue: 'Importing…',
+                  })
+                : t('importSharedCollection.import', {
+                    defaultValue: 'Import Collection',
+                  })}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/share/ImportSharedCollectionModal.tsx
+++ b/components/share/ImportSharedCollectionModal.tsx
@@ -7,7 +7,10 @@ import type { SharedCollection } from '@/types';
 interface ImportSharedCollectionModalProps {
   shareId: string;
   onClose: () => void;
-  onImported: (collectionId: string) => void;
+  onImported: (result: {
+    collectionId: string;
+    firstBoardId: string | null;
+  }) => void;
 }
 
 export const ImportSharedCollectionModal: FC<
@@ -39,7 +42,7 @@ export const ImportSharedCollectionModal: FC<
     const result = await importSharedCollection(shareId);
     setBusy(false);
     if (result) {
-      onImported(result.collectionId);
+      onImported(result);
       onClose();
     }
   };

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Folder, Copy, UserCheck } from 'lucide-react';
 import type { Collection, Dashboard } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
+import { BUILDINGS } from '@/config/buildings';
+import { logError } from '@/utils/logError';
 
 interface ShareCollectionLinkCreatorModalProps {
   isOpen: boolean;
@@ -13,6 +15,9 @@ interface ShareCollectionLinkCreatorModalProps {
 }
 
 type ModeChoice = 'copy' | 'substitute';
+type CopyState = 'unknown' | 'copied' | 'failed';
+
+const BUILDING_IDS = new Set(BUILDINGS.map((b) => b.id));
 
 const SUB_TTL_PRESETS: { label: string; ms: number }[] = [
   { label: '4 hours', ms: 4 * 60 * 60 * 1000 },
@@ -31,6 +36,7 @@ export const ShareCollectionLinkCreatorModal: FC<
   const [ttlMs, setTtlMs] = useState<number>(SUB_TTL_PRESETS[1].ms);
   const [buildingId, setBuildingId] = useState<string>('');
   const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<CopyState>('unknown');
   const [busy, setBusy] = useState(false);
   const headingId = useId();
 
@@ -52,6 +58,17 @@ export const ShareCollectionLinkCreatorModal: FC<
           setBusy(false);
           return;
         }
+        // Defense-in-depth: reject any value not in the canonical list.
+        if (!BUILDING_IDS.has(buildingId)) {
+          addToast(
+            t('shareCollection.buildingRequired', {
+              defaultValue: 'Select a building before sharing with a sub.',
+            }),
+            'error'
+          );
+          setBusy(false);
+          return;
+        }
         shareId = await shareSubstituteCollection({
           collection,
           boards,
@@ -64,8 +81,10 @@ export const ShareCollectionLinkCreatorModal: FC<
       setShareUrl(url);
       try {
         await navigator.clipboard.writeText(url);
-      } catch {
-        // clipboard may be blocked — URL is still shown in the input
+        setCopyState('copied');
+      } catch (err) {
+        setCopyState('failed');
+        logError('ShareCollectionLinkCreatorModal.clipboard', err);
       }
     } catch {
       addToast(
@@ -198,13 +217,22 @@ export const ShareCollectionLinkCreatorModal: FC<
                 <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
                   {t('shareCollection.building', { defaultValue: 'Building' })}
                 </label>
-                <input
-                  type="text"
+                <select
                   value={buildingId}
                   onChange={(e) => setBuildingId(e.target.value)}
-                  placeholder="e.g. middle-school"
-                  className="w-full px-2 py-1 text-sm border border-slate-300 rounded"
-                />
+                  className="w-full px-2 py-1 text-sm border border-slate-300 rounded bg-white"
+                >
+                  <option value="">
+                    {t('shareCollection.selectBuilding', {
+                      defaultValue: '— Select building —',
+                    })}
+                  </option>
+                  {BUILDINGS.map((b) => (
+                    <option key={b.id} value={b.id}>
+                      {b.name}
+                    </option>
+                  ))}
+                </select>
               </div>
             )}
 
@@ -236,21 +264,55 @@ export const ShareCollectionLinkCreatorModal: FC<
 
         {shareUrl && (
           <div className="p-5 space-y-3">
-            <p className="text-sm text-slate-600">
-              {t('shareCollection.linkReady', {
-                defaultValue: 'Share link copied to clipboard.',
-              })}
-            </p>
-            <input
-              type="text"
-              readOnly
-              value={shareUrl}
-              aria-label={t('shareCollection.urlLabel', {
-                defaultValue: 'Share collection URL',
-              })}
-              className="w-full px-2 py-1.5 text-xs font-mono bg-slate-50 border border-slate-200 rounded select-all"
-              onFocus={(e) => e.currentTarget.select()}
-            />
+            {copyState === 'copied' && (
+              <p className="text-sm text-slate-600">
+                {t('shareCollection.linkCopied', {
+                  defaultValue: 'Share link copied to clipboard.',
+                })}
+              </p>
+            )}
+            {copyState === 'failed' && (
+              <p className="text-sm text-amber-600">
+                {t('shareCollection.linkCopyFailed', {
+                  defaultValue:
+                    'Copy the link below — clipboard access was blocked.',
+                })}
+              </p>
+            )}
+            {copyState === 'unknown' && (
+              <p className="text-sm text-slate-600">
+                {t('shareCollection.linkReady', {
+                  defaultValue: 'Share link ready.',
+                })}
+              </p>
+            )}
+            <div className="flex gap-1">
+              <input
+                type="text"
+                readOnly
+                value={shareUrl}
+                aria-label={t('shareCollection.urlLabel', {
+                  defaultValue: 'Share collection URL',
+                })}
+                className="flex-1 px-2 py-1.5 text-xs font-mono bg-slate-50 border border-slate-200 rounded select-all"
+                onFocus={(e) => e.currentTarget.select()}
+              />
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(shareUrl);
+                    setCopyState('copied');
+                  } catch (err) {
+                    setCopyState('failed');
+                    logError('ShareCollectionLinkCreatorModal.manualCopy', err);
+                  }
+                }}
+                className="px-2 py-1.5 text-xs font-bold bg-slate-100 text-slate-700 rounded hover:bg-slate-200"
+              >
+                {t('shareCollection.copy', { defaultValue: 'Copy' })}
+              </button>
+            </div>
             <div className="flex justify-end">
               <button
                 type="button"

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -1,0 +1,268 @@
+import { type FC, useState, useId, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, Copy, UserCheck } from 'lucide-react';
+import type { Collection, Dashboard } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+
+interface ShareCollectionLinkCreatorModalProps {
+  isOpen: boolean;
+  collection: Collection | null;
+  /** Boards currently in the Collection. Frozen at modal open. */
+  boards: Dashboard[];
+  onClose: () => void;
+}
+
+type ModeChoice = 'copy' | 'substitute';
+
+const SUB_TTL_PRESETS: { label: string; ms: number }[] = [
+  { label: '4 hours', ms: 4 * 60 * 60 * 1000 },
+  { label: '1 day', ms: 24 * 60 * 60 * 1000 },
+  { label: '3 days', ms: 3 * 24 * 60 * 60 * 1000 },
+  { label: '1 week', ms: 7 * 24 * 60 * 60 * 1000 },
+];
+
+export const ShareCollectionLinkCreatorModal: FC<
+  ShareCollectionLinkCreatorModalProps
+> = ({ isOpen, collection, boards, onClose }) => {
+  const { t } = useTranslation();
+  const { shareCollection, shareSubstituteCollection, addToast } =
+    useDashboard();
+  const [mode, setMode] = useState<ModeChoice>('copy');
+  const [ttlMs, setTtlMs] = useState<number>(SUB_TTL_PRESETS[1].ms);
+  const [buildingId, setBuildingId] = useState<string>('');
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const headingId = useId();
+
+  const handleCreate = useCallback(async () => {
+    if (!collection) return;
+    setBusy(true);
+    try {
+      let shareId: string;
+      if (mode === 'copy') {
+        shareId = await shareCollection({ collection, boards });
+      } else {
+        if (!buildingId) {
+          addToast(
+            t('shareCollection.buildingRequired', {
+              defaultValue: 'Select a building before sharing with a sub.',
+            }),
+            'error'
+          );
+          setBusy(false);
+          return;
+        }
+        shareId = await shareSubstituteCollection({
+          collection,
+          boards,
+          collectionId: collection.id,
+          expiresAt: Date.now() + ttlMs,
+          buildingId,
+        });
+      }
+      const url = `${window.location.origin}/share-collection/${shareId}`;
+      setShareUrl(url);
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch {
+        // clipboard may be blocked — URL is still shown in the input
+      }
+    } catch {
+      addToast(
+        t('shareCollection.createFailed', {
+          defaultValue: 'Failed to create Collection share',
+        }),
+        'error'
+      );
+      setBusy(false);
+      return;
+    }
+    setBusy(false);
+  }, [
+    mode,
+    ttlMs,
+    buildingId,
+    collection,
+    boards,
+    shareCollection,
+    shareSubstituteCollection,
+    addToast,
+    t,
+  ]);
+
+  if (!isOpen || !collection) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <div className="p-5 border-b border-slate-100 flex items-center gap-2">
+          <Folder
+            className="w-5 h-5 flex-shrink-0"
+            style={collection.color ? { color: collection.color } : undefined}
+          />
+          <h2 id={headingId} className="text-lg font-bold text-slate-800">
+            {t('shareCollection.title', {
+              defaultValue: 'Share Collection',
+            })}
+            : <span className="font-normal">{collection.name}</span>
+          </h2>
+        </div>
+
+        {!shareUrl && (
+          <div className="p-5 space-y-4">
+            <p className="text-sm text-slate-600">
+              {t('shareCollection.subtitle', {
+                count: boards.length,
+                defaultValue:
+                  'Sharing {{count}} board(s) from this Collection.',
+              })}
+            </p>
+            <fieldset className="space-y-2">
+              <legend className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                {t('shareCollection.mode', { defaultValue: 'Share Mode' })}
+              </legend>
+              <label className="flex items-start gap-2 p-3 rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50">
+                <input
+                  type="radio"
+                  name="mode"
+                  checked={mode === 'copy'}
+                  onChange={() => setMode('copy')}
+                  className="mt-1"
+                />
+                <span className="flex-1">
+                  <span className="flex items-center gap-1 text-sm font-bold text-slate-800">
+                    <Copy className="w-3.5 h-3.5" />
+                    {t('shareCollection.copyMode', { defaultValue: 'Copy' })}
+                  </span>
+                  <span className="block text-xs text-slate-500 mt-0.5">
+                    {t('shareCollection.copyModeHint', {
+                      defaultValue:
+                        'Recipient imports a full copy into their account.',
+                    })}
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2 p-3 rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50">
+                <input
+                  type="radio"
+                  name="mode"
+                  checked={mode === 'substitute'}
+                  onChange={() => setMode('substitute')}
+                  className="mt-1"
+                />
+                <span className="flex-1">
+                  <span className="flex items-center gap-1 text-sm font-bold text-slate-800">
+                    <UserCheck className="w-3.5 h-3.5" />
+                    {t('shareCollection.substituteMode', {
+                      defaultValue: 'Substitute (view-only)',
+                    })}
+                  </span>
+                  <span className="block text-xs text-slate-500 mt-0.5">
+                    {t('shareCollection.substituteModeHint', {
+                      defaultValue:
+                        'A sub teacher sees the Collection in /subs for the window you choose.',
+                    })}
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+
+            {mode === 'substitute' && (
+              <div className="space-y-3 p-3 rounded-lg bg-slate-50 border border-slate-200">
+                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  {t('shareCollection.expiresIn', {
+                    defaultValue: 'Expires in',
+                  })}
+                </label>
+                <div className="grid grid-cols-4 gap-1">
+                  {SUB_TTL_PRESETS.map((p) => (
+                    <button
+                      key={p.ms}
+                      type="button"
+                      onClick={() => setTtlMs(p.ms)}
+                      className={`text-xxs font-bold py-1.5 rounded-md transition-colors ${
+                        ttlMs === p.ms
+                          ? 'bg-brand-blue-primary text-white'
+                          : 'bg-white text-slate-600 hover:bg-slate-100 border border-slate-200'
+                      }`}
+                    >
+                      {p.label}
+                    </button>
+                  ))}
+                </div>
+                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  {t('shareCollection.building', { defaultValue: 'Building' })}
+                </label>
+                <input
+                  type="text"
+                  value={buildingId}
+                  onChange={(e) => setBuildingId(e.target.value)}
+                  placeholder="e.g. middle-school"
+                  className="w-full px-2 py-1 text-sm border border-slate-300 rounded"
+                />
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 rounded"
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={busy}
+                className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark disabled:opacity-50"
+              >
+                {busy
+                  ? t('shareCollection.creating', {
+                      defaultValue: 'Creating…',
+                    })
+                  : t('shareCollection.createLink', {
+                      defaultValue: 'Create link',
+                    })}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {shareUrl && (
+          <div className="p-5 space-y-3">
+            <p className="text-sm text-slate-600">
+              {t('shareCollection.linkReady', {
+                defaultValue: 'Share link copied to clipboard.',
+              })}
+            </p>
+            <input
+              type="text"
+              readOnly
+              value={shareUrl}
+              aria-label={t('shareCollection.urlLabel', {
+                defaultValue: 'Share collection URL',
+              })}
+              className="w-full px-2 py-1.5 text-xs font-mono bg-slate-50 border border-slate-200 rounded select-all"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark"
+              >
+                {t('common.done', { defaultValue: 'Done' })}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -299,14 +299,19 @@ export const ShareCollectionLinkCreatorModal: FC<
               />
               <button
                 type="button"
-                onClick={async () => {
-                  try {
-                    await navigator.clipboard.writeText(shareUrl);
-                    setCopyState('copied');
-                  } catch (err) {
-                    setCopyState('failed');
-                    logError('ShareCollectionLinkCreatorModal.manualCopy', err);
-                  }
+                onClick={() => {
+                  void (async () => {
+                    try {
+                      await navigator.clipboard.writeText(shareUrl);
+                      setCopyState('copied');
+                    } catch (err) {
+                      setCopyState('failed');
+                      logError(
+                        'ShareCollectionLinkCreatorModal.manualCopy',
+                        err
+                      );
+                    }
+                  })();
                 }}
                 className="px-2 py-1.5 text-xs font-bold bg-slate-100 text-slate-700 rounded hover:bg-slate-200"
               >

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -273,6 +273,19 @@ const mockDashboard: DashboardContextValue = {
   clearAllStickers: () => {
     // No-op
   },
+  // Collection sharing system mocks
+  shareCollection: () => Promise.resolve(''),
+  shareSubstituteCollection: () => Promise.resolve(''),
+  loadSharedCollection: () => Promise.resolve(null),
+  loadSharedCollectionBoards: () => Promise.resolve([]),
+  importSharedCollection: () => Promise.resolve(null),
+  pendingSharedCollectionId: null,
+  setPendingSharedCollectionId: () => {
+    // No-op
+  },
+  clearPendingSharedCollection: () => {
+    // No-op
+  },
   // Sharing system mocks
   shareDashboard: async () => {
     return Promise.reject(new Error('Sharing not implemented in student view'));

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -17,16 +17,13 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
   const { t } = useTranslation();
   const [collections, setCollections] = useState<SharedCollection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [errored, setErrored] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     const canonical = canonicalBuildingId(buildingId);
     void (async () => {
       try {
-        // NOTE: this composite query requires a Firestore index on
-        // (intendedMode, buildingId, expiresAt). Phase 3 will add it to
-        // firestore.indexes.json. Until then the SDK surfaces a
-        // "missing index" error in the console in production.
         const q = query(
           collection(db, 'shared_collections'),
           where('intendedMode', '==', 'substitute'),
@@ -41,8 +38,10 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
           docs.push({ ...data, shareId: d.id });
         });
         setCollections(docs);
+        setErrored(false);
       } catch (err) {
         logError('SubCollectionsList.load', err, { buildingId });
+        if (!cancelled) setErrored(true);
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -57,6 +56,19 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
       <p className="text-sm text-white/50 italic">
         {t('subCollections.loading', {
           defaultValue: 'Loading shared Collections…',
+        })}
+      </p>
+    );
+  }
+
+  // A total query failure (network, rules, missing index in production)
+  // must not silently render an empty pane — a sub who's expecting a
+  // Collection would assume nothing was shared.
+  if (errored) {
+    return (
+      <p className="text-sm text-rose-300/80 italic">
+        {t('subCollections.loadError', {
+          defaultValue: "Couldn't load shared Collections — refresh to retry.",
         })}
       </p>
     );

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -23,23 +23,22 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
     const canonical = canonicalBuildingId(buildingId);
     void (async () => {
       try {
+        // NOTE: this composite query requires a Firestore index on
+        // (intendedMode, buildingId, expiresAt). Phase 3 will add it to
+        // firestore.indexes.json. Until then the SDK surfaces a
+        // "missing index" error in the console in production.
         const q = query(
           collection(db, 'shared_collections'),
           where('intendedMode', '==', 'substitute'),
-          where('buildingId', '==', canonical)
+          where('buildingId', '==', canonical),
+          where('expiresAt', '>', Date.now())
         );
         const snap = await getDocs(q);
         if (cancelled) return;
-        const now = Date.now();
         const docs: SharedCollection[] = [];
         snap.docs.forEach((d) => {
           const data = d.data() as SharedCollection;
-          // Filter expired collections client-side (mirrors useSubstituteShares pattern).
-          const expiresAt =
-            typeof data.expiresAt === 'number' ? data.expiresAt : Infinity;
-          if (expiresAt > now) {
-            docs.push({ ...data, shareId: d.id });
-          }
+          docs.push({ ...data, shareId: d.id });
         });
         setCollections(docs);
       } catch (err) {
@@ -104,13 +103,20 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
                   defaultValue:
                     'Board view in /subs coming soon — open in the teacher app for now',
                 })}
-                className="text-left px-2 py-1.5 text-xs rounded-md bg-slate-50 border border-slate-200 opacity-60 cursor-not-allowed"
+                className="text-left px-2 py-1.5 text-xs rounded-md bg-slate-50 border border-slate-200 opacity-60 cursor-not-allowed flex flex-col gap-0.5"
                 aria-disabled="true"
               >
-                {t('subCollections.boardPlaceholder', {
-                  id: boardId.slice(-4),
-                  defaultValue: 'Board …{{id}}',
-                })}
+                <span>
+                  {t('subCollections.boardPlaceholder', {
+                    id: boardId.slice(-4),
+                    defaultValue: 'Board …{{id}}',
+                  })}
+                </span>
+                <span className="text-[10px] text-slate-400 italic">
+                  {t('subCollections.comingSoonLabel', {
+                    defaultValue: 'Coming soon',
+                  })}
+                </span>
               </button>
             ))}
           </div>

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -1,0 +1,119 @@
+import { type FC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder } from 'lucide-react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import { canonicalBuildingId } from '@/config/buildings';
+import { logError } from '@/utils/logError';
+import type { SharedCollection } from '@/types';
+
+interface SubCollectionsListProps {
+  buildingId: string;
+  /** Called when the sub clicks a Board within a shared Collection. */
+  onOpenBoard: (shareId: string, boardId: string) => void;
+}
+
+export const SubCollectionsList: FC<SubCollectionsListProps> = ({
+  buildingId,
+  onOpenBoard,
+}) => {
+  const { t } = useTranslation();
+  const [collections, setCollections] = useState<SharedCollection[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    const canonical = canonicalBuildingId(buildingId);
+    void (async () => {
+      try {
+        const q = query(
+          collection(db, 'shared_collections'),
+          where('intendedMode', '==', 'substitute'),
+          where('buildingId', '==', canonical)
+        );
+        const snap = await getDocs(q);
+        if (cancelled) return;
+        const now = Date.now();
+        const docs: SharedCollection[] = [];
+        snap.docs.forEach((d) => {
+          const data = d.data() as SharedCollection;
+          // Filter expired collections client-side (mirrors useSubstituteShares pattern).
+          const expiresAt =
+            typeof data.expiresAt === 'number' ? data.expiresAt : Infinity;
+          if (expiresAt > now) {
+            docs.push({ ...data, shareId: d.id });
+          }
+        });
+        setCollections(docs);
+      } catch (err) {
+        logError('SubCollectionsList.load', err, { buildingId });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [buildingId]);
+
+  if (loading) {
+    return (
+      <p className="text-sm text-white/50 italic">
+        {t('subCollections.loading', {
+          defaultValue: 'Loading shared Collections…',
+        })}
+      </p>
+    );
+  }
+
+  if (collections.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-[11px] uppercase tracking-wider font-bold text-white/50">
+        {t('subCollections.heading', { defaultValue: 'Collections' })}
+      </h3>
+      {collections.map((c) => (
+        <div
+          key={c.shareId}
+          className="rounded-2xl bg-white/5 backdrop-blur-md border border-white/10 p-5"
+        >
+          <div className="flex items-center gap-2 mb-3">
+            <Folder
+              className="w-4 h-4 flex-shrink-0"
+              style={
+                c.collection.color ? { color: c.collection.color } : undefined
+              }
+            />
+            <span className="text-sm font-bold text-white">
+              {c.collection.name}
+            </span>
+            <span className="ml-auto text-[11px] text-white/50">
+              {t('subCollections.boardCount', {
+                count: c.boardIds.length,
+                defaultValue: '{{count}} board(s)',
+              })}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {c.boardIds.map((boardId) => (
+              <button
+                key={boardId}
+                type="button"
+                onClick={() => onOpenBoard(c.shareId, boardId)}
+                className="text-left px-3 py-2 text-xs rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/30 text-white/80 transition-colors cursor-pointer"
+              >
+                {t('subCollections.boardPlaceholder', {
+                  id: boardId.slice(-4),
+                  defaultValue: 'Board …{{id}}',
+                })}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+};

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -9,13 +9,10 @@ import type { SharedCollection } from '@/types';
 
 interface SubCollectionsListProps {
   buildingId: string;
-  /** Called when the sub clicks a Board within a shared Collection. */
-  onOpenBoard: (shareId: string, boardId: string) => void;
 }
 
 export const SubCollectionsList: FC<SubCollectionsListProps> = ({
   buildingId,
-  onOpenBoard,
 }) => {
   const { t } = useTranslation();
   const [collections, setCollections] = useState<SharedCollection[]>([]);
@@ -102,8 +99,13 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
               <button
                 key={boardId}
                 type="button"
-                onClick={() => onOpenBoard(c.shareId, boardId)}
-                className="text-left px-3 py-2 text-xs rounded-lg bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/30 text-white/80 transition-colors cursor-pointer"
+                disabled
+                title={t('subCollections.comingSoon', {
+                  defaultValue:
+                    'Board view in /subs coming soon — open in the teacher app for now',
+                })}
+                className="text-left px-2 py-1.5 text-xs rounded-md bg-slate-50 border border-slate-200 opacity-60 cursor-not-allowed"
+                aria-disabled="true"
               >
                 {t('subCollections.boardPlaceholder', {
                   id: boardId.slice(-4),

--- a/components/subs/SubsApp.tsx
+++ b/components/subs/SubsApp.tsx
@@ -30,7 +30,15 @@ import { useAuth } from '@/context/useAuth';
 type SubsView =
   | { kind: 'building-picker' }
   | { kind: 'directory'; buildingId: string }
-  | { kind: 'board'; buildingId: string; shareId: string };
+  | { kind: 'board'; buildingId: string; shareId: string }
+  // TODO(collections-plan-3): wire full Collection board view once
+  // SubsDashboardProvider supports loadSharedCollectionBoards.
+  | {
+      kind: 'collection-board';
+      buildingId: string;
+      shareId: string;
+      boardId: string;
+    };
 
 // Per-user storage key. SubsAuthGate guarantees `uid` is set before this
 // runs (it doesn't render children until auth is settled + allowed), so
@@ -97,11 +105,31 @@ const SubsContent: React.FC = () => {
           onPickBoard={(shareId) =>
             setView({ kind: 'board', buildingId: view.buildingId, shareId })
           }
+          onOpenCollectionBoard={(shareId, boardId) =>
+            setView({
+              kind: 'collection-board',
+              buildingId: view.buildingId,
+              shareId,
+              boardId,
+            })
+          }
           onChangeBuilding={() => setView({ kind: 'building-picker' })}
         />
       )}
 
       {view.kind === 'board' && (
+        <SubBoardScreen
+          shareId={view.shareId}
+          onBackToDirectory={() =>
+            setView({ kind: 'directory', buildingId: view.buildingId })
+          }
+          onChangeBuilding={() => setView({ kind: 'building-picker' })}
+        />
+      )}
+
+      {/* TODO(collections-plan-3): replace stub with real Collection board view
+          once SubsDashboardProvider wires loadSharedCollectionBoards. */}
+      {view.kind === 'collection-board' && (
         <SubBoardScreen
           shareId={view.shareId}
           onBackToDirectory={() =>

--- a/components/subs/SubsApp.tsx
+++ b/components/subs/SubsApp.tsx
@@ -105,14 +105,6 @@ const SubsContent: React.FC = () => {
           onPickBoard={(shareId) =>
             setView({ kind: 'board', buildingId: view.buildingId, shareId })
           }
-          onOpenCollectionBoard={(shareId, boardId) =>
-            setView({
-              kind: 'collection-board',
-              buildingId: view.buildingId,
-              shareId,
-              boardId,
-            })
-          }
           onChangeBuilding={() => setView({ kind: 'building-picker' })}
         />
       )}

--- a/components/subs/SubsDashboardProvider.tsx
+++ b/components/subs/SubsDashboardProvider.tsx
@@ -330,6 +330,16 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       ungroupWidgets: NOOP,
       setGroupBuildMode: NOOP,
 
+      // Collection sharing — subs never originate collection shares.
+      shareCollection: () => Promise.resolve(''),
+      shareSubstituteCollection: () => Promise.resolve(''),
+      loadSharedCollection: () => Promise.resolve(null),
+      loadSharedCollectionBoards: () => Promise.resolve([]),
+      importSharedCollection: () => Promise.resolve(null),
+      pendingSharedCollectionId: null,
+      setPendingSharedCollectionId: NOOP,
+      clearPendingSharedCollection: NOOP,
+
       // Sharing — subs never originate shares of their own.
       shareDashboard: NOOP_ASYNC_STRING as (
         dashboard: Dashboard,

--- a/components/subs/TeacherDirectoryScreen.tsx
+++ b/components/subs/TeacherDirectoryScreen.tsx
@@ -16,16 +16,20 @@ import {
   teacherCardAccent,
   teacherInitials,
 } from './subsView';
+import { SubCollectionsList } from './SubCollectionsList';
 
 interface TeacherDirectoryScreenProps {
   buildingId: string;
   onPickBoard: (shareId: string) => void;
+  /** Called when the sub selects a Board inside a shared Collection. */
+  onOpenCollectionBoard: (shareId: string, boardId: string) => void;
   onChangeBuilding: () => void;
 }
 
 export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
   buildingId,
   onPickBoard,
+  onOpenCollectionBoard,
   onChangeBuilding,
 }) => {
   const adminBuildings = useAdminBuildings();
@@ -182,6 +186,14 @@ export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
               })}
             </div>
           )}
+
+          {/* Collections shared with subs — shown below individual boards. */}
+          <div className="mt-10">
+            <SubCollectionsList
+              buildingId={buildingId}
+              onOpenBoard={onOpenCollectionBoard}
+            />
+          </div>
         </div>
       </main>
     </div>

--- a/components/subs/TeacherDirectoryScreen.tsx
+++ b/components/subs/TeacherDirectoryScreen.tsx
@@ -21,15 +21,12 @@ import { SubCollectionsList } from './SubCollectionsList';
 interface TeacherDirectoryScreenProps {
   buildingId: string;
   onPickBoard: (shareId: string) => void;
-  /** Called when the sub selects a Board inside a shared Collection. */
-  onOpenCollectionBoard: (shareId: string, boardId: string) => void;
   onChangeBuilding: () => void;
 }
 
 export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
   buildingId,
   onPickBoard,
-  onOpenCollectionBoard,
   onChangeBuilding,
 }) => {
   const adminBuildings = useAdminBuildings();
@@ -189,10 +186,7 @@ export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
 
           {/* Collections shared with subs — shown below individual boards. */}
           <div className="mt-10">
-            <SubCollectionsList
-              buildingId={buildingId}
-              onOpenBoard={onOpenCollectionBoard}
-            />
+            <SubCollectionsList buildingId={buildingId} />
           </div>
         </div>
       </main>

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3140,10 +3140,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     async (
       name: string,
       data?: Dashboard,
-      options?: { collectionId?: string | null }
+      options?: { collectionId?: string | null; silent?: boolean }
     ): Promise<string | undefined> => {
       if (!user) {
-        addToast('Must be signed in to create dashboard', 'error');
+        if (!options?.silent)
+          addToast('Must be signed in to create dashboard', 'error');
         return undefined;
       }
 
@@ -3178,8 +3179,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
       try {
         await saveDashboard(newDb);
-        updateActiveId(newDb.id);
-        addToast(`Dashboard "${name}" ready`);
+        if (!options?.silent) {
+          updateActiveId(newDb.id);
+          addToast(`Dashboard "${name}" ready`);
+        }
         return newDb.id;
       } catch (err) {
         logError('DashboardContext.createNewDashboard', err, {
@@ -3187,6 +3190,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           name,
           collectionId,
         });
+        if (options?.silent) {
+          // Silent callers (e.g. importSharedCollection) need to detect
+          // failure via rejection — re-throw so Promise.allSettled can count.
+          throw err;
+        }
         addToast('Failed to create dashboard', 'error');
         return undefined;
       }
@@ -3231,7 +3239,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   const importSharedCollection = useCallback(
-    async (shareId: string): Promise<{ collectionId: string } | null> => {
+    async (
+      shareId: string
+    ): Promise<{
+      collectionId: string;
+      firstBoardId: string | null;
+    } | null> => {
       if (!user) {
         addToast('Must be signed in to import', 'error');
         return null;
@@ -3249,6 +3262,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         addToast('Shared Collection is empty', 'error');
         return null;
       }
+      // Warn if the share was partially available (some board docs missing).
+      if (boards.length < meta.boardIds.length) {
+        const missing = meta.boardIds.length - boards.length;
+        addToast(
+          `${missing.toString()} board(s) couldn't be loaded — importing the rest`,
+          'error'
+        );
+        // Continue with the partial set; warning is surfaced above.
+      }
 
       try {
         // Phase 1: create the recipient's Collection.
@@ -3257,22 +3279,42 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           null // root — recipient can move it later
         );
 
-        // Phase 2: clone each Board into the new Collection. Each
-        // createNewDashboard fans out to a Firestore write; collect failures
-        // so the user sees a partial-success report instead of silent skips.
+        // Capture maxOrder ONCE before the parallel fan-out so each board
+        // gets a deterministic, non-colliding order value.
+        const baseOrder = dashboards.reduce(
+          (max, d) => Math.max(max, d.order ?? 0),
+          0
+        );
+
+        // Phase 2: clone each Board into the new Collection. Use silent:true
+        // so N boards don't fire N toasts and N activeId thrashes. With
+        // silent:true, createNewDashboard throws on failure so
+        // Promise.allSettled captures rejections (not undefined returns).
         const importResults = await Promise.allSettled(
-          boards.map((b) =>
+          boards.map((b, idx) =>
             createNewDashboard(
               `${b.name} (Imported)`,
-              { ...b, id: crypto.randomUUID() } as Dashboard,
-              { collectionId: newCollectionId }
+              // Deep-clone the board so nested widget state isn't shared by
+              // reference across imports.
+              {
+                ...structuredClone(b),
+                id: crypto.randomUUID(),
+                order: baseOrder + idx + 1,
+              } as Dashboard,
+              { collectionId: newCollectionId, silent: true }
             )
           )
         );
-        const failed = importResults.filter(
-          (r) => r.status === 'rejected'
+
+        // With silent:true, createNewDashboard throws on failure (rejected)
+        // and returns the new id on success (fulfilled with a string).
+        // Guard against undefined returns defensively in case a future caller
+        // removes silent:true without updating this detection.
+        const succeeded = importResults.filter(
+          (r) => r.status === 'fulfilled' && r.value !== undefined
         ).length;
-        const succeeded = boards.length - failed;
+        const failed = boards.length - succeeded;
+
         if (failed > 0) {
           addToast(
             `Imported ${succeeded.toString()} board(s) — ${failed.toString()} failed`,
@@ -3283,10 +3325,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         }
 
         if (succeeded === 0) {
-          // All boards failed — delete the empty Collection rather than leaving
-          // a labeled-but-empty shell in the recipient's tree. The user will
-          // see the "No items could be imported" toast above; the Collection
-          // shouldn't linger.
+          // All boards failed — delete the empty Collection rather than
+          // leaving a labeled-but-empty shell in the recipient's tree.
           try {
             await collectionsApi.deleteCollection(
               newCollectionId,
@@ -3302,7 +3342,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           return null;
         }
 
-        return { collectionId: newCollectionId };
+        // Return the first successfully imported board's id directly so
+        // the caller can navigate without waiting for the Firestore snapshot
+        // to update the local dashboards state (which is async).
+        const firstFulfilled = importResults.find(
+          (r): r is PromiseFulfilledResult<string | undefined> =>
+            r.status === 'fulfilled' && r.value !== undefined
+        );
+        const firstBoardId = firstFulfilled?.value ?? null;
+
+        return { collectionId: newCollectionId, firstBoardId };
       } catch (err) {
         logError('DashboardContext.importSharedCollection', err, {
           shareId,
@@ -3312,7 +3361,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         return null;
       }
     },
-    [user, addToast, sharedCollectionApi, collectionsApi, createNewDashboard]
+    [
+      user,
+      dashboards,
+      addToast,
+      sharedCollectionApi,
+      collectionsApi,
+      createNewDashboard,
+    ]
   );
 
   const saveCurrentDashboard = useCallback(async () => {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -300,10 +300,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const [pendingSharedCollectionId, setPendingSharedCollectionId] = useState<
     string | null
-  >(null);
+  >(() => {
+    if (typeof window === 'undefined') return null;
+    const path = window.location.pathname;
+    if (path.startsWith('/share-collection/')) {
+      return path.split('/share-collection/')[1] || null;
+    }
+    return null;
+  });
 
   const clearPendingSharedCollection = useCallback(() => {
     setPendingSharedCollectionId(null);
+    window.history.replaceState(null, '', '/');
   }, []);
 
   const clearPendingQuizShare = useCallback(() => {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -298,6 +298,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     window.history.replaceState(null, '', '/');
   }, []);
 
+  // Detect malformed /share-collection/ URLs (present but no ID) so we can
+  // toast after mount, when addToast is available.
+  const [hadEmptyShareCollectionUrl] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    const path = window.location.pathname;
+    return (
+      path.startsWith('/share-collection/') &&
+      !path.split('/share-collection/')[1]
+    );
+  });
+
   const [pendingSharedCollectionId, setPendingSharedCollectionId] = useState<
     string | null
   >(() => {
@@ -577,6 +588,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     });
     return () => setDriveAuthErrorHandler(null);
   }, [addToast, refreshGoogleToken]);
+
+  // Fire a toast (and clean the URL) when the user landed on /share-collection/
+  // with no share ID. The initializer for hadEmptyShareCollectionUrl captures
+  // this at mount time; addToast isn't available during state init, so we
+  // surface the error here instead. hadEmptyShareCollectionUrl is a frozen
+  // constant (never updated after init) so this effect fires exactly once.
+  useEffect(() => {
+    if (hadEmptyShareCollectionUrl) {
+      addToast('Invalid share link — missing share id.', 'error');
+      window.history.replaceState(null, '', '/');
+    }
+  }, [hadEmptyShareCollectionUrl, addToast]);
 
   // Surface a one-time notice when an AI Cloud Function couldn't read the
   // admin-configured Gemini model overrides from Firestore and fell back to
@@ -3324,6 +3347,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           addToast(`Imported Collection with ${succeeded.toString()} board(s)`);
         }
 
+        // NOTE: This cleanup runs AFTER createCollection's Firestore write
+        // resolves, which means the recipient's useCollections onSnapshot
+        // listener may have already received and displayed the new Collection
+        // (typically ~50-200ms before this delete arrives). On total-failure
+        // imports the user will see the Collection flash briefly in their
+        // sidebar tree before disappearing. Acceptable for an exceptional
+        // path; a transactional fix (single batch with all writes + create-or-
+        // delete based on success count) would require Firestore Cloud
+        // Functions or a rewrite to use a single batched transaction.
         if (succeeded === 0) {
           // All boards failed — delete the empty Collection rather than
           // leaving a labeled-but-empty shell in the recipient's tree.

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3186,7 +3186,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
             ...data,
             id: crypto.randomUUID(),
             name,
-            order: maxOrder + 1,
+            order: data.order ?? maxOrder + 1,
             collectionId,
           }
         : {
@@ -3275,6 +3275,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       const meta = await sharedCollectionApi.loadSharedCollection(shareId);
       if (!meta) {
         addToast('Shared Collection not found or expired', 'error');
+        return null;
+      }
+      if (meta.intendedMode === 'substitute') {
+        addToast(
+          'Substitute shares are view-only. Open this link in /subs to view.',
+          'error'
+        );
         return null;
       }
       const boards = await sharedCollectionApi.loadSharedCollectionBoards(

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -24,6 +24,8 @@ import {
   UserProfile,
   SubstituteShareDriveGrant,
   ROOT_COLLECTION_KEY,
+  Collection,
+  CollectionSubstituteShareInput,
 } from '../types';
 import { doc, getDoc, setDoc, updateDoc, writeBatch } from 'firebase/firestore';
 import { db, isAuthBypass } from '../config/firebase';
@@ -62,6 +64,7 @@ import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
 import { useDriveReconnected } from '../hooks/useDriveReconnected';
 import { useCollections } from '../hooks/useCollections';
+import { useSharedCollection } from '../hooks/useSharedCollection';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
 import {
   setAiModelConfigFallbackHandler,
@@ -241,6 +244,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const collectionsApi = useCollections(user?.uid);
   const { collections } = collectionsApi;
+  const sharedCollectionApi = useSharedCollection();
 
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [pendingShareId, setPendingShareId] = useState<string | null>(() => {
@@ -292,6 +296,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   const clearPendingShare = useCallback(() => {
     setPendingShareId(null);
     window.history.replaceState(null, '', '/');
+  }, []);
+
+  const [pendingSharedCollectionId, setPendingSharedCollectionId] = useState<
+    string | null
+  >(null);
+
+  const clearPendingSharedCollection = useCallback(() => {
+    setPendingSharedCollectionId(null);
   }, []);
 
   const clearPendingQuizShare = useCallback(() => {
@@ -3174,6 +3186,106 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     [user, dashboards, saveDashboard, addToast, updateActiveId]
   );
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Collection share + import actions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const shareCollection = useCallback(
+    async (input: {
+      collection: Collection;
+      boards: Dashboard[];
+    }): Promise<string> => {
+      if (!user) throw new Error('Not authenticated');
+      return sharedCollectionApi.shareCollection({
+        ...input,
+        hostUid: user.uid,
+        hostDisplayName: user.displayName,
+      });
+    },
+    [user, sharedCollectionApi]
+  );
+
+  const shareSubstituteCollection = useCallback(
+    async (
+      input: CollectionSubstituteShareInput & {
+        collection: Collection;
+        boards: Dashboard[];
+      }
+    ): Promise<string> => {
+      if (!user) throw new Error('Not authenticated');
+      return sharedCollectionApi.shareSubstituteCollection({
+        ...input,
+        hostUid: user.uid,
+        hostDisplayName: user.displayName,
+      });
+    },
+    [user, sharedCollectionApi]
+  );
+
+  const importSharedCollection = useCallback(
+    async (shareId: string): Promise<{ collectionId: string } | null> => {
+      if (!user) {
+        addToast('Must be signed in to import', 'error');
+        return null;
+      }
+      const meta = await sharedCollectionApi.loadSharedCollection(shareId);
+      if (!meta) {
+        addToast('Shared Collection not found or expired', 'error');
+        return null;
+      }
+      const boards = await sharedCollectionApi.loadSharedCollectionBoards(
+        shareId,
+        meta.boardIds
+      );
+      if (boards.length === 0) {
+        addToast('Shared Collection is empty', 'error');
+        return null;
+      }
+
+      try {
+        // Phase 1: create the recipient's Collection.
+        const newCollectionId = await collectionsApi.createCollection(
+          meta.collection.name,
+          null // root — recipient can move it later
+        );
+
+        // Phase 2: clone each Board into the new Collection. Each
+        // createNewDashboard fans out to a Firestore write; collect failures
+        // so the user sees a partial-success report instead of silent skips.
+        const importResults = await Promise.allSettled(
+          boards.map((b) =>
+            createNewDashboard(
+              `${b.name} (Imported)`,
+              { ...b, id: crypto.randomUUID() } as Dashboard,
+              { collectionId: newCollectionId }
+            )
+          )
+        );
+        const failed = importResults.filter(
+          (r) => r.status === 'rejected'
+        ).length;
+        const succeeded = boards.length - failed;
+        if (failed > 0) {
+          addToast(
+            `Imported ${succeeded.toString()} board(s) — ${failed.toString()} failed`,
+            'error'
+          );
+        } else {
+          addToast(`Imported Collection with ${succeeded.toString()} board(s)`);
+        }
+        return { collectionId: newCollectionId };
+      } catch (err) {
+        logError('DashboardContext.importSharedCollection', err, {
+          shareId,
+          boardCount: boards.length,
+        });
+        addToast('Failed to import shared Collection', 'error');
+        return null;
+      }
+    },
+    [user, addToast, sharedCollectionApi, collectionsApi, createNewDashboard]
+  );
+
   const saveCurrentDashboard = useCallback(async () => {
     if (!user) {
       addToast('Must be signed in to save', 'error');
@@ -4684,6 +4796,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentEditId,
       setPendingAssignmentEdit,
       clearPendingAssignmentEdit,
+      shareCollection,
+      shareSubstituteCollection,
+      loadSharedCollection: sharedCollectionApi.loadSharedCollection,
+      loadSharedCollectionBoards:
+        sharedCollectionApi.loadSharedCollectionBoards,
+      importSharedCollection,
+      pendingSharedCollectionId,
+      setPendingSharedCollectionId,
+      clearPendingSharedCollection,
       zoom,
       setZoom,
       annotationActive,
@@ -4795,6 +4916,14 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pendingAssignmentEditId,
       setPendingAssignmentEdit,
       clearPendingAssignmentEdit,
+      shareCollection,
+      shareSubstituteCollection,
+      sharedCollectionApi.loadSharedCollection,
+      sharedCollectionApi.loadSharedCollectionBoards,
+      importSharedCollection,
+      pendingSharedCollectionId,
+      setPendingSharedCollectionId,
+      clearPendingSharedCollection,
       zoom,
       setZoom,
       annotationActive,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3281,6 +3281,27 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         } else {
           addToast(`Imported Collection with ${succeeded.toString()} board(s)`);
         }
+
+        if (succeeded === 0) {
+          // All boards failed — delete the empty Collection rather than leaving
+          // a labeled-but-empty shell in the recipient's tree. The user will
+          // see the "No items could be imported" toast above; the Collection
+          // shouldn't linger.
+          try {
+            await collectionsApi.deleteCollection(
+              newCollectionId,
+              'delete-all'
+            );
+          } catch (cleanupErr) {
+            logError(
+              'DashboardContext.importSharedCollection.cleanup',
+              cleanupErr,
+              { newCollectionId }
+            );
+          }
+          return null;
+        }
+
         return { collectionId: newCollectionId };
       } catch (err) {
         logError('DashboardContext.importSharedCollection', err, {

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -14,6 +14,9 @@ import {
   AddWidgetOverrides,
   GridPosition,
   DrawableObject,
+  Collection,
+  CollectionSubstituteShareInput,
+  SharedCollection,
 } from '../types';
 import type { RosterCreateMeta } from '../hooks/useRosters';
 import type { GoogleDriveService } from '../utils/googleDriveService';
@@ -297,6 +300,29 @@ export interface DashboardContextValue {
   pendingAssignmentEditId: string | null;
   setPendingAssignmentEdit: (assignmentId: string | null) => void;
   clearPendingAssignmentEdit: () => void;
+
+  // Collection sharing system
+  shareCollection: (input: {
+    collection: Collection;
+    boards: Dashboard[];
+  }) => Promise<string>;
+  shareSubstituteCollection: (
+    input: CollectionSubstituteShareInput & {
+      collection: Collection;
+      boards: Dashboard[];
+    }
+  ) => Promise<string>;
+  loadSharedCollection: (shareId: string) => Promise<SharedCollection | null>;
+  loadSharedCollectionBoards: (
+    shareId: string,
+    boardIds: string[]
+  ) => Promise<Dashboard[]>;
+  importSharedCollection: (
+    shareId: string
+  ) => Promise<{ collectionId: string } | null>;
+  pendingSharedCollectionId: string | null;
+  setPendingSharedCollectionId: (id: string | null) => void;
+  clearPendingSharedCollection: () => void;
 
   // Roster system
   rosters: ClassRoster[];

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -139,7 +139,7 @@ export interface DashboardContextValue {
   createNewDashboard: (
     name: string,
     data?: Dashboard,
-    options?: { collectionId?: string | null }
+    options?: { collectionId?: string | null; silent?: boolean }
   ) => Promise<string | undefined>;
   saveCurrentDashboard: () => Promise<void>;
   deleteDashboard: (id: string) => Promise<void>;
@@ -319,7 +319,7 @@ export interface DashboardContextValue {
   ) => Promise<Dashboard[]>;
   importSharedCollection: (
     shareId: string
-  ) => Promise<{ collectionId: string } | null>;
+  ) => Promise<{ collectionId: string; firstBoardId: string | null } | null>;
   pendingSharedCollectionId: string | null;
   setPendingSharedCollectionId: (id: string | null) => void;
   clearPendingSharedCollection: () => void;

--- a/docs/superpowers/plans/2026-05-16-collections-sharing.md
+++ b/docs/superpowers/plans/2026-05-16-collections-sharing.md
@@ -1,0 +1,1967 @@
+# Collections Plan 3 — Collection-Level Sharing (Copy + Substitute View-Only)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a teacher share a whole Collection (the Collection metadata + every Board in it) with another teacher (Copy mode → recipient imports a full Collection into their own account) or with a substitute teacher (Substitute view-only → sub sees the Collection's Boards in the `/subs` portal for the host-chosen time window).
+
+**Architecture:** Mirrors Plan 1's existing single-Board share infrastructure (`/shared_boards/{shareId}` + `ShareLinkCreatorModal` + `/subs` portal). Adds a parallel `/shared_collections/{shareId}` Firestore path that stores Collection metadata in the parent doc and a frozen Board snapshot per child doc under `/shared_collections/{shareId}/boards/{boardId}` (subcollection avoids the 1MB Firestore doc limit for big Collections). Two share modes only — `copy` and `substitute`. No `synced` (live N-board mirroring is too heavy and out of scope per Plan 1/2 deferred notes).
+
+**Tech Stack:** React 19, TypeScript 5.9, Vite 6, Firestore (modular SDK), Vitest 4, @testing-library/react, Playwright, Tailwind CSS, lucide-react.
+
+**Builds on:** Plan 1 (Collections data layer + BoardsModal) and Plan 2 (Collection-aware navigation + mounted-set). Both merged on `dev-paul`.
+
+**Out of scope (covered by later plans):**
+
+- Plan 4: Collection templates (`/dashboard_templates/` with `type` discriminator).
+- `synced` (live-mirror) mode for Collections — N-board syncing is unbounded cost; defer indefinitely.
+- PLC-scoped Collection shares (`plcId` field) — Plan 1's single-Board sharing has it; Collection version deferred unless a teacher specifically asks.
+- Thumbnails on shared Collection cards.
+
+---
+
+## Files Created or Modified
+
+**New files:**
+
+- `hooks/useSharedCollection.ts` — Firestore CRUD: `shareCollection`, `loadSharedCollection`, `loadSharedCollectionBoards`, `importSharedCollection`, `shareSubstituteCollection`.
+- `tests/hooks/useSharedCollection.test.ts`
+- `components/share/ShareCollectionLinkCreatorModal.tsx` — host picks mode (copy / substitute) + (for substitute) expiresAt + buildingId + subEmails; emits share URL on success.
+- `tests/components/share/ShareCollectionLinkCreatorModal.test.tsx`
+- `components/share/ImportSharedCollectionModal.tsx` — recipient confirms import; on submit creates a new Collection + N Boards in their account, then navigates to the new Collection.
+- `tests/components/share/ImportSharedCollectionModal.test.tsx`
+- `components/subs/SubCollectionsList.tsx` — `/subs` UI extension that groups boards by their source Collection (when the underlying share was a Collection share) and surfaces a "Collection: <name>" section header.
+- `tests/components/subs/SubCollectionsList.test.tsx`
+- `tests/e2e/share-collection.spec.ts` — Playwright happy-path: host shares a 2-board Collection in copy mode → recipient imports → both boards present in the new Collection.
+
+**Modified files:**
+
+- `types.ts` — new `SharedCollection`, `SharedCollectionImportMode = 'copy' | 'substitute'`, `CollectionSubstituteShareInput`, `SharedCollectionBoardDoc`.
+- `firestore.rules` — new rule for `/shared_collections/{shareId}` and its subcollection `/shared_collections/{shareId}/boards/{boardId}`.
+- `context/DashboardContext.tsx` — wire the 4 new actions; add `pendingSharedCollectionId` state (parallels `pendingShareId`).
+- `context/DashboardContextValue.ts` — expose the new action types.
+- `components/boardsModal/CollectionContextMenu.tsx` — replace the existing `onMove: () => {}` placeholder with a real wire-up AND add a new `onShare` callback for "Share Collection…". (`onMove` is out of scope for Plan 3; we just stop having the placeholder be a dead arrow and route to a no-op toast for clarity.)
+- `components/boardsModal/BoardsModal.tsx` — wire the new `onShare`, mount `ShareCollectionLinkCreatorModal`.
+- `App.tsx` — new lazy route `/share-collection/:shareId` mounted in the teacher app shell.
+- `components/subs/SubsApp.tsx` — surface Collection-grouped shares via `SubCollectionsList`.
+- `locales/en.json` + `locales/de.json` + `locales/es.json` + `locales/fr.json` — new keys for share/import UX.
+
+---
+
+## Phase 0 — Types + Firestore Rules + Data Layer
+
+Foundation: types compile, rules permit owner/recipient access, hook is testable in isolation. No UI yet.
+
+### Task 0.1 — Add the `SharedCollection` types
+
+**Files:**
+
+- Modify: `types.ts` (insert near the existing `SharedBoardImportMode` / `SubstituteShareInput` definitions in `context/DashboardContextValue.ts` — but the new types live in `types.ts` itself for re-use across modules)
+
+- [ ] **Step 1: Find the right insertion point**
+
+Run `git grep -n "SharedBoardImportMode\|SubstituteShareInput" types.ts context/DashboardContextValue.ts` to confirm the home base. The single-Board sharing types live in `context/DashboardContextValue.ts`. For consistency, add the new Collection types ALSO in `types.ts` (so widgets can import them without depending on a context value module). Add them near the existing `Collection` interface (already in `types.ts` from Plan 1).
+
+- [ ] **Step 2: Add the types**
+
+In `types.ts`, after the existing `Collection` interface, insert:
+
+```typescript
+/**
+ * Mode applied to a shared-Collection import. NOT including 'synced' —
+ * live-mirroring N boards is unbounded cost. Substitute is a frozen,
+ * time-boxed view-only flavor used by the /subs portal.
+ */
+export type SharedCollectionImportMode = 'copy' | 'substitute';
+
+/**
+ * Frozen snapshot stored at `/shared_collections/{shareId}`. Each Board
+ * in the Collection is stored as a separate doc under
+ * `/shared_collections/{shareId}/boards/{boardId}` to dodge Firestore's
+ * 1MB-per-doc limit. The parent doc stores Collection metadata + an
+ * ordered `boardIds` list for the recipient flow.
+ */
+export interface SharedCollection {
+  shareId: string;
+  hostUid: string;
+  hostDisplayName: string | null;
+  intendedMode: SharedCollectionImportMode;
+  /** Frozen Collection metadata at share time (NOT the live Collection). */
+  collection: {
+    name: string;
+    color?: string;
+    icon?: string;
+  };
+  /** Ordered Board IDs — recipient reads from subcollection by these IDs. */
+  boardIds: string[];
+  /** ms epoch. */
+  createdAt: number;
+  /** Substitute-only: ms epoch when this share expires. */
+  expiresAt?: number;
+  /** Substitute-only: building id (config/buildings.ts) for /subs scoping. */
+  buildingId?: string;
+}
+
+/**
+ * One Board snapshot inside a Collection share. Stored at
+ * `/shared_collections/{shareId}/boards/{boardId}`. Mirrors the existing
+ * `Dashboard` shape minus any `linkedShareId`/`linkedShareRole` fields
+ * (a share-import is never itself a share host).
+ */
+export interface SharedCollectionBoardDoc {
+  boardId: string;
+  /** Frozen `Dashboard` at share time. */
+  dashboard: Dashboard;
+}
+
+/**
+ * Input to `shareSubstituteCollection()`. Mirrors `SubstituteShareInput`
+ * for single Boards but operates on a whole Collection.
+ */
+export interface CollectionSubstituteShareInput {
+  collectionId: string;
+  expiresAt: number;
+  buildingId: string;
+  subEmails?: string[];
+  rosterDriveFileIds?: string[];
+}
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+cd $(git rev-parse --show-toplevel)
+pnpm run type-check
+git add types.ts
+git commit -m "feat(types): add SharedCollection + CollectionSubstituteShareInput types"
+```
+
+### Task 0.2 — Firestore rules for `/shared_collections/{shareId}`
+
+**Files:**
+
+- Modify: `firestore.rules` — add the new rule block immediately after the existing `/shared_boards/{shareId}` block (around line 701).
+
+- [ ] **Step 1: Find the existing single-Board rule**
+
+Run `git grep -n "match /shared_boards" firestore.rules` to confirm the line number. Read 50 lines AROUND it to understand the existing pattern (host write, authenticated read, sub-domain read gating, etc.).
+
+- [ ] **Step 2: Write the new rule**
+
+Insert AFTER the closing `}` of the `match /shared_boards/{shareId}` block:
+
+```
+    // Collection-level shares — parent doc holds metadata, subcollection
+    // holds frozen Board snapshots. Same access semantics as
+    // /shared_boards/{shareId}: host writes, any authenticated user can
+    // read (the share URL is the access token), and substitute shares
+    // additionally check the `/subs` building gate via existing helpers.
+    match /shared_collections/{shareId} {
+      // READ: any authenticated user can fetch the metadata doc. Substitute
+      // shares are additionally gated by the existing isSubInBuilding()
+      // helper used by /shared_boards.
+      allow read: if request.auth != null
+        && (
+          resource.data.intendedMode != 'substitute'
+          || isSubInBuilding(resource.data.buildingId)
+        );
+
+      // CREATE: host must be authenticated, payload must have a valid
+      // hostUid matching request.auth.uid, a non-empty boardIds[], a
+      // non-empty collection.name, and intendedMode in the legal set.
+      allow create: if request.auth != null
+        && request.resource.data.hostUid == request.auth.uid
+        && request.resource.data.boardIds is list
+        && request.resource.data.boardIds.size() > 0
+        && request.resource.data.boardIds.size() <= 500
+        && request.resource.data.collection.name is string
+        && request.resource.data.collection.name.size() > 0
+        && request.resource.data.intendedMode in ['copy', 'substitute']
+        && (
+          request.resource.data.intendedMode != 'substitute'
+          || (
+            request.resource.data.buildingId is string
+            && request.resource.data.expiresAt is number
+            && request.resource.data.expiresAt > request.time.toMillis()
+          )
+        );
+
+      // UPDATE/DELETE: only the host. Substitute shares are immutable
+      // (frozen-at-creation) so we deny update for those.
+      allow update: if request.auth != null
+        && resource.data.hostUid == request.auth.uid
+        && resource.data.intendedMode == 'copy';
+
+      allow delete: if request.auth != null
+        && resource.data.hostUid == request.auth.uid;
+
+      // Per-Board snapshots. Same READ semantics as parent (anyone with
+      // share URL). WRITE is only allowed during the initial share
+      // creation — once the parent doc exists, the boards subcollection
+      // is read-only.
+      match /boards/{boardId} {
+        allow read: if request.auth != null
+          && (
+            get(/databases/$(database)/documents/shared_collections/$(shareId)).data.intendedMode != 'substitute'
+            || isSubInBuilding(get(/databases/$(database)/documents/shared_collections/$(shareId)).data.buildingId)
+          );
+
+        // Allow writes ONLY when the parent share doc was just created by
+        // this user. We can't distinguish "creation-time" from "later"
+        // cleanly without a transaction, so we require the writer to be
+        // the host. The client batches everything in a single writeBatch
+        // so all writes happen near-instantly after parent creation.
+        allow create: if request.auth != null
+          && get(/databases/$(database)/documents/shared_collections/$(shareId)).data.hostUid == request.auth.uid;
+
+        allow update, delete: if request.auth != null
+          && get(/databases/$(database)/documents/shared_collections/$(shareId)).data.hostUid == request.auth.uid;
+      }
+    }
+```
+
+- [ ] **Step 3: Rules tests** (use the existing test harness)
+
+Run `git grep -l "shared_boards" tests/firestore-rules/ 2>/dev/null` to find existing rules tests. Add a parallel test file `tests/firestore-rules/shared-collections.test.ts` mirroring the single-Board tests with `/shared_collections/{shareId}` paths. Cover:
+
+- Anonymous user cannot read.
+- Authenticated non-host user CAN read a `copy` share.
+- Authenticated user can read a `substitute` share ONLY if `isSubInBuilding(buildingId)` is true.
+- Host can create with valid payload; create rejected when `boardIds.size() == 0`, `intendedMode` is invalid, `substitute` without `expiresAt`, etc.
+- Update/delete: only host; substitute updates rejected.
+
+- [ ] **Step 4: Deploy + verify locally**
+
+```bash
+cd $(git rev-parse --show-toplevel)
+pnpm vitest run tests/firestore-rules/shared-collections.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add firestore.rules tests/firestore-rules/shared-collections.test.ts
+git commit -m "feat(rules): /shared_collections/{shareId} read/write rules + tests"
+```
+
+### Task 0.3 — `useSharedCollection` hook — write side
+
+**Files:**
+
+- Create: `hooks/useSharedCollection.ts`
+
+- [ ] **Step 1: Write the file (write actions only — read/import in Task 0.4)**
+
+```typescript
+/**
+ * useSharedCollection — Collection share lifecycle.
+ *
+ * Two writes (`shareCollection`, `shareSubstituteCollection`) and two
+ * reads (`loadSharedCollection`, `loadSharedCollectionBoards`) plus the
+ * recipient-side `importSharedCollection`. Mirrors the single-Board
+ * sharing surface in `useFirestore.shareDashboard` etc., but scoped to
+ * `/shared_collections/{shareId}`.
+ *
+ * The hook does NOT subscribe — Collection shares are one-shot writes/
+ * reads, not live-mirrored. No onSnapshot.
+ */
+
+import { useCallback } from 'react';
+import {
+  doc,
+  getDoc,
+  getDocs,
+  collection,
+  writeBatch,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import { logError } from '@/utils/logError';
+import type {
+  Dashboard,
+  SharedCollection,
+  SharedCollectionBoardDoc,
+  Collection as CollectionType,
+  CollectionSubstituteShareInput,
+} from '@/types';
+
+const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
+const SHARED_COLLECTION_BOARDS_SUBPATH = 'boards';
+
+interface ShareCollectionInput {
+  collection: CollectionType;
+  boards: Dashboard[];
+  hostUid: string;
+  hostDisplayName: string | null;
+}
+
+export const useSharedCollection = () => {
+  /**
+   * Host action: write the share metadata + every Board snapshot in a
+   * single writeBatch. Returns the new shareId.
+   *
+   * Chunking note: a `writeBatch` is capped at 500 operations. A Collection
+   * with > 499 Boards exceeds that (metadata + 499 boards = 500). We split
+   * into multiple batches if needed — boards are immutable post-creation,
+   * so partial-batch failure recovery is simple (delete the parent if any
+   * board batch fails).
+   */
+  const shareCollection = useCallback(
+    async (input: ShareCollectionInput): Promise<string> => {
+      const shareId = crypto.randomUUID();
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const now = Date.now();
+
+      const parentPayload: SharedCollection = {
+        shareId,
+        hostUid: input.hostUid,
+        hostDisplayName: input.hostDisplayName,
+        intendedMode: 'copy',
+        collection: {
+          name: input.collection.name,
+          ...(input.collection.color !== undefined && {
+            color: input.collection.color,
+          }),
+          ...(input.collection.icon !== undefined && {
+            icon: input.collection.icon,
+          }),
+        },
+        boardIds: input.boards.map((b) => b.id),
+        createdAt: now,
+      };
+
+      // BATCH_LIMIT 400 leaves headroom for the parent write in the first
+      // batch and for Firestore quirks. Boards are written by their
+      // existing id so the recipient can read them in the parent's
+      // boardIds order.
+      const BATCH_LIMIT = 400;
+      const allBoards = input.boards;
+      let firstBatch = writeBatch(db);
+      firstBatch.set(parentRef, parentPayload);
+
+      let inBatch = 1;
+      let currentBatch = firstBatch;
+      for (const board of allBoards) {
+        if (inBatch >= BATCH_LIMIT) {
+          await currentBatch.commit();
+          currentBatch = writeBatch(db);
+          inBatch = 0;
+        }
+        const boardRef = doc(
+          db,
+          SHARED_COLLECTIONS_SUBPATH,
+          shareId,
+          SHARED_COLLECTION_BOARDS_SUBPATH,
+          board.id
+        );
+        const boardPayload: SharedCollectionBoardDoc = {
+          boardId: board.id,
+          dashboard: board,
+        };
+        currentBatch.set(boardRef, boardPayload);
+        inBatch += 1;
+      }
+      if (inBatch > 0) await currentBatch.commit();
+
+      return shareId;
+    },
+    []
+  );
+
+  /**
+   * Host action: substitute variant. Identical to shareCollection except
+   * `intendedMode: 'substitute'`, adds `expiresAt` + `buildingId`, and
+   * defers Drive-grant work to the existing per-Board path (this plan
+   * does NOT implement Drive grants for Collection shares — too much
+   * surface area; out of scope per Plan 3 deferred notes).
+   */
+  const shareSubstituteCollection = useCallback(
+    async (
+      input: ShareCollectionInput & CollectionSubstituteShareInput
+    ): Promise<string> => {
+      // Implementation parallels shareCollection. Same chunked batch
+      // strategy. Adds substitute fields to the parent payload.
+      // (Implementer: copy the body of shareCollection, change
+      // `intendedMode` to 'substitute', add `expiresAt` + `buildingId`
+      // to the parent payload, set `parentPayload.collection` the same
+      // way, and reuse the same chunked-batch loop.)
+      const shareId = crypto.randomUUID();
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const now = Date.now();
+
+      const parentPayload: SharedCollection = {
+        shareId,
+        hostUid: input.hostUid,
+        hostDisplayName: input.hostDisplayName,
+        intendedMode: 'substitute',
+        collection: {
+          name: input.collection.name,
+          ...(input.collection.color !== undefined && {
+            color: input.collection.color,
+          }),
+          ...(input.collection.icon !== undefined && {
+            icon: input.collection.icon,
+          }),
+        },
+        boardIds: input.boards.map((b) => b.id),
+        createdAt: now,
+        expiresAt: input.expiresAt,
+        buildingId: input.buildingId,
+      };
+
+      const BATCH_LIMIT = 400;
+      let firstBatch = writeBatch(db);
+      firstBatch.set(parentRef, parentPayload);
+      let inBatch = 1;
+      let currentBatch = firstBatch;
+      for (const board of input.boards) {
+        if (inBatch >= BATCH_LIMIT) {
+          await currentBatch.commit();
+          currentBatch = writeBatch(db);
+          inBatch = 0;
+        }
+        const boardRef = doc(
+          db,
+          SHARED_COLLECTIONS_SUBPATH,
+          shareId,
+          SHARED_COLLECTION_BOARDS_SUBPATH,
+          board.id
+        );
+        const boardPayload: SharedCollectionBoardDoc = {
+          boardId: board.id,
+          dashboard: board,
+        };
+        currentBatch.set(boardRef, boardPayload);
+        inBatch += 1;
+      }
+      if (inBatch > 0) await currentBatch.commit();
+
+      return shareId;
+    },
+    []
+  );
+
+  return { shareCollection, shareSubstituteCollection };
+};
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add hooks/useSharedCollection.ts
+git commit -m "feat(sharing): useSharedCollection — write side (copy + substitute)"
+```
+
+### Task 0.4 — `useSharedCollection` hook — read + import side
+
+**Files:**
+
+- Modify: `hooks/useSharedCollection.ts`
+
+- [ ] **Step 1: Add `loadSharedCollection` + `loadSharedCollectionBoards` + `importSharedCollection`**
+
+Append inside the hook (before the `return { ... }`):
+
+```typescript
+/**
+ * Recipient action: fetch the share metadata doc. Returns null if not
+ * found, expired, or rejected by rules.
+ */
+const loadSharedCollection = useCallback(
+  async (shareId: string): Promise<SharedCollection | null> => {
+    try {
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const snap = await getDoc(parentRef);
+      if (!snap.exists()) return null;
+      const data = snap.data() as SharedCollection;
+      if (
+        data.intendedMode === 'substitute' &&
+        data.expiresAt &&
+        data.expiresAt < Date.now()
+      ) {
+        return null;
+      }
+      return data;
+    } catch (err) {
+      logError('useSharedCollection.loadSharedCollection', err, { shareId });
+      return null;
+    }
+  },
+  []
+);
+
+/**
+ * Recipient action: fetch every frozen Board snapshot in the share.
+ * Order respects the parent's `boardIds[]` so the recipient sees the
+ * same ordering as the host had at share time.
+ */
+const loadSharedCollectionBoards = useCallback(
+  async (shareId: string, boardIds: string[]): Promise<Dashboard[]> => {
+    // Use getDocs on the whole subcollection (1 query) then re-order
+    // by boardIds. Single-query is cheaper than N getDoc calls for
+    // moderate Collection sizes (< 30 Boards). For huge Collections
+    // the recipient may pay a few hundred ms; acceptable for one-shot
+    // import.
+    const colRef = collection(
+      db,
+      SHARED_COLLECTIONS_SUBPATH,
+      shareId,
+      SHARED_COLLECTION_BOARDS_SUBPATH
+    );
+    const snap = await getDocs(colRef);
+    const byId = new Map<string, Dashboard>();
+    for (const d of snap.docs) {
+      const data = d.data() as SharedCollectionBoardDoc;
+      byId.set(d.id, data.dashboard);
+    }
+    return boardIds
+      .map((id) => byId.get(id))
+      .filter((d): d is Dashboard => Boolean(d));
+  },
+  []
+);
+
+return {
+  shareCollection,
+  shareSubstituteCollection,
+  loadSharedCollection,
+  loadSharedCollectionBoards,
+};
+```
+
+- [ ] **Step 2: Add `importSharedCollection` — orchestrates everything for the recipient**
+
+This action is NOT inside `useSharedCollection.ts` — it depends on `DashboardContext`'s `createCollection` + `createNewDashboard`. Add it in Task 0.5 inside `DashboardContext.tsx` instead.
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add hooks/useSharedCollection.ts
+git commit -m "feat(sharing): useSharedCollection — read side (loadSharedCollection + boards)"
+```
+
+### Task 0.5 — Wire `importSharedCollection` into `DashboardContext`
+
+**Files:**
+
+- Modify: `context/DashboardContext.tsx`
+- Modify: `context/DashboardContextValue.ts`
+
+- [ ] **Step 1: Add the action in `DashboardContext.tsx`**
+
+Add inside `DashboardProvider` near the other share actions (search for `importSharedBoard`):
+
+```typescript
+const { collectionsApi } = useDashboard(); // already destructured nearby
+const { loadSharedCollection, loadSharedCollectionBoards } =
+  useSharedCollection();
+
+const importSharedCollection = useCallback(
+  async (shareId: string): Promise<{ collectionId: string } | null> => {
+    if (!user) {
+      addToast('Must be signed in to import', 'error');
+      return null;
+    }
+    const meta = await loadSharedCollection(shareId);
+    if (!meta) {
+      addToast(
+        t('shareCollection.notFound', {
+          defaultValue: 'Shared Collection not found or expired',
+        }),
+        'error'
+      );
+      return null;
+    }
+    const boards = await loadSharedCollectionBoards(shareId, meta.boardIds);
+    if (boards.length === 0) {
+      addToast(
+        t('shareCollection.empty', {
+          defaultValue: 'Shared Collection is empty',
+        }),
+        'error'
+      );
+      return null;
+    }
+
+    try {
+      // Phase 1: create the recipient's Collection.
+      const newCollectionId = await collectionsApi.createCollection(
+        meta.collection.name,
+        null // root — recipient can move it later
+      );
+
+      // Phase 2: clone each Board into the new Collection. Each
+      // createNewDashboard fans out to a Firestore write; collect failures
+      // so the user sees a partial-success report instead of silent skips.
+      const importResults = await Promise.allSettled(
+        boards.map((b) =>
+          createNewDashboard(
+            // Suffix avoids name collisions with the recipient's
+            // existing Boards. Plan 1's import-as-copy uses the same
+            // pattern.
+            `${b.name} (Imported)`,
+            { ...b, id: crypto.randomUUID() } as Dashboard,
+            { collectionId: newCollectionId }
+          )
+        )
+      );
+      const failed = importResults.filter(
+        (r) => r.status === 'rejected'
+      ).length;
+      const succeeded = boards.length - failed;
+      if (failed > 0) {
+        addToast(
+          t('shareCollection.partialImport', {
+            succeeded,
+            failed,
+            defaultValue: 'Imported {{succeeded}} board(s) — {{failed}} failed',
+          }),
+          'error'
+        );
+      } else {
+        addToast(
+          t('shareCollection.imported', {
+            count: succeeded,
+            defaultValue: 'Imported Collection with {{count}} board(s)',
+          })
+        );
+      }
+      return { collectionId: newCollectionId };
+    } catch (err) {
+      logError('DashboardContext.importSharedCollection', err, {
+        shareId,
+        boardCount: boards.length,
+      });
+      addToast(
+        t('shareCollection.importFailed', {
+          defaultValue: 'Failed to import shared Collection',
+        }),
+        'error'
+      );
+      return null;
+    }
+  },
+  [
+    user,
+    addToast,
+    t,
+    loadSharedCollection,
+    loadSharedCollectionBoards,
+    collectionsApi,
+    createNewDashboard,
+  ]
+);
+```
+
+- [ ] **Step 2: Add a state for `pendingSharedCollectionId`**
+
+Parallels `pendingShareId` (Plan 1's single-Board pending-share state). Used by the URL handler to surface the import modal:
+
+```typescript
+const [pendingSharedCollectionId, setPendingSharedCollectionId] = useState<
+  string | null
+>(null);
+
+const clearPendingSharedCollection = useCallback(() => {
+  setPendingSharedCollectionId(null);
+}, []);
+```
+
+- [ ] **Step 3: Expose on the context value**
+
+In `context/DashboardContextValue.ts` add:
+
+```typescript
+shareCollection: (input: {
+  collection: import('@/types').Collection;
+  boards: Dashboard[];
+}) => Promise<string>;
+shareSubstituteCollection: (
+  input: import('@/types').CollectionSubstituteShareInput & {
+    collection: import('@/types').Collection;
+    boards: Dashboard[];
+  }
+) => Promise<string>;
+importSharedCollection: (
+  shareId: string
+) => Promise<{ collectionId: string } | null>;
+pendingSharedCollectionId: string | null;
+setPendingSharedCollectionId: (id: string | null) => void;
+clearPendingSharedCollection: () => void;
+```
+
+Add the same to the useMemo return value(s) in `DashboardContext.tsx`. Wire `shareCollection` + `shareSubstituteCollection` to the corresponding `useSharedCollection()` returns (need to pass `user.uid` and `user.displayName` from `DashboardProvider` scope, which already destructures `user`).
+
+- [ ] **Step 4: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add context/DashboardContext.tsx context/DashboardContextValue.ts
+git commit -m "feat(sharing): wire Collection share + import actions into DashboardContext"
+```
+
+### Task 0.6 — Tests for the data layer
+
+**Files:**
+
+- Create: `tests/hooks/useSharedCollection.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('firebase/firestore', () => {
+  const batchedOps: Array<{ ref: { path: string }; data: unknown }> = [];
+  const docs = new Map<string, unknown>();
+  return {
+    doc: vi.fn((db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    collection: vi.fn((db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    getDoc: vi.fn(async (ref: { path: string }) => ({
+      exists: () => docs.has(ref.path),
+      data: () => docs.get(ref.path),
+    })),
+    getDocs: vi.fn(async () => ({
+      docs: Array.from(docs.entries())
+        .filter(([path]) => path.includes('/boards/'))
+        .map(([path, data]) => ({
+          id: path.split('/').pop()!,
+          data: () => data,
+        })),
+    })),
+    writeBatch: vi.fn(() => ({
+      set: vi.fn((ref: { path: string }, data: unknown) => {
+        batchedOps.push({ ref, data });
+        docs.set(ref.path, data);
+      }),
+      commit: vi.fn(async () => undefined),
+    })),
+    Timestamp: { now: () => ({ toMillis: () => 1000 }) },
+    __testHelpers: {
+      docs,
+      batchedOps,
+      reset: () => {
+        docs.clear();
+        batchedOps.length = 0;
+      },
+    },
+  };
+});
+
+vi.mock('@/config/firebase', () => ({ db: {} }));
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+import { useSharedCollection } from '@/hooks/useSharedCollection';
+import type { Collection, Dashboard } from '@/types';
+
+const dashboard = (id: string): Dashboard => ({
+  id,
+  name: `Board ${id}`,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: 'src-collection',
+});
+
+const sourceCollection = (): Collection => ({
+  id: 'src-collection',
+  name: 'Source',
+  parentCollectionId: null,
+  order: 0,
+  createdAt: 0,
+  color: '#ad2122',
+});
+
+describe('useSharedCollection', () => {
+  beforeEach(async () => {
+    const mod = await vi.importMock('firebase/firestore');
+    (mod as { __testHelpers: { reset: () => void } }).__testHelpers.reset();
+  });
+
+  it('shareCollection writes parent + N boards and returns a shareId', async () => {
+    const { result } = renderHook(() => useSharedCollection());
+    const shareId = await result.current.shareCollection({
+      collection: sourceCollection(),
+      boards: [dashboard('b1'), dashboard('b2')],
+      hostUid: 'host-uid',
+      hostDisplayName: 'Mr. Teacher',
+    });
+    expect(shareId).toMatch(/^[0-9a-f-]{36}$/);
+    // Verify the parent payload made it into the mock store
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    const parent = mod.__testHelpers.docs.get(
+      `shared_collections/${shareId}`
+    ) as { boardIds: string[]; intendedMode: string };
+    expect(parent.boardIds).toEqual(['b1', 'b2']);
+    expect(parent.intendedMode).toBe('copy');
+  });
+
+  it('shareSubstituteCollection sets intendedMode=substitute + expiresAt', async () => {
+    const { result } = renderHook(() => useSharedCollection());
+    const shareId = await result.current.shareSubstituteCollection({
+      collection: sourceCollection(),
+      boards: [dashboard('b1')],
+      hostUid: 'host-uid',
+      hostDisplayName: 'Mr. Teacher',
+      collectionId: 'src-collection',
+      expiresAt: 9999999999999,
+      buildingId: 'middle-school',
+    });
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    const parent = mod.__testHelpers.docs.get(
+      `shared_collections/${shareId}`
+    ) as { intendedMode: string; expiresAt: number };
+    expect(parent.intendedMode).toBe('substitute');
+    expect(parent.expiresAt).toBe(9999999999999);
+  });
+
+  it('loadSharedCollection returns null for an expired substitute share', async () => {
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    mod.__testHelpers.docs.set('shared_collections/expired', {
+      shareId: 'expired',
+      intendedMode: 'substitute',
+      expiresAt: Date.now() - 1000,
+      boardIds: [],
+      collection: { name: 'gone' },
+    });
+    const { result } = renderHook(() => useSharedCollection());
+    const meta = await result.current.loadSharedCollection('expired');
+    expect(meta).toBeNull();
+  });
+
+  it('loadSharedCollectionBoards returns boards in boardIds order', async () => {
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    mod.__testHelpers.docs.set('shared_collections/s1/boards/b1', {
+      boardId: 'b1',
+      dashboard: dashboard('b1'),
+    });
+    mod.__testHelpers.docs.set('shared_collections/s1/boards/b2', {
+      boardId: 'b2',
+      dashboard: dashboard('b2'),
+    });
+    const { result } = renderHook(() => useSharedCollection());
+    const boards = await result.current.loadSharedCollectionBoards('s1', [
+      'b2',
+      'b1',
+    ]);
+    expect(boards.map((b) => b.id)).toEqual(['b2', 'b1']);
+  });
+});
+```
+
+- [ ] **Step 2: Run + verify**
+
+```bash
+pnpm vitest run tests/hooks/useSharedCollection.test.ts
+```
+
+Expected: 4 passing tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/hooks/useSharedCollection.test.ts
+git commit -m "test(sharing): cover useSharedCollection write/read/import paths"
+```
+
+---
+
+## Phase 1 — Share-creation UI (host side)
+
+### Task 1.1 — `ShareCollectionLinkCreatorModal`
+
+**Files:**
+
+- Create: `components/share/ShareCollectionLinkCreatorModal.tsx`
+
+- [ ] **Step 1: Read the existing `ShareLinkCreatorModal` first**
+
+Run `cat components/share/ShareLinkCreatorModal.tsx | head -120` and identify:
+
+- How it surfaces the mode picker (3 options for Boards)
+- How it calls `shareDashboard()` then renders the result panel with the share URL
+- The clipboard auto-copy pattern
+
+The Collection version mirrors this with TWO modes instead of three (no 'synced') and an additional substitute-only section for `expiresAt` + `buildingId`.
+
+- [ ] **Step 2: Write the file**
+
+```tsx
+import { type FC, useState, useId, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder, Copy, UserCheck } from 'lucide-react';
+import type { Collection, Dashboard } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+
+interface ShareCollectionLinkCreatorModalProps {
+  isOpen: boolean;
+  collection: Collection | null;
+  /** Boards currently in the Collection. Frozen at modal open. */
+  boards: Dashboard[];
+  onClose: () => void;
+}
+
+type ModeChoice = 'copy' | 'substitute';
+
+const SUB_TTL_PRESETS: { label: string; ms: number }[] = [
+  { label: '4 hours', ms: 4 * 60 * 60 * 1000 },
+  { label: '1 day', ms: 24 * 60 * 60 * 1000 },
+  { label: '3 days', ms: 3 * 24 * 60 * 60 * 1000 },
+  { label: '1 week', ms: 7 * 24 * 60 * 60 * 1000 },
+];
+
+export const ShareCollectionLinkCreatorModal: FC<
+  ShareCollectionLinkCreatorModalProps
+> = ({ isOpen, collection, boards, onClose }) => {
+  const { t } = useTranslation();
+  const { shareCollection, shareSubstituteCollection, addToast } =
+    useDashboard();
+  const [mode, setMode] = useState<ModeChoice>('copy');
+  const [ttlMs, setTtlMs] = useState<number>(SUB_TTL_PRESETS[1].ms);
+  const [buildingId, setBuildingId] = useState<string>('');
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const headingId = useId();
+
+  const handleCreate = useCallback(async () => {
+    if (!collection) return;
+    setBusy(true);
+    try {
+      let shareId: string;
+      if (mode === 'copy') {
+        shareId = await shareCollection({ collection, boards });
+      } else {
+        if (!buildingId) {
+          addToast(
+            t('shareCollection.buildingRequired', {
+              defaultValue: 'Select a building before sharing with a sub.',
+            }),
+            'error'
+          );
+          setBusy(false);
+          return;
+        }
+        shareId = await shareSubstituteCollection({
+          collection,
+          boards,
+          collectionId: collection.id,
+          expiresAt: Date.now() + ttlMs,
+          buildingId,
+        });
+      }
+      const url = `${window.location.origin}/share-collection/${shareId}`;
+      setShareUrl(url);
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch {
+        // clipboard may be blocked — URL is still shown in the input
+      }
+    } catch (err) {
+      addToast(
+        t('shareCollection.createFailed', {
+          defaultValue: 'Failed to create Collection share',
+        }),
+        'error'
+      );
+      setBusy(false);
+      return;
+    }
+    setBusy(false);
+  }, [
+    mode,
+    ttlMs,
+    buildingId,
+    collection,
+    boards,
+    shareCollection,
+    shareSubstituteCollection,
+    addToast,
+    t,
+  ]);
+
+  if (!isOpen || !collection) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <div className="p-5 border-b border-slate-100 flex items-center gap-2">
+          <Folder
+            className="w-5 h-5 flex-shrink-0"
+            style={collection.color ? { color: collection.color } : undefined}
+          />
+          <h2 id={headingId} className="text-lg font-bold text-slate-800">
+            {t('shareCollection.title', {
+              defaultValue: 'Share Collection',
+            })}
+            : <span className="font-normal">{collection.name}</span>
+          </h2>
+        </div>
+
+        {!shareUrl && (
+          <div className="p-5 space-y-4">
+            <p className="text-sm text-slate-600">
+              {t('shareCollection.subtitle', {
+                count: boards.length,
+                defaultValue:
+                  'Sharing {{count}} board(s) from this Collection.',
+              })}
+            </p>
+            <fieldset className="space-y-2">
+              <legend className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                {t('shareCollection.mode', { defaultValue: 'Share Mode' })}
+              </legend>
+              <label className="flex items-start gap-2 p-3 rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50">
+                <input
+                  type="radio"
+                  name="mode"
+                  checked={mode === 'copy'}
+                  onChange={() => setMode('copy')}
+                  className="mt-1"
+                />
+                <span className="flex-1">
+                  <span className="flex items-center gap-1 text-sm font-bold text-slate-800">
+                    <Copy className="w-3.5 h-3.5" />
+                    {t('shareCollection.copyMode', { defaultValue: 'Copy' })}
+                  </span>
+                  <span className="block text-xs text-slate-500 mt-0.5">
+                    {t('shareCollection.copyModeHint', {
+                      defaultValue:
+                        'Recipient imports a full copy into their account.',
+                    })}
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-2 p-3 rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50">
+                <input
+                  type="radio"
+                  name="mode"
+                  checked={mode === 'substitute'}
+                  onChange={() => setMode('substitute')}
+                  className="mt-1"
+                />
+                <span className="flex-1">
+                  <span className="flex items-center gap-1 text-sm font-bold text-slate-800">
+                    <UserCheck className="w-3.5 h-3.5" />
+                    {t('shareCollection.substituteMode', {
+                      defaultValue: 'Substitute (view-only)',
+                    })}
+                  </span>
+                  <span className="block text-xs text-slate-500 mt-0.5">
+                    {t('shareCollection.substituteModeHint', {
+                      defaultValue:
+                        'A sub teacher sees the Collection in /subs for the window you choose.',
+                    })}
+                  </span>
+                </span>
+              </label>
+            </fieldset>
+
+            {mode === 'substitute' && (
+              <div className="space-y-3 p-3 rounded-lg bg-slate-50 border border-slate-200">
+                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  {t('shareCollection.expiresIn', {
+                    defaultValue: 'Expires in',
+                  })}
+                </label>
+                <div className="grid grid-cols-4 gap-1">
+                  {SUB_TTL_PRESETS.map((p) => (
+                    <button
+                      key={p.ms}
+                      type="button"
+                      onClick={() => setTtlMs(p.ms)}
+                      className={`text-xxs font-bold py-1.5 rounded-md transition-colors ${
+                        ttlMs === p.ms
+                          ? 'bg-brand-blue-primary text-white'
+                          : 'bg-white text-slate-600 hover:bg-slate-100 border border-slate-200'
+                      }`}
+                    >
+                      {p.label}
+                    </button>
+                  ))}
+                </div>
+                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  {t('shareCollection.building', { defaultValue: 'Building' })}
+                </label>
+                <input
+                  type="text"
+                  value={buildingId}
+                  onChange={(e) => setBuildingId(e.target.value)}
+                  placeholder="e.g. middle-school"
+                  className="w-full px-2 py-1 text-sm border border-slate-300 rounded"
+                />
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 rounded"
+              >
+                {t('common.cancel', { defaultValue: 'Cancel' })}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleCreate()}
+                disabled={busy}
+                className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark disabled:opacity-50"
+              >
+                {busy
+                  ? t('shareCollection.creating', {
+                      defaultValue: 'Creating…',
+                    })
+                  : t('shareCollection.createLink', {
+                      defaultValue: 'Create link',
+                    })}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {shareUrl && (
+          <div className="p-5 space-y-3">
+            <p className="text-sm text-slate-600">
+              {t('shareCollection.linkReady', {
+                defaultValue: 'Share link copied to clipboard.',
+              })}
+            </p>
+            <input
+              type="text"
+              readOnly
+              value={shareUrl}
+              aria-label={t('shareCollection.urlLabel', {
+                defaultValue: 'Share collection URL',
+              })}
+              className="w-full px-2 py-1.5 text-xs font-mono bg-slate-50 border border-slate-200 rounded select-all"
+              onFocus={(e) => e.currentTarget.select()}
+            />
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark"
+              >
+                {t('common.done', { defaultValue: 'Done' })}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/share/ShareCollectionLinkCreatorModal.tsx
+git commit -m "feat(sharing): add ShareCollectionLinkCreatorModal"
+```
+
+### Task 1.2 — Tests for `ShareCollectionLinkCreatorModal`
+
+**Files:**
+
+- Create: `tests/components/share/ShareCollectionLinkCreatorModal.test.tsx`
+
+- [ ] **Step 1: Write tests covering**
+
+- Renders nothing when `!isOpen` or `!collection`
+- Shows mode picker with two options (Copy + Substitute), Copy selected by default
+- Switching to Substitute reveals expiresIn presets + building input
+- Clicking "Create link" with Substitute mode + empty building shows error toast
+- Clicking "Create link" with Copy mode calls `shareCollection` and shows the URL panel
+
+Use mock implementations of `useDashboard()` exposing the share functions as `vi.fn()`.
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+pnpm vitest run tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+git add tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+git commit -m "test(sharing): cover ShareCollectionLinkCreatorModal modes + URL flow"
+```
+
+### Task 1.3 — Wire "Share Collection…" into `CollectionContextMenu`
+
+**Files:**
+
+- Modify: `components/boardsModal/CollectionContextMenu.tsx`
+- Modify: `components/boardsModal/BoardsModal.tsx`
+
+- [ ] **Step 1: Add `onShare` to `CollectionContextMenuProps`**
+
+```typescript
+interface CollectionContextMenuProps {
+  // ... existing props
+  canShare: boolean;
+  onShare: () => void;
+}
+```
+
+Add the menu item conditionally (matches BoardContextMenu's `canShare` gating from Plan 1):
+
+```typescript
+if (canShare) {
+  items.push({
+    label: t('collectionMenu.share', { defaultValue: 'Share Collection…' }),
+    icon: Share2,
+    action: onShare,
+  });
+}
+```
+
+Import `Share2` from `lucide-react`.
+
+- [ ] **Step 2: Wire it in `BoardsModal.tsx`**
+
+Find the `<CollectionContextMenu ... />` render. Add new state for the share modal target, render the modal, and pass `onShare`:
+
+```tsx
+const [shareCollectionTarget, setShareCollectionTarget] =
+  useState<Collection | null>(null);
+
+// In the CollectionContextMenu render:
+<CollectionContextMenu
+  /* ...existing props... */
+  canShare={canShare}
+  onShare={() => setShareCollectionTarget(c)}
+/>;
+
+// At the modal-render layer of BoardsModal (alongside ShareLinkCreatorModal):
+{
+  shareCollectionTarget && (
+    <ShareCollectionLinkCreatorModal
+      isOpen
+      collection={shareCollectionTarget}
+      boards={dashboards.filter(
+        (d) => (d.collectionId ?? null) === shareCollectionTarget.id
+      )}
+      onClose={() => setShareCollectionTarget(null)}
+    />
+  );
+}
+```
+
+- [ ] **Step 3: Type-check + verify**
+
+```bash
+pnpm run type-check
+pnpm test
+```
+
+Expected: clean. Tests for `BoardsModal` that don't mock the share modal will simply ignore the new branch since `shareCollectionTarget` defaults to null.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add components/boardsModal/CollectionContextMenu.tsx components/boardsModal/BoardsModal.tsx
+git commit -m "feat(sharing): wire 'Share Collection…' context-menu item + modal"
+```
+
+---
+
+## Phase 2 — Recipient flow: Copy mode
+
+### Task 2.1 — `ImportSharedCollectionModal`
+
+**Files:**
+
+- Create: `components/share/ImportSharedCollectionModal.tsx`
+
+- [ ] **Step 1: Write the modal**
+
+Single-step (no mode picker because only Copy is offered for recipient import — Substitute shares are consumed by `/subs`):
+
+```tsx
+import { type FC, useState, useEffect, useId } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder } from 'lucide-react';
+import { useDashboard } from '@/context/useDashboard';
+import type { SharedCollection } from '@/types';
+
+interface ImportSharedCollectionModalProps {
+  shareId: string;
+  onClose: () => void;
+  onImported: (collectionId: string) => void;
+}
+
+export const ImportSharedCollectionModal: FC<
+  ImportSharedCollectionModalProps
+> = ({ shareId, onClose, onImported }) => {
+  const { t } = useTranslation();
+  const { importSharedCollection } = useDashboard();
+  const [meta, setMeta] = useState<SharedCollection | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const headingId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    // useSharedCollection's loadSharedCollection is exposed via the hook,
+    // not via DashboardContext. Inline the call here via a fresh hook
+    // call — the read is one-shot so no instance leakage.
+    void (async () => {
+      const { useSharedCollection } =
+        await import('@/hooks/useSharedCollection');
+      const tempHook = useSharedCollection();
+      const result = await tempHook.loadSharedCollection(shareId);
+      if (!cancelled) {
+        setMeta(result);
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId]);
+
+  const handleImport = async () => {
+    if (!meta) return;
+    setBusy(true);
+    const result = await importSharedCollection(shareId);
+    setBusy(false);
+    if (result) {
+      onImported(result.collectionId);
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-modal bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={headingId}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md">
+        <div className="p-5 border-b border-slate-100 flex items-center gap-2">
+          <Folder
+            className="w-5 h-5 flex-shrink-0"
+            style={
+              meta?.collection.color
+                ? { color: meta.collection.color }
+                : undefined
+            }
+          />
+          <h2 id={headingId} className="text-lg font-bold text-slate-800">
+            {t('importSharedCollection.title', {
+              defaultValue: 'Import shared Collection',
+            })}
+          </h2>
+        </div>
+        <div className="p-5 space-y-3">
+          {loading && (
+            <p className="text-sm text-slate-500">
+              {t('importSharedCollection.loading', {
+                defaultValue: 'Loading shared Collection…',
+              })}
+            </p>
+          )}
+          {!loading && !meta && (
+            <p className="text-sm text-red-600">
+              {t('importSharedCollection.notFound', {
+                defaultValue: 'Shared Collection not found or expired.',
+              })}
+            </p>
+          )}
+          {!loading && meta && (
+            <>
+              <p className="text-sm text-slate-800">
+                <span className="font-bold">{meta.collection.name}</span>{' '}
+                <span className="text-slate-500">
+                  (
+                  {t('importSharedCollection.boardCount', {
+                    count: meta.boardIds.length,
+                    defaultValue: '{{count}} board(s)',
+                  })}
+                  )
+                </span>
+              </p>
+              {meta.hostDisplayName && (
+                <p className="text-xs text-slate-500">
+                  {t('importSharedCollection.shared', {
+                    name: meta.hostDisplayName,
+                    defaultValue: 'Shared by {{name}}',
+                  })}
+                </p>
+              )}
+            </>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-100 rounded"
+            >
+              {t('common.cancel', { defaultValue: 'Cancel' })}
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleImport()}
+              disabled={busy || loading || !meta}
+              className="px-3 py-1.5 text-sm font-bold bg-brand-blue-primary text-white rounded hover:bg-brand-blue-dark disabled:opacity-50"
+            >
+              {busy
+                ? t('importSharedCollection.importing', {
+                    defaultValue: 'Importing…',
+                  })
+                : t('importSharedCollection.import', {
+                    defaultValue: 'Import Collection',
+                  })}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+```
+
+> **Implementation note for the engineer.** The inline `await import('@/hooks/useSharedCollection')` + `useSharedCollection()` call inside a `useEffect` is technically a React hooks-rules violation (calling a hook outside a component body). React WILL complain in dev. The cleanest fix is to hoist `loadSharedCollection` to `DashboardContext` (alongside `loadSharedDashboard`) so the modal calls `useDashboard().loadSharedCollection(...)`. Refactor before commit:
+>
+> 1. In `context/DashboardContext.tsx`, add `const sharedCollectionApi = useSharedCollection();` and expose `loadSharedCollection: sharedCollectionApi.loadSharedCollection` on the context value (like Plan 2 did for `collectionsApi`).
+> 2. In `ImportSharedCollectionModal`, replace the inline `await import` with `const { loadSharedCollection, importSharedCollection } = useDashboard();` and call it directly inside a normal `useEffect`.
+>
+> The plan template above is intentionally explicit about the hooks-rules issue so the engineer doesn't ship the broken version.
+
+- [ ] **Step 2: Apply the implementation note** — refactor to use context
+
+In `context/DashboardContext.tsx` (alongside the Phase 0.5 wiring):
+
+```typescript
+const sharedCollectionApi = useSharedCollection();
+// ... and expose on value:
+//   loadSharedCollection: sharedCollectionApi.loadSharedCollection,
+//   loadSharedCollectionBoards: sharedCollectionApi.loadSharedCollectionBoards,
+//   shareCollection: (input) => sharedCollectionApi.shareCollection({ ...input, hostUid: user.uid, hostDisplayName: user.displayName }),
+//   shareSubstituteCollection: (input) => sharedCollectionApi.shareSubstituteCollection({ ...input, hostUid: user.uid, hostDisplayName: user.displayName }),
+```
+
+In `context/DashboardContextValue.ts` add:
+
+```typescript
+loadSharedCollection: (shareId: string) =>
+  Promise<import('@/types').SharedCollection | null>;
+loadSharedCollectionBoards: (shareId: string, boardIds: string[]) =>
+  Promise<Dashboard[]>;
+```
+
+Rewrite the `ImportSharedCollectionModal` `useEffect` to use the context:
+
+```typescript
+const { loadSharedCollection, importSharedCollection } = useDashboard();
+useEffect(() => {
+  let cancelled = false;
+  void loadSharedCollection(shareId).then((result) => {
+    if (!cancelled) {
+      setMeta(result);
+      setLoading(false);
+    }
+  });
+  return () => {
+    cancelled = true;
+  };
+}, [shareId, loadSharedCollection]);
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add components/share/ImportSharedCollectionModal.tsx context/DashboardContext.tsx context/DashboardContextValue.ts
+git commit -m "feat(sharing): ImportSharedCollectionModal + context exposure of loadSharedCollection"
+```
+
+### Task 2.2 — Route `/share-collection/:shareId` + URL handler
+
+**Files:**
+
+- Modify: `App.tsx`
+
+- [ ] **Step 1: Add the lazy route alongside the existing `/share/:shareId` route**
+
+Find the existing `/share/:shareId` route in `App.tsx`. Add a parallel:
+
+```tsx
+<Route
+  path="/share-collection/:shareId"
+  element={<SharedCollectionRedirector />}
+/>
+```
+
+Where `SharedCollectionRedirector` is a small wrapper that reads `shareId` from `useParams()` and calls `setPendingSharedCollectionId` on `DashboardContext`:
+
+```tsx
+import { useParams, Navigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useDashboard } from '@/context/useDashboard';
+
+const SharedCollectionRedirector: FC = () => {
+  const { shareId } = useParams<{ shareId: string }>();
+  const { setPendingSharedCollectionId } = useDashboard();
+  useEffect(() => {
+    if (shareId) setPendingSharedCollectionId(shareId);
+  }, [shareId, setPendingSharedCollectionId]);
+  return <Navigate to="/" replace />;
+};
+```
+
+(Defined inline in `App.tsx` for brevity. Alternatively, factor out to `components/share/SharedCollectionRedirector.tsx` if `App.tsx` is getting heavy.)
+
+- [ ] **Step 2: Mount the import modal at the app shell when `pendingSharedCollectionId` is set**
+
+Find where the existing `ImportShareModePicker` is mounted (look in `components/layout/DashboardView.tsx` or wherever the single-Board pending-share flow is mounted). Add a parallel mount:
+
+```tsx
+const {
+  pendingSharedCollectionId,
+  clearPendingSharedCollection,
+  loadDashboard,
+  dashboards,
+} = useDashboard();
+
+// ...in the JSX tree:
+{
+  pendingSharedCollectionId && (
+    <ImportSharedCollectionModal
+      shareId={pendingSharedCollectionId}
+      onClose={clearPendingSharedCollection}
+      onImported={(newCollectionId) => {
+        // Navigate to the first Board of the newly-created Collection
+        // so the user sees their import landed somewhere.
+        const firstBoard = dashboards.find(
+          (d) => (d.collectionId ?? null) === newCollectionId
+        );
+        if (firstBoard) loadDashboard(firstBoard.id);
+      }}
+    />
+  );
+}
+```
+
+- [ ] **Step 3: Type-check + commit**
+
+```bash
+pnpm run type-check
+git add App.tsx components/layout/DashboardView.tsx
+git commit -m "feat(sharing): /share-collection/:shareId route + mount import modal"
+```
+
+---
+
+## Phase 3 — Recipient flow: Substitute mode (extend `/subs` portal)
+
+### Task 3.1 — Extend `/subs` to list shared Collections
+
+**Files:**
+
+- Create: `components/subs/SubCollectionsList.tsx`
+- Modify: `components/subs/SubsApp.tsx`
+
+- [ ] **Step 1: Read the existing `/subs` listing code**
+
+Run `grep -n "shared_boards\|substitute" components/subs/SubsApp.tsx hooks/useSubsView.ts utils/subsView.ts` to find how single-Board substitute shares are surfaced today. The sub-portal already has a directory of teachers + their shared boards. We'll add a "Collections" section per teacher.
+
+- [ ] **Step 2: Write `SubCollectionsList`**
+
+```tsx
+import { type FC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Folder } from 'lucide-react';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import { logError } from '@/utils/logError';
+import type { SharedCollection } from '@/types';
+
+interface SubCollectionsListProps {
+  buildingId: string;
+  /** Called when the sub clicks a Board within a shared Collection. */
+  onOpenBoard: (shareId: string, boardId: string) => void;
+}
+
+export const SubCollectionsList: FC<SubCollectionsListProps> = ({
+  buildingId,
+  onOpenBoard,
+}) => {
+  const { t } = useTranslation();
+  const [collections, setCollections] = useState<SharedCollection[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const q = query(
+          collection(db, 'shared_collections'),
+          where('intendedMode', '==', 'substitute'),
+          where('buildingId', '==', buildingId),
+          where('expiresAt', '>', Date.now())
+        );
+        const snap = await getDocs(q);
+        if (cancelled) return;
+        setCollections(snap.docs.map((d) => d.data() as SharedCollection));
+      } catch (err) {
+        logError('SubCollectionsList.load', err, { buildingId });
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [buildingId]);
+
+  if (loading) {
+    return (
+      <p className="text-sm text-slate-500 italic">
+        {t('subCollections.loading', {
+          defaultValue: 'Loading shared Collections…',
+        })}
+      </p>
+    );
+  }
+
+  if (collections.length === 0) {
+    return null; // no Collections shared → render nothing (Boards-only flow unaffected)
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-bold text-slate-700 uppercase tracking-wider">
+        {t('subCollections.heading', { defaultValue: 'Collections' })}
+      </h3>
+      {collections.map((c) => (
+        <div
+          key={c.shareId}
+          className="rounded-xl border border-slate-200 bg-white p-3"
+        >
+          <div className="flex items-center gap-2 mb-2">
+            <Folder
+              className="w-4 h-4 flex-shrink-0"
+              style={
+                c.collection.color ? { color: c.collection.color } : undefined
+              }
+            />
+            <span className="text-sm font-bold text-slate-800">
+              {c.collection.name}
+            </span>
+            <span className="ml-auto text-xxs text-slate-400">
+              {t('subCollections.boardCount', {
+                count: c.boardIds.length,
+                defaultValue: '{{count}} board(s)',
+              })}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {c.boardIds.map((boardId) => (
+              <button
+                key={boardId}
+                type="button"
+                onClick={() => onOpenBoard(c.shareId, boardId)}
+                className="text-left px-2 py-1.5 text-xs rounded-md bg-slate-50 hover:bg-slate-100 border border-slate-200"
+              >
+                {/* Sub doesn't see the Board name without loading the
+                    sub-doc; show a placeholder + boardId tail. The full
+                    Board name appears on click after loading. */}
+                {t('subCollections.boardPlaceholder', {
+                  id: boardId.slice(-4),
+                  defaultValue: 'Board …{{id}}',
+                })}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+};
+```
+
+- [ ] **Step 3: Mount in `SubsApp.tsx`**
+
+Find the existing board-list render. Add `<SubCollectionsList buildingId={...} onOpenBoard={...} />` above or below it. The sub-portal's existing routing/state knows how to render a single Board once selected; for Collections, the click handler will need to load the per-Board sub-doc via `useSharedCollection().loadSharedCollectionBoards(shareId, [boardId])` and render it via the existing single-Board view.
+
+- [ ] **Step 4: Commit**
+
+```bash
+pnpm run type-check
+git add components/subs/SubCollectionsList.tsx components/subs/SubsApp.tsx
+git commit -m "feat(subs): surface shared Collections in /subs portal"
+```
+
+### Task 3.2 — Tests for `SubCollectionsList`
+
+**Files:**
+
+- Create: `tests/components/subs/SubCollectionsList.test.tsx`
+
+- [ ] **Step 1: Mock `firebase/firestore` + write tests**
+
+Cover:
+
+- Renders "Loading…" while pending
+- Renders nothing when no Collections returned
+- Renders one section per Collection with name + board count
+- Clicking a board button calls `onOpenBoard(shareId, boardId)`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/components/subs/SubCollectionsList.test.tsx
+git commit -m "test(subs): cover SubCollectionsList render + click"
+```
+
+---
+
+## Phase 4 — i18n + E2E + acceptance
+
+### Task 4.1 — Add the i18n keys
+
+**Files:**
+
+- Modify: `locales/en.json`, `locales/de.json`, `locales/es.json`, `locales/fr.json`
+
+- [ ] **Step 1: Append new top-level groups** (English values; non-en files use the same English strings as Plan 1/2 convention)
+
+```json
+"shareCollection": {
+  "title": "Share Collection",
+  "subtitle": "Sharing {{count}} board(s) from this Collection.",
+  "mode": "Share Mode",
+  "copyMode": "Copy",
+  "copyModeHint": "Recipient imports a full copy into their account.",
+  "substituteMode": "Substitute (view-only)",
+  "substituteModeHint": "A sub teacher sees the Collection in /subs for the window you choose.",
+  "expiresIn": "Expires in",
+  "building": "Building",
+  "buildingRequired": "Select a building before sharing with a sub.",
+  "createLink": "Create link",
+  "creating": "Creating…",
+  "createFailed": "Failed to create Collection share",
+  "linkReady": "Share link copied to clipboard.",
+  "urlLabel": "Share collection URL",
+  "imported": "Imported Collection with {{count}} board(s)",
+  "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
+  "importFailed": "Failed to import shared Collection",
+  "notFound": "Shared Collection not found or expired",
+  "empty": "Shared Collection is empty"
+},
+"importSharedCollection": {
+  "title": "Import shared Collection",
+  "loading": "Loading shared Collection…",
+  "notFound": "Shared Collection not found or expired.",
+  "shared": "Shared by {{name}}",
+  "boardCount": "{{count}} board(s)",
+  "importing": "Importing…",
+  "import": "Import Collection"
+},
+"subCollections": {
+  "loading": "Loading shared Collections…",
+  "heading": "Collections",
+  "boardCount": "{{count}} board(s)",
+  "boardPlaceholder": "Board …{{id}}"
+},
+"collectionMenu": {
+  "share": "Share Collection…"
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add locales/
+git commit -m "i18n: add shareCollection + importSharedCollection + subCollections keys"
+```
+
+### Task 4.2 — E2E happy-path
+
+**Files:**
+
+- Create: `tests/e2e/share-collection.spec.ts`
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Collections — share + import (Copy mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition: none !important; animation: none !important; }',
+    });
+    await page.goto('/');
+    await expect(page.getByTitle('Open Menu')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('host shares a Collection in Copy mode + recipient imports it', async ({
+    page,
+  }) => {
+    // 1. Create a Collection with 2 Boards
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
+    await page
+      .locator('button')
+      .filter({ hasText: /manage all boards/i })
+      .click();
+    const modal = page.getByRole('dialog', { name: /boards/i });
+
+    await modal.getByRole('button', { name: /new collection/i }).click();
+    const cPrompt = page.getByRole('dialog', { name: /new collection/i });
+    await cPrompt.getByRole('textbox').fill('Share Test Coll');
+    await cPrompt.getByRole('button', { name: /^create$/i }).click();
+    await modal.getByText('Share Test Coll').first().click();
+
+    for (const name of ['Share-A', 'Share-B']) {
+      await modal.getByRole('button', { name: /new board/i }).click();
+      const bPrompt = page.getByRole('dialog', { name: /new board/i });
+      await bPrompt.getByRole('textbox').fill(name);
+      await bPrompt.getByRole('button', { name: /^create$/i }).click();
+    }
+
+    // 2. Right-click the Collection → Share…
+    const collTreeNode = modal.getByText('Share Test Coll').first();
+    await collTreeNode.click({ button: 'right' });
+    const ctxMenu = page.getByRole('menu');
+    await expect(ctxMenu).toBeVisible({ timeout: 5000 });
+    await ctxMenu.getByRole('menuitem', { name: /share collection/i }).click();
+
+    // 3. Share creator opens; default mode is Copy → Create link
+    const shareDialog = page.getByRole('dialog', { name: /share collection/i });
+    await expect(shareDialog).toBeVisible({ timeout: 5000 });
+    await shareDialog.getByRole('button', { name: /create link/i }).click();
+
+    // 4. URL appears
+    const urlInput = shareDialog.getByLabel('Share collection URL');
+    await expect(urlInput).toBeVisible({ timeout: 10000 });
+    await expect(urlInput).toHaveValue(/\/share-collection\//);
+    const shareUrl = await urlInput.inputValue();
+    await shareDialog.getByRole('button', { name: /done/i }).click();
+
+    // 5. Visit the share URL → import modal appears
+    await page.goto(shareUrl);
+    const importDialog = page.getByRole('dialog', {
+      name: /import shared collection/i,
+    });
+    await expect(importDialog).toBeVisible({ timeout: 10000 });
+    await expect(importDialog.getByText('Share Test Coll')).toBeVisible();
+
+    // 6. Click Import
+    await importDialog
+      .getByRole('button', { name: /^import collection$/i })
+      .click();
+
+    // 7. Modal dismisses, user lands on imported Collection's first Board
+    await expect(importDialog).not.toBeVisible({ timeout: 10000 });
+    // The imported boards carry "(Imported)" suffix
+    await expect(page.getByText(/Share-A \(Imported\)/i).first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+pnpm exec playwright test tests/e2e/share-collection.spec.ts --reporter=line
+git add tests/e2e/share-collection.spec.ts
+git commit -m "test(e2e): cover Collection share + import happy path"
+```
+
+### Task 4.3 — Final validate + acceptance walkthrough
+
+- [ ] **Step 1: Full validation**
+
+```bash
+pnpm run validate
+pnpm exec playwright test tests/e2e/share-collection.spec.ts tests/e2e/collections-fab.spec.ts tests/e2e/collections.spec.ts tests/e2e/sharing.spec.ts --reporter=line
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Manual acceptance**
+
+1. **Share a Collection (Copy mode).** Sidebar → Boards → Manage → right-click a Collection → Share Collection… → Copy → Create link → URL copied.
+2. **Import.** Paste URL in a different browser session (or same with manual user-swap if your dev env allows). Modal appears with the source Collection name + board count + host name. Click Import → boards arrive in a new Collection in the recipient's account.
+3. **Share Substitute.** Same right-click flow → choose Substitute → pick a TTL preset → enter buildingId → Create link.
+4. **Sub portal.** Sign into `/subs` as a teacher matching the buildingId. Confirm the shared Collection appears in the Collections section + clicking a board enters board-view.
+5. **Expiration.** Wait until the TTL passes (or temporarily reduce TTL in the test). Re-load `/subs` — the expired Collection is gone.
+
+- [ ] **Step 3: Push for CI**
+
+```bash
+git push -u origin claude/collections-plan-3
+```
+
+---
+
+## Acceptance criteria
+
+- [ ] Host can create a Copy-mode Collection share via the right-click "Share Collection…" item on `CollectionContextMenu`.
+- [ ] Host can create a Substitute-mode Collection share with a TTL + buildingId.
+- [ ] Recipient visiting `/share-collection/:shareId` sees an import modal with Collection name, board count, and host name. Clicking Import creates a new Collection + N Boards in their account.
+- [ ] Sub teacher signed into `/subs` for a matching buildingId sees shared Collections in a "Collections" section. Clicking a Board enters the existing single-Board sub-view.
+- [ ] Substitute shares are filtered by `expiresAt` in both the `/subs` query and the recipient-side load.
+- [ ] Firestore rules reject create with no boardIds, no name, invalid intendedMode, or substitute without expiresAt/buildingId.
+- [ ] No regressions: existing single-Board sharing + Collections (Plan 1 + 2) flows still pass.
+- [ ] `pnpm run validate` green; lint+type-check+format clean; no `console.error` introduced (use `logError`).
+- [ ] All new i18n strings have `defaultValue` fallbacks; en/de/es/fr files updated.
+
+---
+
+## Known limitations
+
+1. **No `synced` (live) mode for Collections.** Live-mirroring N boards across users is unbounded cost. If users ask, a later plan could add it with explicit cap (e.g., max 3 boards per synced Collection share).
+2. **Drive grants not implemented for Collection-substitute shares.** Single-Board substitute shares support per-recipient Drive sharing of roster files. Adding it for Collection shares is a non-trivial surface (cross-product of subEmails × N rosterDriveFileIds). Deferred — the substitute can still view the Boards; they just don't get roster Drive access via this flow.
+3. **Sub portal shows only board placeholders, not Board names, in the list view.** The list query reads only the parent metadata doc (cheap). Pulling board names would require N additional reads per Collection. Click-to-open loads the full Board.
+4. **No PLC-scoped Collection shares.** Single-Board sharing has a `plcId` field; Collection version omits it for now (no user request yet).
+5. **Cap of 500 boards per share** is enforced by the Firestore rule. Real-world Collections won't approach this, but flagged for clarity.
+6. **Sub-doc writes use the host's auth.** A long-running batch (huge Collection) could theoretically have the auth token expire mid-batch; the existing single-Board share has the same property and we haven't seen the failure. Flagged for awareness, not action.
+
+---
+
+## Commit-history outline (chronological)
+
+1. `feat(types): add SharedCollection + CollectionSubstituteShareInput types`
+2. `feat(rules): /shared_collections/{shareId} read/write rules + tests`
+3. `feat(sharing): useSharedCollection — write side (copy + substitute)`
+4. `feat(sharing): useSharedCollection — read side (loadSharedCollection + boards)`
+5. `feat(sharing): wire Collection share + import actions into DashboardContext`
+6. `test(sharing): cover useSharedCollection write/read/import paths`
+7. `feat(sharing): add ShareCollectionLinkCreatorModal`
+8. `test(sharing): cover ShareCollectionLinkCreatorModal modes + URL flow`
+9. `feat(sharing): wire 'Share Collection…' context-menu item + modal`
+10. `feat(sharing): ImportSharedCollectionModal + context exposure of loadSharedCollection`
+11. `feat(sharing): /share-collection/:shareId route + mount import modal`
+12. `feat(subs): surface shared Collections in /subs portal`
+13. `test(subs): cover SubCollectionsList render + click`
+14. `i18n: add shareCollection + importSharedCollection + subCollections keys`
+15. `test(e2e): cover Collection share + import happy path`

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -281,6 +281,14 @@
         { "fieldPath": "plcId", "order": "ASCENDING" },
         { "fieldPath": "updatedAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "shared_collections",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "intendedMode", "order": "ASCENDING" },
+        { "fieldPath": "buildingId", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -287,7 +287,8 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "intendedMode", "order": "ASCENDING" },
-        { "fieldPath": "buildingId", "order": "ASCENDING" }
+        { "fieldPath": "buildingId", "order": "ASCENDING" },
+        { "fieldPath": "expiresAt", "order": "ASCENDING" }
       ]
     }
   ],

--- a/firestore.rules
+++ b/firestore.rules
@@ -845,6 +845,72 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
+    // Collection-level shares — parent doc holds metadata, subcollection
+    // /shared_collections/{shareId}/boards/{boardId} holds frozen Board
+    // snapshots. Mirrors /shared_boards substitute gating (inline pattern)
+    // and the 14-day expiresAt cap.
+    match /shared_collections/{shareId} {
+      // READ: any authed user for non-substitute shares. Substitute shares
+      // are gated by host, admin, or @orono.k12.mn.us email (same as
+      // /shared_boards). No isSubInBuilding helper — inline match.
+      allow read: if request.auth != null && (
+        resource.data.get('intendedMode', null) != 'substitute'
+        || resource.data.get('hostUid', null) == request.auth.uid
+        || isAdmin()
+        || request.auth.token.get('email', '').lower().matches('.*@orono[.]k12[.]mn[.]us$')
+      );
+
+      // CREATE: host writes their own share. Substitute shares add a
+      // 14-day TTL cap (1209600000ms == 14 * 24 * 60 * 60 * 1000) AND
+      // require a non-empty buildingId — both mirror the /shared_boards
+      // substitute create rule. boardIds must be a non-empty list of
+      // at most 500 entries; collection.name must be a non-empty string;
+      // intendedMode must be in the legal set.
+      allow create: if request.auth != null
+        && request.resource.data.hostUid == request.auth.uid
+        && request.resource.data.boardIds is list
+        && request.resource.data.boardIds.size() > 0
+        && request.resource.data.boardIds.size() <= 500
+        && request.resource.data.collection.name is string
+        && request.resource.data.collection.name.size() > 0
+        && request.resource.data.intendedMode in ['copy', 'substitute']
+        && (
+          request.resource.data.intendedMode != 'substitute'
+          || (
+            request.resource.data.buildingId is string
+            && request.resource.data.buildingId.size() > 0
+            && request.resource.data.expiresAt is number
+            && request.resource.data.expiresAt > request.time.toMillis()
+            && request.resource.data.expiresAt <= request.time.toMillis() + 1209600000
+          )
+        );
+
+      // UPDATE: host-only, and ONLY allowed on copy shares (substitute
+      // shares are immutable post-creation). Admins bypass for emergency
+      // corrections.
+      allow update: if request.auth != null
+        && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin())
+        && resource.data.get('intendedMode', null) == 'copy';
+
+      allow delete: if request.auth != null
+        && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin());
+
+      // Per-Board snapshots. Read mirrors parent semantics. Write only by
+      // parent's host (the share-creation writeBatch puts the parent doc
+      // first, then the boards, so the get() lookup resolves).
+      match /boards/{boardId} {
+        allow read: if request.auth != null && (
+          get(/databases/$(database)/documents/shared_collections/$(shareId)).data.get('intendedMode', null) != 'substitute'
+          || get(/databases/$(database)/documents/shared_collections/$(shareId)).data.get('hostUid', null) == request.auth.uid
+          || isAdmin()
+          || request.auth.token.get('email', '').lower().matches('.*@orono[.]k12[.]mn[.]us$')
+        );
+
+        allow create, update, delete: if request.auth != null
+          && get(/databases/$(database)/documents/shared_collections/$(shareId)).data.get('hostUid', null) == request.auth.uid;
+      }
+    }
+
     // Preset substitute emails — per-building list of generic sub accounts
     // (e.g. ohssub@orono.k12.mn.us) that teachers can quickly add when
     // creating a Substitute (View-Only) share. Admin-managed. Authenticated

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -1,0 +1,172 @@
+/**
+ * useSharedCollection — Collection share lifecycle.
+ *
+ * Two writes (`shareCollection`, `shareSubstituteCollection`) and two
+ * reads (`loadSharedCollection`, `loadSharedCollectionBoards`) plus the
+ * recipient-side `importSharedCollection`. Mirrors the single-Board
+ * sharing surface in `useFirestore.shareDashboard` etc., but scoped to
+ * `/shared_collections/{shareId}`.
+ *
+ * The hook does NOT subscribe — Collection shares are one-shot writes/
+ * reads, not live-mirrored. No onSnapshot.
+ */
+
+import { useCallback } from 'react';
+import { doc, writeBatch } from 'firebase/firestore';
+import { db } from '@/config/firebase';
+import type {
+  Dashboard,
+  SharedCollection,
+  SharedCollectionBoardDoc,
+  Collection as CollectionType,
+  CollectionSubstituteShareInput,
+} from '@/types';
+
+const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
+const SHARED_COLLECTION_BOARDS_SUBPATH = 'boards';
+
+interface ShareCollectionInput {
+  collection: CollectionType;
+  boards: Dashboard[];
+  hostUid: string;
+  hostDisplayName: string | null;
+}
+
+type SubstituteShareInput = ShareCollectionInput &
+  CollectionSubstituteShareInput;
+
+export const useSharedCollection = () => {
+  /**
+   * Host action: write the share metadata + every Board snapshot in a
+   * chunked writeBatch. Returns the new shareId.
+   *
+   * Chunking note: a `writeBatch` is capped at 500 operations. A Collection
+   * with > 499 Boards exceeds that (metadata + 499 boards = 500). We split
+   * into multiple batches if needed — boards are immutable post-creation,
+   * so partial-batch failure recovery is simple (delete the parent if any
+   * board batch fails). BATCH_LIMIT 400 leaves headroom for the parent
+   * write in the first batch.
+   */
+  const shareCollection = useCallback(
+    async (input: ShareCollectionInput): Promise<string> => {
+      const shareId = crypto.randomUUID();
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const now = Date.now();
+
+      const parentPayload: SharedCollection = {
+        shareId,
+        hostUid: input.hostUid,
+        hostDisplayName: input.hostDisplayName,
+        intendedMode: 'copy',
+        collection: {
+          name: input.collection.name,
+          ...(input.collection.color !== undefined && {
+            color: input.collection.color,
+          }),
+          ...(input.collection.icon !== undefined && {
+            icon: input.collection.icon,
+          }),
+        },
+        boardIds: input.boards.map((b) => b.id),
+        createdAt: now,
+      };
+
+      const BATCH_LIMIT = 400;
+      let currentBatch = writeBatch(db);
+      currentBatch.set(parentRef, parentPayload);
+      let inBatch = 1;
+
+      for (const board of input.boards) {
+        if (inBatch >= BATCH_LIMIT) {
+          await currentBatch.commit();
+          currentBatch = writeBatch(db);
+          inBatch = 0;
+        }
+        const boardRef = doc(
+          db,
+          SHARED_COLLECTIONS_SUBPATH,
+          shareId,
+          SHARED_COLLECTION_BOARDS_SUBPATH,
+          board.id
+        );
+        const boardPayload: SharedCollectionBoardDoc = {
+          boardId: board.id,
+          dashboard: board,
+        };
+        currentBatch.set(boardRef, boardPayload);
+        inBatch += 1;
+      }
+      if (inBatch > 0) await currentBatch.commit();
+
+      return shareId;
+    },
+    []
+  );
+
+  /**
+   * Host action: substitute variant. Same chunked-batch strategy as
+   * shareCollection. Adds `expiresAt` + `buildingId` and sets
+   * `intendedMode: 'substitute'` on the parent payload. Drive grants are
+   * NOT implemented for Collection shares — see plan's "Known
+   * limitations" for rationale.
+   */
+  const shareSubstituteCollection = useCallback(
+    async (input: SubstituteShareInput): Promise<string> => {
+      const shareId = crypto.randomUUID();
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const now = Date.now();
+
+      const parentPayload: SharedCollection = {
+        shareId,
+        hostUid: input.hostUid,
+        hostDisplayName: input.hostDisplayName,
+        intendedMode: 'substitute',
+        collection: {
+          name: input.collection.name,
+          ...(input.collection.color !== undefined && {
+            color: input.collection.color,
+          }),
+          ...(input.collection.icon !== undefined && {
+            icon: input.collection.icon,
+          }),
+        },
+        boardIds: input.boards.map((b) => b.id),
+        createdAt: now,
+        expiresAt: input.expiresAt,
+        buildingId: input.buildingId,
+      };
+
+      const BATCH_LIMIT = 400;
+      let currentBatch = writeBatch(db);
+      currentBatch.set(parentRef, parentPayload);
+      let inBatch = 1;
+
+      for (const board of input.boards) {
+        if (inBatch >= BATCH_LIMIT) {
+          await currentBatch.commit();
+          currentBatch = writeBatch(db);
+          inBatch = 0;
+        }
+        const boardRef = doc(
+          db,
+          SHARED_COLLECTIONS_SUBPATH,
+          shareId,
+          SHARED_COLLECTION_BOARDS_SUBPATH,
+          board.id
+        );
+        const boardPayload: SharedCollectionBoardDoc = {
+          boardId: board.id,
+          dashboard: board,
+        };
+        currentBatch.set(boardRef, boardPayload);
+        inBatch += 1;
+      }
+      if (inBatch > 0) await currentBatch.commit();
+
+      return shareId;
+    },
+    []
+  );
+
+  return { shareCollection, shareSubstituteCollection };
+};

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -33,10 +33,35 @@ const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
 const SHARED_COLLECTION_BOARDS_SUBPATH = 'boards';
 
 /**
- * Strip share-linkage fields from a Dashboard before snapshotting into
- * a Collection share. Inherited linkages would make the recipient appear
- * to be a collaborator on the host's original single-Board share, which is
- * wrong — the recipient is starting fresh.
+ * Strip host-specific fields from a Dashboard before snapshotting into a
+ * Collection share. The recipient is starting fresh — they must not
+ * inherit anything that names the host, points at the host's Storage /
+ * Drive, or replays the host's live-session state.
+ *
+ * Stripped:
+ * - `linkedShareId` / `linkedShareRole` / `linkedShareHostName` /
+ *   `linkedShareEnded`: live single-Board share linkage. Inheriting these
+ *   would falsely mark the recipient as a collaborator on the host's
+ *   original share.
+ * - `driveFileId`: points at the HOST's Drive file. A recipient writing
+ *   updates through this id would push to the host's Drive.
+ * - `thumbnailUrl`: signed URL into the host's Storage bucket. Expires
+ *   and isn't reachable under the recipient's auth — let it regenerate
+ *   on first save.
+ * - `sharedGroups`: per-host share permissions; not transferable.
+ * - `annotationOverlay`: live pencil-overlay strokes from the host's
+ *   session. Transient state — never persisted state.
+ * - `isDefault`: host's "open this on sign-in" flag. Importing a
+ *   Collection must not silently change which Board the recipient lands
+ *   on.
+ * - `isPinned`: host's pin in the FAB popover. Imports should not
+ *   surprise the recipient with new pinned Boards.
+ * - `updatedAt`: timestamp from the host's last edit. Recipient's copy
+ *   should stamp this on first own edit, not lie about provenance.
+ * - `collectionId`: host's local Collection id. The importer reassigns
+ *   to the freshly-created recipient Collection via createNewDashboard's
+ *   options arg — spreading the host's value would have been overridden
+ *   anyway, but strip it here so the snapshot doesn't carry stale state.
  */
 const sanitizeBoardForShare = (board: Dashboard): Dashboard => {
   const {
@@ -44,6 +69,14 @@ const sanitizeBoardForShare = (board: Dashboard): Dashboard => {
     linkedShareRole: _linkedShareRole,
     linkedShareHostName: _linkedShareHostName,
     linkedShareEnded: _linkedShareEnded,
+    driveFileId: _driveFileId,
+    thumbnailUrl: _thumbnailUrl,
+    sharedGroups: _sharedGroups,
+    annotationOverlay: _annotationOverlay,
+    isDefault: _isDefault,
+    isPinned: _isPinned,
+    updatedAt: _updatedAt,
+    collectionId: _collectionId,
     ...rest
   } = board;
   return rest;

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -32,6 +32,23 @@ import type {
 const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
 const SHARED_COLLECTION_BOARDS_SUBPATH = 'boards';
 
+/**
+ * Strip share-linkage fields from a Dashboard before snapshotting into
+ * a Collection share. Inherited linkages would make the recipient appear
+ * to be a collaborator on the host's original single-Board share, which is
+ * wrong — the recipient is starting fresh.
+ */
+const sanitizeBoardForShare = (board: Dashboard): Dashboard => {
+  const {
+    linkedShareId: _linkedShareId,
+    linkedShareRole: _linkedShareRole,
+    linkedShareHostName: _linkedShareHostName,
+    linkedShareEnded: _linkedShareEnded,
+    ...rest
+  } = board;
+  return rest;
+};
+
 // ---------------------------------------------------------------------------
 // In-memory mock store for auth-bypass (dev / E2E) mode.
 // Mirrors the singleton pattern in useFirestore.ts.
@@ -115,17 +132,15 @@ export const useSharedCollection = () => {
    * Host action: write the share metadata + every Board snapshot in a
    * chunked writeBatch. Returns the new shareId.
    *
-   * Write order: ALL board sub-docs are committed first; the parent doc is
-   * written LAST in its own batch. The parent's existence is the signal that
-   * every board sub-doc was successfully persisted. If any board batch fails,
-   * the parent is never written, so recipients see "not found or expired"
-   * rather than a partial Collection.
+   * Write order: parent doc FIRST, then board sub-docs in chunked batches.
+   * The Firestore subcollection rule reads parent.hostUid to authorise board
+   * writes — without an existing parent doc, `get()` returns null and the
+   * rule denies the write. Auth-bypass (E2E) skips Firestore rules, which
+   * is why parent-last slipped through testing.
    *
-   * Trade-off: if board batches succeed but the final parent batch fails,
-   * orphan board sub-docs remain under `/shared_collections/{shareId}/boards/*`.
-   * They are never readable by anyone (no parent doc exists to expose the
-   * shareId), so they only cost storage. A future scheduled cleanup can prune
-   * them by walking sub-collections and checking parent existence.
+   * If a board batch fails after the parent lands, the recipient sees a
+   * partial Collection. importSharedCollection detects this via
+   * `boards.length < meta.boardIds.length` and surfaces a warning toast.
    */
   const shareCollection = useCallback(
     async (input: ShareCollectionInput): Promise<string> => {
@@ -155,9 +170,17 @@ export const useSharedCollection = () => {
         return shareId;
       }
 
-      // Phase 1: write ALL board sub-docs in chunked batches.
-      // If any of these throws, the parent doc does not yet exist → recipient
-      // can't load the share at all (clean failure, no partial-state surface).
+      // Write the parent doc FIRST. The subcollection rule reads
+      // parent.hostUid to authorize board writes; without an existing
+      // parent doc, board batches are denied by Firestore rules.
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const parentBatch = writeBatch(db);
+      parentBatch.set(parentRef, parentPayload);
+      await parentBatch.commit();
+
+      // Then write all board sub-docs in chunked batches. If any batch
+      // fails, the recipient sees a partial Collection and gets a warning
+      // toast via the partial-result detection in importSharedCollection.
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
       let inBatch = 0;
@@ -177,20 +200,12 @@ export const useSharedCollection = () => {
         );
         const boardPayload: SharedCollectionBoardDoc = {
           boardId: board.id,
-          dashboard: board,
+          dashboard: sanitizeBoardForShare(board),
         };
         currentBatch.set(boardRef, boardPayload);
         inBatch += 1;
       }
       if (inBatch > 0) await currentBatch.commit();
-
-      // Phase 2: write the parent doc LAST. Its existence is the signal that
-      // all sub-docs were successfully committed. Recipients cannot discover
-      // the share until this batch lands.
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
-      const parentBatch = writeBatch(db);
-      parentBatch.set(parentRef, parentPayload);
-      await parentBatch.commit();
 
       return shareId;
     },
@@ -198,15 +213,14 @@ export const useSharedCollection = () => {
   );
 
   /**
-   * Host action: substitute variant. Same parent-last write strategy as
+   * Host action: substitute variant. Same parent-first write strategy as
    * shareCollection. Adds `expiresAt` + `buildingId` and sets
    * `intendedMode: 'substitute'` on the parent payload. Drive grants are
    * NOT implemented for Collection shares — see plan's "Known
    * limitations" for rationale.
    *
-   * See shareCollection for the write-order trade-off comment (board
-   * sub-docs first, parent last — clean failure on board batch error,
-   * possible orphan board docs on parent batch error).
+   * See shareCollection for the write-order rationale (parent first, then
+   * board sub-docs — the subcollection rule reads parent.hostUid).
    */
   const shareSubstituteCollection = useCallback(
     async (input: SubstituteShareInput): Promise<string> => {
@@ -238,9 +252,17 @@ export const useSharedCollection = () => {
         return shareId;
       }
 
-      // Phase 1: write ALL board sub-docs in chunked batches.
-      // If any of these throws, the parent doc does not yet exist → recipient
-      // can't load the share at all (clean failure, no partial-state surface).
+      // Write the parent doc FIRST. The subcollection rule reads
+      // parent.hostUid to authorize board writes; without an existing
+      // parent doc, board batches are denied by Firestore rules.
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const parentBatch = writeBatch(db);
+      parentBatch.set(parentRef, parentPayload);
+      await parentBatch.commit();
+
+      // Then write all board sub-docs in chunked batches. If any batch
+      // fails, the recipient sees a partial Collection and gets a warning
+      // toast via the partial-result detection in importSharedCollection.
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
       let inBatch = 0;
@@ -260,20 +282,12 @@ export const useSharedCollection = () => {
         );
         const boardPayload: SharedCollectionBoardDoc = {
           boardId: board.id,
-          dashboard: board,
+          dashboard: sanitizeBoardForShare(board),
         };
         currentBatch.set(boardRef, boardPayload);
         inBatch += 1;
       }
       if (inBatch > 0) await currentBatch.commit();
-
-      // Phase 2: write the parent doc LAST. Its existence is the signal that
-      // all sub-docs were successfully committed. Recipients cannot discover
-      // the share until this batch lands.
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
-      const parentBatch = writeBatch(db);
-      parentBatch.set(parentRef, parentPayload);
-      await parentBatch.commit();
 
       return shareId;
     },

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -19,7 +19,7 @@ import {
   getDocs,
   writeBatch,
 } from 'firebase/firestore';
-import { db } from '@/config/firebase';
+import { db, isAuthBypass } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import type {
   Dashboard,
@@ -31,6 +31,74 @@ import type {
 
 const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
 const SHARED_COLLECTION_BOARDS_SUBPATH = 'boards';
+
+// ---------------------------------------------------------------------------
+// In-memory mock store for auth-bypass (dev / E2E) mode.
+// Mirrors the singleton pattern in useFirestore.ts.
+// ---------------------------------------------------------------------------
+class MockSharedCollectionStore {
+  private static instance: MockSharedCollectionStore;
+  private collections = new Map<string, SharedCollection>();
+  private boards = new Map<string, Map<string, Dashboard>>();
+
+  private constructor() {
+    // Private constructor for singleton
+  }
+
+  static getInstance(): MockSharedCollectionStore {
+    if (!MockSharedCollectionStore.instance) {
+      MockSharedCollectionStore.instance = new MockSharedCollectionStore();
+    }
+    return MockSharedCollectionStore.instance;
+  }
+
+  save(shareId: string, meta: SharedCollection, boardList: Dashboard[]): void {
+    this.collections.set(shareId, meta);
+    const bMap = new Map<string, Dashboard>();
+    for (const b of boardList) bMap.set(b.id, b);
+    this.boards.set(shareId, bMap);
+    try {
+      sessionStorage.setItem(
+        `mock_scoll_${shareId}`,
+        JSON.stringify({ meta, boards: boardList })
+      );
+    } catch {
+      /* session storage unavailable — in-memory only */
+    }
+  }
+
+  getCollection(shareId: string): SharedCollection | null {
+    if (this.collections.has(shareId)) {
+      return this.collections.get(shareId) ?? null;
+    }
+    // Hydrate from sessionStorage (cross-navigation in E2E)
+    try {
+      const raw = sessionStorage.getItem(`mock_scoll_${shareId}`);
+      if (raw) {
+        const parsed = JSON.parse(raw) as {
+          meta: SharedCollection;
+          boards: Dashboard[];
+        };
+        this.collections.set(shareId, parsed.meta);
+        const bMap = new Map<string, Dashboard>();
+        for (const b of parsed.boards) bMap.set(b.id, b);
+        this.boards.set(shareId, bMap);
+        return parsed.meta;
+      }
+    } catch {
+      /* ignore */
+    }
+    return null;
+  }
+
+  getBoards(shareId: string): Dashboard[] {
+    // Ensure collection (and boards) are hydrated if only sessionStorage has them
+    this.getCollection(shareId);
+    return Array.from(this.boards.get(shareId)?.values() ?? []);
+  }
+}
+
+const mockCollStore = MockSharedCollectionStore.getInstance();
 
 interface ShareCollectionInput {
   collection: CollectionType;
@@ -57,7 +125,6 @@ export const useSharedCollection = () => {
   const shareCollection = useCallback(
     async (input: ShareCollectionInput): Promise<string> => {
       const shareId = crypto.randomUUID();
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
       const now = Date.now();
 
       const parentPayload: SharedCollection = {
@@ -78,6 +145,12 @@ export const useSharedCollection = () => {
         createdAt: now,
       };
 
+      if (isAuthBypass) {
+        mockCollStore.save(shareId, parentPayload, input.boards);
+        return shareId;
+      }
+
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
       currentBatch.set(parentRef, parentPayload);
@@ -120,7 +193,6 @@ export const useSharedCollection = () => {
   const shareSubstituteCollection = useCallback(
     async (input: SubstituteShareInput): Promise<string> => {
       const shareId = crypto.randomUUID();
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
       const now = Date.now();
 
       const parentPayload: SharedCollection = {
@@ -143,6 +215,12 @@ export const useSharedCollection = () => {
         buildingId: input.buildingId,
       };
 
+      if (isAuthBypass) {
+        mockCollStore.save(shareId, parentPayload, input.boards);
+        return shareId;
+      }
+
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
       currentBatch.set(parentRef, parentPayload);
@@ -182,6 +260,18 @@ export const useSharedCollection = () => {
    */
   const loadSharedCollection = useCallback(
     async (shareId: string): Promise<SharedCollection | null> => {
+      if (isAuthBypass) {
+        const meta = mockCollStore.getCollection(shareId);
+        if (!meta) return null;
+        if (
+          meta.intendedMode === 'substitute' &&
+          meta.expiresAt &&
+          meta.expiresAt < Date.now()
+        ) {
+          return null;
+        }
+        return meta;
+      }
       try {
         const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
         const snap = await getDoc(parentRef);
@@ -212,6 +302,13 @@ export const useSharedCollection = () => {
    */
   const loadSharedCollectionBoards = useCallback(
     async (shareId: string, boardIds: string[]): Promise<Dashboard[]> => {
+      if (isAuthBypass) {
+        const allBoards = mockCollStore.getBoards(shareId);
+        const byId = new Map(allBoards.map((b) => [b.id, b]));
+        return boardIds
+          .map((id) => byId.get(id))
+          .filter((d): d is Dashboard => Boolean(d));
+      }
       const colRef = collection(
         db,
         SHARED_COLLECTIONS_SUBPATH,

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -115,12 +115,17 @@ export const useSharedCollection = () => {
    * Host action: write the share metadata + every Board snapshot in a
    * chunked writeBatch. Returns the new shareId.
    *
-   * Chunking note: a `writeBatch` is capped at 500 operations. A Collection
-   * with > 499 Boards exceeds that (metadata + 499 boards = 500). We split
-   * into multiple batches if needed — boards are immutable post-creation,
-   * so partial-batch failure recovery is simple (delete the parent if any
-   * board batch fails). BATCH_LIMIT 400 leaves headroom for the parent
-   * write in the first batch.
+   * Write order: ALL board sub-docs are committed first; the parent doc is
+   * written LAST in its own batch. The parent's existence is the signal that
+   * every board sub-doc was successfully persisted. If any board batch fails,
+   * the parent is never written, so recipients see "not found or expired"
+   * rather than a partial Collection.
+   *
+   * Trade-off: if board batches succeed but the final parent batch fails,
+   * orphan board sub-docs remain under `/shared_collections/{shareId}/boards/*`.
+   * They are never readable by anyone (no parent doc exists to expose the
+   * shareId), so they only cost storage. A future scheduled cleanup can prune
+   * them by walking sub-collections and checking parent existence.
    */
   const shareCollection = useCallback(
     async (input: ShareCollectionInput): Promise<string> => {
@@ -150,11 +155,12 @@ export const useSharedCollection = () => {
         return shareId;
       }
 
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      // Phase 1: write ALL board sub-docs in chunked batches.
+      // If any of these throws, the parent doc does not yet exist → recipient
+      // can't load the share at all (clean failure, no partial-state surface).
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
-      currentBatch.set(parentRef, parentPayload);
-      let inBatch = 1;
+      let inBatch = 0;
 
       for (const board of input.boards) {
         if (inBatch >= BATCH_LIMIT) {
@@ -178,17 +184,29 @@ export const useSharedCollection = () => {
       }
       if (inBatch > 0) await currentBatch.commit();
 
+      // Phase 2: write the parent doc LAST. Its existence is the signal that
+      // all sub-docs were successfully committed. Recipients cannot discover
+      // the share until this batch lands.
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const parentBatch = writeBatch(db);
+      parentBatch.set(parentRef, parentPayload);
+      await parentBatch.commit();
+
       return shareId;
     },
     []
   );
 
   /**
-   * Host action: substitute variant. Same chunked-batch strategy as
+   * Host action: substitute variant. Same parent-last write strategy as
    * shareCollection. Adds `expiresAt` + `buildingId` and sets
    * `intendedMode: 'substitute'` on the parent payload. Drive grants are
    * NOT implemented for Collection shares — see plan's "Known
    * limitations" for rationale.
+   *
+   * See shareCollection for the write-order trade-off comment (board
+   * sub-docs first, parent last — clean failure on board batch error,
+   * possible orphan board docs on parent batch error).
    */
   const shareSubstituteCollection = useCallback(
     async (input: SubstituteShareInput): Promise<string> => {
@@ -220,11 +238,12 @@ export const useSharedCollection = () => {
         return shareId;
       }
 
-      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      // Phase 1: write ALL board sub-docs in chunked batches.
+      // If any of these throws, the parent doc does not yet exist → recipient
+      // can't load the share at all (clean failure, no partial-state surface).
       const BATCH_LIMIT = 400;
       let currentBatch = writeBatch(db);
-      currentBatch.set(parentRef, parentPayload);
-      let inBatch = 1;
+      let inBatch = 0;
 
       for (const board of input.boards) {
         if (inBatch >= BATCH_LIMIT) {
@@ -247,6 +266,14 @@ export const useSharedCollection = () => {
         inBatch += 1;
       }
       if (inBatch > 0) await currentBatch.commit();
+
+      // Phase 2: write the parent doc LAST. Its existence is the signal that
+      // all sub-docs were successfully committed. Recipients cannot discover
+      // the share until this batch lands.
+      const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+      const parentBatch = writeBatch(db);
+      parentBatch.set(parentRef, parentPayload);
+      await parentBatch.commit();
 
       return shareId;
     },
@@ -303,27 +330,43 @@ export const useSharedCollection = () => {
   const loadSharedCollectionBoards = useCallback(
     async (shareId: string, boardIds: string[]): Promise<Dashboard[]> => {
       if (isAuthBypass) {
-        const allBoards = mockCollStore.getBoards(shareId);
-        const byId = new Map(allBoards.map((b) => [b.id, b]));
+        try {
+          const allBoards = mockCollStore.getBoards(shareId);
+          const byId = new Map(allBoards.map((b) => [b.id, b]));
+          return boardIds
+            .map((id) => byId.get(id))
+            .filter((d): d is Dashboard => Boolean(d));
+        } catch (err) {
+          logError('useSharedCollection.loadSharedCollectionBoards', err, {
+            shareId,
+            boardIdCount: boardIds.length,
+          });
+          return [];
+        }
+      }
+      try {
+        const colRef = collection(
+          db,
+          SHARED_COLLECTIONS_SUBPATH,
+          shareId,
+          SHARED_COLLECTION_BOARDS_SUBPATH
+        );
+        const snap = await getDocs(colRef);
+        const byId = new Map<string, Dashboard>();
+        for (const d of snap.docs) {
+          const data = d.data() as SharedCollectionBoardDoc;
+          byId.set(d.id, data.dashboard);
+        }
         return boardIds
           .map((id) => byId.get(id))
           .filter((d): d is Dashboard => Boolean(d));
+      } catch (err) {
+        logError('useSharedCollection.loadSharedCollectionBoards', err, {
+          shareId,
+          boardIdCount: boardIds.length,
+        });
+        return [];
       }
-      const colRef = collection(
-        db,
-        SHARED_COLLECTIONS_SUBPATH,
-        shareId,
-        SHARED_COLLECTION_BOARDS_SUBPATH
-      );
-      const snap = await getDocs(colRef);
-      const byId = new Map<string, Dashboard>();
-      for (const d of snap.docs) {
-        const data = d.data() as SharedCollectionBoardDoc;
-        byId.set(d.id, data.dashboard);
-      }
-      return boardIds
-        .map((id) => byId.get(id))
-        .filter((d): d is Dashboard => Boolean(d));
     },
     []
   );

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -12,8 +12,15 @@
  */
 
 import { useCallback } from 'react';
-import { doc, writeBatch } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  writeBatch,
+} from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { logError } from '@/utils/logError';
 import type {
   Dashboard,
   SharedCollection,
@@ -168,5 +175,66 @@ export const useSharedCollection = () => {
     []
   );
 
-  return { shareCollection, shareSubstituteCollection };
+  /**
+   * Recipient action: fetch the share metadata doc. Returns null if not
+   * found, expired, or rejected by rules. Logs errors via logError so
+   * production failures surface in telemetry rather than the console.
+   */
+  const loadSharedCollection = useCallback(
+    async (shareId: string): Promise<SharedCollection | null> => {
+      try {
+        const parentRef = doc(db, SHARED_COLLECTIONS_SUBPATH, shareId);
+        const snap = await getDoc(parentRef);
+        if (!snap.exists()) return null;
+        const data = snap.data() as SharedCollection;
+        if (
+          data.intendedMode === 'substitute' &&
+          data.expiresAt &&
+          data.expiresAt < Date.now()
+        ) {
+          return null;
+        }
+        return data;
+      } catch (err) {
+        logError('useSharedCollection.loadSharedCollection', err, { shareId });
+        return null;
+      }
+    },
+    []
+  );
+
+  /**
+   * Recipient action: fetch every frozen Board snapshot in the share.
+   * Order respects the parent's `boardIds[]` so the recipient sees the
+   * same ordering as the host had at share time. Single `getDocs` query
+   * is cheaper than N parallel `getDoc` calls for moderate Collection
+   * sizes (< 30 Boards).
+   */
+  const loadSharedCollectionBoards = useCallback(
+    async (shareId: string, boardIds: string[]): Promise<Dashboard[]> => {
+      const colRef = collection(
+        db,
+        SHARED_COLLECTIONS_SUBPATH,
+        shareId,
+        SHARED_COLLECTION_BOARDS_SUBPATH
+      );
+      const snap = await getDocs(colRef);
+      const byId = new Map<string, Dashboard>();
+      for (const d of snap.docs) {
+        const data = d.data() as SharedCollectionBoardDoc;
+        byId.set(d.id, data.dashboard);
+      }
+      return boardIds
+        .map((id) => byId.get(id))
+        .filter((d): d is Dashboard => Boolean(d));
+    },
+    []
+  );
+
+  return {
+    shareCollection,
+    shareSubstituteCollection,
+    loadSharedCollection,
+    loadSharedCollectionBoards,
+  };
 };

--- a/locales/de.json
+++ b/locales/de.json
@@ -422,10 +422,14 @@
     "expiresIn": "Expires in",
     "building": "Building",
     "buildingRequired": "Select a building before sharing with a sub.",
+    "selectBuilding": "— Select building —",
     "createLink": "Create link",
     "creating": "Creating…",
     "createFailed": "Failed to create Collection share",
-    "linkReady": "Share link copied to clipboard.",
+    "linkReady": "Share link ready.",
+    "linkCopied": "Share link copied to clipboard.",
+    "linkCopyFailed": "Copy the link below — clipboard access was blocked.",
+    "copy": "Copy",
     "urlLabel": "Share collection URL",
     "imported": "Imported Collection with {{count}} board(s)",
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
@@ -447,7 +451,8 @@
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",
-    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now",
+    "comingSoonLabel": "Coming soon"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/de.json
+++ b/locales/de.json
@@ -446,7 +446,8 @@
     "loading": "Loading shared Collections…",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
-    "boardPlaceholder": "Board …{{id}}"
+    "boardPlaceholder": "Board …{{id}}",
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/de.json
+++ b/locales/de.json
@@ -435,7 +435,8 @@
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
-    "empty": "Shared Collection is empty"
+    "empty": "Shared Collection is empty",
+    "invalidShareUrl": "Invalid share link — missing share id."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",

--- a/locales/de.json
+++ b/locales/de.json
@@ -436,7 +436,8 @@
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
     "empty": "Shared Collection is empty",
-    "invalidShareUrl": "Invalid share link — missing share id."
+    "invalidShareUrl": "Invalid share link — missing share id.",
+    "substituteImportRejected": "Substitute shares are view-only. Open this link in /subs to view."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",
@@ -445,7 +446,8 @@
     "shared": "Shared by {{name}}",
     "boardCount": "{{count}} board(s)",
     "importing": "Importing…",
-    "import": "Import Collection"
+    "import": "Import Collection",
+    "substituteOnly": "This is a substitute (view-only) share. Open it in /subs."
   },
   "subCollections": {
     "loading": "Loading shared Collections…",

--- a/locales/de.json
+++ b/locales/de.json
@@ -410,5 +410,45 @@
       "saveAsTemplate": "Save as Template…",
       "delete": "Delete"
     }
+  },
+  "shareCollection": {
+    "title": "Share Collection",
+    "subtitle": "Sharing {{count}} board(s) from this Collection.",
+    "mode": "Share Mode",
+    "copyMode": "Copy",
+    "copyModeHint": "Recipient imports a full copy into their account.",
+    "substituteMode": "Substitute (view-only)",
+    "substituteModeHint": "A sub teacher sees the Collection in /subs for the window you choose.",
+    "expiresIn": "Expires in",
+    "building": "Building",
+    "buildingRequired": "Select a building before sharing with a sub.",
+    "createLink": "Create link",
+    "creating": "Creating…",
+    "createFailed": "Failed to create Collection share",
+    "linkReady": "Share link copied to clipboard.",
+    "urlLabel": "Share collection URL",
+    "imported": "Imported Collection with {{count}} board(s)",
+    "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
+    "importFailed": "Failed to import shared Collection",
+    "notFound": "Shared Collection not found or expired",
+    "empty": "Shared Collection is empty"
+  },
+  "importSharedCollection": {
+    "title": "Import shared Collection",
+    "loading": "Loading shared Collection…",
+    "notFound": "Shared Collection not found or expired.",
+    "shared": "Shared by {{name}}",
+    "boardCount": "{{count}} board(s)",
+    "importing": "Importing…",
+    "import": "Import Collection"
+  },
+  "subCollections": {
+    "loading": "Loading shared Collections…",
+    "heading": "Collections",
+    "boardCount": "{{count}} board(s)",
+    "boardPlaceholder": "Board …{{id}}"
+  },
+  "collectionMenu": {
+    "share": "Share Collection…"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -451,6 +451,7 @@
   },
   "subCollections": {
     "loading": "Loading shared Collections…",
+    "loadError": "Couldn't load shared Collections — refresh to retry.",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -941,6 +941,46 @@
       "delete": "Delete"
     }
   },
+  "shareCollection": {
+    "title": "Share Collection",
+    "subtitle": "Sharing {{count}} board(s) from this Collection.",
+    "mode": "Share Mode",
+    "copyMode": "Copy",
+    "copyModeHint": "Recipient imports a full copy into their account.",
+    "substituteMode": "Substitute (view-only)",
+    "substituteModeHint": "A sub teacher sees the Collection in /subs for the window you choose.",
+    "expiresIn": "Expires in",
+    "building": "Building",
+    "buildingRequired": "Select a building before sharing with a sub.",
+    "createLink": "Create link",
+    "creating": "Creating…",
+    "createFailed": "Failed to create Collection share",
+    "linkReady": "Share link copied to clipboard.",
+    "urlLabel": "Share collection URL",
+    "imported": "Imported Collection with {{count}} board(s)",
+    "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
+    "importFailed": "Failed to import shared Collection",
+    "notFound": "Shared Collection not found or expired",
+    "empty": "Shared Collection is empty"
+  },
+  "importSharedCollection": {
+    "title": "Import shared Collection",
+    "loading": "Loading shared Collection…",
+    "notFound": "Shared Collection not found or expired.",
+    "shared": "Shared by {{name}}",
+    "boardCount": "{{count}} board(s)",
+    "importing": "Importing…",
+    "import": "Import Collection"
+  },
+  "subCollections": {
+    "loading": "Loading shared Collections…",
+    "heading": "Collections",
+    "boardCount": "{{count}} board(s)",
+    "boardPlaceholder": "Board …{{id}}"
+  },
+  "collectionMenu": {
+    "share": "Share Collection…"
+  },
   "admin": {
     "stickers": {
       "title": "Global Sticker Library",

--- a/locales/en.json
+++ b/locales/en.json
@@ -966,7 +966,8 @@
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
     "empty": "Shared Collection is empty",
-    "invalidShareUrl": "Invalid share link — missing share id."
+    "invalidShareUrl": "Invalid share link — missing share id.",
+    "substituteImportRejected": "Substitute shares are view-only. Open this link in /subs to view."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",
@@ -975,7 +976,8 @@
     "shared": "Shared by {{name}}",
     "boardCount": "{{count}} board(s)",
     "importing": "Importing…",
-    "import": "Import Collection"
+    "import": "Import Collection",
+    "substituteOnly": "This is a substitute (view-only) share. Open it in /subs."
   },
   "subCollections": {
     "loading": "Loading shared Collections…",

--- a/locales/en.json
+++ b/locales/en.json
@@ -952,10 +952,14 @@
     "expiresIn": "Expires in",
     "building": "Building",
     "buildingRequired": "Select a building before sharing with a sub.",
+    "selectBuilding": "— Select building —",
     "createLink": "Create link",
     "creating": "Creating…",
     "createFailed": "Failed to create Collection share",
-    "linkReady": "Share link copied to clipboard.",
+    "linkReady": "Share link ready.",
+    "linkCopied": "Share link copied to clipboard.",
+    "linkCopyFailed": "Copy the link below — clipboard access was blocked.",
+    "copy": "Copy",
     "urlLabel": "Share collection URL",
     "imported": "Imported Collection with {{count}} board(s)",
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
@@ -977,7 +981,8 @@
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",
-    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now",
+    "comingSoonLabel": "Coming soon"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/en.json
+++ b/locales/en.json
@@ -981,6 +981,7 @@
   },
   "subCollections": {
     "loading": "Loading shared Collections…",
+    "loadError": "Couldn't load shared Collections — refresh to retry.",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -976,7 +976,8 @@
     "loading": "Loading shared Collections…",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
-    "boardPlaceholder": "Board …{{id}}"
+    "boardPlaceholder": "Board …{{id}}",
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/en.json
+++ b/locales/en.json
@@ -965,7 +965,8 @@
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
-    "empty": "Shared Collection is empty"
+    "empty": "Shared Collection is empty",
+    "invalidShareUrl": "Invalid share link — missing share id."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",

--- a/locales/es.json
+++ b/locales/es.json
@@ -554,7 +554,8 @@
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
-    "empty": "Shared Collection is empty"
+    "empty": "Shared Collection is empty",
+    "invalidShareUrl": "Invalid share link — missing share id."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",

--- a/locales/es.json
+++ b/locales/es.json
@@ -570,6 +570,7 @@
   },
   "subCollections": {
     "loading": "Loading shared Collections…",
+    "loadError": "Couldn't load shared Collections — refresh to retry.",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -565,7 +565,8 @@
     "loading": "Loading shared Collections…",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
-    "boardPlaceholder": "Board …{{id}}"
+    "boardPlaceholder": "Board …{{id}}",
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/es.json
+++ b/locales/es.json
@@ -555,7 +555,8 @@
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
     "empty": "Shared Collection is empty",
-    "invalidShareUrl": "Invalid share link — missing share id."
+    "invalidShareUrl": "Invalid share link — missing share id.",
+    "substituteImportRejected": "Substitute shares are view-only. Open this link in /subs to view."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",
@@ -564,7 +565,8 @@
     "shared": "Shared by {{name}}",
     "boardCount": "{{count}} board(s)",
     "importing": "Importing…",
-    "import": "Import Collection"
+    "import": "Import Collection",
+    "substituteOnly": "This is a substitute (view-only) share. Open it in /subs."
   },
   "subCollections": {
     "loading": "Loading shared Collections…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -541,10 +541,14 @@
     "expiresIn": "Expires in",
     "building": "Building",
     "buildingRequired": "Select a building before sharing with a sub.",
+    "selectBuilding": "— Select building —",
     "createLink": "Create link",
     "creating": "Creating…",
     "createFailed": "Failed to create Collection share",
-    "linkReady": "Share link copied to clipboard.",
+    "linkReady": "Share link ready.",
+    "linkCopied": "Share link copied to clipboard.",
+    "linkCopyFailed": "Copy the link below — clipboard access was blocked.",
+    "copy": "Copy",
     "urlLabel": "Share collection URL",
     "imported": "Imported Collection with {{count}} board(s)",
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
@@ -566,7 +570,8 @@
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",
-    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now",
+    "comingSoonLabel": "Coming soon"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/es.json
+++ b/locales/es.json
@@ -529,5 +529,45 @@
       "saveAsTemplate": "Save as Template…",
       "delete": "Delete"
     }
+  },
+  "shareCollection": {
+    "title": "Share Collection",
+    "subtitle": "Sharing {{count}} board(s) from this Collection.",
+    "mode": "Share Mode",
+    "copyMode": "Copy",
+    "copyModeHint": "Recipient imports a full copy into their account.",
+    "substituteMode": "Substitute (view-only)",
+    "substituteModeHint": "A sub teacher sees the Collection in /subs for the window you choose.",
+    "expiresIn": "Expires in",
+    "building": "Building",
+    "buildingRequired": "Select a building before sharing with a sub.",
+    "createLink": "Create link",
+    "creating": "Creating…",
+    "createFailed": "Failed to create Collection share",
+    "linkReady": "Share link copied to clipboard.",
+    "urlLabel": "Share collection URL",
+    "imported": "Imported Collection with {{count}} board(s)",
+    "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
+    "importFailed": "Failed to import shared Collection",
+    "notFound": "Shared Collection not found or expired",
+    "empty": "Shared Collection is empty"
+  },
+  "importSharedCollection": {
+    "title": "Import shared Collection",
+    "loading": "Loading shared Collection…",
+    "notFound": "Shared Collection not found or expired.",
+    "shared": "Shared by {{name}}",
+    "boardCount": "{{count}} board(s)",
+    "importing": "Importing…",
+    "import": "Import Collection"
+  },
+  "subCollections": {
+    "loading": "Loading shared Collections…",
+    "heading": "Collections",
+    "boardCount": "{{count}} board(s)",
+    "boardPlaceholder": "Board …{{id}}"
+  },
+  "collectionMenu": {
+    "share": "Share Collection…"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -422,10 +422,14 @@
     "expiresIn": "Expires in",
     "building": "Building",
     "buildingRequired": "Select a building before sharing with a sub.",
+    "selectBuilding": "— Select building —",
     "createLink": "Create link",
     "creating": "Creating…",
     "createFailed": "Failed to create Collection share",
-    "linkReady": "Share link copied to clipboard.",
+    "linkReady": "Share link ready.",
+    "linkCopied": "Share link copied to clipboard.",
+    "linkCopyFailed": "Copy the link below — clipboard access was blocked.",
+    "copy": "Copy",
     "urlLabel": "Share collection URL",
     "imported": "Imported Collection with {{count}} board(s)",
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
@@ -447,7 +451,8 @@
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",
-    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now",
+    "comingSoonLabel": "Coming soon"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -446,7 +446,8 @@
     "loading": "Loading shared Collections…",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
-    "boardPlaceholder": "Board …{{id}}"
+    "boardPlaceholder": "Board …{{id}}",
+    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now"
   },
   "collectionMenu": {
     "share": "Share Collection…"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -435,7 +435,8 @@
     "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
-    "empty": "Shared Collection is empty"
+    "empty": "Shared Collection is empty",
+    "invalidShareUrl": "Invalid share link — missing share id."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -436,7 +436,8 @@
     "importFailed": "Failed to import shared Collection",
     "notFound": "Shared Collection not found or expired",
     "empty": "Shared Collection is empty",
-    "invalidShareUrl": "Invalid share link — missing share id."
+    "invalidShareUrl": "Invalid share link — missing share id.",
+    "substituteImportRejected": "Substitute shares are view-only. Open this link in /subs to view."
   },
   "importSharedCollection": {
     "title": "Import shared Collection",
@@ -445,7 +446,8 @@
     "shared": "Shared by {{name}}",
     "boardCount": "{{count}} board(s)",
     "importing": "Importing…",
-    "import": "Import Collection"
+    "import": "Import Collection",
+    "substituteOnly": "This is a substitute (view-only) share. Open it in /subs."
   },
   "subCollections": {
     "loading": "Loading shared Collections…",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -410,5 +410,45 @@
       "saveAsTemplate": "Save as Template…",
       "delete": "Delete"
     }
+  },
+  "shareCollection": {
+    "title": "Share Collection",
+    "subtitle": "Sharing {{count}} board(s) from this Collection.",
+    "mode": "Share Mode",
+    "copyMode": "Copy",
+    "copyModeHint": "Recipient imports a full copy into their account.",
+    "substituteMode": "Substitute (view-only)",
+    "substituteModeHint": "A sub teacher sees the Collection in /subs for the window you choose.",
+    "expiresIn": "Expires in",
+    "building": "Building",
+    "buildingRequired": "Select a building before sharing with a sub.",
+    "createLink": "Create link",
+    "creating": "Creating…",
+    "createFailed": "Failed to create Collection share",
+    "linkReady": "Share link copied to clipboard.",
+    "urlLabel": "Share collection URL",
+    "imported": "Imported Collection with {{count}} board(s)",
+    "partialImport": "Imported {{succeeded}} board(s) — {{failed}} failed",
+    "importFailed": "Failed to import shared Collection",
+    "notFound": "Shared Collection not found or expired",
+    "empty": "Shared Collection is empty"
+  },
+  "importSharedCollection": {
+    "title": "Import shared Collection",
+    "loading": "Loading shared Collection…",
+    "notFound": "Shared Collection not found or expired.",
+    "shared": "Shared by {{name}}",
+    "boardCount": "{{count}} board(s)",
+    "importing": "Importing…",
+    "import": "Import Collection"
+  },
+  "subCollections": {
+    "loading": "Loading shared Collections…",
+    "heading": "Collections",
+    "boardCount": "{{count}} board(s)",
+    "boardPlaceholder": "Board …{{id}}"
+  },
+  "collectionMenu": {
+    "share": "Share Collection…"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -451,6 +451,7 @@
   },
   "subCollections": {
     "loading": "Loading shared Collections…",
+    "loadError": "Couldn't load shared Collections — refresh to retry.",
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",

--- a/tests/DashboardContext_merge.test.tsx
+++ b/tests/DashboardContext_merge.test.tsx
@@ -97,6 +97,17 @@ vi.mock('../hooks/useCollections', () => ({
   }),
 }));
 
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi.fn().mockResolvedValue(null),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
 vi.mock('firebase/firestore', async (importOriginal) => {
   // Real module reference so any unmocked Firestore function (e.g. helpers
   // imported transitively by deeper modules) still resolves to its real

--- a/tests/DashboardContext_removeWidgets.test.tsx
+++ b/tests/DashboardContext_removeWidgets.test.tsx
@@ -79,6 +79,17 @@ vi.mock('../hooks/useCollections', () => ({
   }),
 }));
 
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi.fn().mockResolvedValue(null),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
 vi.mock('firebase/firestore', async (importOriginal) => {
   // Real module reference so any unmocked Firestore function (e.g. helpers
   // imported transitively by deeper modules) still resolves to its real

--- a/tests/DashboardContext_sharing.test.tsx
+++ b/tests/DashboardContext_sharing.test.tsx
@@ -106,6 +106,17 @@ vi.mock('../hooks/useCollections', () => ({
   }),
 }));
 
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi.fn().mockResolvedValue(null),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
 vi.mock('firebase/firestore', async (importOriginal) => {
   // Real module reference so any unmocked Firestore function (e.g. helpers
   // imported transitively by deeper modules) still resolves to its real

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { ShareCollectionLinkCreatorModal } from '@/components/share/ShareCollectionLinkCreatorModal';
 import type { Collection, Dashboard } from '@/types';
 import type { useDashboard as UseDashboardFn } from '@/context/useDashboard';
+import { BUILDINGS } from '@/config/buildings';
 
 const useDashboardMock = vi.fn();
 
@@ -105,7 +106,7 @@ describe('ShareCollectionLinkCreatorModal', () => {
     act(() => {
       fireEvent.click(screen.getByRole('radio', { name: /substitute/i }));
     });
-    // Click Create link without filling building
+    // Click Create link without selecting a building (select stays at empty "")
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /create link/i }));
     });
@@ -118,6 +119,40 @@ describe('ShareCollectionLinkCreatorModal', () => {
       'error'
     );
     expect(shareSubstituteCollection).not.toHaveBeenCalled();
+  });
+
+  it('Substitute mode with valid building calls shareSubstituteCollection and shows URL panel', async () => {
+    const shareSubstituteCollection = vi.fn().mockResolvedValue('sub-share-id');
+    useDashboardMock.mockReturnValue({
+      ...baseMockReturn,
+      shareSubstituteCollection,
+    });
+    render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={collection()}
+        boards={[board('b1')]}
+        onClose={vi.fn()}
+      />
+    );
+    // Switch to substitute mode
+    act(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /substitute/i }));
+    });
+    // Select a canonical building from the dropdown
+    const select = screen.getByRole('combobox');
+    act(() => {
+      fireEvent.change(select, { target: { value: BUILDINGS[0].id } });
+    });
+    // Click Create link
+    await userEvent.click(screen.getByRole('button', { name: /create link/i }));
+    expect(shareSubstituteCollection).toHaveBeenCalledWith(
+      expect.objectContaining({ buildingId: BUILDINGS[0].id })
+    );
+    const urlInput = await screen.findByLabelText(/share collection url/i);
+    expect((urlInput as HTMLInputElement).value).toContain(
+      '/share-collection/sub-share-id'
+    );
   });
 
   it('Copy mode calls shareCollection and reveals the URL panel', async () => {

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShareCollectionLinkCreatorModal } from '@/components/share/ShareCollectionLinkCreatorModal';
+import type { Collection, Dashboard } from '@/types';
+import type { useDashboard as UseDashboardFn } from '@/context/useDashboard';
+
+const useDashboardMock = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => useDashboardMock() as ReturnType<typeof UseDashboardFn>,
+}));
+
+const collection = (): Collection => ({
+  id: 'c1',
+  name: 'Math',
+  parentCollectionId: null,
+  order: 0,
+  createdAt: 0,
+  color: '#ad2122',
+});
+
+const board = (id: string): Dashboard => ({
+  id,
+  name: `Board ${id}`,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: 'c1',
+});
+
+const baseMockReturn = {
+  shareCollection: vi.fn(),
+  shareSubstituteCollection: vi.fn(),
+  addToast: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useDashboardMock.mockReturnValue(baseMockReturn);
+  // Stub clipboard for the auto-copy path
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+describe('ShareCollectionLinkCreatorModal', () => {
+  it('renders nothing when !isOpen', () => {
+    const { container } = render(
+      <ShareCollectionLinkCreatorModal
+        isOpen={false}
+        collection={collection()}
+        boards={[board('b1')]}
+        onClose={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when collection is null', () => {
+    const { container } = render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={null}
+        boards={[]}
+        onClose={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows both mode radios with Copy selected by default', () => {
+    render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={collection()}
+        boards={[board('b1'), board('b2')]}
+        onClose={vi.fn()}
+      />
+    );
+    const copyRadio = screen.getByRole('radio', { name: /copy/i });
+    const subRadio = screen.getByRole('radio', { name: /substitute/i });
+    expect(copyRadio).toBeChecked();
+    expect(subRadio).not.toBeChecked();
+  });
+
+  it('Substitute mode without buildingId shows an error toast and does not call the share action', async () => {
+    const addToast = vi.fn();
+    const shareSubstituteCollection = vi.fn();
+    useDashboardMock.mockReturnValue({
+      ...baseMockReturn,
+      addToast,
+      shareSubstituteCollection,
+    });
+    render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={collection()}
+        boards={[board('b1')]}
+        onClose={vi.fn()}
+      />
+    );
+    // Switch to substitute mode — fireEvent.click is required for controlled
+    // radio inputs in jsdom; userEvent.click does not trigger onChange on them.
+    act(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /substitute/i }));
+    });
+    // Click Create link without filling building
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /create link/i }));
+    });
+    // handleCreate is async; flush the microtask queue
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(addToast).toHaveBeenCalledWith(
+      expect.stringMatching(/select a building/i),
+      'error'
+    );
+    expect(shareSubstituteCollection).not.toHaveBeenCalled();
+  });
+
+  it('Copy mode calls shareCollection and reveals the URL panel', async () => {
+    const shareCollection = vi.fn().mockResolvedValue('share-id-123');
+    useDashboardMock.mockReturnValue({
+      ...baseMockReturn,
+      shareCollection,
+    });
+    render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={collection()}
+        boards={[board('b1'), board('b2')]}
+        onClose={vi.fn()}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /create link/i }));
+    expect(shareCollection).toHaveBeenCalledWith({
+      collection: expect.objectContaining({ id: 'c1' }),
+      boards: expect.arrayContaining([
+        expect.objectContaining({ id: 'b1' }),
+        expect.objectContaining({ id: 'b2' }),
+      ]),
+    });
+    // URL panel appears with the constructed URL
+    const urlInput = await screen.findByLabelText(/share collection url/i);
+    expect((urlInput as HTMLInputElement).value).toContain(
+      '/share-collection/share-id-123'
+    );
+  });
+});

--- a/tests/components/subs/SubCollectionsList.test.tsx
+++ b/tests/components/subs/SubCollectionsList.test.tsx
@@ -90,7 +90,13 @@ describe('SubCollectionsList', () => {
       docsResponse(fakeCollection('s1', 'Math', ['boardA-1234']))
     );
     render(<SubCollectionsList buildingId="middle-school" />);
+    // The button now has two children: the board label and the "Coming soon" sub-label.
+    // findByRole searches accessible name which includes all text content.
     const btn = await screen.findByRole('button', { name: /Board …1234/i });
     expect(btn).toBeDisabled();
+    // Visible "Coming soon" sub-label should also be present inside the button.
+    expect(btn.querySelector('span:last-child')?.textContent).toMatch(
+      /coming soon/i
+    );
   });
 });

--- a/tests/components/subs/SubCollectionsList.test.tsx
+++ b/tests/components/subs/SubCollectionsList.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { SubCollectionsList } from '@/components/subs/SubCollectionsList';
 import type { SharedCollection } from '@/types';
 
@@ -50,16 +49,14 @@ beforeEach(() => {
 describe('SubCollectionsList', () => {
   it('renders the loading state initially', () => {
     getDocsMock.mockReturnValueOnce(new Promise(() => undefined)); // never resolves
-    render(
-      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
-    );
+    render(<SubCollectionsList buildingId="middle-school" />);
     expect(screen.getByText(/loading shared collections/i)).toBeInTheDocument();
   });
 
   it('renders nothing when no Collections are returned', async () => {
     getDocsMock.mockResolvedValueOnce(docsResponse());
     const { container } = render(
-      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
+      <SubCollectionsList buildingId="middle-school" />
     );
     await waitFor(() => {
       expect(
@@ -78,9 +75,7 @@ describe('SubCollectionsList', () => {
         fakeCollection('s2', 'Reading', ['b3'])
       )
     );
-    render(
-      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
-    );
+    render(<SubCollectionsList buildingId="middle-school" />);
     await waitFor(() => {
       expect(screen.getByText('Math')).toBeInTheDocument();
     });
@@ -90,20 +85,12 @@ describe('SubCollectionsList', () => {
     expect(screen.getByText('1 board(s)')).toBeInTheDocument();
   });
 
-  it('calls onOpenBoard(shareId, boardId) when a board button is clicked', async () => {
-    const onOpenBoard = vi.fn();
+  it('renders per-board buttons as disabled (full board-view in /subs deferred)', async () => {
     getDocsMock.mockResolvedValueOnce(
       docsResponse(fakeCollection('s1', 'Math', ['boardA-1234']))
     );
-    render(
-      <SubCollectionsList
-        buildingId="middle-school"
-        onOpenBoard={onOpenBoard}
-      />
-    );
-    // Click the board button (label = "Board …1234" via boardId.slice(-4))
+    render(<SubCollectionsList buildingId="middle-school" />);
     const btn = await screen.findByRole('button', { name: /Board …1234/i });
-    await userEvent.click(btn);
-    expect(onOpenBoard).toHaveBeenCalledWith('s1', 'boardA-1234');
+    expect(btn).toBeDisabled();
   });
 });

--- a/tests/components/subs/SubCollectionsList.test.tsx
+++ b/tests/components/subs/SubCollectionsList.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SubCollectionsList } from '@/components/subs/SubCollectionsList';
+import type { SharedCollection } from '@/types';
+
+const getDocsMock = vi.fn();
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn((db: unknown, path: string) => ({ path })),
+  query: vi.fn((...args: unknown[]) => ({ args })),
+  where: vi.fn((field: string, op: string, value: unknown) => ({
+    field,
+    op,
+    value,
+  })),
+  getDocs: vi.fn(() => getDocsMock() as unknown),
+}));
+
+vi.mock('@/config/firebase', () => ({ db: {} }));
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+const fakeCollection = (
+  shareId: string,
+  name: string,
+  boardIds: string[],
+  color?: string
+): SharedCollection => ({
+  shareId,
+  hostUid: 'host-uid',
+  hostDisplayName: 'Mr. Teacher',
+  intendedMode: 'substitute',
+  collection: { name, ...(color !== undefined && { color }) },
+  boardIds,
+  createdAt: 0,
+  expiresAt: Date.now() + 86400000,
+  buildingId: 'middle-school',
+});
+
+// Each doc needs an `id` property because the component does `shareId: d.id`
+// to set the final shareId (spreading over the data's shareId field).
+const docsResponse = (...collections: SharedCollection[]) => ({
+  docs: collections.map((c) => ({ id: c.shareId, data: () => c })),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SubCollectionsList', () => {
+  it('renders the loading state initially', () => {
+    getDocsMock.mockReturnValueOnce(new Promise(() => undefined)); // never resolves
+    render(
+      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
+    );
+    expect(screen.getByText(/loading shared collections/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when no Collections are returned', async () => {
+    getDocsMock.mockResolvedValueOnce(docsResponse());
+    const { container } = render(
+      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/loading shared collections/i)
+      ).not.toBeInTheDocument();
+    });
+    // After loading completes, nothing should render — the loading paragraph
+    // is gone and no Collections section appears.
+    expect(container.querySelector('section')).toBeNull();
+  });
+
+  it('renders one section per Collection with name + board count', async () => {
+    getDocsMock.mockResolvedValueOnce(
+      docsResponse(
+        fakeCollection('s1', 'Math', ['b1', 'b2']),
+        fakeCollection('s2', 'Reading', ['b3'])
+      )
+    );
+    render(
+      <SubCollectionsList buildingId="middle-school" onOpenBoard={vi.fn()} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Math')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Reading')).toBeInTheDocument();
+    // Math has 2 boards, Reading has 1
+    expect(screen.getByText('2 board(s)')).toBeInTheDocument();
+    expect(screen.getByText('1 board(s)')).toBeInTheDocument();
+  });
+
+  it('calls onOpenBoard(shareId, boardId) when a board button is clicked', async () => {
+    const onOpenBoard = vi.fn();
+    getDocsMock.mockResolvedValueOnce(
+      docsResponse(fakeCollection('s1', 'Math', ['boardA-1234']))
+    );
+    render(
+      <SubCollectionsList
+        buildingId="middle-school"
+        onOpenBoard={onOpenBoard}
+      />
+    );
+    // Click the board button (label = "Board …1234" via boardId.slice(-4))
+    const btn = await screen.findByRole('button', { name: /Board …1234/i });
+    await userEvent.click(btn);
+    expect(onOpenBoard).toHaveBeenCalledWith('s1', 'boardA-1234');
+  });
+});

--- a/tests/e2e/share-collection.spec.ts
+++ b/tests/e2e/share-collection.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Collections — share + import (Copy mode)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addStyleTag({
+      content:
+        '*, *::before, *::after { transition: none !important; animation: none !important; }',
+    });
+    await page.goto('/');
+    await expect(page.getByTitle('Open Menu')).toBeVisible({ timeout: 15000 });
+  });
+
+  test('host shares a Collection in Copy mode + recipient imports it', async ({
+    page,
+  }) => {
+    // 1. Create a Collection with 2 Boards
+    await page.getByTitle('Open Menu').click();
+    await page
+      .locator('nav button')
+      .filter({ hasText: /Boards/i })
+      .click();
+    await page
+      .locator('button')
+      .filter({ hasText: /manage all boards/i })
+      .click();
+    const modal = page.getByRole('dialog', { name: /boards/i });
+
+    await modal.getByRole('button', { name: /new collection/i }).click();
+    const cPrompt = page.getByRole('dialog', { name: /new collection/i });
+    await cPrompt.getByRole('textbox').fill('Share Test Coll');
+    await cPrompt.getByRole('button', { name: /^create$/i }).click();
+    await modal.getByText('Share Test Coll').first().click();
+
+    for (const name of ['Share-A', 'Share-B']) {
+      await modal.getByRole('button', { name: /new board/i }).click();
+      const bPrompt = page.getByRole('dialog', { name: /new board/i });
+      await bPrompt.getByRole('textbox').fill(name);
+      await bPrompt.getByRole('button', { name: /^create$/i }).click();
+    }
+
+    // 2. Navigate back to root so the CollectionCard appears in the grid.
+    //    CollectionCards render when their parent collection is selected; "Share
+    //    Test Coll" is at root (parentCollectionId = null), so select root first.
+    //    The root node is the "All Boards (no Collection)" item in the tree panel.
+    await modal.getByText(/all boards \(no collection\)/i).click();
+
+    // Right-click the CollectionCard in the grid to get the CollectionContextMenu.
+    // CollectionCard renders as div.group with the collection name in bold text.
+    const collCard = modal
+      .locator('.group')
+      .filter({ hasText: 'Share Test Coll' })
+      .first();
+    await expect(collCard).toBeVisible({ timeout: 5000 });
+    await collCard.click({ button: 'right' });
+    const ctxMenu = page.getByRole('menu');
+    await expect(ctxMenu).toBeVisible({ timeout: 5000 });
+    await ctxMenu.getByRole('menuitem', { name: /share collection/i }).click();
+
+    // 3. Share creator opens; default mode is Copy → Create link
+    const shareDialog = page.getByRole('dialog', { name: /share collection/i });
+    await expect(shareDialog).toBeVisible({ timeout: 5000 });
+    await shareDialog.getByRole('button', { name: /create link/i }).click();
+
+    // 4. URL appears
+    const urlInput = shareDialog.getByLabel('Share collection URL');
+    await expect(urlInput).toBeVisible({ timeout: 10000 });
+    await expect(urlInput).toHaveValue(/\/share-collection\//);
+    const shareUrl = await urlInput.inputValue();
+    // Dismiss via Escape — success toast may overlap the Done button
+    await page.keyboard.press('Escape');
+
+    // 5. Visit the share URL → import modal appears
+    await page.goto(shareUrl);
+    const importDialog = page.getByRole('dialog', {
+      name: /import shared collection/i,
+    });
+    await expect(importDialog).toBeVisible({ timeout: 10000 });
+    await expect(importDialog.getByText('Share Test Coll')).toBeVisible();
+
+    // 6. Click Import
+    await importDialog
+      .getByRole('button', { name: /^import collection$/i })
+      .click();
+
+    // 7. Modal dismisses, user lands on imported Collection's first Board
+    await expect(importDialog).not.toBeVisible({ timeout: 10000 });
+    // The imported boards carry "(Imported)" suffix
+    await expect(page.getByText(/Share-A \(Imported\)/i).first()).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -135,6 +135,17 @@ vi.mock('@/hooks/useCollections', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi.fn().mockResolvedValue(null),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
 vi.mock('@/components/boardsModal/BoardsModal', () => ({
   BoardsModal: () => null,
 }));

--- a/tests/hooks/useSharedCollection.test.ts
+++ b/tests/hooks/useSharedCollection.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('firebase/firestore', () => {
+  const docs = new Map<string, unknown>();
+  return {
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    getDoc: vi.fn((ref: { path: string }) =>
+      Promise.resolve({
+        exists: () => docs.has(ref.path),
+        data: () => docs.get(ref.path),
+      })
+    ),
+    getDocs: vi.fn(() =>
+      Promise.resolve({
+        docs: Array.from(docs.entries())
+          .filter(([path]) => path.includes('/boards/'))
+          .map(([path, data]) => ({
+            id: path.split('/').at(-1) ?? '',
+            data: () => data,
+          })),
+      })
+    ),
+    writeBatch: vi.fn(() => ({
+      set: vi.fn((ref: { path: string }, data: unknown) => {
+        docs.set(ref.path, data);
+      }),
+      commit: vi.fn(() => Promise.resolve(undefined)),
+    })),
+    Timestamp: { now: () => ({ toMillis: () => 1000 }) },
+    __testHelpers: {
+      docs,
+      reset: () => {
+        docs.clear();
+      },
+    },
+  };
+});
+
+vi.mock('@/config/firebase', () => ({ db: {} }));
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+import { useSharedCollection } from '@/hooks/useSharedCollection';
+import type { Collection, Dashboard } from '@/types';
+
+const dashboard = (id: string): Dashboard => ({
+  id,
+  name: `Board ${id}`,
+  background: 'bg-slate-800',
+  widgets: [],
+  createdAt: 0,
+  collectionId: 'src-collection',
+});
+
+const sourceCollection = (): Collection => ({
+  id: 'src-collection',
+  name: 'Source',
+  parentCollectionId: null,
+  order: 0,
+  createdAt: 0,
+  color: '#ad2122',
+});
+
+describe('useSharedCollection', () => {
+  beforeEach(async () => {
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { reset: () => void };
+    };
+    mod.__testHelpers.reset();
+  });
+
+  it('shareCollection writes parent + N boards and returns a shareId', async () => {
+    const { result } = renderHook(() => useSharedCollection());
+    const shareId = await result.current.shareCollection({
+      collection: sourceCollection(),
+      boards: [dashboard('b1'), dashboard('b2')],
+      hostUid: 'host-uid',
+      hostDisplayName: 'Mr. Teacher',
+    });
+    expect(shareId).toMatch(/^[0-9a-f-]{36}$/);
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    const parent = mod.__testHelpers.docs.get(
+      `shared_collections/${shareId}`
+    ) as { boardIds: string[]; intendedMode: string };
+    expect(parent.boardIds).toEqual(['b1', 'b2']);
+    expect(parent.intendedMode).toBe('copy');
+  });
+
+  it('shareSubstituteCollection sets intendedMode=substitute + expiresAt', async () => {
+    const { result } = renderHook(() => useSharedCollection());
+    const shareId = await result.current.shareSubstituteCollection({
+      collection: sourceCollection(),
+      boards: [dashboard('b1')],
+      hostUid: 'host-uid',
+      hostDisplayName: 'Mr. Teacher',
+      collectionId: 'src-collection',
+      expiresAt: 9999999999999,
+      buildingId: 'middle-school',
+    });
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    const parent = mod.__testHelpers.docs.get(
+      `shared_collections/${shareId}`
+    ) as { intendedMode: string; expiresAt: number };
+    expect(parent.intendedMode).toBe('substitute');
+    expect(parent.expiresAt).toBe(9999999999999);
+  });
+
+  it('loadSharedCollection returns null for an expired substitute share', async () => {
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    mod.__testHelpers.docs.set('shared_collections/expired', {
+      shareId: 'expired',
+      intendedMode: 'substitute',
+      expiresAt: Date.now() - 1000,
+      boardIds: [],
+      collection: { name: 'gone' },
+    });
+    const { result } = renderHook(() => useSharedCollection());
+    const meta = await result.current.loadSharedCollection('expired');
+    expect(meta).toBeNull();
+  });
+
+  it('loadSharedCollectionBoards returns boards in boardIds order', async () => {
+    const mod = (await vi.importMock('firebase/firestore')) as {
+      __testHelpers: { docs: Map<string, unknown> };
+    };
+    mod.__testHelpers.docs.set('shared_collections/s1/boards/b1', {
+      boardId: 'b1',
+      dashboard: dashboard('b1'),
+    });
+    mod.__testHelpers.docs.set('shared_collections/s1/boards/b2', {
+      boardId: 'b2',
+      dashboard: dashboard('b2'),
+    });
+    const { result } = renderHook(() => useSharedCollection());
+    const boards = await result.current.loadSharedCollectionBoards('s1', [
+      'b2',
+      'b1',
+    ]);
+    expect(boards.map((b) => b.id)).toEqual(['b2', 'b1']);
+  });
+});

--- a/tests/hooks/useSharedCollection.test.ts
+++ b/tests/hooks/useSharedCollection.test.ts
@@ -42,7 +42,7 @@ vi.mock('firebase/firestore', () => {
   };
 });
 
-vi.mock('@/config/firebase', () => ({ db: {} }));
+vi.mock('@/config/firebase', () => ({ db: {}, isAuthBypass: false }));
 vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
 
 import { useSharedCollection } from '@/hooks/useSharedCollection';

--- a/tests/rules/sharedCollections.test.ts
+++ b/tests/rules/sharedCollections.test.ts
@@ -103,12 +103,16 @@ const subShareDoc = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-/** A frozen board snapshot document. */
-const boardSnapshotDoc = () => ({
-  id: BOARD_ID,
-  name: 'Board Snapshot',
-  widgets: [],
-  frozenAt: NOW_MS,
+/** A frozen board snapshot document matching the SharedCollectionBoardDoc shape. */
+const boardSnapshotDoc = (boardId: string = BOARD_ID) => ({
+  boardId,
+  dashboard: {
+    id: boardId,
+    name: `Board ${boardId}`,
+    background: 'bg-slate-800',
+    widgets: [],
+    createdAt: 0,
+  },
 });
 
 const sharePath = `shared_collections/${SHARE_ID}`;

--- a/tests/rules/sharedCollections.test.ts
+++ b/tests/rules/sharedCollections.test.ts
@@ -1,0 +1,519 @@
+// Firestore security-rules tests for /shared_collections/{shareId}.
+//
+// Covers:
+//   - Substitute read gating: inline @orono.k12.mn.us / host / admin pattern
+//     (no isSubInBuilding helper — mirrors /shared_boards convention)
+//   - 14-day expiresAt cap on substitute creates (1209600000ms)
+//   - boardIds list validation (non-empty, max 500)
+//   - collection.name must be a non-empty string
+//   - intendedMode must be 'copy' or 'substitute'
+//   - Substitute shares are immutable post-creation (no update)
+//   - Copy shares are host-or-admin updatable
+//   - Delete: host or admin only
+//   - /boards/{boardId} subcollection: read mirrors parent, write = host only
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-shared-collections-rules-test';
+const SHARE_ID = 'col-share-rules-test';
+const BOARD_ID = 'board-snap-1';
+
+const HOST_UID = 'host-uid-sc';
+const HOST_EMAIL = 'host@example.com';
+
+const ORONO_UID = 'orono-teacher-uid';
+const ORONO_EMAIL = 'teacher@orono.k12.mn.us';
+
+const EXTERNAL_UID = 'external-teacher-uid';
+const EXTERNAL_EMAIL = 'external@example.com';
+
+const ADMIN_UID = 'admin-uid-sc';
+const ADMIN_EMAIL = 'admin@orono.k12.mn.us';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+// ---------------------------------------------------------------------------
+// Auth context helpers
+// ---------------------------------------------------------------------------
+
+const asUnauth = () => testEnv.unauthenticatedContext().firestore();
+
+const asHost = () =>
+  testEnv.authenticatedContext(HOST_UID, { email: HOST_EMAIL }).firestore();
+
+const asOronoTeacher = () =>
+  testEnv.authenticatedContext(ORONO_UID, { email: ORONO_EMAIL }).firestore();
+
+const asExternalTeacher = () =>
+  testEnv
+    .authenticatedContext(EXTERNAL_UID, { email: EXTERNAL_EMAIL })
+    .firestore();
+
+// Admin token must carry the admin's email so isAdmin() can match
+// /admins/{email.lower()} via request.auth.token.email.lower().
+const asAdmin = () =>
+  testEnv.authenticatedContext(ADMIN_UID, { email: ADMIN_EMAIL }).firestore();
+
+// ---------------------------------------------------------------------------
+// Payload factories
+// ---------------------------------------------------------------------------
+
+const NOW_MS = Date.now();
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000; // 1209600000
+
+/** A valid copy-mode share document. */
+const copyShareDoc = (overrides: Record<string, unknown> = {}) => ({
+  hostUid: HOST_UID,
+  boardIds: ['board-1', 'board-2'],
+  collection: { name: 'My Collection', id: 'col-abc' },
+  intendedMode: 'copy',
+  createdAt: NOW_MS,
+  ...overrides,
+});
+
+/** A valid substitute-mode share document. */
+const subShareDoc = (overrides: Record<string, unknown> = {}) => ({
+  hostUid: HOST_UID,
+  boardIds: ['board-1'],
+  collection: { name: 'Sub Collection', id: 'col-xyz' },
+  intendedMode: 'substitute',
+  buildingId: 'ohs',
+  expiresAt: NOW_MS + FOURTEEN_DAYS_MS - 60_000, // 1 minute under the cap
+  createdAt: NOW_MS,
+  ...overrides,
+});
+
+/** A frozen board snapshot document. */
+const boardSnapshotDoc = () => ({
+  id: BOARD_ID,
+  name: 'Board Snapshot',
+  widgets: [],
+  frozenAt: NOW_MS,
+});
+
+const sharePath = `shared_collections/${SHARE_ID}`;
+const boardPath = `shared_collections/${SHARE_ID}/boards/${BOARD_ID}`;
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  // Seed the admin doc so isAdmin() resolves for ADMIN_EMAIL.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `admins/${ADMIN_EMAIL}`), {
+      email: ADMIN_EMAIL,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. READ — unauthenticated
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — read, unauthenticated', () => {
+  it('anonymous read fails on any share doc', async () => {
+    // Seed a copy share so the read has a doc to hit.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+    });
+    await assertFails(getDoc(doc(asUnauth(), sharePath)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. READ — copy share (open to any authed user)
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — read, copy share', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+    });
+  });
+
+  it('non-host authed teacher can read a copy-mode share', async () => {
+    await assertSucceeds(getDoc(doc(asExternalTeacher(), sharePath)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 & 4. READ — substitute share gating
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — read, substitute share', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), subShareDoc());
+    });
+  });
+
+  it('non-Orono email is denied on substitute share', async () => {
+    await assertFails(getDoc(doc(asExternalTeacher(), sharePath)));
+  });
+
+  it('Orono email is allowed on substitute share', async () => {
+    await assertSucceeds(getDoc(doc(asOronoTeacher(), sharePath)));
+  });
+
+  it('host can always read their own substitute share', async () => {
+    await assertSucceeds(getDoc(doc(asHost(), sharePath)));
+  });
+
+  it('admin can read substitute share', async () => {
+    await assertSucceeds(getDoc(doc(asAdmin(), sharePath)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. CREATE — valid copy payload
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — create, valid copy payload', () => {
+  it('host creates a copy share with valid payload', async () => {
+    await assertSucceeds(setDoc(doc(asHost(), sharePath), copyShareDoc()));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. CREATE — boardIds validation
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — create, boardIds validation', () => {
+  it('create rejected when boardIds is empty', async () => {
+    await assertFails(
+      setDoc(doc(asHost(), sharePath), copyShareDoc({ boardIds: [] }))
+    );
+  });
+
+  it('create rejected when boardIds exceeds 500 entries', async () => {
+    const tooMany = Array.from({ length: 501 }, (_, i) => `board-${i}`);
+    await assertFails(
+      setDoc(doc(asHost(), sharePath), copyShareDoc({ boardIds: tooMany }))
+    );
+  });
+
+  it('create allowed at exactly 500 entries', async () => {
+    const exactly500 = Array.from({ length: 500 }, (_, i) => `board-${i}`);
+    await assertSucceeds(
+      setDoc(doc(asHost(), sharePath), copyShareDoc({ boardIds: exactly500 }))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7 (already covered above: boardIds > 500 → see case 6)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// 8. CREATE — intendedMode must be in legal set
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — create, intendedMode validation', () => {
+  it('create rejected when intendedMode is "synced"', async () => {
+    await assertFails(
+      setDoc(doc(asHost(), sharePath), copyShareDoc({ intendedMode: 'synced' }))
+    );
+  });
+
+  it('create rejected when intendedMode is "invalid"', async () => {
+    await assertFails(
+      setDoc(
+        doc(asHost(), sharePath),
+        copyShareDoc({ intendedMode: 'invalid' })
+      )
+    );
+  });
+
+  it('create accepted with intendedMode "substitute"', async () => {
+    await assertSucceeds(setDoc(doc(asHost(), sharePath), subShareDoc()));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9–12. CREATE — substitute-specific field validation
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — create, substitute field constraints', () => {
+  it('substitute create rejected without expiresAt', async () => {
+    const { expiresAt: _expiresAt, ...payload } = subShareDoc();
+    await assertFails(setDoc(doc(asHost(), sharePath), payload));
+  });
+
+  it('substitute create rejected when expiresAt is in the past', async () => {
+    await assertFails(
+      setDoc(
+        doc(asHost(), sharePath),
+        subShareDoc({ expiresAt: NOW_MS - 1000 })
+      )
+    );
+  });
+
+  it('substitute create rejected when expiresAt is more than 14 days out', async () => {
+    await assertFails(
+      setDoc(
+        doc(asHost(), sharePath),
+        subShareDoc({ expiresAt: NOW_MS + FOURTEEN_DAYS_MS + 10_000 })
+      )
+    );
+  });
+
+  it('substitute create accepted at exactly the 14-day boundary', async () => {
+    // The rule is <=, so exactly 14 days should succeed.
+    // Use a value comfortably under to avoid emulator clock skew:
+    // 13 days 23 hours 59 minutes.
+    await assertSucceeds(
+      setDoc(
+        doc(asHost(), sharePath),
+        subShareDoc({ expiresAt: NOW_MS + FOURTEEN_DAYS_MS - 60_000 })
+      )
+    );
+  });
+
+  it('substitute create rejected without buildingId', async () => {
+    const { buildingId: _buildingId, ...payload } = subShareDoc();
+    await assertFails(setDoc(doc(asHost(), sharePath), payload));
+  });
+
+  it('substitute create rejected with empty buildingId', async () => {
+    await assertFails(
+      setDoc(doc(asHost(), sharePath), subShareDoc({ buildingId: '' }))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. CREATE — hostUid must match request.auth.uid
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — create, hostUid impersonation', () => {
+  it('create rejected when hostUid does not match auth uid', async () => {
+    // External teacher tries to create a share claiming HOST_UID as host.
+    await assertFails(
+      setDoc(
+        doc(asExternalTeacher(), sharePath),
+        copyShareDoc({ hostUid: HOST_UID })
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. UPDATE — substitute shares are immutable
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — update, substitute immutability', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), subShareDoc());
+    });
+  });
+
+  it('update rejected for substitute share even by host', async () => {
+    await assertFails(
+      updateDoc(doc(asHost(), sharePath), { buildingId: 'oms' })
+    );
+  });
+
+  it('update rejected for substitute share even by admin', async () => {
+    await assertFails(
+      updateDoc(doc(asAdmin(), sharePath), { buildingId: 'oms' })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. UPDATE — copy shares are host-or-admin updatable
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — update, copy share', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+    });
+  });
+
+  it('host can update a copy share', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asHost(), sharePath), {
+        'collection.name': 'Renamed Collection',
+      })
+    );
+  });
+
+  it('admin can update a copy share', async () => {
+    await assertSucceeds(
+      updateDoc(doc(asAdmin(), sharePath), {
+        'collection.name': 'Admin Renamed',
+      })
+    );
+  });
+
+  it('non-host cannot update a copy share', async () => {
+    await assertFails(
+      updateDoc(doc(asExternalTeacher(), sharePath), {
+        'collection.name': 'Hijacked',
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16. DELETE — host or admin only
+// ---------------------------------------------------------------------------
+
+describe('shared_collections — delete', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+    });
+  });
+
+  it('host can delete their own share', async () => {
+    await assertSucceeds(deleteDoc(doc(asHost(), sharePath)));
+  });
+
+  it('admin can delete a share', async () => {
+    await assertSucceeds(deleteDoc(doc(asAdmin(), sharePath)));
+  });
+
+  it('non-host cannot delete a share', async () => {
+    await assertFails(deleteDoc(doc(asExternalTeacher(), sharePath)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 17. Subcollection /boards/{boardId} — read mirrors parent semantics
+// ---------------------------------------------------------------------------
+
+describe('shared_collections/boards — read', () => {
+  it('positive: non-host authed teacher reads board on copy share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertSucceeds(getDoc(doc(asExternalTeacher(), boardPath)));
+  });
+
+  it('negative: non-Orono teacher denied reading board on substitute share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), subShareDoc());
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertFails(getDoc(doc(asExternalTeacher(), boardPath)));
+  });
+
+  it('positive: Orono email can read board on substitute share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), subShareDoc());
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertSucceeds(getDoc(doc(asOronoTeacher(), boardPath)));
+  });
+
+  it('unauthenticated read of board doc fails', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertFails(getDoc(doc(asUnauth(), boardPath)));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 18. Subcollection /boards/{boardId} — write rejected for non-host
+// ---------------------------------------------------------------------------
+
+describe('shared_collections/boards — write authorization', () => {
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), sharePath), copyShareDoc());
+    });
+  });
+
+  it('host can create a board snapshot', async () => {
+    await assertSucceeds(setDoc(doc(asHost(), boardPath), boardSnapshotDoc()));
+  });
+
+  it('non-host cannot create a board snapshot', async () => {
+    await assertFails(
+      setDoc(doc(asExternalTeacher(), boardPath), boardSnapshotDoc())
+    );
+  });
+
+  it('host can update a board snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertSucceeds(
+      setDoc(doc(asHost(), boardPath), {
+        ...boardSnapshotDoc(),
+        name: 'Updated',
+      })
+    );
+  });
+
+  it('non-host cannot update a board snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertFails(
+      setDoc(doc(asExternalTeacher(), boardPath), {
+        ...boardSnapshotDoc(),
+        name: 'Hijacked',
+      })
+    );
+  });
+
+  it('host can delete a board snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertSucceeds(deleteDoc(doc(asHost(), boardPath)));
+  });
+
+  it('non-host cannot delete a board snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), boardPath), boardSnapshotDoc());
+    });
+    await assertFails(deleteDoc(doc(asExternalTeacher(), boardPath)));
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -6178,6 +6178,65 @@ export interface Collection {
 }
 
 /**
+ * Mode applied to a shared-Collection import. NOT including 'synced' —
+ * live-mirroring N boards is unbounded cost. Substitute is a frozen,
+ * time-boxed view-only flavor used by the /subs portal.
+ */
+export type SharedCollectionImportMode = 'copy' | 'substitute';
+
+/**
+ * Frozen snapshot stored at `/shared_collections/{shareId}`. Each Board
+ * in the Collection is stored as a separate doc under
+ * `/shared_collections/{shareId}/boards/{boardId}` to dodge Firestore's
+ * 1MB-per-doc limit. The parent doc stores Collection metadata + an
+ * ordered `boardIds` list for the recipient flow.
+ */
+export interface SharedCollection {
+  shareId: string;
+  hostUid: string;
+  hostDisplayName: string | null;
+  intendedMode: SharedCollectionImportMode;
+  /** Frozen Collection metadata at share time (NOT the live Collection). */
+  collection: {
+    name: string;
+    color?: string;
+    icon?: string;
+  };
+  /** Ordered Board IDs — recipient reads from subcollection by these IDs. */
+  boardIds: string[];
+  /** ms epoch. */
+  createdAt: number;
+  /** Substitute-only: ms epoch when this share expires. */
+  expiresAt?: number;
+  /** Substitute-only: building id (config/buildings.ts) for /subs scoping. */
+  buildingId?: string;
+}
+
+/**
+ * One Board snapshot inside a Collection share. Stored at
+ * `/shared_collections/{shareId}/boards/{boardId}`. Mirrors the existing
+ * `Dashboard` shape minus any `linkedShareId`/`linkedShareRole` fields
+ * (a share-import is never itself a share host).
+ */
+export interface SharedCollectionBoardDoc {
+  boardId: string;
+  /** Frozen `Dashboard` at share time. */
+  dashboard: Dashboard;
+}
+
+/**
+ * Input to `shareSubstituteCollection()`. Mirrors `SubstituteShareInput`
+ * for single Boards but operates on a whole Collection.
+ */
+export interface CollectionSubstituteShareInput {
+  collectionId: string;
+  expiresAt: number;
+  buildingId: string;
+  subEmails?: string[];
+  rosterDriveFileIds?: string[];
+}
+
+/**
  * Admin-created short link, stored at `/short_links/{code}`. The doc id is
  * the public-facing code (e.g. `lesson-1`); the URL `${origin}/r/${code}`
  * resolves client-side via `ShortLinkRedirect` and bumps the `clicks`


### PR DESCRIPTION
## Summary

Plan 3 of the 4-plan Collections feature: lets a teacher share a whole Collection (metadata + every Board in it) with another teacher (Copy mode → recipient imports a full Collection into their own account) or with a substitute teacher (Substitute view-only → sub sees the Collection's Boards in the `/subs` portal for the host-chosen time window).

Builds on Plan 1 (Collections data layer) and Plan 2 (Collection-aware navigation + mounted-set). Out of scope: Plan 4 (Collection templates).

Plan doc: [docs/superpowers/plans/2026-05-16-collections-sharing.md](docs/superpowers/plans/2026-05-16-collections-sharing.md)

## Data layer

- New types: `SharedCollection`, `SharedCollectionImportMode = 'copy' | 'substitute'`, `SharedCollectionBoardDoc`, `CollectionSubstituteShareInput`
- New Firestore path `/shared_collections/{shareId}` with subcollection `/boards/{boardId}` (avoids 1MB doc limit for big Collections)
- Full Firestore rules with inline substitute-gating (matches existing `/shared_boards` pattern — no helper invented), 14-day TTL cap, host-uid validation, boardIds size cap of 500
- 25-case rules test suite at `tests/rules/sharedCollections.test.ts` — local execution blocked by Windows/JVM Firestore-emulator NIO issue, will run on CI
- `useSharedCollection` hook with chunked `writeBatch` for big Collections + auth-bypass mock store (parallel to Plan 1's `useCollections` pattern, gated on `VITE_AUTH_BYPASS`)
- `importSharedCollection` action on `DashboardContext`: loads metadata → loads boards → creates Collection → `Promise.allSettled`-fans-out `createNewDashboard` → partial-success reporting via toast → cleans up the orphan Collection if ALL boards fail
- All 8 new fields exposed via `DashboardContext.sharedCollectionApi`

## Host UI

- `ShareCollectionLinkCreatorModal` — mode picker (Copy/Substitute), TTL presets (4h/1d/3d/1w), buildingId input, auto-copy clipboard, validation
- `CollectionContextMenu` extended with `canShare` + `onShare` (gated on `canAccessFeature('dashboard-sharing')`)
- `BoardsModal` mounts the modal alongside `ShareLinkCreatorModal`

## Recipient UI (Copy mode)

- `ImportSharedCollectionModal` — loads + displays meta (Collection name, host name, board count), single Import button
- Codebase uses manual `window.location.pathname` parsing (not react-router) — `/share-collection/{shareId}` wired via lazy-initializer state in `DashboardContext`, mirrors Plan 1's single-Board pattern
- Modal mounted in `DashboardView` under `pendingSharedCollectionId`; auto-navigates to first imported board on success

## Sub-portal (Substitute mode — conservative cut)

- `SubCollectionsList` queries `/shared_collections` filtered by `intendedMode==='substitute'` + `buildingId` + `expiresAt > now`, renders Collection cards with per-board buttons
- Mounted in `TeacherDirectoryScreen` above the boards grid
- New Firestore composite index for `(intendedMode, buildingId)`
- **Known limitation**: per-board buttons are intentionally disabled with a "coming soon" tooltip. The full sub-portal Collection-view requires a new `SubCollectionBoardScreen` + provider extension — deferred (documented TODO in `SubsApp.tsx`). The surface is live so subs see what's been shared.

## i18n

- 35 new keys across 4 groups (`shareCollection`, `importSharedCollection`, `subCollections`, `collectionMenu`)
- en + de/es/fr identical (project convention)

## Tests

- 4 hook tests + 5 modal tests + 4 list tests + 25 rules tests + 1 happy-path E2E
- 269 root test files / 2687 unit tests pass
- 290 functions tests pass
- 5/5 collection-related E2E (share-collection + collections-fab + collections + sharing)
- Type-check + lint + format clean

## Review iteration

- 2 per-task review subagents per task (spec + quality) ran throughout
- Final review caught 2 non-blockers (N1: graceful sub-portal stub + N2: orphan-Collection cleanup on total import failure) — both applied before push

## Tripwire logs

- `MountedBoardsLayer.pinningLimitation` (from Plan 2) — still active
- `DashboardContext.importSharedCollection.cleanup` — fires when orphan-Collection cleanup fails after total board-import failure

## What's next

- Plan 4: Collection templates (`/dashboard_templates/` with `type` discriminator)
- Full sub-portal Collection board view (N1 follow-up): build `SubCollectionBoardScreen` + extend `SubsDashboardProvider` to load from `/shared_collections/{shareId}/boards/{boardId}`