### PR TITLE
fix(styles): register tailwindcss-animate so animate-in classes actually animate

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "postcss": "^8.5.6",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.19",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^6.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(yaml@2.8.2)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.19(yaml@2.8.2))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -5733,6 +5736,11 @@ packages:
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
 
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
@@ -12825,6 +12833,10 @@ snapshots:
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(yaml@2.8.2)):
+    dependencies:
+      tailwindcss: 3.4.19(yaml@2.8.2)
 
   tailwindcss@3.4.19(yaml@2.8.2):
     dependencies:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,4 @@
+import tailwindcssAnimate from 'tailwindcss-animate';
 import { Z_INDEX } from './config/zIndex';
 import { HIGHLIGHT_BG_CLASSES } from './utils/writtenAnnotations';
 
@@ -234,5 +235,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [tailwindcssAnimate],
 };


### PR DESCRIPTION
## Summary

The codebase uses `animate-in fade-in slide-in-from-*` Tailwind utility classes in 150+ spots (modals, popovers, banners, toasts, FAB menus, sidebars, etc.) — and CLAUDE.md's "UI Styling" section explicitly lists these as part of the project's animation vocabulary — but `tailwindcss-animate` was never installed or registered. Those classes compiled to nothing, so elements mounted instantly with no animation.

This PR installs `tailwindcss-animate` and wires it into `tailwind.config.js` so every existing call site animates as its author intended.

## Changes

- `package.json` / `pnpm-lock.yaml`: add `tailwindcss-animate@1.0.7` as a devDependency
- `tailwind.config.js`: ESM-import the plugin and add it to `plugins`

No call sites were modified — they were already written correctly and just needed the plugin to be active.

## Verification

- ✅ `pnpm run build` succeeds — output CSS now contains `@keyframes enter`, `@keyframes exit`, and the `--tw-enter-*` driver variables, plus all referenced variants (`animate-in`, `fade-in`, `zoom-in-95`, `slide-in-from-{top,bottom,left,right}-{1,2,4,5,8}`, `motion-safe:animate-in`).
- ✅ `pnpm run type-check` clean
- ✅ `pnpm run lint` clean
- ✅ `pnpm run format:check` clean
- ✅ `pnpm test` — 250 files, 2581 tests passing

## Notes / Out of scope

- Per the task spec, I did **not** replace the custom `.animate-disclosure-expand` class added by the recent What's New PR — it works as-is.
- I did **not** audit for places that *should* use `animate-in` but don't — only fixed the broken classes that already existed.
- The CLAUDE.md guidance on animations is now actually accurate; no doc changes required.
- E2E tests were not run in this environment (no Firebase credentials available); they should run in CI. Worth watching for any interaction tests that previously raced on instant mount.

## Call sites confirmed to now animate (sample — 150+ total via `grep`)

The task description listed 5; the grep turned up many more. The plugin is global, so all of these light up at once:

- `components/widgets/QuizWidget/components/QuizResults.tsx`
- `components/layout/sidebar/Sidebar.tsx`
- `components/layout/CollectionSwitcherMenu.tsx`
- `components/layout/BoardNavFab.tsx`
- `components/common/DriveDisconnectBanner.tsx`
- `components/common/Modal.tsx` (modal backdrop fade + content zoom)
- `components/common/DialogContainer.tsx` (dialog enter)
- `components/common/FloatingPanel.tsx` (popover enter)
- `components/common/CheatSheetModal.tsx`
- `components/admin/AdminSettings.tsx` (tab transitions)
- `components/admin/Organization/components/primitives.tsx` (toasts + modals)
- `components/layout/Dock.tsx` (dock menu)
- `components/layout/RemoteControlMenu.tsx`
- `components/layout/sidebar/StylePanel.tsx` (tab transitions)
- `components/layout/AnnotationOverlay.tsx`
- `components/layout/DashboardView.tsx` (toast slide-in)
- `components/quiz/QuizStudentApp.tsx` (multiple answer-block transitions)
- ...and ~130 more across admin modals, dock pickers, library modals, MagicInput error states, etc.

## Test plan

- [ ] CI passes (build, lint, type-check, format, unit tests)
- [ ] E2E tests pass in CI
- [ ] Manual: open a modal — backdrop should fade and content should zoom-in (not pop in instantly)
- [ ] Manual: open the BoardNavFab — menu should slide up from the FAB
- [ ] Manual: open Sidebar style tabs — sections should slide-in from the side
- [ ] Manual: disconnect Drive to surface the banner — should slide in from bottom-right

https://claude.ai/code/session_012JmfVJ2aNv5QgR5oYtTRQr

---
_Generated by [Claude Code](https://claude.ai/code/session_012JmfVJ2aNv5QgR5oYtTRQr)_