### PR TITLE
perf(functions): drop minInstances on studentLoginV1 to cut idle billing

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3120,7 +3120,6 @@ function isOneRosterStudent(user: OneRosterUserWithRole): boolean {
 export const studentLoginV1 = onCall(
   {
     memory: '256MiB',
-    minInstances: 1,
     cors: ALLOWED_ORIGINS,
     secrets: [
       CLASSLINK_CLIENT_ID,


### PR DESCRIPTION
## Summary
- Removes \`minInstances: 1\` from \`studentLoginV1\` (functions/src/index.ts:3123).
- Eliminates ~$8–10/mo of always-warm Cloud Run idle billing — the dominant Cloud Run memory-allocation cost on the project per `run.googleapis.com/container/memory/allocation_time`.
- Trade-off: ~1–3 second cold-start on the first student login each morning (and after any ~15-min idle gap). Reviewed and accepted.
- `getPseudonymsForAssignmentV1` deliberately keeps `minInstances: 1` — it powers the teacher grading view (PII pseudonym → name lookup) where a per-open cold-start is more disruptive than morning login lag.

## Context
Found during a cost audit. SpartBoard's monthly Firebase bill is almost entirely:
1. `studentLoginV1` always-warm idle (this PR removes)
2. `getPseudonymsForAssignmentV1` always-warm idle (intentional — kept)
3. Artifact Registry baseline ~$1.10/mo (irreducible without deleting functions)

Everything else (Firestore, Storage, Hosting, Logging, Gemini, Functions runtime) is comfortably inside the free tier.

## Test plan
- [x] `pnpm run type-check:all` passes
- [x] `pnpm run lint` passes (0 warnings)
- [x] `pnpm run format:check` passes
- [ ] After merge to main, CI auto-deploys via `.github/workflows/firebase-deploy.yml`; verify in GCP console that `studentloginv1` shows min=0 and confirm first-of-morning login still works (cold start ~1–3s expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)