### PR TITLE
feat(quiz): teacher unlock control on Results > Students tab

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -833,6 +833,7 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         tabWarningsEnabled={liveSession?.tabWarningsEnabled ?? true}
         session={liveSession}
         onDeleteResponse={removeStudent}
+        onUnlockResultsForStudent={unlockResultsForStudent}
         onPlcSheetUrlReplaced={async (newUrl) => {
           // After QuizResults regenerates a stale PLC sheet (404
           // recovery), replace the URL on this widget's config so future

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1994,7 +1994,12 @@ const StudentsTab: React.FC<{
                         style={{ fontSize: 'min(10px, 3cqmin)' }}
                         title={`${warnings} Tab Switch Warning(s)`}
                       >
-                        <AlertTriangle style={{ width: 10, height: 10 }} />
+                        <AlertTriangle
+                          style={{
+                            width: 'min(10px, 3cqmin)',
+                            height: 'min(10px, 3cqmin)',
+                          }}
+                        />
                         {warnings}
                       </span>
                     )}
@@ -2013,7 +2018,12 @@ const StudentsTab: React.FC<{
                         style={{ fontSize: 'min(10px, 3cqmin)' }}
                         title={`Results locked after ${resultsTabWarnings} of ${resultsTabWarningThreshold} tab-switch warnings`}
                       >
-                        <Lock style={{ width: 10, height: 10 }} />
+                        <Lock
+                          style={{
+                            width: 'min(10px, 3cqmin)',
+                            height: 'min(10px, 3cqmin)',
+                          }}
+                        />
                         Locked ({resultsTabWarnings}/
                         {resultsTabWarningThreshold})
                       </span>

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -29,6 +29,7 @@ import {
   Hash,
   Trash2,
   RefreshCw,
+  Lock,
 } from 'lucide-react';
 import { QuizResponse, QuizData, QuizQuestion, QuizConfig } from '@/types';
 import { useAuth } from '@/context/useAuth';
@@ -130,6 +131,14 @@ interface QuizResultsProps {
    */
   onDeleteResponse?: (responseKey: string) => Promise<void>;
   /**
+   * Unlock a student's results-view lockout (triggered when the
+   * `resultsTabWarnings` threshold was hit while viewing published results).
+   * Decrements warnings by 1 and clears the lockout — one more tab-switch
+   * after this re-locks them. Pass the response's deterministic doc key
+   * (`getResponseDocKey(r)`), same key used by `onDeleteResponse`.
+   */
+  onUnlockResultsForStudent?: (responseKey: string) => Promise<void>;
+  /**
    * Called after the 404 stale-sheet recovery replaces a missing PLC sheet
    * with a fresh one. Lets the parent widget persist the new URL onto the
    * widget config and the active assignment doc so future exports don't
@@ -198,6 +207,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   tabWarningsEnabled,
   session,
   onDeleteResponse,
+  onUnlockResultsForStudent,
   onPlcSheetUrlReplaced,
   initialExportUrl,
   plcSheetUrl: assignmentPlcSheetUrl,
@@ -1464,6 +1474,10 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
                 tabWarningsEnabled={tabWarningsEnabled ?? true}
                 session={session}
                 onDeleteResponse={onDeleteResponse}
+                onUnlockResultsForStudent={onUnlockResultsForStudent}
+                resultsTabWarningThreshold={
+                  session?.protection?.tabWarningThreshold ?? 3
+                }
                 addToast={addToast}
               />
             )}
@@ -1777,6 +1791,8 @@ const StudentsTab: React.FC<{
   tabWarningsEnabled: boolean;
   session?: import('@/types').QuizSession | null;
   onDeleteResponse?: (responseKey: string) => Promise<void>;
+  onUnlockResultsForStudent?: (responseKey: string) => Promise<void>;
+  resultsTabWarningThreshold: number;
   addToast: (message: string, type?: import('@/types').Toast['type']) => void;
 }> = ({
   responses,
@@ -1786,15 +1802,46 @@ const StudentsTab: React.FC<{
   tabWarningsEnabled,
   session,
   onDeleteResponse,
+  onUnlockResultsForStudent,
+  resultsTabWarningThreshold,
   addToast,
 }) => {
   const [showResults, setShowResults] = useState(false);
   const [confirmDeleteKey, setConfirmDeleteKey] =
     useState<ResponseDocKey | null>(null);
   const [deletingKey, setDeletingKey] = useState<ResponseDocKey | null>(null);
+  const [unlockingKey, setUnlockingKey] = useState<ResponseDocKey | null>(null);
   const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
   const gamified = isGamificationActive(session);
   const suffix = getScoreSuffix(session);
+
+  // Mirror QuizLiveMonitor.handleUnlockResultsForStudent — same toast copy
+  // and same one-shot semantics (decrement warnings by 1; one more
+  // tab-switch re-locks). Surfacing this on the post-session Results view
+  // matters because the live monitor goes away once the assignment ends,
+  // but the lockout flag persists on the response doc.
+  const handleUnlockResultsForStudent = useCallback(
+    async (responseKey: ResponseDocKey, displayName: string) => {
+      if (!onUnlockResultsForStudent) return;
+      setUnlockingKey(responseKey);
+      try {
+        await onUnlockResultsForStudent(responseKey);
+        addToast(
+          `${displayName} can view results again — one more tab-switch will re-lock them.`,
+          'success'
+        );
+      } catch (err) {
+        logError('QuizResults.unlockResultsForStudent', err);
+        addToast(
+          `Could not unlock ${displayName}'s results — try again or check your connection.`,
+          'error'
+        );
+      } finally {
+        setUnlockingKey((k) => (k === responseKey ? null : k));
+      }
+    },
+    [onUnlockResultsForStudent, addToast]
+  );
 
   return (
     <div className="space-y-2">
@@ -1854,6 +1901,8 @@ const StudentsTab: React.FC<{
             const score = getDisplayScore(r, questions, session);
             const earned = getEarnedPoints(r, questions, session);
             const warnings = r.tabSwitchWarnings ?? 0;
+            const resultsLockedOut = r.resultsLockedOut === true;
+            const resultsTabWarnings = r.resultsTabWarnings ?? 0;
 
             const displayName = resolveResponseDisplayName(
               r,
@@ -1867,8 +1916,11 @@ const StudentsTab: React.FC<{
             const isResolved = !r.pin || displayName !== `PIN ${r.pin}`;
             const rowKey = getResponseDocKey(r);
             const canDelete = Boolean(onDeleteResponse);
+            const canUnlockResults =
+              resultsLockedOut && Boolean(onUnlockResultsForStudent);
             const isConfirming = confirmDeleteKey === rowKey;
             const isDeleting = deletingKey === rowKey;
+            const isUnlocking = unlockingKey === rowKey;
 
             if (isConfirming) {
               return (
@@ -1946,6 +1998,26 @@ const StudentsTab: React.FC<{
                         {warnings}
                       </span>
                     )}
+                    {/* Results-view lockout indicator. Student crossed the
+                        `protection.tabWarningThreshold` while viewing
+                        published results — the student app redirected
+                        them out and wrote `resultsLockedOut: true`. Sits
+                        next to the in-quiz tab-switch warning badge above
+                        because both come from the same "nav warning"
+                        family but track different surfaces (live attempt
+                        vs. published results). */}
+                    {resultsLockedOut && (
+                      <span
+                        aria-label="Results locked"
+                        className="flex items-center gap-1 bg-rose-100 text-rose-800 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
+                        style={{ fontSize: 'min(10px, 3cqmin)' }}
+                        title={`Results locked after ${resultsTabWarnings} of ${resultsTabWarningThreshold} tab-switch warnings`}
+                      >
+                        <Lock style={{ width: 10, height: 10 }} />
+                        Locked ({resultsTabWarnings}/
+                        {resultsTabWarningThreshold})
+                      </span>
+                    )}
                   </div>
                 </div>
 
@@ -1992,6 +2064,44 @@ const StudentsTab: React.FC<{
                     </div>
                   )}
                 </div>
+
+                {/* Unlock-results action — only when this student is
+                    currently locked out of viewing published results.
+                    Decrements `resultsTabWarnings` by 1 and clears the
+                    flag; one more tab-switch re-locks them (zero grace
+                    warnings post-unlock, matching QuizLiveMonitor's
+                    behavior). */}
+                {canUnlockResults && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void handleUnlockResultsForStudent(rowKey, displayName)
+                    }
+                    disabled={isUnlocking}
+                    title="Decrement warnings by 1 and reopen the results view for this student"
+                    aria-label={`Unlock results for ${displayName}`}
+                    className="ml-2 shrink-0 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-slate-900 font-bold rounded-lg px-3 py-1.5 transition-colors flex items-center gap-1"
+                    style={{ fontSize: 'min(11px, 3cqmin)' }}
+                  >
+                    {isUnlocking ? (
+                      <Loader2
+                        className="animate-spin"
+                        style={{
+                          width: 'min(14px, 4cqmin)',
+                          height: 'min(14px, 4cqmin)',
+                        }}
+                      />
+                    ) : (
+                      <Lock
+                        style={{
+                          width: 'min(14px, 4cqmin)',
+                          height: 'min(14px, 4cqmin)',
+                        }}
+                      />
+                    )}
+                    Unlock results
+                  </button>
+                )}
 
                 {canDelete && (
                   <button

--- a/tests/components/widgets/QuizResults.unlock.test.tsx
+++ b/tests/components/widgets/QuizResults.unlock.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { QuizConfig, QuizData, QuizResponse, QuizSession } from '@/types';
+
+// Hook stub set mirrors QuizResults.regenerate.test.tsx — only the surface
+// QuizResults reaches during render + Students-tab interaction. The
+// QuizDriveService mock is unused here (no export click), but registering it
+// avoids the real module pulling in `googleapis` during the render pass.
+const addToast = vi.fn();
+const updateWidget = vi.fn();
+const addWidget = vi.fn();
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    activeDashboard: { widgets: [] },
+    updateWidget,
+    addWidget,
+    addToast,
+    rosters: [],
+  }),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    googleAccessToken: null,
+    user: { uid: 'teacher-1' },
+    orgId: null,
+  }),
+}));
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: () => ({
+    plcs: [],
+    clearPlcSharedSheetUrl: vi.fn(),
+    setPlcSharedSheetUrl: vi.fn(),
+  }),
+}));
+vi.mock('@/hooks/useAssignmentPseudonyms', () => ({
+  useAssignmentPseudonymsMulti: () => ({
+    byStudentUid: new Map(),
+    byAssignmentPseudonym: new Map(),
+  }),
+  formatStudentName: () => '',
+}));
+vi.mock('@/hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }));
+vi.mock('@/utils/quizDriveService', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/utils/quizDriveService')>();
+  class MockQuizDriveService {
+    exportResultsToSheet = vi.fn();
+    createPlcSheetAndShare = vi.fn();
+    regeneratePlcSheet = vi.fn();
+  }
+  return { ...actual, QuizDriveService: MockQuizDriveService };
+});
+
+import { QuizResults } from '@/components/widgets/QuizWidget/components/QuizResults';
+
+function makeQuiz(): QuizData {
+  return {
+    id: 'quiz-1',
+    title: 'Sample Quiz',
+    questions: [
+      {
+        id: 'q1',
+        type: 'MC',
+        text: 'Q1',
+        correctAnswer: 'a',
+        incorrectAnswers: ['b'],
+        timeLimit: 30,
+        points: 1,
+      },
+    ],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makeLockedResponse(pin: string): QuizResponse {
+  return {
+    studentUid: `uid-${pin}`,
+    _responseKey: `pin-Period 1-${pin}`,
+    pin,
+    classPeriod: 'Period 1',
+    answers: [{ questionId: 'q1', answer: 'a', timestamp: 100 }],
+    status: 'completed',
+    submittedAt: 200,
+    tabSwitchWarnings: 0,
+    resultsTabWarnings: 3,
+    resultsLockedOut: true,
+    resultsLockedOutAt: 1700000000000,
+  } as unknown as QuizResponse;
+}
+
+function makeConfig(): QuizConfig {
+  return { view: 'results', teacherName: 'Teacher A' } as unknown as QuizConfig;
+}
+
+function makeSession(): QuizSession {
+  return {
+    id: 'session-1',
+    quizId: 'quiz-1',
+    teacherUid: 'teacher-1',
+    classIds: [],
+    protection: {
+      watermarkEnabled: false,
+      tabWarningEnabled: true,
+      tabWarningThreshold: 3,
+    },
+  } as unknown as QuizSession;
+}
+
+describe('QuizResults — Students tab results-lockout unlock control', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the Locked badge and Unlock button for a locked-out student, and invokes the callback + success toast on click', async () => {
+    const onUnlockResultsForStudent = vi.fn().mockResolvedValue(undefined);
+    const response = makeLockedResponse('1111');
+
+    render(
+      <QuizResults
+        quiz={makeQuiz()}
+        responses={[response]}
+        config={makeConfig()}
+        onBack={vi.fn()}
+        session={makeSession()}
+        tabWarningsEnabled
+        onUnlockResultsForStudent={onUnlockResultsForStudent}
+      />
+    );
+
+    // Default tab is overview — switch to Students. The tab buttons render
+    // their lowercase key as label, so the accessible name is "students".
+    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+
+    // Students tab gates the per-student rows behind a Show/Hide toggle so a
+    // teacher doesn't accidentally project scores. Reveal them so the
+    // locked-out row mounts.
+    fireEvent.click(screen.getByRole('button', { name: /show results/i }));
+
+    // Badge: "Locked (3/3)" — currentWarnings/threshold from the response +
+    // session.protection. The aria-label is the stable selector.
+    const badge = await screen.findByLabelText('Results locked');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toMatch(/Locked\s*\(3\/3\)/);
+
+    // Button: amber CTA next to the row.
+    const unlockButton = screen.getByRole('button', {
+      name: /unlock results for/i,
+    });
+    expect(unlockButton).toBeInTheDocument();
+
+    fireEvent.click(unlockButton);
+
+    // Callback must receive the deterministic doc key (_responseKey),
+    // NOT the studentUid — the unlock function in useQuizSession indexes
+    // into /quiz_sessions/{sessionId}/responses/{responseKey}.
+    await waitFor(() => {
+      expect(onUnlockResultsForStudent).toHaveBeenCalledTimes(1);
+    });
+    expect(onUnlockResultsForStudent).toHaveBeenCalledWith('pin-Period 1-1111');
+
+    // Success toast copy matches QuizLiveMonitor's so teachers see
+    // consistent messaging across the live and results surfaces.
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringMatching(/can view results again.*re-lock/i),
+        'success'
+      );
+    });
+  });
+
+  it('surfaces an error toast and does not crash when the unlock callback rejects', async () => {
+    const onUnlockResultsForStudent = vi
+      .fn()
+      .mockRejectedValue(new Error('Firestore offline'));
+    const response = makeLockedResponse('2222');
+
+    render(
+      <QuizResults
+        quiz={makeQuiz()}
+        responses={[response]}
+        config={makeConfig()}
+        onBack={vi.fn()}
+        session={makeSession()}
+        tabWarningsEnabled
+        onUnlockResultsForStudent={onUnlockResultsForStudent}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show results/i }));
+
+    const unlockButton = await screen.findByRole('button', {
+      name: /unlock results for/i,
+    });
+    fireEvent.click(unlockButton);
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringMatching(/could not unlock.*try again/i),
+        'error'
+      );
+    });
+  });
+
+  it('does not render the Unlock button when the student is not locked out', () => {
+    const onUnlockResultsForStudent = vi.fn();
+    const response = {
+      ...makeLockedResponse('3333'),
+      resultsLockedOut: false,
+      resultsTabWarnings: 1,
+    } as QuizResponse;
+
+    render(
+      <QuizResults
+        quiz={makeQuiz()}
+        responses={[response]}
+        config={makeConfig()}
+        onBack={vi.fn()}
+        session={makeSession()}
+        tabWarningsEnabled
+        onUnlockResultsForStudent={onUnlockResultsForStudent}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show results/i }));
+
+    // The student row mounts (verify by looking for the score), but neither
+    // the badge nor the unlock button should be present — the lock UI is
+    // strictly gated on `resultsLockedOut === true`.
+    expect(screen.queryByLabelText('Results locked')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /unlock results for/i })
+    ).not.toBeInTheDocument();
+    expect(onUnlockResultsForStudent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- A student who navigates away from published quiz results too many times gets `resultsLockedOut: true` on their response doc and is bounced back to `/my-assignments` with a red "Locked" pill. The teacher already has an "Unlock results" affordance in **QuizLiveMonitor**, but that surface disappears once the assignment ends — and the lockout flag persists, leaving no way to let the student back in.
- Mirrored QuizLiveMonitor's lock badge + amber "Unlock results" button on each student row inside `QuizResults` → **Students** tab. Wired through the existing `unlockResultsForStudent` from `useQuizSessionTeacher` (already destructured in `Widget.tsx`), so semantics match exactly: decrement `resultsTabWarnings` by 1, clear `resultsLockedOut`, delete `resultsLockedOutAt` — one more tab-switch re-locks them (zero grace warnings post-unlock, intentional).
- No changes to the underlying unlock logic, Firestore fields, or rules — purely surfacing the existing action on a second teacher-facing view.

## Test plan

- [ ] As a teacher, publish quiz results with `protection.tabWarningEnabled = true` and `tabWarningThreshold = 1`.
- [ ] As a student, view results and trigger the lockout (switch tabs / blur the window).
- [ ] Confirm the student is bounced to `/my-assignments` and sees the red "Locked" pill on the assignment row.
- [ ] As the teacher, open the quiz widget → Results → **Students** tab. Verify the locked student's row shows the rose "Locked (N/threshold)" badge next to their name and an amber "Unlock results" button on the right.
- [ ] Click "Unlock results" → toast confirms "{name} can view results again — one more tab-switch will re-lock them."
- [ ] On the student device, refresh / re-tap the assignment — verify they can re-enter results.
- [ ] Re-trigger the lockout (one tab-switch) and confirm the badge + button reappear on the teacher's Students tab.
- [ ] Regression: confirm the existing "Unlock results" control in the live monitor still works during an active session.
- [ ] `pnpm run validate` — type-check + lint + format + tests all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pc4nopLmSVn1Jg7aSwdXUB)_