### PR TITLE
feat(music): per-teacher Spotify auth + Web Playback SDK in Music widget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,19 @@ VITE_AUTH_BYPASS="false"
 # Get this from: Google Cloud Console > APIs & Services > Credentials > OAuth 2.0 Client IDs
 VITE_GOOGLE_CLIENT_ID=""
 
-# Spotify OAuth client ID (PKCE flow — no client secret needed on the frontend).
-# Required for the Music widget's "Use my own Spotify" feature. The client secret
-# lives in Firebase Functions secrets (SPOTIFY_OAUTH_CLIENT_SECRET) and never
-# reaches the browser. Get the client ID from:
+# Spotify OAuth client ID (PKCE flow — the client secret stays server-side).
+# Required for the Music widget's "Use my own Spotify" feature. Get the
+# client ID from:
 #   https://developer.spotify.com/dashboard → Create app
 # Add redirect URIs to the Spotify app:
 #   https://<your-domain>/spotify-callback
 #   http://localhost:3000/spotify-callback   (for dev)
+#
+# Companion Firebase Functions secrets (set with `firebase functions:secrets:set`):
+#   SPOTIFY_OAUTH_CLIENT_ID            — same value as VITE_SPOTIFY_CLIENT_ID
+#   SPOTIFY_OAUTH_CLIENT_SECRET        — from the Spotify dashboard
+#   SPOTIFY_OAUTH_REFRESH_TOKEN_KEY    — any strong random string; encrypts
+#                                        refresh tokens at rest in Firestore
 VITE_SPOTIFY_CLIENT_ID=""
 
 # Extension API Keys (Required for local MCP server configuration)

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ VITE_AUTH_BYPASS="false"
 # Get this from: Google Cloud Console > APIs & Services > Credentials > OAuth 2.0 Client IDs
 VITE_GOOGLE_CLIENT_ID=""
 
+# Spotify OAuth client ID (PKCE flow — no client secret needed on the frontend).
+# Required for the Music widget's "Use my own Spotify" feature. The client secret
+# lives in Firebase Functions secrets (SPOTIFY_OAUTH_CLIENT_SECRET) and never
+# reaches the browser. Get the client ID from:
+#   https://developer.spotify.com/dashboard → Create app
+# Add redirect URIs to the Spotify app:
+#   https://<your-domain>/spotify-callback
+#   http://localhost:3000/spotify-callback   (for dev)
+VITE_SPOTIFY_CLIENT_ID=""
+
 # Extension API Keys (Required for local MCP server configuration)
 STITCH_API_KEY="placeholder"
 JULES_TOKEN="placeholder"

--- a/App.tsx
+++ b/App.tsx
@@ -123,6 +123,11 @@ const SubsApp = lazy(() =>
     default: module.SubsApp,
   }))
 );
+const SpotifyCallback = lazy(() =>
+  import('./components/spotify/SpotifyCallback').then((module) => ({
+    default: module.SpotifyCallback,
+  }))
+);
 
 const FullPageLoader = () => (
   <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
@@ -329,6 +334,17 @@ const App: React.FC = () => {
     return (
       <Suspense fallback={<FullPageLoader />}>
         <ShortLinkRedirect />
+      </Suspense>
+    );
+  }
+
+  // Spotify OAuth callback — loaded into the popup window opened by
+  // `connectSpotify()`. Posts the auth code back to `window.opener` and
+  // closes itself; no providers, no auth, no Firestore listeners needed.
+  if (pathname === '/spotify-callback') {
+    return (
+      <Suspense fallback={<FullPageLoader />}>
+        <SpotifyCallback />
       </Suspense>
     );
   }

--- a/components/spotify/SpotifyCallback.tsx
+++ b/components/spotify/SpotifyCallback.tsx
@@ -1,0 +1,129 @@
+/**
+ * OAuth callback page that the Spotify consent popup lands on.
+ *
+ * Reads `?code=...&state=...` (or `?error=...`) from the URL, posts the
+ * result back to `window.opener` via `postMessage`, then closes itself.
+ * The opener (`connectSpotify` in `utils/spotifyAuth.ts`) handles the
+ * backend exchange.
+ *
+ * Falls back to a manual "Close window" button if `window.opener` is
+ * missing — typically because the user opened the URL in a fresh tab or
+ * the opener was reloaded mid-flow.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import type { SpotifyCallbackMessage } from '@/utils/spotifyAuth';
+
+interface InitialState {
+  status: 'posting' | 'orphaned';
+  message: SpotifyCallbackMessage;
+  initialError: string;
+}
+
+/**
+ * Compute the initial render state synchronously from URL + window.opener.
+ * Doing this in a useState initializer avoids `react-hooks/set-state-in-effect`
+ * by keeping all decisions inside the render phase rather than chasing them
+ * with a setState() inside useEffect.
+ */
+function computeInitialState(): InitialState {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code') ?? undefined;
+  const state = params.get('state') ?? undefined;
+  const error = params.get('error') ?? undefined;
+  const message: SpotifyCallbackMessage = {
+    source: 'spartboard-spotify-callback',
+    code,
+    state,
+    error,
+  };
+  const opener = window.opener as Window | null;
+  const hasOpener = !!opener && !opener.closed;
+  return {
+    status: hasOpener ? 'posting' : 'orphaned',
+    message,
+    initialError: error ?? '',
+  };
+}
+
+export const SpotifyCallback: React.FC = () => {
+  const [initial] = useState<InitialState>(computeInitialState);
+  const [postError, setPostError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initial.status !== 'posting') return;
+    const opener = window.opener as Window | null;
+    if (!opener || opener.closed) return;
+
+    try {
+      opener.postMessage(initial.message, window.location.origin);
+    } catch (err) {
+      console.error('[SpotifyCallback] postMessage failed', err);
+      // Defer the state update past the effect's synchronous body so
+      // `react-hooks/set-state-in-effect` doesn't flag a cascading render.
+      // postMessage failures here are terminal (the opener can't receive
+      // the code) so there's nothing else for the effect to do this tick.
+      queueMicrotask(() =>
+        setPostError(err instanceof Error ? err.message : String(err))
+      );
+      return;
+    }
+
+    // Tiny delay so the opener's message listener has a tick to run before
+    // the popup window vanishes. Closing is best-effort — some browsers
+    // block window.close() on windows not opened by script.
+    const t = window.setTimeout(() => {
+      try {
+        window.close();
+      } catch {
+        /* ignored */
+      }
+    }, 100);
+    return () => window.clearTimeout(t);
+  }, [initial]);
+
+  const showError = postError !== null;
+  const orphanedMessage = initial.initialError
+    ? `Spotify reported: ${initial.initialError}`
+    : 'Return to SpartBoard to finish connecting Spotify.';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
+      <div className="max-w-sm w-full bg-white rounded-2xl shadow-lg p-8 text-center">
+        {showError ? (
+          <>
+            <h1 className="text-lg font-semibold text-slate-800">
+              Something went wrong
+            </h1>
+            <p className="text-sm text-slate-500 mt-2">{postError}</p>
+          </>
+        ) : initial.status === 'orphaned' ? (
+          <>
+            <h1 className="text-lg font-semibold text-slate-800">
+              Spotify connection
+            </h1>
+            <p className="text-sm text-slate-500 mt-2">{orphanedMessage}</p>
+            <button
+              type="button"
+              onClick={() => window.close()}
+              className="mt-4 px-4 py-2 rounded-lg bg-slate-800 text-white text-sm font-medium hover:bg-slate-700"
+            >
+              Close window
+            </button>
+          </>
+        ) : (
+          <>
+            <Loader2 className="w-10 h-10 text-green-600 animate-spin mx-auto mb-4" />
+            <h1 className="text-lg font-semibold text-slate-800">
+              Connecting Spotify…
+            </h1>
+            <p className="text-sm text-slate-500 mt-2">
+              You can close this window if it doesn&apos;t close on its own.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/spotify/SpotifyPremiumDialog.tsx
+++ b/components/spotify/SpotifyPremiumDialog.tsx
@@ -1,0 +1,115 @@
+/**
+ * One-time-per-user notice that personal Spotify playback in the Music
+ * widget needs a Spotify Premium subscription. Free accounts can still
+ * connect, but the Web Playback SDK refuses to start playback; Spotify
+ * will reject `PUT /me/player/play` with 403 and the widget falls back
+ * to the embed iframe (which limits Free users to 30-sec previews).
+ *
+ * Three exits:
+ *   - "Got it, continue" — proceeds; remembered as shown for this session
+ *   - "Don't show this again" + "Continue" — saves the preference and proceeds
+ *   - "Cancel" — caller reverts to curated-stations source
+ *
+ * The "don't show again" preference lives in `utils/spotifyPremiumNotice.ts`
+ * so this file exports only a React component (keeps Vite's react-refresh
+ * happy).
+ */
+
+import React, { useState } from 'react';
+import { Music2, X } from 'lucide-react';
+import { setSpotifyPremiumNoticeDismissed } from '@/utils/spotifyPremiumNotice';
+
+interface Props {
+  uid: string;
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export const SpotifyPremiumDialog: React.FC<Props> = ({
+  uid,
+  onContinue,
+  onCancel,
+}) => {
+  const [dontShow, setDontShow] = useState(false);
+
+  const handleContinue = () => {
+    if (dontShow) setSpotifyPremiumNoticeDismissed(uid);
+    onContinue();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="spotify-premium-title"
+    >
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden">
+        <div className="flex items-center justify-between px-6 pt-5 pb-2">
+          <div className="flex items-center gap-2.5">
+            <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
+              <Music2 className="w-5 h-5 text-green-700" />
+            </div>
+            <h2
+              id="spotify-premium-title"
+              className="text-lg font-bold text-slate-900"
+            >
+              Spotify Premium required
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-slate-400 hover:text-slate-600 transition"
+            aria-label="Cancel"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-4 space-y-3 text-sm text-slate-700">
+          <p>
+            Using your personal Spotify account for full playback in the Music
+            widget requires an active{' '}
+            <span className="font-semibold">Spotify Premium</span> subscription.
+          </p>
+          <p className="text-slate-600">
+            If you connect a free Spotify account, the widget will fall back to
+            the standard Spotify embed (which limits free accounts to 30-second
+            previews). You can disconnect at any time and return to the curated
+            stations.
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 px-6 py-3 border-t border-slate-100 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={dontShow}
+            onChange={(e) => setDontShow(e.target.checked)}
+            className="w-4 h-4 rounded border-slate-300 text-green-600 focus:ring-green-500"
+          />
+          <span className="text-sm text-slate-700">
+            Don&apos;t show this again
+          </span>
+        </label>
+
+        <div className="px-6 pb-5 pt-2 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-slate-700 hover:bg-slate-100 transition"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleContinue}
+            className="px-4 py-2 rounded-lg text-sm font-semibold text-white bg-green-600 hover:bg-green-700 transition"
+          >
+            Got it, continue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/components/spotify/SpotifyPremiumDialog.tsx
+++ b/components/spotify/SpotifyPremiumDialog.tsx
@@ -1,21 +1,28 @@
 /**
- * One-time-per-user notice that personal Spotify playback in the Music
- * widget needs a Spotify Premium subscription. Free accounts can still
- * connect, but the Web Playback SDK refuses to start playback; Spotify
- * will reject `PUT /me/player/play` with 403 and the widget falls back
- * to the embed iframe (which limits Free users to 30-sec previews).
+ * Notice that personal Spotify playback in the Music widget needs a Spotify
+ * Premium subscription. Free accounts can still connect, but the Web
+ * Playback SDK refuses to start playback; Spotify will reject
+ * `PUT /me/player/play` with 403 and the widget falls back to the embed
+ * iframe (which limits Free users to 30-sec previews).
  *
  * Three exits:
- *   - "Got it, continue" — proceeds; remembered as shown for this session
- *   - "Don't show this again" + "Continue" — saves the preference and proceeds
+ *   - "Got it, continue" — proceeds with the connect flow
+ *   - "Don't show this again" + "Continue" — persists the suppression and
+ *     proceeds; future connect attempts skip this dialog
  *   - "Cancel" — caller reverts to curated-stations source
  *
  * The "don't show again" preference lives in `utils/spotifyPremiumNotice.ts`
  * so this file exports only a React component (keeps Vite's react-refresh
  * happy).
+ *
+ * Portalled to `document.body`. The widget's settings panel applies
+ * `will-change: transform`, which establishes a containing block for fixed
+ * descendants — a `position: fixed` modal rendered as a child would be
+ * clipped to the panel instead of the viewport.
  */
 
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Music2, X } from 'lucide-react';
 import { setSpotifyPremiumNoticeDismissed } from '@/utils/spotifyPremiumNotice';
 
@@ -37,7 +44,10 @@ export const SpotifyPremiumDialog: React.FC<Props> = ({
     onContinue();
   };
 
-  return (
+  // Guard against SSR / test environments without a DOM.
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
     <div
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
       role="dialog"
@@ -110,6 +120,7 @@ export const SpotifyPremiumDialog: React.FC<Props> = ({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };

--- a/components/widgets/MusicWidget/PersonalSpotifyPanel.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyPanel.tsx
@@ -12,7 +12,6 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import {
-  AlertCircle,
   CheckCircle2,
   Crown,
   Disc3,
@@ -30,6 +29,7 @@ import {
   parseSpotifyResource,
   searchSpotify,
   SpotifySearchResult,
+  spotifyOpenUrlFromInput,
 } from '@/utils/spotifyAuth';
 import { SpotifyPremiumDialog } from '@/components/spotify/SpotifyPremiumDialog';
 import { hasDismissedSpotifyPremiumNotice } from '@/utils/spotifyPremiumNotice';
@@ -57,7 +57,9 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
   const [searchResults, setSearchResults] = useState<SpotifySearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
-  const [connectError, setConnectError] = useState<string | null>(null);
+  const [disconnectWarning, setDisconnectWarning] = useState<string | null>(
+    null
+  );
 
   // Keep the input in sync if the config changes externally (e.g. via another tab).
   useEffect(() => {
@@ -109,16 +111,20 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
   }, [urlInput, isConnected, getAccessToken]);
 
   const triggerConnect = useCallback(async () => {
-    setConnectError(null);
-    const outcome = await connect();
-    if (outcome.kind === 'error') {
-      setConnectError(prettifyConnectError(outcome.reason));
-    } else if (outcome.kind === 'needs-consent') {
-      setConnectError(
-        'Spotify needs re-consent. Try connecting again — if it keeps failing, contact your admin.'
-      );
-    }
+    // Error prettification + state surfacing live in `useSpotifyAuth` so
+    // every subscriber (panel + already-mounted player) sees the same
+    // message. We just need to fire the popup here.
+    setDisconnectWarning(null);
+    await connect();
   }, [connect]);
+
+  const triggerDisconnect = useCallback(async () => {
+    setDisconnectWarning(null);
+    const result = await disconnect();
+    if (!result.ok) {
+      setDisconnectWarning(result.message);
+    }
+  }, [disconnect]);
 
   const handleConnectClick = useCallback(() => {
     if (!user) return;
@@ -153,16 +159,25 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
       });
       return;
     }
-    if (parseSpotifyResource(trimmed)) {
-      updateWidget(widget.id, {
-        config: { ...config, personalSpotifyUrl: trimmed },
-      });
-    }
+    if (!parseSpotifyResource(trimmed)) return;
+    // Clear the cached label + thumbnail unless this input already matches
+    // the saved selection. Without this, pasting a different valid URL
+    // leaves the prior track's label/thumbnail displayed alongside the new
+    // URL until the SDK happens to update it.
+    if (trimmed === config.personalSpotifyUrl) return;
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        personalSpotifyUrl: trimmed,
+        personalSpotifyLabel: '',
+        personalSpotifyThumbnail: '',
+      },
+    });
   }, [urlInput, config, widget.id, updateWidget]);
 
   const pickResult = useCallback(
     (result: SpotifySearchResult) => {
-      const openUrl = spotifyUriToOpenUrl(result.uri) ?? result.uri;
+      const openUrl = spotifyOpenUrlFromInput(result.uri) ?? result.uri;
       updateWidget(widget.id, {
         config: {
           ...config,
@@ -196,22 +211,14 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
       )}
 
       {state.status === 'disconnected' && (
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={handleConnectClick}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold text-sm transition shadow-sm"
-          >
-            <Music2 className="w-4 h-4" />
-            Connect Spotify account
-          </button>
-          {connectError && (
-            <p className="text-xs text-red-600 flex items-start gap-1.5">
-              <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-              <span>{connectError}</span>
-            </p>
-          )}
-        </div>
+        <button
+          type="button"
+          onClick={handleConnectClick}
+          className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold text-sm transition shadow-sm"
+        >
+          <Music2 className="w-4 h-4" />
+          Connect Spotify account
+        </button>
       )}
 
       {state.status === 'connecting' && (
@@ -262,7 +269,7 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
             </div>
             <button
               type="button"
-              onClick={() => void disconnect()}
+              onClick={() => void triggerDisconnect()}
               className="p-1.5 text-slate-500 hover:text-red-600 hover:bg-red-50 rounded transition"
               title="Disconnect Spotify"
               aria-label="Disconnect Spotify"
@@ -270,6 +277,12 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
               <LogOut className="w-4 h-4" />
             </button>
           </div>
+
+          {disconnectWarning && (
+            <div className="px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
+              {disconnectWarning}
+            </div>
+          )}
 
           {!isPremium && (
             <div className="px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
@@ -354,25 +367,3 @@ export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
     </div>
   );
 };
-
-function prettifyConnectError(reason: string): string {
-  switch (reason) {
-    case 'popup-blocked':
-      return 'Your browser blocked the Spotify sign-in popup. Allow popups for this site and try again.';
-    case 'auth-bypass-mode':
-      return 'Spotify cannot be connected in auth-bypass mode.';
-    case 'callback-missing-code':
-      return 'Spotify did not return an authorization code. Try again.';
-    case 'access_denied':
-      return 'Spotify access was denied. Try connecting again and approve the requested permissions.';
-    default:
-      return reason;
-  }
-}
-
-/** Convert `spotify:track:abc` → `https://open.spotify.com/track/abc`. */
-function spotifyUriToOpenUrl(uri: string): string | null {
-  const m = uri.match(/^spotify:(track|album|playlist|artist):([A-Za-z0-9]+)$/);
-  if (!m) return null;
-  return `https://open.spotify.com/${m[1]}/${m[2]}`;
-}

--- a/components/widgets/MusicWidget/PersonalSpotifyPanel.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyPanel.tsx
@@ -1,0 +1,378 @@
+/**
+ * "Use my own Spotify" panel rendered inside the Music widget settings when
+ * `config.source === 'personal'`. Encapsulates:
+ *   - Connect / Disconnect flow (via `useSpotifyAuth`)
+ *   - Premium-required dialog gate (first-time-per-user)
+ *   - Spotify URL paste field + live search dropdown
+ *   - Account status display (email + Premium badge)
+ *
+ * Kept as its own file because the settings flow is the most complex part of
+ * the widget and would otherwise dominate Settings.tsx.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Crown,
+  Disc3,
+  ListMusic,
+  Loader2,
+  LogOut,
+  Music2,
+  Search,
+} from 'lucide-react';
+import { WidgetData, MusicConfig } from '@/types';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
+import {
+  parseSpotifyResource,
+  searchSpotify,
+  SpotifySearchResult,
+} from '@/utils/spotifyAuth';
+import { SpotifyPremiumDialog } from '@/components/spotify/SpotifyPremiumDialog';
+import { hasDismissedSpotifyPremiumNotice } from '@/utils/spotifyPremiumNotice';
+
+const TYPE_ICONS = {
+  track: Disc3,
+  album: Disc3,
+  playlist: ListMusic,
+  artist: Music2,
+} as const;
+
+interface Props {
+  widget: WidgetData;
+}
+
+export const PersonalSpotifyPanel: React.FC<Props> = ({ widget }) => {
+  const { user } = useAuth();
+  const { updateWidget } = useDashboard();
+  const config = widget.config as MusicConfig;
+  const { state, isConnected, isPremium, connect, disconnect, getAccessToken } =
+    useSpotifyAuth();
+
+  const [showPremiumDialog, setShowPremiumDialog] = useState(false);
+  const [urlInput, setUrlInput] = useState(config.personalSpotifyUrl ?? '');
+  const [searchResults, setSearchResults] = useState<SpotifySearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  // Keep the input in sync if the config changes externally (e.g. via another tab).
+  useEffect(() => {
+    setUrlInput(config.personalSpotifyUrl ?? '');
+  }, [config.personalSpotifyUrl]);
+
+  // Debounced Spotify search whenever the user types something that isn't a URL.
+  // URLs go straight to the save handler — no point burning a search call.
+  useEffect(() => {
+    const trimmed = urlInput.trim();
+    if (!trimmed || !isConnected) {
+      setSearchResults([]);
+      setSearchError(null);
+      return;
+    }
+    if (parseSpotifyResource(trimmed)) {
+      // Pasted a valid URL — no search needed.
+      setSearchResults([]);
+      setSearchError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setIsSearching(true);
+      setSearchError(null);
+      try {
+        const token = await getAccessToken();
+        if (!token) {
+          setSearchError('Spotify session expired — reconnect.');
+          setSearchResults([]);
+          return;
+        }
+        const results = await searchSpotify(token, trimmed, controller.signal);
+        setSearchResults(results);
+      } catch (err) {
+        if ((err as { name?: string })?.name === 'AbortError') return;
+        setSearchError(err instanceof Error ? err.message : 'Search failed.');
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [urlInput, isConnected, getAccessToken]);
+
+  const triggerConnect = useCallback(async () => {
+    setConnectError(null);
+    const outcome = await connect();
+    if (outcome.kind === 'error') {
+      setConnectError(prettifyConnectError(outcome.reason));
+    } else if (outcome.kind === 'needs-consent') {
+      setConnectError(
+        'Spotify needs re-consent. Try connecting again — if it keeps failing, contact your admin.'
+      );
+    }
+  }, [connect]);
+
+  const handleConnectClick = useCallback(() => {
+    if (!user) return;
+    if (hasDismissedSpotifyPremiumNotice(user.uid)) {
+      void triggerConnect();
+      return;
+    }
+    setShowPremiumDialog(true);
+  }, [user, triggerConnect]);
+
+  const handlePremiumContinue = useCallback(() => {
+    setShowPremiumDialog(false);
+    void triggerConnect();
+  }, [triggerConnect]);
+
+  const handlePremiumCancel = useCallback(() => {
+    setShowPremiumDialog(false);
+    // Revert source so the widget goes back to curated stations.
+    updateWidget(widget.id, { config: { ...config, source: 'curated' } });
+  }, [config, widget.id, updateWidget]);
+
+  const handleUrlBlur = useCallback(() => {
+    const trimmed = urlInput.trim();
+    if (!trimmed) {
+      updateWidget(widget.id, {
+        config: {
+          ...config,
+          personalSpotifyUrl: '',
+          personalSpotifyLabel: '',
+          personalSpotifyThumbnail: '',
+        },
+      });
+      return;
+    }
+    if (parseSpotifyResource(trimmed)) {
+      updateWidget(widget.id, {
+        config: { ...config, personalSpotifyUrl: trimmed },
+      });
+    }
+  }, [urlInput, config, widget.id, updateWidget]);
+
+  const pickResult = useCallback(
+    (result: SpotifySearchResult) => {
+      const openUrl = spotifyUriToOpenUrl(result.uri) ?? result.uri;
+      updateWidget(widget.id, {
+        config: {
+          ...config,
+          personalSpotifyUrl: openUrl,
+          personalSpotifyLabel: `${result.name} — ${result.subtitle}`,
+          personalSpotifyThumbnail: result.imageUrl ?? '',
+        },
+      });
+      setUrlInput(openUrl);
+      setSearchResults([]);
+    },
+    [config, widget.id, updateWidget]
+  );
+
+  return (
+    <div className="space-y-4">
+      {showPremiumDialog && user && (
+        <SpotifyPremiumDialog
+          uid={user.uid}
+          onContinue={handlePremiumContinue}
+          onCancel={handlePremiumCancel}
+        />
+      )}
+
+      {/* ── Connection status / Connect button ── */}
+      {state.status === 'unknown' && (
+        <div className="flex items-center gap-2 p-3 bg-slate-50 rounded-lg border border-slate-200 text-sm text-slate-500">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Checking Spotify connection…
+        </div>
+      )}
+
+      {state.status === 'disconnected' && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={handleConnectClick}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-semibold text-sm transition shadow-sm"
+          >
+            <Music2 className="w-4 h-4" />
+            Connect Spotify account
+          </button>
+          {connectError && (
+            <p className="text-xs text-red-600 flex items-start gap-1.5">
+              <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+              <span>{connectError}</span>
+            </p>
+          )}
+        </div>
+      )}
+
+      {state.status === 'connecting' && (
+        <div className="flex items-center gap-2 p-3 bg-green-50 rounded-lg border border-green-200 text-sm text-green-700">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          Waiting for Spotify consent…
+        </div>
+      )}
+
+      {state.status === 'error' && (
+        <div className="space-y-2">
+          <div className="p-3 bg-red-50 rounded-lg border border-red-200 text-xs text-red-700">
+            <p className="font-semibold mb-1">Couldn&apos;t connect Spotify</p>
+            <p>{state.message}</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleConnectClick}
+            className="w-full px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white rounded-lg text-sm font-medium transition"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {state.status === 'connected' && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between p-3 bg-green-50 border border-green-200 rounded-lg">
+            <div className="flex items-center gap-2.5 min-w-0">
+              <CheckCircle2 className="w-5 h-5 text-green-600 shrink-0" />
+              <div className="min-w-0">
+                <p className="text-xs font-semibold text-green-900 truncate">
+                  {state.profile.displayName ??
+                    state.profile.email ??
+                    'Spotify connected'}
+                </p>
+                <p className="text-xs text-green-700 flex items-center gap-1">
+                  {isPremium ? (
+                    <>
+                      <Crown className="w-3 h-3" />
+                      Premium
+                    </>
+                  ) : (
+                    'Free (preview-only playback)'
+                  )}
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => void disconnect()}
+              className="p-1.5 text-slate-500 hover:text-red-600 hover:bg-red-50 rounded transition"
+              title="Disconnect Spotify"
+              aria-label="Disconnect Spotify"
+            >
+              <LogOut className="w-4 h-4" />
+            </button>
+          </div>
+
+          {!isPremium && (
+            <div className="px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
+              Your Spotify account isn&apos;t Premium. Playback will fall back
+              to Spotify&apos;s embed player (30-second previews only).
+            </div>
+          )}
+
+          {/* ── URL / search input ── */}
+          <div className="space-y-1.5">
+            <label className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
+              Spotify URL or search
+            </label>
+            <div className="relative">
+              <Search className="w-4 h-4 text-slate-400 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+              <input
+                type="text"
+                value={urlInput}
+                onChange={(e) => setUrlInput(e.target.value)}
+                onBlur={handleUrlBlur}
+                placeholder="Paste a Spotify URL or search…"
+                className="w-full pl-9 pr-3 py-2 bg-white border border-slate-300 rounded-lg text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500"
+              />
+            </div>
+            {config.personalSpotifyLabel && (
+              <p className="text-xs text-slate-500 truncate">
+                Selected:{' '}
+                <span className="text-slate-700 font-medium">
+                  {config.personalSpotifyLabel}
+                </span>
+              </p>
+            )}
+            {searchError && (
+              <p className="text-xs text-red-600">{searchError}</p>
+            )}
+          </div>
+
+          {/* ── Search results ── */}
+          {(isSearching || searchResults.length > 0) && (
+            <div className="border border-slate-200 rounded-lg overflow-hidden max-h-64 overflow-y-auto">
+              {isSearching && (
+                <div className="flex items-center gap-2 px-3 py-2 text-xs text-slate-500 bg-slate-50">
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                  Searching Spotify…
+                </div>
+              )}
+              {searchResults.map((r) => {
+                const Icon = TYPE_ICONS[r.type] ?? Music2;
+                return (
+                  <button
+                    key={`${r.type}-${r.id}`}
+                    type="button"
+                    onClick={() => pickResult(r)}
+                    className="w-full flex items-center gap-3 px-3 py-2 hover:bg-slate-50 transition text-left border-b border-slate-100 last:border-b-0"
+                  >
+                    {r.imageUrl ? (
+                      <img
+                        src={r.imageUrl}
+                        alt=""
+                        className="w-10 h-10 rounded object-cover shrink-0"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded bg-slate-100 flex items-center justify-center shrink-0">
+                        <Icon className="w-4 h-4 text-slate-400" />
+                      </div>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-slate-900 truncate">
+                        {r.name}
+                      </p>
+                      <p className="text-xs text-slate-500 truncate">
+                        {r.subtitle}
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function prettifyConnectError(reason: string): string {
+  switch (reason) {
+    case 'popup-blocked':
+      return 'Your browser blocked the Spotify sign-in popup. Allow popups for this site and try again.';
+    case 'auth-bypass-mode':
+      return 'Spotify cannot be connected in auth-bypass mode.';
+    case 'callback-missing-code':
+      return 'Spotify did not return an authorization code. Try again.';
+    case 'access_denied':
+      return 'Spotify access was denied. Try connecting again and approve the requested permissions.';
+    default:
+      return reason;
+  }
+}
+
+/** Convert `spotify:track:abc` → `https://open.spotify.com/track/abc`. */
+function spotifyUriToOpenUrl(uri: string): string | null {
+  const m = uri.match(/^spotify:(track|album|playlist|artist):([A-Za-z0-9]+)$/);
+  if (!m) return null;
+  return `https://open.spotify.com/${m[1]}/${m[2]}`;
+}

--- a/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
@@ -301,9 +301,15 @@ const PremiumSdkPlayer: React.FC<PremiumProps> = ({
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg === 'spotify-premium-required') {
+          // Premium-required can surface here too (Spotify returns 403 on the
+          // play API even when the SDK itself initialized fine — e.g. account
+          // downgraded between connect and first play). Flip sdkFailed so the
+          // render-time guard below swaps in the embed iframe; without this
+          // the user sees a permanently-broken play button.
           setError(
             'Spotify rejected playback (Premium required). Falling back to preview.'
           );
+          setSdkFailed(true);
         } else {
           setError(msg);
         }

--- a/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
@@ -1,0 +1,404 @@
+/**
+ * Renders the Music widget's front face when `config.source === 'personal'`.
+ *
+ * Behaviour:
+ *  - Not connected → prompt to flip widget and connect.
+ *  - Connected + Premium + valid URL → Spotify Web Playback SDK control surface
+ *    (album art + track name + play/pause). Plays the user-selected URI on
+ *    a SpartBoard "device" that lives only in this browser tab.
+ *  - Connected + Free OR SDK init failure → falls back to the standard
+ *    Spotify embed iframe (30-second previews on Free accounts).
+ *
+ * Premium gating is the *runtime* check (Spotify returns 403 on Free
+ * accounts), not a hard front-end gate — the iframe fallback works for
+ * everyone and the settings dialog has already warned the teacher.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Loader2,
+  Music2,
+  Pause,
+  Play,
+  Settings as SettingsIcon,
+} from 'lucide-react';
+import { WidgetData, MusicConfig } from '@/types';
+import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
+import { parseSpotifyResource, playOnDevice } from '@/utils/spotifyAuth';
+import {
+  loadSpotifySdk,
+  SpotifyPlayer,
+  SpotifyPlayerState,
+} from '@/utils/spotifyPlaybackSdk';
+import { buildSpotifyEmbedUrl } from './utils';
+
+interface Props {
+  widget: WidgetData;
+}
+
+export const PersonalSpotifyPlayer: React.FC<Props> = ({ widget }) => {
+  const config = widget.config as MusicConfig;
+  const {
+    isConnected,
+    isPremium,
+    state: authState,
+    getAccessToken,
+  } = useSpotifyAuth();
+
+  const url = config.personalSpotifyUrl ?? '';
+  const parsed = url ? parseSpotifyResource(url) : null;
+  const embedUrl = url ? buildSpotifyEmbedUrl(url) : null;
+
+  // ---------- empty / disconnected states ----------
+  if (authState.status === 'unknown') {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <ScaledEmptyState
+            icon={Music2}
+            title="Loading Spotify…"
+            subtitle="Checking your connection."
+          />
+        }
+      />
+    );
+  }
+
+  if (!isConnected) {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <ScaledEmptyState
+            icon={Music2}
+            title="Connect Spotify"
+            subtitle="Flip this widget and connect your Spotify account."
+          />
+        }
+      />
+    );
+  }
+
+  if (!parsed) {
+    return (
+      <WidgetLayout
+        padding="p-0"
+        content={
+          <ScaledEmptyState
+            icon={SettingsIcon}
+            title="Pick something to play"
+            subtitle="Flip the widget to paste a Spotify URL or search."
+          />
+        }
+      />
+    );
+  }
+
+  // Free accounts: skip SDK entirely and use the embed fallback (preview-only).
+  if (!isPremium) {
+    return embedUrl ? (
+      <EmbedFallback url={embedUrl} title={config.personalSpotifyLabel} />
+    ) : null;
+  }
+
+  return (
+    <PremiumSdkPlayer
+      widget={widget}
+      contextUri={parsed.type === 'track' ? null : parsed.uri}
+      trackUri={parsed.type === 'track' ? parsed.uri : null}
+      label={config.personalSpotifyLabel}
+      thumbnail={config.personalSpotifyThumbnail}
+      getAccessToken={getAccessToken}
+      embedFallbackUrl={embedUrl}
+    />
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Free-tier embed fallback
+// ---------------------------------------------------------------------------
+
+const EmbedFallback: React.FC<{ url: string; title?: string }> = ({
+  url,
+  title,
+}) => (
+  <WidgetLayout
+    padding="p-0"
+    content={
+      <div className="w-full h-full overflow-hidden rounded-2xl bg-black">
+        <iframe
+          src={url}
+          title={`Spotify: ${title ?? 'preview'}`}
+          width="100%"
+          height="100%"
+          allow="encrypted-media; autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+          className="border-none w-full h-full"
+        />
+      </div>
+    }
+  />
+);
+
+// ---------------------------------------------------------------------------
+// Premium SDK player
+// ---------------------------------------------------------------------------
+
+interface PremiumProps {
+  widget: WidgetData;
+  contextUri: string | null;
+  trackUri: string | null;
+  label?: string;
+  thumbnail?: string;
+  embedFallbackUrl: string | null;
+  getAccessToken: () => Promise<string | null>;
+}
+
+const PremiumSdkPlayer: React.FC<PremiumProps> = ({
+  widget,
+  contextUri,
+  trackUri,
+  label,
+  thumbnail,
+  embedFallbackUrl,
+  getAccessToken,
+}) => {
+  const [deviceId, setDeviceId] = useState<string | null>(null);
+  const [isPaused, setIsPaused] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentTrack, setCurrentTrack] = useState<{
+    name?: string;
+    artist?: string;
+    image?: string;
+  }>({});
+  const playerRef = useRef<SpotifyPlayer | null>(null);
+  const lastPlayedUriRef = useRef<string | null>(null);
+
+  // Initialize the Web Playback SDK once per widget instance.
+  useEffect(() => {
+    let destroyed = false;
+
+    loadSpotifySdk(async () => {
+      if (destroyed || !window.Spotify) return;
+      const player = new window.Spotify.Player({
+        name: `SpartBoard (widget ${widget.id.slice(0, 6)})`,
+        getOAuthToken: (cb) => {
+          void getAccessToken().then((t) => {
+            if (t) cb(t);
+          });
+        },
+        volume: 0.5,
+      });
+
+      player.addListener('ready', ({ device_id }) => {
+        if (destroyed) return;
+        setDeviceId(device_id);
+      });
+      player.addListener('not_ready', () => {
+        if (destroyed) return;
+        setDeviceId(null);
+      });
+      player.addListener('player_state_changed', (s: SpotifyPlayerState) => {
+        if (destroyed || !s) return;
+        setIsPaused(s.paused);
+        const t = s.track_window?.current_track;
+        setCurrentTrack({
+          name: t?.name,
+          artist: t?.artists?.map((a) => a.name).join(', '),
+          image: t?.album?.images?.[0]?.url,
+        });
+      });
+      player.addListener('initialization_error', ({ message }) => {
+        if (!destroyed) setError(`Spotify SDK init failed: ${message}`);
+      });
+      player.addListener('authentication_error', ({ message }) => {
+        if (!destroyed) setError(`Spotify auth error: ${message}`);
+      });
+      player.addListener('account_error', ({ message }) => {
+        if (!destroyed) {
+          // Most common cause: account isn't Premium. Surface a clean message.
+          setError(
+            message.toLowerCase().includes('premium')
+              ? 'Spotify Premium is required for full playback. Falling back to preview.'
+              : `Spotify account error: ${message}`
+          );
+        }
+      });
+      player.addListener('playback_error', ({ message }) => {
+        if (!destroyed) setError(`Spotify playback error: ${message}`);
+      });
+
+      try {
+        const connected = await player.connect();
+        if (!connected && !destroyed) {
+          setError('Spotify Web Playback SDK could not connect.');
+        }
+        playerRef.current = player;
+      } catch (err) {
+        if (!destroyed) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    });
+
+    return () => {
+      destroyed = true;
+      try {
+        playerRef.current?.disconnect();
+      } catch {
+        /* SDK can throw during teardown — best-effort */
+      }
+      playerRef.current = null;
+    };
+  }, [widget.id, getAccessToken]);
+
+  const togglePlay = async () => {
+    if (!playerRef.current) return;
+    setError(null);
+
+    // First play: start the selected URI on this device.
+    const targetUri = trackUri ?? contextUri;
+    if (targetUri && lastPlayedUriRef.current !== targetUri) {
+      const token = await getAccessToken();
+      if (!token || !deviceId) {
+        setError('Spotify not ready yet — try again in a moment.');
+        return;
+      }
+      try {
+        await playOnDevice(token, deviceId, {
+          contextUri: contextUri ?? undefined,
+          uris: trackUri ? [trackUri] : undefined,
+        });
+        lastPlayedUriRef.current = targetUri;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg === 'spotify-premium-required') {
+          setError(
+            'Spotify rejected playback (Premium required). Falling back to preview.'
+          );
+        } else {
+          setError(msg);
+        }
+      }
+      return;
+    }
+
+    try {
+      await playerRef.current.togglePlay();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  // If the SDK keeps failing for a Premium-required reason, fall back to embed
+  // so the teacher still gets *something* rather than a broken card.
+  if (error && error.toLowerCase().includes('premium') && embedFallbackUrl) {
+    return <EmbedFallback url={embedFallbackUrl} title={label} />;
+  }
+
+  const displayImage = currentTrack.image ?? thumbnail;
+  const displayName = currentTrack.name ?? label ?? 'Spotify';
+  const displayArtist = currentTrack.artist ?? '';
+
+  return (
+    <WidgetLayout
+      padding="p-0"
+      content={
+        <div className="w-full h-full rounded-2xl overflow-hidden relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-950 flex flex-col">
+          <div
+            className="flex-1 flex flex-col items-center justify-center text-center"
+            style={{
+              padding: 'min(16px, 5cqmin)',
+              gap: 'min(12px, 4cqmin)',
+            }}
+          >
+            {displayImage ? (
+              <img
+                src={displayImage}
+                alt=""
+                className="rounded-xl object-cover shadow-2xl"
+                style={{
+                  width: 'min(140px, 50cqmin)',
+                  height: 'min(140px, 50cqmin)',
+                }}
+              />
+            ) : (
+              <div
+                className="rounded-xl bg-slate-700 flex items-center justify-center shadow-2xl"
+                style={{
+                  width: 'min(140px, 50cqmin)',
+                  height: 'min(140px, 50cqmin)',
+                }}
+              >
+                <Music2
+                  className="text-slate-400"
+                  style={{
+                    width: 'min(48px, 20cqmin)',
+                    height: 'min(48px, 20cqmin)',
+                  }}
+                />
+              </div>
+            )}
+            <div className="w-full">
+              <p
+                className="font-black text-white truncate"
+                style={{ fontSize: 'min(16px, 7cqmin)' }}
+              >
+                {displayName}
+              </p>
+              {displayArtist && (
+                <p
+                  className="font-medium text-white/70 truncate"
+                  style={{
+                    fontSize: 'min(12px, 5cqmin)',
+                    marginTop: 'min(2px, 1cqmin)',
+                  }}
+                >
+                  {displayArtist}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={() => void togglePlay()}
+              aria-label={isPaused ? 'Play' : 'Pause'}
+              disabled={!deviceId}
+              className="rounded-full bg-white/90 hover:bg-white text-slate-900 flex items-center justify-center shadow-xl transition disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                width: 'min(56px, 20cqmin)',
+                height: 'min(56px, 20cqmin)',
+              }}
+            >
+              {!deviceId ? (
+                <Loader2
+                  className="animate-spin"
+                  style={{ width: '40%', height: '40%' }}
+                />
+              ) : isPaused ? (
+                <Play
+                  className="fill-current"
+                  style={{ width: '40%', height: '40%', marginLeft: '8%' }}
+                />
+              ) : (
+                <Pause
+                  className="fill-current"
+                  style={{ width: '40%', height: '40%' }}
+                />
+              )}
+            </button>
+            {error && (
+              <p
+                className="text-amber-300 font-medium"
+                style={{ fontSize: 'min(11px, 4cqmin)' }}
+              >
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+      }
+    />
+  );
+};

--- a/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx
@@ -26,7 +26,11 @@ import { WidgetData, MusicConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { useSpotifyAuth } from '@/hooks/useSpotifyAuth';
-import { parseSpotifyResource, playOnDevice } from '@/utils/spotifyAuth';
+import {
+  parseSpotifyResource,
+  playOnDevice,
+  spotifyOpenUrlFromInput,
+} from '@/utils/spotifyAuth';
 import {
   loadSpotifySdk,
   SpotifyPlayer,
@@ -49,7 +53,13 @@ export const PersonalSpotifyPlayer: React.FC<Props> = ({ widget }) => {
 
   const url = config.personalSpotifyUrl ?? '';
   const parsed = url ? parseSpotifyResource(url) : null;
-  const embedUrl = url ? buildSpotifyEmbedUrl(url) : null;
+  // The embed iframe only understands https URLs. If the teacher pasted a
+  // `spotify:track:...` URI, normalize it via `spotifyOpenUrlFromInput` so
+  // the Free-tier fallback below doesn't render a blank card.
+  const openUrlForEmbed = url ? spotifyOpenUrlFromInput(url) : null;
+  const embedUrl = openUrlForEmbed
+    ? buildSpotifyEmbedUrl(openUrlForEmbed)
+    : null;
 
   // ---------- empty / disconnected states ----------
   if (authState.status === 'unknown') {
@@ -168,6 +178,10 @@ const PremiumSdkPlayer: React.FC<PremiumProps> = ({
   const [deviceId, setDeviceId] = useState<string | null>(null);
   const [isPaused, setIsPaused] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Any unrecoverable SDK failure (script never loaded, init/auth/account
+  // errors, connect() returned false) sets this. When true the component
+  // falls back to the embed iframe rather than rendering a broken SDK shell.
+  const [sdkFailed, setSdkFailed] = useState(false);
   const [currentTrack, setCurrentTrack] = useState<{
     name?: string;
     artist?: string;
@@ -180,68 +194,80 @@ const PremiumSdkPlayer: React.FC<PremiumProps> = ({
   useEffect(() => {
     let destroyed = false;
 
-    loadSpotifySdk(async () => {
-      if (destroyed || !window.Spotify) return;
-      const player = new window.Spotify.Player({
-        name: `SpartBoard (widget ${widget.id.slice(0, 6)})`,
-        getOAuthToken: (cb) => {
-          void getAccessToken().then((t) => {
-            if (t) cb(t);
-          });
-        },
-        volume: 0.5,
-      });
+    const failSdk = (message: string) => {
+      if (destroyed) return;
+      setError(message);
+      setSdkFailed(true);
+    };
 
-      player.addListener('ready', ({ device_id }) => {
-        if (destroyed) return;
-        setDeviceId(device_id);
-      });
-      player.addListener('not_ready', () => {
-        if (destroyed) return;
-        setDeviceId(null);
-      });
-      player.addListener('player_state_changed', (s: SpotifyPlayerState) => {
-        if (destroyed || !s) return;
-        setIsPaused(s.paused);
-        const t = s.track_window?.current_track;
-        setCurrentTrack({
-          name: t?.name,
-          artist: t?.artists?.map((a) => a.name).join(', '),
-          image: t?.album?.images?.[0]?.url,
+    loadSpotifySdk(
+      async () => {
+        if (destroyed || !window.Spotify) return;
+        const player = new window.Spotify.Player({
+          name: `SpartBoard (widget ${widget.id.slice(0, 6)})`,
+          getOAuthToken: (cb) => {
+            void getAccessToken().then((t) => {
+              if (t) cb(t);
+            });
+          },
+          volume: 0.5,
         });
-      });
-      player.addListener('initialization_error', ({ message }) => {
-        if (!destroyed) setError(`Spotify SDK init failed: ${message}`);
-      });
-      player.addListener('authentication_error', ({ message }) => {
-        if (!destroyed) setError(`Spotify auth error: ${message}`);
-      });
-      player.addListener('account_error', ({ message }) => {
-        if (!destroyed) {
-          // Most common cause: account isn't Premium. Surface a clean message.
-          setError(
+
+        player.addListener('ready', ({ device_id }) => {
+          if (destroyed) return;
+          setDeviceId(device_id);
+        });
+        player.addListener('not_ready', () => {
+          if (destroyed) return;
+          setDeviceId(null);
+        });
+        player.addListener('player_state_changed', (s: SpotifyPlayerState) => {
+          if (destroyed || !s) return;
+          setIsPaused(s.paused);
+          const t = s.track_window?.current_track;
+          setCurrentTrack({
+            name: t?.name,
+            artist: t?.artists?.map((a) => a.name).join(', '),
+            image: t?.album?.images?.[0]?.url,
+          });
+        });
+        player.addListener('initialization_error', ({ message }) => {
+          failSdk(`Spotify SDK init failed: ${message}`);
+        });
+        player.addListener('authentication_error', ({ message }) => {
+          failSdk(`Spotify auth error: ${message}`);
+        });
+        player.addListener('account_error', ({ message }) => {
+          failSdk(
             message.toLowerCase().includes('premium')
               ? 'Spotify Premium is required for full playback. Falling back to preview.'
               : `Spotify account error: ${message}`
           );
-        }
-      });
-      player.addListener('playback_error', ({ message }) => {
-        if (!destroyed) setError(`Spotify playback error: ${message}`);
-      });
+        });
+        player.addListener('playback_error', ({ message }) => {
+          // Playback errors are usually transient (network blip) — surface
+          // but don't collapse to the embed; the user can retry.
+          if (!destroyed) setError(`Spotify playback error: ${message}`);
+        });
 
-      try {
-        const connected = await player.connect();
-        if (!connected && !destroyed) {
-          setError('Spotify Web Playback SDK could not connect.');
+        try {
+          const connected = await player.connect();
+          if (!connected) {
+            failSdk('Spotify Web Playback SDK could not connect.');
+            return;
+          }
+          playerRef.current = player;
+        } catch (err) {
+          failSdk(err instanceof Error ? err.message : String(err));
         }
-        playerRef.current = player;
-      } catch (err) {
-        if (!destroyed) {
-          setError(err instanceof Error ? err.message : String(err));
-        }
+      },
+      (err) => {
+        // SDK script never loaded (CDN blocked, network failure, timeout).
+        failSdk(
+          `Couldn't load Spotify Web Playback SDK: ${err.message}. Falling back to preview.`
+        );
       }
-    });
+    );
 
     return () => {
       destroyed = true;
@@ -292,9 +318,10 @@ const PremiumSdkPlayer: React.FC<PremiumProps> = ({
     }
   };
 
-  // If the SDK keeps failing for a Premium-required reason, fall back to embed
-  // so the teacher still gets *something* rather than a broken card.
-  if (error && error.toLowerCase().includes('premium') && embedFallbackUrl) {
+  // Any unrecoverable SDK failure → embed iframe so the teacher still gets
+  // *something* rather than a broken card. Covers Premium-required, SDK
+  // script load failure, init/auth errors, and connect()-returned-false.
+  if (sdkFailed && embedFallbackUrl) {
     return <EmbedFallback url={embedFallbackUrl} title={label} />;
   }
 

--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LayoutGrid, Music, Palette } from 'lucide-react';
-import { WidgetData, MusicConfig, MusicLayout } from '@/types';
+import { LayoutGrid, Music, Music2, Palette, Radio } from 'lucide-react';
+import { WidgetData, MusicConfig, MusicLayout, MusicSource } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useMusicStations } from '@/hooks/useMusicStations';
 import { Toggle } from '@/components/common/Toggle';
@@ -11,6 +11,7 @@ import {
 } from '@/config/colors';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { buildSpotifyEmbedUrl } from './utils';
+import { PersonalSpotifyPanel } from './PersonalSpotifyPanel';
 
 // ---------------------------------------------------------------------------
 // Layout option descriptor
@@ -85,21 +86,89 @@ const LAYOUT_OPTIONS: {
 // MusicSettings — back face
 // ---------------------------------------------------------------------------
 
+const SOURCE_OPTIONS: {
+  value: MusicSource;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  {
+    value: 'curated',
+    label: 'Curated stations',
+    description: 'Pick from stations your admin has added.',
+    icon: Radio,
+  },
+  {
+    value: 'personal',
+    label: 'My Spotify',
+    description: 'Connect your own Spotify account (Premium recommended).',
+    icon: Music2,
+  },
+];
+
 export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as MusicConfig;
   const { stations, isLoading } = useMusicStations();
-  const { layout = 'default' } = config;
+  const { layout = 'default', source = 'curated' } = config;
 
   const activeStation = stations.find((s) => s.id === config.stationId);
-  const isSpotify = activeStation?.url
+  const isCuratedSpotify = activeStation?.url
     ? buildSpotifyEmbedUrl(activeStation.url) !== null
     : false;
+  // The Time-Tool sync depends on the YouTube IFrame API; it's never available
+  // for Spotify content (curated or personal) because Spotify embeds and the
+  // Web Playback SDK don't expose the same hooks.
+  const syncDisabled = isCuratedSpotify || source === 'personal';
 
   return (
     <div className="space-y-5">
-      {/* ── Layout selector ── */}
+      {/* ── Source selector ── */}
       <div className="space-y-2">
+        <SettingsLabel icon={Music2}>Source</SettingsLabel>
+        <div className="grid grid-cols-2 gap-2">
+          {SOURCE_OPTIONS.map((opt) => {
+            const isActive = source === opt.value;
+            const Icon = opt.icon;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() =>
+                  updateWidget(widget.id, {
+                    config: {
+                      ...config,
+                      source: opt.value,
+                      // Disable Time-Tool sync when switching to Spotify-based source.
+                      ...(opt.value === 'personal' && config.syncWithTimeTool
+                        ? { syncWithTimeTool: false }
+                        : {}),
+                    },
+                  })
+                }
+                title={opt.description}
+                className={`flex items-center gap-2 p-3 rounded-xl border-2 transition-all text-left ${
+                  isActive
+                    ? 'border-green-500 bg-green-50 shadow-sm'
+                    : 'border-slate-100 hover:border-slate-300 bg-white'
+                }`}
+              >
+                <Icon
+                  className={`w-4 h-4 shrink-0 ${isActive ? 'text-green-700' : 'text-slate-500'}`}
+                />
+                <span
+                  className={`text-xs font-bold truncate ${isActive ? 'text-green-800' : 'text-slate-700'}`}
+                >
+                  {opt.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Layout selector ── */}
+      <div className="space-y-2 pt-1 border-t border-slate-100">
         <SettingsLabel icon={LayoutGrid}>Layout</SettingsLabel>
         <div className="grid grid-cols-3 gap-2">
           {LAYOUT_OPTIONS.map((opt) => {
@@ -131,73 +200,84 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         </div>
       </div>
 
-      {/* ── Station selector ── */}
-      <div className="space-y-2 pt-1 border-t border-slate-100">
-        <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider pt-4">
-          Select a Station
-        </p>
-
-        {isLoading ? (
-          <p className="text-xs text-slate-400 animate-pulse">
-            Loading stations...
+      {/* ── Source-specific body ── */}
+      {source === 'personal' ? (
+        <div className="pt-1 border-t border-slate-100">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider pt-4 pb-2">
+            Personal Spotify
           </p>
-        ) : stations.length === 0 ? (
-          <div className="p-3 bg-slate-50 border border-slate-200 rounded-lg">
-            <p className="text-xs text-slate-500">
-              No stations available. An admin needs to add them in Admin
-              Settings.
+          <PersonalSpotifyPanel widget={widget} />
+        </div>
+      ) : (
+        <div className="space-y-2 pt-1 border-t border-slate-100">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider pt-4">
+            Select a Station
+          </p>
+
+          {isLoading ? (
+            <p className="text-xs text-slate-400 animate-pulse">
+              Loading stations...
             </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto pr-1">
-            {stations.map((station) => {
-              const isActive = config.stationId === station.id;
-              return (
-                <button
-                  key={station.id}
-                  onClick={() => {
-                    const selectedIsSpotify =
-                      buildSpotifyEmbedUrl(station.url) !== null;
-                    updateWidget(widget.id, {
-                      config: {
-                        ...config,
-                        stationId: station.id,
-                        ...(selectedIsSpotify && config.syncWithTimeTool
-                          ? { syncWithTimeTool: false }
-                          : {}),
-                      },
-                    });
-                  }}
-                  className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-center ${
-                    isActive
-                      ? 'border-indigo-500 bg-indigo-50 shadow-sm'
-                      : 'border-slate-100 hover:border-slate-300 bg-white'
-                  }`}
-                >
-                  {station.thumbnail ? (
-                    <div
-                      className="w-10 h-10 rounded-full bg-cover bg-center shadow-sm"
-                      style={{ backgroundImage: `url(${station.thumbnail})` }}
-                    />
-                  ) : (
-                    <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
-                      <Music className="w-4 h-4 text-slate-400" />
-                    </div>
-                  )}
-                  <span className="text-xxs font-bold block w-full truncate text-slate-800">
-                    {station.title}
-                  </span>
-                  {station.genre && (
-                    <span className="text-xxs text-slate-400 font-normal truncate w-full">
-                      {station.genre}
+          ) : stations.length === 0 ? (
+            <div className="p-3 bg-slate-50 border border-slate-200 rounded-lg">
+              <p className="text-xs text-slate-500">
+                No stations available. An admin needs to add them in Admin
+                Settings.
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto pr-1">
+              {stations.map((station) => {
+                const isActive = config.stationId === station.id;
+                return (
+                  <button
+                    key={station.id}
+                    onClick={() => {
+                      const selectedIsSpotify =
+                        buildSpotifyEmbedUrl(station.url) !== null;
+                      updateWidget(widget.id, {
+                        config: {
+                          ...config,
+                          stationId: station.id,
+                          ...(selectedIsSpotify && config.syncWithTimeTool
+                            ? { syncWithTimeTool: false }
+                            : {}),
+                        },
+                      });
+                    }}
+                    className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all text-center ${
+                      isActive
+                        ? 'border-indigo-500 bg-indigo-50 shadow-sm'
+                        : 'border-slate-100 hover:border-slate-300 bg-white'
+                    }`}
+                  >
+                    {station.thumbnail ? (
+                      <div
+                        className="w-10 h-10 rounded-full bg-cover bg-center shadow-sm"
+                        style={{
+                          backgroundImage: `url(${station.thumbnail})`,
+                        }}
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
+                        <Music className="w-4 h-4 text-slate-400" />
+                      </div>
+                    )}
+                    <span className="text-xxs font-bold block w-full truncate text-slate-800">
+                      {station.title}
                     </span>
-                  )}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
+                    {station.genre && (
+                      <span className="text-xxs text-slate-400 font-normal truncate w-full">
+                        {station.genre}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* ── Nexus sync toggle ── */}
       <div className="pt-4 border-t border-slate-100">
@@ -212,12 +292,12 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 config: { ...config, syncWithTimeTool: checked },
               })
             }
-            disabled={isSpotify}
+            disabled={syncDisabled}
             size="sm"
           />
         </div>
         <p className="text-xs text-slate-400 mt-1.5">
-          {isSpotify
+          {syncDisabled
             ? 'Auto-sync is only available for YouTube stations due to Spotify browser restrictions.'
             : 'Music will automatically play and pause with your active Time Tool.'}
         </p>

--- a/components/widgets/MusicWidget/Widget.tsx
+++ b/components/widgets/MusicWidget/Widget.tsx
@@ -12,6 +12,7 @@ import {
   buildSpotifyEmbedUrl,
   YTPlayer,
 } from '@/utils/youtube';
+import { PersonalSpotifyPlayer } from './PersonalSpotifyPlayer';
 
 // ---------------------------------------------------------------------------
 // Shared play/pause overlay button
@@ -76,7 +77,20 @@ const PlayButton: React.FC<PlayButtonProps> = ({
 // MusicWidget — front face
 // ---------------------------------------------------------------------------
 
+/**
+ * Top-level dispatch: personal-Spotify mode mounts the dedicated SDK player
+ * (with its own hooks); curated mode mounts the original station-based
+ * widget. Splitting them this way keeps both branches' hooks unconditional.
+ */
 export const MusicWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
+  const source = (widget.config as MusicConfig).source ?? 'curated';
+  if (source === 'personal') {
+    return <PersonalSpotifyPlayer widget={widget} />;
+  }
+  return <CuratedMusicWidget widget={widget} />;
+};
+
+const CuratedMusicWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { activeDashboard } = useDashboard();
   const config = widget.config as MusicConfig;
   const {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -43,6 +43,11 @@ export {
   refreshGoogleAccessToken,
   revokeGoogleRefreshToken,
 } from './googleOAuth';
+export {
+  exchangeSpotifyAuthCode,
+  refreshSpotifyAccessToken,
+  revokeSpotifyAuth,
+} from './spotifyOAuth';
 
 setGlobalOptions({ region: 'us-central1' });
 

--- a/functions/src/spotifyOAuth.ts
+++ b/functions/src/spotifyOAuth.ts
@@ -353,27 +353,51 @@ export const refreshSpotifyAccessToken = onCall(
         throw transientError('Spotify refresh returned no access_token.');
       }
 
-      // Spotify rotates refresh_tokens — re-encrypt and persist if one came back.
+      // Spotify rotates refresh_tokens — re-encrypt and persist if one came
+      // back. This is the load-bearing write: if Spotify rotated and we fail
+      // to persist, the OLD refresh_token is now invalid and the next refresh
+      // call will hit `invalid_grant` and force the teacher to re-consent.
+      // Retry the Firestore write a few times before giving up.
       if (res.data.refresh_token) {
         const reEncrypted = encryptRefreshToken(
           res.data.refresh_token,
           SPOTIFY_OAUTH_REFRESH_TOKEN_KEY.value()
         );
-        await ref
-          .set(
+        const rotated: StoredSpotifyAuth = {
+          encryptedRefreshToken: reEncrypted,
+          updatedAt: Date.now(),
+          scope: res.data.scope ?? stored.scope,
+        };
+        const persistDelaysMs = [0, 200, 500];
+        let persistErr: unknown = null;
+        for (const delay of persistDelaysMs) {
+          if (delay) await new Promise((r) => setTimeout(r, delay));
+          try {
+            await ref.set(rotated, { merge: true });
+            persistErr = null;
+            break;
+          } catch (err) {
+            persistErr = err;
+          }
+        }
+        if (persistErr) {
+          // All retries failed. We must NOT return the access_token as if
+          // everything is fine — the next call will fail with invalid_grant.
+          // Surface as transient so the client retries; if the Firestore
+          // outage clears, the next call grabs the still-valid refresh_token
+          // by way of the original stored ciphertext (Spotify allows brief
+          // overlap on rotation).
+          logWarn(
+            'refreshSpotifyAccessToken.persistRotatedExhausted',
+            persistErr,
             {
-              encryptedRefreshToken: reEncrypted,
-              updatedAt: Date.now(),
-              scope: res.data.scope ?? stored.scope,
-            } satisfies StoredSpotifyAuth,
-            { merge: true }
-          )
-          .catch((err) => {
-            // Persist failure is non-fatal — the old refresh_token still
-            // works for at least one more cycle. Surface it in logs so
-            // sustained failures are debuggable.
-            logWarn('refreshSpotifyAccessToken.persistRotated', err, { uid });
-          });
+              uid,
+            }
+          );
+          throw transientError(
+            'Spotify token rotated but could not be persisted. Try again in a moment.'
+          );
+        }
       }
 
       return {
@@ -385,14 +409,16 @@ export const refreshSpotifyAccessToken = onCall(
       if (axios.isAxiosError(err)) {
         const spotifyErr = (err.response?.data as { error?: string })?.error;
         if (spotifyErr === 'invalid_grant') {
-          // Race-safe delete: another tab may have already rotated the
+          // Race-safe handling: another tab may have already rotated the
           // refresh_token (T0 both tabs read R0; T1 tab A rotates to R1
           // and writes; T2 tab B's refresh with R0 fails as invalid_grant).
-          // If we unconditionally deleted here we'd erase R1 and force a
-          // re-consent that wasn't actually needed. The transaction reads
-          // the doc again and only deletes if the ciphertext we just used
-          // is still the stored ciphertext — otherwise leave the rotated
-          // token alone.
+          // Two outcomes:
+          //  - ciphertext unchanged → token was revoked for real, delete & needs-consent
+          //  - ciphertext rotated   → another tab won the race, surface as
+          //                           transient so the client retries against
+          //                           the freshly-written token instead of
+          //                           forcing a needless re-consent
+          let anotherTabRotated = false;
           await db
             .runTransaction(async (tx) => {
               const fresh = await tx.get(ref);
@@ -407,14 +433,21 @@ export const refreshSpotifyAccessToken = onCall(
                 stored.encryptedRefreshToken
               ) {
                 tx.delete(ref);
+              } else {
+                anotherTabRotated = true;
               }
-              // else: another tab rotated the token; leave the new doc in place.
             })
             .catch((delErr) => {
               logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, {
                 uid,
               });
             });
+
+          if (anotherTabRotated) {
+            throw transientError(
+              'Spotify token refresh raced with another tab. Retry.'
+            );
+          }
           throw needsConsent(
             'invalid-grant',
             'needs-consent: stored Spotify refresh token was revoked.'

--- a/functions/src/spotifyOAuth.ts
+++ b/functions/src/spotifyOAuth.ts
@@ -1,0 +1,426 @@
+/**
+ * Server-side Spotify OAuth Authorization-Code-with-PKCE flow.
+ *
+ * Mirrors the security model of `googleOAuth.ts`: the refresh_token is
+ * AES-encrypted with an application-managed key and persisted at
+ * `/users/{uid}/private/spotifyAuth`, where Firestore rules deny ALL client
+ * access. Only the Admin SDK from this module reads or writes that path.
+ *
+ * Operations:
+ * - `exchangeSpotifyAuthCode` — swap a one-time PKCE authorization code for
+ *   access_token + refresh_token. Stores the encrypted refresh_token. Returns
+ *   the access_token + expires_in so the client can use it immediately.
+ * - `refreshSpotifyAccessToken` — exchange the stored refresh_token for a
+ *   fresh access_token. On `invalid_grant` the stored token is dropped and
+ *   the client gets `needs-consent` so it re-routes through the auth-code
+ *   flow instead of looping.
+ * - `revokeSpotifyAuth` — drop the stored refresh_token. Spotify has no
+ *   public revoke endpoint, so this is local-only; the user can also
+ *   manage app authorizations at spotify.com/account/apps.
+ */
+
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import { defineSecret } from 'firebase-functions/params';
+import * as admin from 'firebase-admin';
+import * as CryptoJS from 'crypto-js';
+import axios from 'axios';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const SPOTIFY_TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token';
+const SPOTIFY_API_TIMEOUT_MS = 10_000;
+
+// Scopes the widget depends on. Partial-consent rejection at exchange time
+// keeps a half-granted token from being persisted only to fail at SDK init.
+const REQUIRED_SPOTIFY_SCOPES = [
+  'streaming',
+  'user-read-email',
+  'user-read-private',
+  'user-modify-playback-state',
+  'user-read-playback-state',
+];
+
+const PRIVATE_DOC_PATH = (uid: string) =>
+  `users/${uid}/private/spotifyAuth` as const;
+
+const SPOTIFY_OAUTH_CLIENT_ID = defineSecret('SPOTIFY_OAUTH_CLIENT_ID');
+const SPOTIFY_OAUTH_CLIENT_SECRET = defineSecret('SPOTIFY_OAUTH_CLIENT_SECRET');
+const SPOTIFY_OAUTH_REFRESH_TOKEN_KEY = defineSecret(
+  'SPOTIFY_OAUTH_REFRESH_TOKEN_KEY'
+);
+
+type Ciphertext = string & { readonly __ciphertext: unique symbol };
+
+interface SpotifyTokenResponse {
+  access_token?: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope?: string;
+  token_type: string;
+}
+
+interface StoredSpotifyAuth {
+  encryptedRefreshToken: Ciphertext;
+  updatedAt: number;
+  scope: string;
+}
+
+function encryptRefreshToken(plaintext: string, key: string): Ciphertext {
+  return CryptoJS.AES.encrypt(plaintext, key).toString() as Ciphertext;
+}
+
+function decryptRefreshToken(ciphertext: Ciphertext, key: string): string {
+  let decrypted: string;
+  try {
+    decrypted = CryptoJS.AES.decrypt(ciphertext, key).toString(
+      CryptoJS.enc.Utf8
+    );
+  } catch (err) {
+    console.error('[decryptRefreshToken] CryptoJS decrypt threw', err);
+    throw new HttpsError(
+      'internal',
+      'Failed to decrypt stored Spotify refresh token. The encryption key may have rotated.'
+    );
+  }
+  // eslint-disable-next-line no-control-regex
+  const hasControlChars = /[\x00-\x08\x0e-\x1f\x7f]/.test(decrypted);
+  if (!decrypted || hasControlChars) {
+    console.error('[decryptRefreshToken] CryptoJS decrypt returned bad data', {
+      empty: !decrypted,
+      hasControlChars,
+      length: decrypted.length,
+    });
+    throw new HttpsError(
+      'internal',
+      'Failed to decrypt stored Spotify refresh token. The encryption key may have rotated.'
+    );
+  }
+  return decrypted;
+}
+
+function requireAuthUid(authUid: string | undefined): string {
+  if (!authUid) {
+    throw new HttpsError(
+      'unauthenticated',
+      'Must be signed in to manage Spotify OAuth state.'
+    );
+  }
+  return authUid;
+}
+
+function parseStoredSpotifyAuth(data: unknown): StoredSpotifyAuth | null {
+  if (!data || typeof data !== 'object') return null;
+  const d = data as Record<string, unknown>;
+  if (typeof d.encryptedRefreshToken !== 'string') return null;
+  if (typeof d.updatedAt !== 'number') return null;
+  if (typeof d.scope !== 'string') return null;
+  return {
+    encryptedRefreshToken: d.encryptedRefreshToken as Ciphertext,
+    updatedAt: d.updatedAt,
+    scope: d.scope,
+  };
+}
+
+type SpotifyRefreshErrorDetails =
+  | {
+      reason: 'needs-consent';
+      cause:
+        | 'no-stored-token'
+        | 'decrypt-failed'
+        | 'invalid-grant'
+        | 'partial-consent';
+    }
+  | { reason: 'transient' };
+
+function needsConsent(
+  cause: Extract<
+    SpotifyRefreshErrorDetails,
+    { reason: 'needs-consent' }
+  >['cause'],
+  message: string
+): HttpsError {
+  const details: SpotifyRefreshErrorDetails = {
+    reason: 'needs-consent',
+    cause,
+  };
+  return new HttpsError('failed-precondition', message, details);
+}
+
+function transientError(message: string): HttpsError {
+  const details: SpotifyRefreshErrorDetails = { reason: 'transient' };
+  return new HttpsError('internal', message, details);
+}
+
+function logWarn(scope: string, err: unknown, extra?: Record<string, unknown>) {
+  console.warn(`[spotifyOAuth.${scope}]`, err, extra ?? {});
+}
+
+function logInfo(scope: string, extra?: Record<string, unknown>) {
+  console.info(`[spotifyOAuth.${scope}]`, extra ?? {});
+}
+
+/** HTTP Basic header for Spotify token endpoint (client_id:client_secret). */
+function basicAuthHeader(clientId: string, clientSecret: string): string {
+  return (
+    'Basic ' +
+    Buffer.from(`${clientId}:${clientSecret}`, 'utf8').toString('base64')
+  );
+}
+
+/**
+ * Exchange a Spotify PKCE authorization code for tokens, then persist the
+ * encrypted refresh_token.
+ */
+export const exchangeSpotifyAuthCode = onCall(
+  {
+    secrets: [
+      SPOTIFY_OAUTH_CLIENT_ID,
+      SPOTIFY_OAUTH_CLIENT_SECRET,
+      SPOTIFY_OAUTH_REFRESH_TOKEN_KEY,
+    ],
+  },
+  async (req) => {
+    const uid = requireAuthUid(req.auth?.uid);
+    const raw = (req.data ?? {}) as Record<string, unknown>;
+    const code = typeof raw.code === 'string' ? raw.code : '';
+    const redirectUri =
+      typeof raw.redirectUri === 'string' ? raw.redirectUri : '';
+    const codeVerifier =
+      typeof raw.codeVerifier === 'string' ? raw.codeVerifier : '';
+    if (!code) throw new HttpsError('invalid-argument', 'code is required.');
+    if (!redirectUri) {
+      throw new HttpsError('invalid-argument', 'redirectUri is required.');
+    }
+    if (!codeVerifier) {
+      throw new HttpsError('invalid-argument', 'codeVerifier is required.');
+    }
+
+    let tokens: SpotifyTokenResponse;
+    try {
+      const res = await axios.post<SpotifyTokenResponse>(
+        SPOTIFY_TOKEN_ENDPOINT,
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+          client_id: SPOTIFY_OAUTH_CLIENT_ID.value(),
+          code_verifier: codeVerifier,
+        }).toString(),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: basicAuthHeader(
+              SPOTIFY_OAUTH_CLIENT_ID.value(),
+              SPOTIFY_OAUTH_CLIENT_SECRET.value()
+            ),
+          },
+          timeout: SPOTIFY_API_TIMEOUT_MS,
+        }
+      );
+      tokens = res.data;
+    } catch (err) {
+      const spotifyErr = axios.isAxiosError(err)
+        ? ((
+            err.response?.data as { error?: string; error_description?: string }
+          )?.error_description ??
+          (err.response?.data as { error?: string })?.error ??
+          err.message)
+        : err instanceof Error
+          ? err.message
+          : String(err);
+      throw new HttpsError(
+        'failed-precondition',
+        `Spotify token exchange failed: ${spotifyErr}`
+      );
+    }
+
+    if (!tokens.access_token) {
+      throw new HttpsError(
+        'failed-precondition',
+        'Spotify did not return an access_token. Re-consent may be required.'
+      );
+    }
+
+    const grantedScopes = new Set((tokens.scope ?? '').split(' '));
+    const missingScopes = REQUIRED_SPOTIFY_SCOPES.filter(
+      (s) => !grantedScopes.has(s)
+    );
+    if (missingScopes.length > 0) {
+      throw needsConsent(
+        'partial-consent',
+        `partial-consent: missing required scopes: ${missingScopes.join(', ')}`
+      );
+    }
+
+    if (tokens.refresh_token) {
+      const encrypted = encryptRefreshToken(
+        tokens.refresh_token,
+        SPOTIFY_OAUTH_REFRESH_TOKEN_KEY.value()
+      );
+      const stored: StoredSpotifyAuth = {
+        encryptedRefreshToken: encrypted,
+        updatedAt: Date.now(),
+        scope: tokens.scope ?? '',
+      };
+      await admin.firestore().doc(PRIVATE_DOC_PATH(uid)).set(stored);
+    }
+
+    return {
+      accessToken: tokens.access_token,
+      expiresIn: tokens.expires_in,
+      hasRefreshToken: Boolean(tokens.refresh_token),
+    };
+  }
+);
+
+/**
+ * Exchange the stored refresh_token for a fresh access_token.
+ *
+ * Spotify rotates refresh_tokens on every refresh call, so when a new one
+ * comes back we re-encrypt and persist it. If Spotify omits the new
+ * refresh_token (rare but documented) we keep the previous one — the old
+ * one stays valid until explicitly revoked.
+ */
+export const refreshSpotifyAccessToken = onCall(
+  {
+    secrets: [
+      SPOTIFY_OAUTH_CLIENT_ID,
+      SPOTIFY_OAUTH_CLIENT_SECRET,
+      SPOTIFY_OAUTH_REFRESH_TOKEN_KEY,
+    ],
+  },
+  async (req) => {
+    const uid = requireAuthUid(req.auth?.uid);
+    const db = admin.firestore();
+    const ref = db.doc(PRIVATE_DOC_PATH(uid));
+    const snap = await ref.get();
+    if (!snap.exists) {
+      throw needsConsent(
+        'no-stored-token',
+        'needs-consent: no refresh token stored for this user.'
+      );
+    }
+    const stored = parseStoredSpotifyAuth(snap.data());
+    if (!stored) {
+      await ref.delete().catch((delErr) => {
+        logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, { uid });
+      });
+      throw needsConsent(
+        'decrypt-failed',
+        'needs-consent: stored Spotify refresh token document has an unexpected shape.'
+      );
+    }
+
+    let refreshToken: string;
+    try {
+      refreshToken = decryptRefreshToken(
+        stored.encryptedRefreshToken,
+        SPOTIFY_OAUTH_REFRESH_TOKEN_KEY.value()
+      );
+    } catch (err) {
+      logWarn('refreshSpotifyAccessToken.decrypt', err, { uid });
+      await ref.delete().catch((delErr) => {
+        logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, { uid });
+      });
+      throw needsConsent(
+        'decrypt-failed',
+        'needs-consent: stored Spotify refresh token could not be decrypted (key may have rotated).'
+      );
+    }
+
+    try {
+      const res = await axios.post<SpotifyTokenResponse>(
+        SPOTIFY_TOKEN_ENDPOINT,
+        new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: SPOTIFY_OAUTH_CLIENT_ID.value(),
+        }).toString(),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            Authorization: basicAuthHeader(
+              SPOTIFY_OAUTH_CLIENT_ID.value(),
+              SPOTIFY_OAUTH_CLIENT_SECRET.value()
+            ),
+          },
+          timeout: SPOTIFY_API_TIMEOUT_MS,
+        }
+      );
+      if (!res.data.access_token) {
+        throw transientError('Spotify refresh returned no access_token.');
+      }
+
+      // Spotify rotates refresh_tokens — re-encrypt and persist if one came back.
+      if (res.data.refresh_token) {
+        const reEncrypted = encryptRefreshToken(
+          res.data.refresh_token,
+          SPOTIFY_OAUTH_REFRESH_TOKEN_KEY.value()
+        );
+        await ref
+          .set(
+            {
+              encryptedRefreshToken: reEncrypted,
+              updatedAt: Date.now(),
+              scope: res.data.scope ?? stored.scope,
+            } satisfies StoredSpotifyAuth,
+            { merge: true }
+          )
+          .catch((err) => {
+            // Persist failure is non-fatal — the old refresh_token still
+            // works for at least one more cycle. Surface it in logs so
+            // sustained failures are debuggable.
+            logWarn('refreshSpotifyAccessToken.persistRotated', err, { uid });
+          });
+      }
+
+      return {
+        accessToken: res.data.access_token,
+        expiresIn: res.data.expires_in,
+      };
+    } catch (err) {
+      if (err instanceof HttpsError) throw err;
+      if (axios.isAxiosError(err)) {
+        const spotifyErr = (err.response?.data as { error?: string })?.error;
+        if (spotifyErr === 'invalid_grant') {
+          await ref.delete().catch((delErr) => {
+            logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, {
+              uid,
+            });
+          });
+          throw needsConsent(
+            'invalid-grant',
+            'needs-consent: stored Spotify refresh token was revoked.'
+          );
+        }
+        throw transientError(
+          `Spotify refresh failed: ${spotifyErr ?? err.message}`
+        );
+      }
+      throw transientError(
+        `Spotify refresh failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+);
+
+/**
+ * Explicit disconnect — drops the stored refresh_token for this user.
+ *
+ * Spotify has no public per-app revoke endpoint (users must visit
+ * spotify.com/account/apps to fully de-authorize), so this is local-only.
+ * Idempotent: a missing doc is a no-op success.
+ */
+export const revokeSpotifyAuth = onCall(async (req) => {
+  const uid = requireAuthUid(req.auth?.uid);
+  const ref = admin.firestore().doc(PRIVATE_DOC_PATH(uid));
+  const snap = await ref.get();
+  if (!snap.exists) {
+    return { revoked: false, reason: 'no-stored-token' };
+  }
+  await ref.delete();
+  logInfo('revokeSpotifyAuth.success', { uid });
+  return { revoked: true };
+});

--- a/functions/src/spotifyOAuth.ts
+++ b/functions/src/spotifyOAuth.ts
@@ -385,11 +385,36 @@ export const refreshSpotifyAccessToken = onCall(
       if (axios.isAxiosError(err)) {
         const spotifyErr = (err.response?.data as { error?: string })?.error;
         if (spotifyErr === 'invalid_grant') {
-          await ref.delete().catch((delErr) => {
-            logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, {
-              uid,
+          // Race-safe delete: another tab may have already rotated the
+          // refresh_token (T0 both tabs read R0; T1 tab A rotates to R1
+          // and writes; T2 tab B's refresh with R0 fails as invalid_grant).
+          // If we unconditionally deleted here we'd erase R1 and force a
+          // re-consent that wasn't actually needed. The transaction reads
+          // the doc again and only deletes if the ciphertext we just used
+          // is still the stored ciphertext — otherwise leave the rotated
+          // token alone.
+          await db
+            .runTransaction(async (tx) => {
+              const fresh = await tx.get(ref);
+              if (!fresh.exists) return;
+              const freshStored = parseStoredSpotifyAuth(fresh.data());
+              if (!freshStored) {
+                tx.delete(ref);
+                return;
+              }
+              if (
+                freshStored.encryptedRefreshToken ===
+                stored.encryptedRefreshToken
+              ) {
+                tx.delete(ref);
+              }
+              // else: another tab rotated the token; leave the new doc in place.
+            })
+            .catch((delErr) => {
+              logWarn('refreshSpotifyAccessToken.deletePoisonDoc', delErr, {
+                uid,
+              });
             });
-          });
           throw needsConsent(
             'invalid-grant',
             'needs-consent: stored Spotify refresh token was revoked.'

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -14,6 +14,18 @@
  * globally, not per uid. We explicitly clear it whenever Firebase's signed-in
  * uid changes so user B can't inherit user A's still-valid Spotify session in
  * the same browser tab.
+ *
+ * Uid races
+ * ---------
+ * Two paths are guarded against rapid sign-in switches:
+ *   1. `initializeForUid` reads `initializedForUid` after every await and
+ *      bails if it changed. The in-flight init is keyed by uid so a new
+ *      sign-in doesn't get back the previous user's probe promise.
+ *   2. `connect` captures the starting uid, opens the Spotify popup, then
+ *      verifies the uid is still current BEFORE calling the backend
+ *      exchange. Without that check the exchange would run under the new
+ *      user's auth and persist the previous user's refresh_token under
+ *      the wrong `/users/{uid}/private/spotifyAuth` path.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -22,12 +34,14 @@ import {
   ConnectOutcome,
   cacheAccessToken,
   clearAccessTokenCache,
-  connectSpotify,
   disconnectSpotify,
   DisconnectOutcome,
+  exchangeSpotifyCode,
   fetchSpotifyProfile,
   getValidAccessToken,
+  getValidAccessTokenOrNull,
   prettifyConnectErrorReason,
+  runSpotifyAuthPopup,
   SpotifyUserProfile,
 } from '@/utils/spotifyAuth';
 
@@ -55,37 +69,47 @@ let sharedState: SpotifyConnectionState = { status: 'unknown' };
 const subscribers = new Set<(s: SpotifyConnectionState) => void>();
 /** uid the singleton state was initialized for. `null` = signed out or not yet seen. */
 let initializedForUid: string | null = null;
-/** Guards against duplicate initial-probe round-trips when multiple hooks mount at once. */
-let inflightInit: Promise<void> | null = null;
+/**
+ * In-flight initial probe, keyed by uid. Sharing across concurrent mounts
+ * avoids duplicate round-trips. Keying by uid prevents a rapid switch from
+ * returning the previous user's probe — the new uid kicks off its own.
+ */
+let inflight: { uid: string; promise: Promise<void> } | null = null;
 
 function setSharedState(next: SpotifyConnectionState): void {
   sharedState = next;
   subscribers.forEach((cb) => cb(next));
 }
 
-/**
- * Run the initial "is this user already connected?" probe exactly once per
- * uid, broadcasting the result to every mounted hook instance via
- * `setSharedState`. Concurrent mounts share the same in-flight promise so we
- * don't fire duplicate `refreshSpotifyAccessToken` + `/me` round-trips.
- */
 function initializeForUid(uid: string): Promise<void> {
   if (initializedForUid === uid && sharedState.status !== 'unknown') {
     return Promise.resolve();
   }
-  if (inflightInit) return inflightInit;
+  if (inflight && inflight.uid === uid) return inflight.promise;
   initializedForUid = uid;
-  inflightInit = (async () => {
+  const promise = (async () => {
     setSharedState({ status: 'unknown' });
-    const token = await getValidAccessToken();
-    // Uid may have changed mid-probe (rapid sign-out/sign-in). Re-check.
+    const result = await getValidAccessToken();
     if (initializedForUid !== uid) return;
-    if (!token) {
+    if (result.status === 'needs-consent') {
       setSharedState({ status: 'disconnected' });
       return;
     }
+    if (result.status === 'transient') {
+      // Don't flip to "disconnected" for a transient backend failure —
+      // the stored refresh_token is still valid, the next probe will
+      // pick it up. Surface as an error so the teacher can retry.
+      setSharedState({ status: 'error', message: result.message });
+      return;
+    }
+    if (result.status === 'no-cache-bump') {
+      // Cache was cleared mid-flight (sign-out, disconnect, or uid switch
+      // landed concurrently). The new state was already set by whichever
+      // path did the invalidation; don't overwrite it.
+      return;
+    }
     try {
-      const profile = await fetchSpotifyProfile(token);
+      const profile = await fetchSpotifyProfile(result.token);
       if (initializedForUid !== uid) return;
       setSharedState({ status: 'connected', profile });
     } catch (err) {
@@ -96,9 +120,12 @@ function initializeForUid(uid: string): Promise<void> {
       });
     }
   })().finally(() => {
-    inflightInit = null;
+    // Only clear if it's still ours — a uid switch may have replaced it
+    // with a new probe whose `finally` should be the one that clears.
+    if (inflight && inflight.uid === uid) inflight = null;
   });
-  return inflightInit;
+  inflight = { uid, promise };
+  return promise;
 }
 
 export function useSpotifyAuth(): UseSpotifyAuth {
@@ -124,10 +151,9 @@ export function useSpotifyAuth(): UseSpotifyAuth {
   // React to sign-in/sign-out/uid-switch.
   useEffect(() => {
     if (!user) {
-      // Sign-out — clear token cache and state so a different signed-in user
-      // doesn't inherit the previous session.
       if (initializedForUid !== null) {
         initializedForUid = null;
+        inflight = null;
         clearAccessTokenCache();
         setSharedState({ status: 'disconnected' });
       }
@@ -135,42 +161,95 @@ export function useSpotifyAuth(): UseSpotifyAuth {
     }
     // Uid switch (user A → user B in the same tab). Invalidate the global
     // token cache before probing — otherwise user B's first getValidAccessToken()
-    // call returns user A's still-valid cached access_token.
+    // call returns user A's still-valid cached access_token. Clearing
+    // `inflight` here forces a fresh probe for B even if A's probe is still
+    // in flight.
     if (initializedForUid !== null && initializedForUid !== user.uid) {
       clearAccessTokenCache();
       initializedForUid = null;
+      inflight = null;
       setSharedState({ status: 'unknown' });
     }
     void initializeForUid(user.uid);
   }, [user]);
 
   const connect = useCallback(async (): Promise<ConnectOutcome> => {
+    const startUid = user?.uid ?? null;
+    if (!startUid) {
+      return { kind: 'error', reason: 'not-signed-in' };
+    }
     setSharedState({ status: 'connecting' });
-    const outcome = await connectSpotify();
+
+    // Step 1: popup. No backend call here — the popup just collects the
+    // PKCE code from Spotify's consent screen.
+    const popup = await runSpotifyAuthPopup();
+
+    // Uid check #1: bail BEFORE the backend exchange if the user switched
+    // during consent. Calling exchange under user B's auth would store
+    // user A's refresh_token under `/users/B/private/spotifyAuth` — a
+    // cross-user credential write that the server can't detect.
+    if (initializedForUid !== startUid) {
+      // The effect's uid-switch path has already set state to 'unknown'
+      // and kicked off the new uid's probe; don't overwrite it.
+      return { kind: 'cancelled' };
+    }
+
+    if (popup.kind === 'cancelled') {
+      setSharedState({ status: 'disconnected' });
+      return { kind: 'cancelled' };
+    }
+    if (popup.kind === 'error') {
+      setSharedState({
+        status: 'error',
+        message: prettifyConnectErrorReason(popup.reason),
+      });
+      return { kind: 'error', reason: popup.reason };
+    }
+
+    // Step 2: exchange the code for tokens. Now safe because startUid is
+    // confirmed current.
+    const outcome = await exchangeSpotifyCode({
+      code: popup.code,
+      codeVerifier: popup.codeVerifier,
+      redirectUri: popup.redirectUri,
+    });
+
+    // Uid check #2: belt-and-suspenders. The exchange itself was fast
+    // (< 1s typically) but if a switch landed during it, don't pollute
+    // the new uid's state machine with the previous account.
+    if (initializedForUid !== startUid) return { kind: 'cancelled' };
+
     if (outcome.kind === 'success') {
       cacheAccessToken(outcome.result.accessToken, outcome.result.expiresIn);
       try {
         const profile = await fetchSpotifyProfile(outcome.result.accessToken);
+        if (initializedForUid !== startUid) return { kind: 'cancelled' };
         setSharedState({ status: 'connected', profile });
       } catch (err) {
+        if (initializedForUid !== startUid) return { kind: 'cancelled' };
         setSharedState({
           status: 'error',
           message: err instanceof Error ? err.message : String(err),
         });
       }
-    } else if (outcome.kind === 'cancelled') {
-      setSharedState({ status: 'disconnected' });
-    } else {
+    } else if (outcome.kind === 'needs-consent') {
       setSharedState({
         status: 'error',
-        message:
-          outcome.kind === 'error'
-            ? prettifyConnectErrorReason(outcome.reason)
-            : `Spotify needs re-consent (${outcome.cause}). Try connecting again.`,
+        message: `Spotify needs re-consent (${outcome.cause}). Try connecting again.`,
       });
+    } else if (outcome.kind === 'error') {
+      setSharedState({
+        status: 'error',
+        message: prettifyConnectErrorReason(outcome.reason),
+      });
+    } else {
+      // `cancelled` from exchangeSpotifyCode is unreachable in practice (the
+      // popup handles cancellation), but the discriminated union allows it
+      // so we fall back to the same path the popup-cancel branch uses.
+      setSharedState({ status: 'disconnected' });
     }
     return outcome;
-  }, []);
+  }, [user]);
 
   const disconnect = useCallback(async (): Promise<DisconnectOutcome> => {
     const result = await disconnectSpotify();
@@ -182,7 +261,7 @@ export function useSpotifyAuth(): UseSpotifyAuth {
     return result;
   }, []);
 
-  const getAccessToken = useCallback(() => getValidAccessToken(), []);
+  const getAccessToken = useCallback(() => getValidAccessTokenOrNull(), []);
 
   return {
     state,

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -1,0 +1,138 @@
+/**
+ * useSpotifyAuth — connection state + profile for the current user's Spotify account.
+ *
+ * - Calls `refreshSpotifyAccessToken` on mount to detect whether a
+ *   refresh_token is already persisted for this user (any signed-in user
+ *   who had previously connected). If it succeeds, we treat them as
+ *   connected and fetch the profile.
+ * - `connect()` runs the popup auth flow and persists the refresh_token.
+ * - `disconnect()` clears the local cache and tells the backend to drop
+ *   the stored refresh_token.
+ * - `getAccessToken()` returns a valid token (refreshing if needed) for
+ *   downstream Web Playback SDK / Web API calls.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/context/useAuth';
+import {
+  ConnectOutcome,
+  cacheAccessToken,
+  clearAccessTokenCache,
+  connectSpotify,
+  disconnectSpotify,
+  fetchSpotifyProfile,
+  getValidAccessToken,
+  SpotifyUserProfile,
+} from '@/utils/spotifyAuth';
+
+export type SpotifyConnectionState =
+  | { status: 'unknown' }
+  | { status: 'disconnected' }
+  | { status: 'connected'; profile: SpotifyUserProfile }
+  | { status: 'connecting' }
+  | { status: 'error'; message: string };
+
+export interface UseSpotifyAuth {
+  state: SpotifyConnectionState;
+  isConnected: boolean;
+  isPremium: boolean;
+  connect: () => Promise<ConnectOutcome>;
+  disconnect: () => Promise<void>;
+  getAccessToken: () => Promise<string | null>;
+}
+
+export function useSpotifyAuth(): UseSpotifyAuth {
+  const { user } = useAuth();
+  const [state, setState] = useState<SpotifyConnectionState>({
+    status: 'unknown',
+  });
+  // Track the uid the current state was computed for so a sign-out/sign-in
+  // doesn't accidentally show a stale connected state.
+  const lastUidRef = useRef<string | null>(null);
+
+  // Detect existing connection on mount + on user change.
+  useEffect(() => {
+    if (!user) {
+      lastUidRef.current = null;
+      clearAccessTokenCache();
+      setState({ status: 'disconnected' });
+      return;
+    }
+    if (lastUidRef.current === user.uid && state.status !== 'unknown') return;
+    lastUidRef.current = user.uid;
+
+    let cancelled = false;
+    setState({ status: 'unknown' });
+
+    void (async () => {
+      const token = await getValidAccessToken();
+      if (cancelled) return;
+      if (!token) {
+        setState({ status: 'disconnected' });
+        return;
+      }
+      try {
+        const profile = await fetchSpotifyProfile(token);
+        if (cancelled) return;
+        setState({ status: 'connected', profile });
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // `state.status` intentionally omitted: the lastUidRef guard handles
+    // re-runs and we don't want a state setter inside the effect to loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user]);
+
+  const connect = useCallback(async (): Promise<ConnectOutcome> => {
+    setState({ status: 'connecting' });
+    const outcome = await connectSpotify();
+    if (outcome.kind === 'success') {
+      cacheAccessToken(outcome.result.accessToken, outcome.result.expiresIn);
+      try {
+        const profile = await fetchSpotifyProfile(outcome.result.accessToken);
+        setState({ status: 'connected', profile });
+      } catch (err) {
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    } else if (outcome.kind === 'cancelled') {
+      setState({ status: 'disconnected' });
+    } else {
+      setState({
+        status: 'error',
+        message:
+          outcome.kind === 'error'
+            ? outcome.reason
+            : `Spotify requires re-consent (${outcome.cause}).`,
+      });
+    }
+    return outcome;
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    await disconnectSpotify();
+    setState({ status: 'disconnected' });
+  }, []);
+
+  const getAccessToken = useCallback(() => getValidAccessToken(), []);
+
+  return {
+    state,
+    isConnected: state.status === 'connected',
+    isPremium: state.status === 'connected' && state.profile.isPremium,
+    connect,
+    disconnect,
+    getAccessToken,
+  };
+}

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -1,18 +1,22 @@
 /**
  * useSpotifyAuth — connection state + profile for the current user's Spotify account.
  *
- * - Calls `refreshSpotifyAccessToken` on mount to detect whether a
- *   refresh_token is already persisted for this user (any signed-in user
- *   who had previously connected). If it succeeds, we treat them as
- *   connected and fetch the profile.
- * - `connect()` runs the popup auth flow and persists the refresh_token.
- * - `disconnect()` clears the local cache and tells the backend to drop
- *   the stored refresh_token.
- * - `getAccessToken()` returns a valid token (refreshing if needed) for
- *   downstream Web Playback SDK / Web API calls.
+ * Shared state model
+ * ------------------
+ * The connection state lives in a module-level singleton so every `useSpotifyAuth`
+ * subscriber (e.g. the Music widget's settings panel AND its already-mounted
+ * front-face player) observes the same status. Without this, connecting from
+ * the settings panel wouldn't update the front-face player until it remounted.
+ *
+ * Per-uid cache invalidation
+ * --------------------------
+ * The module-level access-token cache (in `utils/spotifyAuth.ts`) is keyed
+ * globally, not per uid. We explicitly clear it whenever Firebase's signed-in
+ * uid changes so user B can't inherit user A's still-valid Spotify session in
+ * the same browser tab.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '@/context/useAuth';
 import {
   ConnectOutcome,
@@ -20,8 +24,10 @@ import {
   clearAccessTokenCache,
   connectSpotify,
   disconnectSpotify,
+  DisconnectOutcome,
   fetchSpotifyProfile,
   getValidAccessToken,
+  prettifyConnectErrorReason,
   SpotifyUserProfile,
 } from '@/utils/spotifyAuth';
 
@@ -37,92 +43,143 @@ export interface UseSpotifyAuth {
   isConnected: boolean;
   isPremium: boolean;
   connect: () => Promise<ConnectOutcome>;
-  disconnect: () => Promise<void>;
+  disconnect: () => Promise<DisconnectOutcome>;
   getAccessToken: () => Promise<string | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton state + subscribers
+// ---------------------------------------------------------------------------
+
+let sharedState: SpotifyConnectionState = { status: 'unknown' };
+const subscribers = new Set<(s: SpotifyConnectionState) => void>();
+/** uid the singleton state was initialized for. `null` = signed out or not yet seen. */
+let initializedForUid: string | null = null;
+/** Guards against duplicate initial-probe round-trips when multiple hooks mount at once. */
+let inflightInit: Promise<void> | null = null;
+
+function setSharedState(next: SpotifyConnectionState): void {
+  sharedState = next;
+  subscribers.forEach((cb) => cb(next));
+}
+
+/**
+ * Run the initial "is this user already connected?" probe exactly once per
+ * uid, broadcasting the result to every mounted hook instance via
+ * `setSharedState`. Concurrent mounts share the same in-flight promise so we
+ * don't fire duplicate `refreshSpotifyAccessToken` + `/me` round-trips.
+ */
+function initializeForUid(uid: string): Promise<void> {
+  if (initializedForUid === uid && sharedState.status !== 'unknown') {
+    return Promise.resolve();
+  }
+  if (inflightInit) return inflightInit;
+  initializedForUid = uid;
+  inflightInit = (async () => {
+    setSharedState({ status: 'unknown' });
+    const token = await getValidAccessToken();
+    // Uid may have changed mid-probe (rapid sign-out/sign-in). Re-check.
+    if (initializedForUid !== uid) return;
+    if (!token) {
+      setSharedState({ status: 'disconnected' });
+      return;
+    }
+    try {
+      const profile = await fetchSpotifyProfile(token);
+      if (initializedForUid !== uid) return;
+      setSharedState({ status: 'connected', profile });
+    } catch (err) {
+      if (initializedForUid !== uid) return;
+      setSharedState({
+        status: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  })().finally(() => {
+    inflightInit = null;
+  });
+  return inflightInit;
 }
 
 export function useSpotifyAuth(): UseSpotifyAuth {
   const { user } = useAuth();
-  const [state, setState] = useState<SpotifyConnectionState>({
-    status: 'unknown',
-  });
-  // Track the uid the current state was computed for so a sign-out/sign-in
-  // doesn't accidentally show a stale connected state.
-  const lastUidRef = useRef<string | null>(null);
+  const [state, setState] = useState<SpotifyConnectionState>(sharedState);
 
-  // Detect existing connection on mount + on user change.
+  // Subscribe this component to shared-state updates for its entire lifetime.
+  useEffect(() => {
+    subscribers.add(setState);
+    // Sync once after subscription in case the singleton changed between
+    // render and effect commit (race with another hook instance's
+    // connect/disconnect). Deferred past the effect body so
+    // `react-hooks/set-state-in-effect` doesn't flag a cascading render —
+    // and so React batches it with anything else in the same microtask.
+    queueMicrotask(() => {
+      setState(sharedState);
+    });
+    return () => {
+      subscribers.delete(setState);
+    };
+  }, []);
+
+  // React to sign-in/sign-out/uid-switch.
   useEffect(() => {
     if (!user) {
-      lastUidRef.current = null;
-      clearAccessTokenCache();
-      setState({ status: 'disconnected' });
+      // Sign-out — clear token cache and state so a different signed-in user
+      // doesn't inherit the previous session.
+      if (initializedForUid !== null) {
+        initializedForUid = null;
+        clearAccessTokenCache();
+        setSharedState({ status: 'disconnected' });
+      }
       return;
     }
-    if (lastUidRef.current === user.uid && state.status !== 'unknown') return;
-    lastUidRef.current = user.uid;
-
-    let cancelled = false;
-    setState({ status: 'unknown' });
-
-    void (async () => {
-      const token = await getValidAccessToken();
-      if (cancelled) return;
-      if (!token) {
-        setState({ status: 'disconnected' });
-        return;
-      }
-      try {
-        const profile = await fetchSpotifyProfile(token);
-        if (cancelled) return;
-        setState({ status: 'connected', profile });
-      } catch (err) {
-        if (cancelled) return;
-        setState({
-          status: 'error',
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-    // `state.status` intentionally omitted: the lastUidRef guard handles
-    // re-runs and we don't want a state setter inside the effect to loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Uid switch (user A → user B in the same tab). Invalidate the global
+    // token cache before probing — otherwise user B's first getValidAccessToken()
+    // call returns user A's still-valid cached access_token.
+    if (initializedForUid !== null && initializedForUid !== user.uid) {
+      clearAccessTokenCache();
+      initializedForUid = null;
+      setSharedState({ status: 'unknown' });
+    }
+    void initializeForUid(user.uid);
   }, [user]);
 
   const connect = useCallback(async (): Promise<ConnectOutcome> => {
-    setState({ status: 'connecting' });
+    setSharedState({ status: 'connecting' });
     const outcome = await connectSpotify();
     if (outcome.kind === 'success') {
       cacheAccessToken(outcome.result.accessToken, outcome.result.expiresIn);
       try {
         const profile = await fetchSpotifyProfile(outcome.result.accessToken);
-        setState({ status: 'connected', profile });
+        setSharedState({ status: 'connected', profile });
       } catch (err) {
-        setState({
+        setSharedState({
           status: 'error',
           message: err instanceof Error ? err.message : String(err),
         });
       }
     } else if (outcome.kind === 'cancelled') {
-      setState({ status: 'disconnected' });
+      setSharedState({ status: 'disconnected' });
     } else {
-      setState({
+      setSharedState({
         status: 'error',
         message:
           outcome.kind === 'error'
-            ? outcome.reason
-            : `Spotify requires re-consent (${outcome.cause}).`,
+            ? prettifyConnectErrorReason(outcome.reason)
+            : `Spotify needs re-consent (${outcome.cause}). Try connecting again.`,
       });
     }
     return outcome;
   }, []);
 
-  const disconnect = useCallback(async () => {
-    await disconnectSpotify();
-    setState({ status: 'disconnected' });
+  const disconnect = useCallback(async (): Promise<DisconnectOutcome> => {
+    const result = await disconnectSpotify();
+    if (result.ok) {
+      setSharedState({ status: 'disconnected' });
+    } else {
+      setSharedState({ status: 'error', message: result.message });
+    }
+    return result;
   }, []);
 
   const getAccessToken = useCallback(() => getValidAccessToken(), []);

--- a/types.ts
+++ b/types.ts
@@ -4072,6 +4072,14 @@ export interface MusicStation {
   buildingIds?: string[];
 }
 
+/**
+ * Music widget audio source.
+ * - `curated` — pick from admin-managed stations (`global_music_stations`).
+ * - `personal` — teacher's own Spotify account (requires OAuth connection;
+ *   full playback requires Spotify Premium, free accounts fall back to embed).
+ */
+export type MusicSource = 'curated' | 'personal';
+
 export interface MusicConfig {
   stationId: string;
   syncWithTimeTool?: boolean;
@@ -4079,6 +4087,18 @@ export interface MusicConfig {
   textColor?: string;
   /** Widget display layout */
   layout?: MusicLayout;
+  /** Audio source — defaults to 'curated' for backward compatibility. */
+  source?: MusicSource;
+  /**
+   * Personal Spotify resource URL or URI to play when `source === 'personal'`.
+   * Supports https://open.spotify.com/{track|album|playlist}/{id} or
+   * spotify:{type}:{id}. Validated at play-time via `parseSpotifyResource`.
+   */
+  personalSpotifyUrl?: string;
+  /** Human-readable label for the personal selection (track/album/playlist name). */
+  personalSpotifyLabel?: string;
+  /** Optional thumbnail for the personal selection. */
+  personalSpotifyThumbnail?: string;
 }
 
 export interface OrganizerNode {

--- a/utils/spotifyAuth.ts
+++ b/utils/spotifyAuth.ts
@@ -119,8 +119,21 @@ function detailsFrom(err: unknown): SpotifyRefreshErrorDetails | null {
   return null;
 }
 
-/** Drive the popup auth flow and exchange the resulting code via the backend. */
-export async function connectSpotify(): Promise<ConnectOutcome> {
+/** Drive the Spotify consent popup. Returns the PKCE code + verifier, or a cancel/error result. */
+export type PopupOutcome =
+  | { kind: 'success'; code: string; codeVerifier: string; redirectUri: string }
+  | { kind: 'cancelled' }
+  | { kind: 'error'; reason: string };
+
+/**
+ * Open the Spotify OAuth popup and wait for the callback.
+ *
+ * Split from {@link exchangeSpotifyCode} so the caller can re-check the
+ * Firebase uid between the popup and the backend exchange. Without that
+ * check, a uid switch mid-popup could store user A's refresh token under
+ * user B's Firestore path (server uses `req.auth.uid`).
+ */
+export async function runSpotifyAuthPopup(): Promise<PopupOutcome> {
   if (isAuthBypass) {
     return { kind: 'error', reason: 'auth-bypass-mode' };
   }
@@ -212,17 +225,34 @@ export async function connectSpotify(): Promise<ConnectOutcome> {
     if (codeOrError.error === 'access_denied') return { kind: 'cancelled' };
     return { kind: 'error', reason: codeOrError.error };
   }
+  return {
+    kind: 'success',
+    code: codeOrError.code,
+    codeVerifier,
+    redirectUri,
+  };
+}
 
+/**
+ * Send the PKCE code to the backend for token exchange. Stores the
+ * refresh_token under the calling user's `/users/{uid}/private/spotifyAuth`.
+ *
+ * IMPORTANT: the server keys the stored token off the current Firebase
+ * `request.auth.uid` — never call this without first confirming the uid
+ * hasn't switched since the popup opened, or you'll write user A's
+ * Spotify refresh_token under user B's path.
+ */
+export async function exchangeSpotifyCode(args: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<ConnectOutcome> {
   try {
     const exchange = httpsCallable<
       { code: string; redirectUri: string; codeVerifier: string },
       { accessToken: string; expiresIn: number; hasRefreshToken: boolean }
     >(functions, 'exchangeSpotifyAuthCode');
-    const res = await exchange({
-      code: codeOrError.code,
-      redirectUri,
-      codeVerifier,
-    });
+    const res = await exchange(args);
     return {
       kind: 'success',
       result: {
@@ -246,6 +276,21 @@ export async function connectSpotify(): Promise<ConnectOutcome> {
   }
 }
 
+/**
+ * @deprecated Prefer {@link runSpotifyAuthPopup} + {@link exchangeSpotifyCode}
+ * with a uid-stability check between them. Kept only for callers that don't
+ * need uid-switch protection.
+ */
+export async function connectSpotify(): Promise<ConnectOutcome> {
+  const popup = await runSpotifyAuthPopup();
+  if (popup.kind !== 'success') return popup;
+  return exchangeSpotifyCode({
+    code: popup.code,
+    codeVerifier: popup.codeVerifier,
+    redirectUri: popup.redirectUri,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Access-token cache + auto-refresh
 // ---------------------------------------------------------------------------
@@ -257,7 +302,7 @@ interface CachedToken {
 }
 
 let cached: CachedToken | null = null;
-let inflightRefresh: Promise<string | null> | null = null;
+let inflightRefresh: Promise<AccessTokenResult> | null = null;
 /**
  * Bumped every time the cache is cleared (sign-out, uid switch, disconnect).
  * Any in-flight refresh started before the bump must check the generation
@@ -278,19 +323,39 @@ export function clearAccessTokenCache(): void {
 }
 
 /**
- * Returns a valid access_token, refreshing via the backend if needed.
- * Returns null if the user is not connected or the refresh failed terminally.
+ * Verbose result of {@link getValidAccessToken}.
+ *
+ * Distinguishing `transient` from `needs-consent` matters: a 500 from the
+ * refresh callable or a Spotify outage is `transient` (the stored refresh
+ * token is still valid, the user is still "connected"), whereas
+ * `needs-consent` means the stored grant is gone and the user must re-auth.
+ * Callers that conflate these into "no token = disconnected" will push
+ * teachers into a re-consent flow during any backend hiccup.
  */
-export async function getValidAccessToken(): Promise<string | null> {
-  if (isAuthBypass) return null;
+export type AccessTokenResult =
+  | { status: 'ok'; token: string }
+  | { status: 'needs-consent' }
+  | { status: 'transient'; message: string }
+  | {
+      status: 'no-cache-bump'; /** swallowed because the cache was cleared mid-refresh */
+    };
+
+/**
+ * Returns the current access_token, refreshing via the backend if needed.
+ *
+ * The full {@link AccessTokenResult} discriminator lets callers tell
+ * `needs-consent` from `transient` — see the type's docs for why.
+ */
+export async function getValidAccessToken(): Promise<AccessTokenResult> {
+  if (isAuthBypass) return { status: 'needs-consent' };
   // 60-second skew so a token never expires mid-API-call.
   if (cached && cached.expiresAt - 60_000 > Date.now()) {
-    return cached.token;
+    return { status: 'ok', token: cached.token };
   }
   if (inflightRefresh) return inflightRefresh;
 
   const generationAtStart = cacheGeneration;
-  inflightRefresh = (async () => {
+  inflightRefresh = (async (): Promise<AccessTokenResult> => {
     try {
       const refresh = httpsCallable<
         Record<string, never>,
@@ -301,20 +366,24 @@ export async function getValidAccessToken(): Promise<string | null> {
       // disconnect, or uid switch). Without this guard, the stale refresh
       // would repopulate the cache after the caller intended it cleared.
       if (cacheGeneration !== generationAtStart) {
-        return null;
+        return { status: 'no-cache-bump' };
       }
       cacheAccessToken(res.data.accessToken, res.data.expiresIn);
-      return res.data.accessToken;
+      return { status: 'ok', token: res.data.accessToken };
     } catch (err) {
       logError('spotifyAuth.refresh', err);
       const d = detailsFrom(err);
-      if (
-        d?.reason === 'needs-consent' &&
-        cacheGeneration === generationAtStart
-      ) {
-        cached = null;
+      if (d?.reason === 'needs-consent') {
+        if (cacheGeneration === generationAtStart) cached = null;
+        return { status: 'needs-consent' };
       }
-      return null;
+      const message =
+        err instanceof FunctionsError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return { status: 'transient', message };
     } finally {
       // Only clear the inflight pointer if it's still ours — a cache reset
       // (which nulls inflightRefresh) may have already happened.
@@ -324,6 +393,16 @@ export async function getValidAccessToken(): Promise<string | null> {
     }
   })();
   return inflightRefresh;
+}
+
+/**
+ * Thin wrapper for callers that don't care to distinguish failure modes
+ * (e.g. fire-and-forget search, single play attempt). Returns the token or
+ * null on any non-`ok` outcome.
+ */
+export async function getValidAccessTokenOrNull(): Promise<string | null> {
+  const result = await getValidAccessToken();
+  return result.status === 'ok' ? result.token : null;
 }
 
 export type DisconnectOutcome = { ok: true } | { ok: false; message: string };

--- a/utils/spotifyAuth.ts
+++ b/utils/spotifyAuth.ts
@@ -1,0 +1,537 @@
+/**
+ * Client-side glue for the Spotify OAuth Authorization-Code-with-PKCE flow.
+ *
+ * Flow:
+ * 1. `connectSpotify()` — generates a PKCE verifier + challenge, opens a
+ *    centered popup window to Spotify's authorize endpoint, and waits for
+ *    the popup to postMessage the resulting authorization code back.
+ * 2. The popup lands on `/spotify-callback` (handled by `SpotifyCallback.tsx`),
+ *    which extracts `?code=...` and posts it to `window.opener` before closing.
+ * 3. `connectSpotify()` calls the `exchangeSpotifyAuthCode` Cloud Function
+ *    with the code + PKCE verifier. The server persists the encrypted
+ *    refresh_token and returns a fresh access_token.
+ *
+ * The refresh_token NEVER reaches the browser. Token refresh goes through
+ * `refreshAccessToken()` which calls the backend callable.
+ *
+ * In-memory cache: `getValidAccessToken()` keeps the current access_token
+ * with its expiry and refreshes it 60s before expiry. Cleared on disconnect.
+ */
+
+import { httpsCallable, FunctionsError } from 'firebase/functions';
+import { functions, isAuthBypass } from '@/config/firebase';
+import { logError } from '@/utils/logError';
+
+/** Spotify OAuth scopes required by the Music widget. Kept in sync with the backend. */
+export const SPOTIFY_SCOPES = [
+  'streaming',
+  'user-read-email',
+  'user-read-private',
+  'user-modify-playback-state',
+  'user-read-playback-state',
+] as const;
+
+export const SPOTIFY_AUTHORIZE_ENDPOINT =
+  'https://accounts.spotify.com/authorize';
+
+/** Returns the OAuth redirect URI the popup will land on after Spotify consent. */
+export function getSpotifyRedirectUri(): string {
+  return `${window.location.origin}/spotify-callback`;
+}
+
+function getClientId(): string {
+  const id = import.meta.env.VITE_SPOTIFY_CLIENT_ID as string | undefined;
+  if (!id) {
+    throw new Error(
+      'VITE_SPOTIFY_CLIENT_ID is not configured. Add it to .env.local and register a Spotify app at https://developer.spotify.com/dashboard.'
+    );
+  }
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// PKCE helpers (Web Crypto)
+// ---------------------------------------------------------------------------
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let str = '';
+  for (const b of bytes) str += String.fromCharCode(b);
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomVerifier(): string {
+  const bytes = new Uint8Array(64);
+  window.crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+async function s256Challenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await window.crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+// ---------------------------------------------------------------------------
+// Popup-based code capture
+// ---------------------------------------------------------------------------
+
+/** Message posted by `/spotify-callback` back to the opener. */
+export interface SpotifyCallbackMessage {
+  source: 'spartboard-spotify-callback';
+  code?: string;
+  state?: string;
+  error?: string;
+}
+
+function openCenteredPopup(url: string, name: string): Window | null {
+  const w = 480;
+  const h = 760;
+  const left = window.screenX + (window.outerWidth - w) / 2;
+  const top = window.screenY + (window.outerHeight - h) / 2;
+  return window.open(
+    url,
+    name,
+    `width=${w},height=${h},left=${Math.max(0, left)},top=${Math.max(0, top)},popup=yes`
+  );
+}
+
+interface ConnectResult {
+  accessToken: string;
+  expiresIn: number;
+}
+
+export type ConnectOutcome =
+  | { kind: 'success'; result: ConnectResult }
+  | { kind: 'cancelled' }
+  | { kind: 'error'; reason: string }
+  | { kind: 'needs-consent'; cause: string };
+
+interface SpotifyRefreshErrorDetails {
+  reason?: 'needs-consent' | 'transient';
+  cause?: string;
+}
+
+function detailsFrom(err: unknown): SpotifyRefreshErrorDetails | null {
+  if (err instanceof FunctionsError) {
+    const d = err.details;
+    if (d && typeof d === 'object') return d as SpotifyRefreshErrorDetails;
+  }
+  return null;
+}
+
+/** Drive the popup auth flow and exchange the resulting code via the backend. */
+export async function connectSpotify(): Promise<ConnectOutcome> {
+  if (isAuthBypass) {
+    return { kind: 'error', reason: 'auth-bypass-mode' };
+  }
+  let clientId: string;
+  try {
+    clientId = getClientId();
+  } catch (err) {
+    return {
+      kind: 'error',
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const redirectUri = getSpotifyRedirectUri();
+  const codeVerifier = randomVerifier();
+  const codeChallenge = await s256Challenge(codeVerifier);
+  // Cryptographic state value tying the popup callback back to this exact
+  // connect attempt. Stored in sessionStorage because the popup runs in
+  // the same origin and can read it back when constructing its postMessage.
+  const state = randomVerifier();
+
+  const authUrl = new URL(SPOTIFY_AUTHORIZE_ENDPOINT);
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', SPOTIFY_SCOPES.join(' '));
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+  authUrl.searchParams.set('code_challenge', codeChallenge);
+  authUrl.searchParams.set('state', state);
+
+  const popup = openCenteredPopup(authUrl.toString(), 'spotify-auth');
+  if (!popup) {
+    return { kind: 'error', reason: 'popup-blocked' };
+  }
+
+  const codeOrError = await new Promise<
+    { code: string } | { error: string } | { cancelled: true }
+  >((resolve) => {
+    const expectedOrigin = window.location.origin;
+    let resolved = false;
+
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage);
+      window.clearInterval(closedCheck);
+    };
+
+    const onMessage = (evt: MessageEvent) => {
+      if (evt.origin !== expectedOrigin) return;
+      const data = evt.data as SpotifyCallbackMessage | undefined;
+      if (!data || data.source !== 'spartboard-spotify-callback') return;
+      if (data.state !== state) {
+        // State mismatch — a different connect attempt or a forged message.
+        // Ignore rather than fail, so the real callback can still arrive.
+        return;
+      }
+      resolved = true;
+      cleanup();
+      try {
+        popup.close();
+      } catch {
+        /* popup may already be closed */
+      }
+      if (data.error) {
+        resolve({ error: data.error });
+      } else if (data.code) {
+        resolve({ code: data.code });
+      } else {
+        resolve({ error: 'callback-missing-code' });
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+
+    // The user closing the popup window without finishing consent has to be
+    // detected by polling — there is no `popupclosed` event. 500ms cadence
+    // is the standard tradeoff between latency and CPU.
+    const closedCheck = window.setInterval(() => {
+      if (resolved) return;
+      if (popup.closed) {
+        cleanup();
+        resolve({ cancelled: true });
+      }
+    }, 500);
+  });
+
+  if ('cancelled' in codeOrError) return { kind: 'cancelled' };
+  if ('error' in codeOrError) {
+    if (codeOrError.error === 'access_denied') return { kind: 'cancelled' };
+    return { kind: 'error', reason: codeOrError.error };
+  }
+
+  try {
+    const exchange = httpsCallable<
+      { code: string; redirectUri: string; codeVerifier: string },
+      { accessToken: string; expiresIn: number; hasRefreshToken: boolean }
+    >(functions, 'exchangeSpotifyAuthCode');
+    const res = await exchange({
+      code: codeOrError.code,
+      redirectUri,
+      codeVerifier,
+    });
+    return {
+      kind: 'success',
+      result: {
+        accessToken: res.data.accessToken,
+        expiresIn: res.data.expiresIn,
+      },
+    };
+  } catch (err) {
+    logError('spotifyAuth.exchange', err);
+    const d = detailsFrom(err);
+    if (d?.reason === 'needs-consent') {
+      return { kind: 'needs-consent', cause: d.cause ?? 'unknown' };
+    }
+    const message =
+      err instanceof FunctionsError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { kind: 'error', reason: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Access-token cache + auto-refresh
+// ---------------------------------------------------------------------------
+
+interface CachedToken {
+  token: string;
+  /** Epoch ms when this access_token expires. */
+  expiresAt: number;
+}
+
+let cached: CachedToken | null = null;
+let inflightRefresh: Promise<string | null> | null = null;
+
+export function cacheAccessToken(token: string, expiresIn: number): void {
+  cached = { token, expiresAt: Date.now() + expiresIn * 1000 };
+}
+
+export function clearAccessTokenCache(): void {
+  cached = null;
+  inflightRefresh = null;
+}
+
+/**
+ * Returns a valid access_token, refreshing via the backend if needed.
+ * Returns null if the user is not connected or the refresh failed terminally.
+ */
+export async function getValidAccessToken(): Promise<string | null> {
+  if (isAuthBypass) return null;
+  // 60-second skew so a token never expires mid-API-call.
+  if (cached && cached.expiresAt - 60_000 > Date.now()) {
+    return cached.token;
+  }
+  if (inflightRefresh) return inflightRefresh;
+
+  inflightRefresh = (async () => {
+    try {
+      const refresh = httpsCallable<
+        Record<string, never>,
+        { accessToken: string; expiresIn: number }
+      >(functions, 'refreshSpotifyAccessToken');
+      const res = await refresh({});
+      cacheAccessToken(res.data.accessToken, res.data.expiresIn);
+      return res.data.accessToken;
+    } catch (err) {
+      logError('spotifyAuth.refresh', err);
+      const d = detailsFrom(err);
+      if (d?.reason === 'needs-consent') {
+        cached = null;
+      }
+      return null;
+    } finally {
+      inflightRefresh = null;
+    }
+  })();
+  return inflightRefresh;
+}
+
+export async function disconnectSpotify(): Promise<void> {
+  clearAccessTokenCache();
+  if (isAuthBypass) return;
+  try {
+    const revoke = httpsCallable<Record<string, never>, { revoked: boolean }>(
+      functions,
+      'revokeSpotifyAuth'
+    );
+    await revoke({});
+  } catch (err) {
+    logError('spotifyAuth.revoke', err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Spotify Web API helpers used by the widget
+// ---------------------------------------------------------------------------
+
+export interface SpotifyUserProfile {
+  id: string;
+  email?: string;
+  displayName?: string;
+  isPremium: boolean;
+}
+
+export async function fetchSpotifyProfile(
+  accessToken: string
+): Promise<SpotifyUserProfile> {
+  const res = await fetch('https://api.spotify.com/v1/me', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Spotify /me returned ${res.status}`);
+  }
+  const data = (await res.json()) as {
+    id: string;
+    email?: string;
+    display_name?: string;
+    product?: string;
+  };
+  return {
+    id: data.id,
+    email: data.email,
+    displayName: data.display_name,
+    isPremium: data.product === 'premium',
+  };
+}
+
+export type SpotifyResourceType = 'track' | 'album' | 'playlist' | 'artist';
+
+export interface SpotifySearchResult {
+  type: SpotifyResourceType;
+  uri: string;
+  id: string;
+  name: string;
+  subtitle: string;
+  imageUrl?: string;
+}
+
+/**
+ * Extracts `{ type, id }` from any Spotify URL or URI. Supports:
+ *   - https://open.spotify.com/track/{id}
+ *   - https://open.spotify.com/playlist/{id}?si=...
+ *   - spotify:track:{id}
+ * Returns null for anything else (including invalid types like `user`).
+ */
+export function parseSpotifyResource(
+  input: string
+): { type: SpotifyResourceType; id: string; uri: string } | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith('spotify:')) {
+    const parts = trimmed.split(':');
+    if (parts.length >= 3) {
+      const type = parts[1];
+      const id = parts[2];
+      if (
+        (type === 'track' ||
+          type === 'album' ||
+          type === 'playlist' ||
+          type === 'artist') &&
+        /^[A-Za-z0-9]+$/.test(id)
+      ) {
+        return { type, id, uri: `spotify:${type}:${id}` };
+      }
+    }
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (
+      url.protocol !== 'https:' ||
+      (url.hostname !== 'open.spotify.com' &&
+        !url.hostname.endsWith('.spotify.com'))
+    ) {
+      return null;
+    }
+    const segments = url.pathname.split('/').filter(Boolean);
+    // Spotify URLs may be locale-prefixed: /intl-de/track/{id}
+    const typeIdx = segments.findIndex((s) =>
+      ['track', 'album', 'playlist', 'artist'].includes(s)
+    );
+    if (typeIdx < 0 || typeIdx + 1 >= segments.length) return null;
+    const type = segments[typeIdx] as SpotifyResourceType;
+    const id = segments[typeIdx + 1];
+    if (!/^[A-Za-z0-9]+$/.test(id)) return null;
+    return { type, id, uri: `spotify:${type}:${id}` };
+  } catch {
+    return null;
+  }
+}
+
+interface SpotifySearchApiResponse {
+  tracks?: {
+    items: Array<{
+      id: string;
+      name: string;
+      uri: string;
+      artists: Array<{ name: string }>;
+      album?: { images?: Array<{ url: string }> };
+    }>;
+  };
+  albums?: {
+    items: Array<{
+      id: string;
+      name: string;
+      uri: string;
+      artists: Array<{ name: string }>;
+      images?: Array<{ url: string }>;
+    }>;
+  };
+  playlists?: {
+    items: Array<{
+      id: string;
+      name: string;
+      uri: string;
+      owner?: { display_name?: string };
+      images?: Array<{ url: string }>;
+    }>;
+  };
+}
+
+export async function searchSpotify(
+  accessToken: string,
+  query: string,
+  signal?: AbortSignal
+): Promise<SpotifySearchResult[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  const url = new URL('https://api.spotify.com/v1/search');
+  url.searchParams.set('q', trimmed);
+  url.searchParams.set('type', 'track,album,playlist');
+  url.searchParams.set('limit', '6');
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`Spotify search returned ${res.status}`);
+  }
+  const data = (await res.json()) as SpotifySearchApiResponse;
+  const out: SpotifySearchResult[] = [];
+  for (const t of data.tracks?.items ?? []) {
+    out.push({
+      type: 'track',
+      uri: t.uri,
+      id: t.id,
+      name: t.name,
+      subtitle: t.artists.map((a) => a.name).join(', '),
+      imageUrl: t.album?.images?.[0]?.url,
+    });
+  }
+  for (const a of data.albums?.items ?? []) {
+    out.push({
+      type: 'album',
+      uri: a.uri,
+      id: a.id,
+      name: a.name,
+      subtitle: `Album · ${a.artists.map((x) => x.name).join(', ')}`,
+      imageUrl: a.images?.[0]?.url,
+    });
+  }
+  for (const p of data.playlists?.items ?? []) {
+    out.push({
+      type: 'playlist',
+      uri: p.uri,
+      id: p.id,
+      name: p.name,
+      subtitle: `Playlist · ${p.owner?.display_name ?? 'Spotify'}`,
+      imageUrl: p.images?.[0]?.url,
+    });
+  }
+  return out;
+}
+
+/**
+ * Issue `play` on the given device. Pass either a context URI (album/playlist/artist)
+ * via `contextUri`, or a list of track URIs via `uris`, but not both.
+ */
+export async function playOnDevice(
+  accessToken: string,
+  deviceId: string,
+  payload: { contextUri?: string; uris?: string[] }
+): Promise<void> {
+  const body: Record<string, unknown> = {};
+  if (payload.contextUri) body.context_uri = payload.contextUri;
+  if (payload.uris) body.uris = payload.uris;
+  const res = await fetch(
+    `https://api.spotify.com/v1/me/player/play?device_id=${encodeURIComponent(deviceId)}`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    }
+  );
+  // 204 is success; some non-Premium accounts return 403.
+  if (res.status === 403) {
+    throw new Error('spotify-premium-required');
+  }
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`Spotify play returned ${res.status}`);
+  }
+}
+
+/** Build the Spotify resource URI (track/album/playlist) for a given input. */
+export function spotifyUriFromInput(input: string): string | null {
+  return parseSpotifyResource(input)?.uri ?? null;
+}

--- a/utils/spotifyAuth.ts
+++ b/utils/spotifyAuth.ts
@@ -137,9 +137,10 @@ export async function connectSpotify(): Promise<ConnectOutcome> {
   const redirectUri = getSpotifyRedirectUri();
   const codeVerifier = randomVerifier();
   const codeChallenge = await s256Challenge(codeVerifier);
-  // Cryptographic state value tying the popup callback back to this exact
-  // connect attempt. Stored in sessionStorage because the popup runs in
-  // the same origin and can read it back when constructing its postMessage.
+  // Random CSRF/state value tying the popup callback back to this exact
+  // connect attempt. Sent as the OAuth `state` query parameter and echoed
+  // back by Spotify in the callback URL; the message listener below
+  // verifies the echoed value matches before accepting the code.
   const state = randomVerifier();
 
   const authUrl = new URL(SPOTIFY_AUTHORIZE_ENDPOINT);
@@ -257,6 +258,14 @@ interface CachedToken {
 
 let cached: CachedToken | null = null;
 let inflightRefresh: Promise<string | null> | null = null;
+/**
+ * Bumped every time the cache is cleared (sign-out, uid switch, disconnect).
+ * Any in-flight refresh started before the bump must check the generation
+ * before writing to the cache — otherwise a refresh request issued for user A
+ * could resolve after user A's session ended and repopulate the token cache
+ * with a stale credential.
+ */
+let cacheGeneration = 0;
 
 export function cacheAccessToken(token: string, expiresIn: number): void {
   cached = { token, expiresAt: Date.now() + expiresIn * 1000 };
@@ -265,6 +274,7 @@ export function cacheAccessToken(token: string, expiresIn: number): void {
 export function clearAccessTokenCache(): void {
   cached = null;
   inflightRefresh = null;
+  cacheGeneration += 1;
 }
 
 /**
@@ -279,6 +289,7 @@ export async function getValidAccessToken(): Promise<string | null> {
   }
   if (inflightRefresh) return inflightRefresh;
 
+  const generationAtStart = cacheGeneration;
   inflightRefresh = (async () => {
     try {
       const refresh = httpsCallable<
@@ -286,33 +297,91 @@ export async function getValidAccessToken(): Promise<string | null> {
         { accessToken: string; expiresIn: number }
       >(functions, 'refreshSpotifyAccessToken');
       const res = await refresh({});
+      // Drop the result if the cache was invalidated mid-flight (sign-out,
+      // disconnect, or uid switch). Without this guard, the stale refresh
+      // would repopulate the cache after the caller intended it cleared.
+      if (cacheGeneration !== generationAtStart) {
+        return null;
+      }
       cacheAccessToken(res.data.accessToken, res.data.expiresIn);
       return res.data.accessToken;
     } catch (err) {
       logError('spotifyAuth.refresh', err);
       const d = detailsFrom(err);
-      if (d?.reason === 'needs-consent') {
+      if (
+        d?.reason === 'needs-consent' &&
+        cacheGeneration === generationAtStart
+      ) {
         cached = null;
       }
       return null;
     } finally {
-      inflightRefresh = null;
+      // Only clear the inflight pointer if it's still ours — a cache reset
+      // (which nulls inflightRefresh) may have already happened.
+      if (cacheGeneration === generationAtStart) {
+        inflightRefresh = null;
+      }
     }
   })();
   return inflightRefresh;
 }
 
-export async function disconnectSpotify(): Promise<void> {
+export type DisconnectOutcome = { ok: true } | { ok: false; message: string };
+
+/**
+ * Disconnects the current user's Spotify integration.
+ *
+ * Returns `{ ok: false, message }` when the backend revoke fails — the
+ * caller must surface this rather than silently flipping the UI to a
+ * disconnected state, otherwise the stored refresh_token survives on the
+ * server and the next page load silently reconnects.
+ *
+ * The local cache is cleared in both branches: even on backend failure the
+ * client-side credential is gone, which limits exposure if the user hits
+ * disconnect because they no longer trust this browser.
+ */
+export async function disconnectSpotify(): Promise<DisconnectOutcome> {
   clearAccessTokenCache();
-  if (isAuthBypass) return;
+  if (isAuthBypass) return { ok: true };
   try {
     const revoke = httpsCallable<Record<string, never>, { revoked: boolean }>(
       functions,
       'revokeSpotifyAuth'
     );
     await revoke({});
+    return { ok: true };
   } catch (err) {
     logError('spotifyAuth.revoke', err);
+    const message =
+      err instanceof FunctionsError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return {
+      ok: false,
+      message: `Spotify disconnect didn't reach the server: ${message}. Your local session is cleared, but the stored connection may need to be removed at spotify.com/account/apps.`,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connect-error message prettification (shared between hook & UI)
+// ---------------------------------------------------------------------------
+
+/** Translates a raw `ConnectOutcome.reason` string into user-facing copy. */
+export function prettifyConnectErrorReason(reason: string): string {
+  switch (reason) {
+    case 'popup-blocked':
+      return 'Your browser blocked the Spotify sign-in popup. Allow popups for this site and try again.';
+    case 'auth-bypass-mode':
+      return 'Spotify cannot be connected in auth-bypass mode.';
+    case 'callback-missing-code':
+      return 'Spotify did not return an authorization code. Try again.';
+    case 'access_denied':
+      return 'Spotify access was denied. Try connecting again and approve the requested permissions.';
+    default:
+      return reason;
   }
 }
 
@@ -359,6 +428,17 @@ export interface SpotifySearchResult {
   name: string;
   subtitle: string;
   imageUrl?: string;
+}
+
+/**
+ * Returns `https://open.spotify.com/{type}/{id}` for any input that
+ * `parseSpotifyResource` accepts. Useful for the embed iframe, which only
+ * understands https URLs — `spotify:` URIs would break it.
+ */
+export function spotifyOpenUrlFromInput(input: string): string | null {
+  const parsed = parseSpotifyResource(input);
+  if (!parsed) return null;
+  return `https://open.spotify.com/${parsed.type}/${parsed.id}`;
 }
 
 /**

--- a/utils/spotifyPlaybackSdk.ts
+++ b/utils/spotifyPlaybackSdk.ts
@@ -1,0 +1,94 @@
+/**
+ * Spotify Web Playback SDK loader + minimal type surface.
+ *
+ * The SDK script (`https://sdk.scdn.co/spotify-player.js`) must be loaded
+ * once per page. It calls `window.onSpotifyWebPlaybackSDKReady` exactly
+ * once when ready; we fan that out to multiple pending callbacks so a
+ * dashboard with two music widgets doesn't trample its own initialization.
+ *
+ * The SDK only works in browsers that support EME (Encrypted Media
+ * Extensions) — i.e. Chrome / Edge / Firefox / Safari on desktop, but
+ * NOT iOS Safari. Callers should fall back to the embed iframe when
+ * `window.Spotify` never arrives.
+ */
+
+const SDK_SRC = 'https://sdk.scdn.co/spotify-player.js';
+const pendingCallbacks: (() => void)[] = [];
+
+export function loadSpotifySdk(callback: () => void): void {
+  if (typeof window === 'undefined') return;
+  if (window.Spotify?.Player) {
+    callback();
+    return;
+  }
+  pendingCallbacks.push(callback);
+  if (document.querySelector(`script[src="${SDK_SRC}"]`)) return;
+  const previousHandler = window.onSpotifyWebPlaybackSDKReady;
+  window.onSpotifyWebPlaybackSDKReady = () => {
+    if (typeof previousHandler === 'function') previousHandler();
+    pendingCallbacks.splice(0).forEach((cb) => cb());
+  };
+  const tag = document.createElement('script');
+  tag.src = SDK_SRC;
+  tag.async = true;
+  document.head.appendChild(tag);
+}
+
+// ---------------------------------------------------------------------------
+// Type declarations — covers only the surface the Music widget uses.
+// The real SDK has many more events and methods.
+// ---------------------------------------------------------------------------
+
+export interface SpotifyPlayerInitOptions {
+  name: string;
+  getOAuthToken: (cb: (token: string) => void) => void;
+  volume?: number;
+}
+
+export interface SpotifyPlayerState {
+  paused: boolean;
+  track_window?: {
+    current_track?: {
+      name: string;
+      uri: string;
+      artists: Array<{ name: string }>;
+      album?: { images?: Array<{ url: string }> };
+    };
+  };
+}
+
+export interface SpotifyPlayer {
+  connect: () => Promise<boolean>;
+  disconnect: () => void;
+  togglePlay: () => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
+  getCurrentState: () => Promise<SpotifyPlayerState | null>;
+  addListener: ((
+    event: 'ready',
+    cb: (data: { device_id: string }) => void
+  ) => void) &
+    ((event: 'not_ready', cb: (data: { device_id: string }) => void) => void) &
+    ((
+      event: 'player_state_changed',
+      cb: (state: SpotifyPlayerState) => void
+    ) => void) &
+    ((
+      event:
+        | 'initialization_error'
+        | 'authentication_error'
+        | 'account_error'
+        | 'playback_error',
+      cb: (data: { message: string }) => void
+    ) => void);
+  removeListener: (event: string) => void;
+}
+
+declare global {
+  interface Window {
+    Spotify?: {
+      Player: new (options: SpotifyPlayerInitOptions) => SpotifyPlayer;
+    };
+    onSpotifyWebPlaybackSDKReady?: () => void;
+  }
+}

--- a/utils/spotifyPlaybackSdk.ts
+++ b/utils/spotifyPlaybackSdk.ts
@@ -10,27 +10,91 @@
  * Extensions) — i.e. Chrome / Edge / Firefox / Safari on desktop, but
  * NOT iOS Safari. Callers should fall back to the embed iframe when
  * `window.Spotify` never arrives.
+ *
+ * Failure modes
+ * -------------
+ * The loader reports failures via the optional `onError` callback:
+ *   - `script-load-failed` — `<script>` emitted an `error` event (CDN blocked,
+ *     CSP violation, network down).
+ *   - `timeout` — neither `error` nor `onSpotifyWebPlaybackSDKReady` fired
+ *     within `SDK_LOAD_TIMEOUT_MS`.
+ * Without this, pending callbacks would sit forever and widgets would render
+ * a permanently disabled play button instead of falling back to the embed.
  */
 
 const SDK_SRC = 'https://sdk.scdn.co/spotify-player.js';
-const pendingCallbacks: (() => void)[] = [];
+const SDK_LOAD_TIMEOUT_MS = 15_000;
 
-export function loadSpotifySdk(callback: () => void): void {
+interface PendingCallback {
+  onReady: () => void;
+  onError?: (err: Error) => void;
+  timeoutId: number;
+}
+
+const pending: PendingCallback[] = [];
+let scriptInjected = false;
+let scriptFailed: Error | null = null;
+
+function fulfillAllReady(): void {
+  while (pending.length) {
+    const cb = pending.shift();
+    if (!cb) continue;
+    window.clearTimeout(cb.timeoutId);
+    cb.onReady();
+  }
+}
+
+function failAllPending(err: Error): void {
+  while (pending.length) {
+    const cb = pending.shift();
+    if (!cb) continue;
+    window.clearTimeout(cb.timeoutId);
+    cb.onError?.(err);
+  }
+}
+
+export function loadSpotifySdk(
+  onReady: () => void,
+  onError?: (err: Error) => void
+): void {
   if (typeof window === 'undefined') return;
   if (window.Spotify?.Player) {
-    callback();
+    onReady();
     return;
   }
-  pendingCallbacks.push(callback);
-  if (document.querySelector(`script[src="${SDK_SRC}"]`)) return;
+  // A previous load attempt definitively failed — don't keep new callers
+  // waiting on a script tag that's never going to load.
+  if (scriptFailed) {
+    onError?.(scriptFailed);
+    return;
+  }
+
+  const timeoutId = window.setTimeout(() => {
+    const err = new Error('timeout');
+    // Mark globally so future callers fail fast too.
+    scriptFailed = err;
+    failAllPending(err);
+  }, SDK_LOAD_TIMEOUT_MS);
+
+  pending.push({ onReady, onError, timeoutId });
+
+  if (scriptInjected) return;
+  scriptInjected = true;
+
   const previousHandler = window.onSpotifyWebPlaybackSDKReady;
   window.onSpotifyWebPlaybackSDKReady = () => {
     if (typeof previousHandler === 'function') previousHandler();
-    pendingCallbacks.splice(0).forEach((cb) => cb());
+    fulfillAllReady();
   };
+
   const tag = document.createElement('script');
   tag.src = SDK_SRC;
   tag.async = true;
+  tag.onerror = () => {
+    const err = new Error('script-load-failed');
+    scriptFailed = err;
+    failAllPending(err);
+  };
   document.head.appendChild(tag);
 }
 

--- a/utils/spotifyPremiumNotice.ts
+++ b/utils/spotifyPremiumNotice.ts
@@ -1,0 +1,31 @@
+/**
+ * Per-user "don't show Premium dialog again" preference.
+ *
+ * Stored in localStorage (`spartboard.spotify.premium-dismiss.<uid>`) because
+ * it's a UX-only flag with no security implications and no value in syncing
+ * across devices — a teacher reinstalling their browser is fine to see the
+ * notice again.
+ *
+ * Lives in `utils/` rather than alongside the dialog component so the dialog
+ * file only exports a React component (avoids the react-refresh lint warning
+ * about mixed exports).
+ */
+
+const DISMISS_KEY_PREFIX = 'spartboard.spotify.premium-dismiss.';
+
+export function hasDismissedSpotifyPremiumNotice(uid: string | null): boolean {
+  if (!uid || typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(DISMISS_KEY_PREFIX + uid) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setSpotifyPremiumNoticeDismissed(uid: string): void {
+  try {
+    window.localStorage.setItem(DISMISS_KEY_PREFIX + uid, '1');
+  } catch {
+    /* localStorage may be disabled — silently ignore */
+  }
+}


### PR DESCRIPTION
## Summary

Adds a **"My Spotify"** source mode to the Music widget so teachers can play from their own Spotify account instead of (or alongside) the admin-curated stations. Teacher connects via OAuth PKCE, and the widget controls playback through the Spotify Web Playback SDK. Free accounts fall back to the existing embed iframe (30-sec previews).

### Before
- Music widget only played admin-curated YouTube/Spotify stations.
- No way for a teacher to use their own Spotify account.

### After
- Settings panel has a **Source** toggle: `Curated stations` ↔ `My Spotify`.
- "My Spotify" path: Connect button → Spotify OAuth popup → encrypted refresh token stored server-side → Spotify Web Playback SDK plays a teacher-selected URL or search result directly on the dashboard.
- First-time connect shows a **"Spotify Premium required"** dialog with a "Don't show this again" checkbox; cancelling reverts to curated stations.

## Architecture

### Backend (`functions/src/spotifyOAuth.ts`)
Mirrors the existing `googleOAuth.ts` security model exactly:
- `exchangeSpotifyAuthCode` — PKCE code → tokens. AES-encrypts the refresh_token with `SPOTIFY_OAUTH_REFRESH_TOKEN_KEY` and stores at `/users/{uid}/private/spotifyAuth` (covered by the existing private-doc deny-all rule).
- `refreshSpotifyAccessToken` — exchanges the stored refresh_token. Spotify rotates refresh tokens on every call, so the new one is re-encrypted and persisted (with retry on Firestore write failure). On `invalid_grant`, race-safely checks whether another tab already rotated the doc and either deletes (→ needs-consent) or surfaces transient for the client to retry.
- `revokeSpotifyAuth` — drops the stored doc (Spotify has no public per-app revoke endpoint).

### Frontend
- `utils/spotifyAuth.ts` — PKCE verifier/challenge generation, popup auth flow (`runSpotifyAuthPopup` + `exchangeSpotifyCode` split so the hook can re-check the Firebase uid between the popup and the backend exchange), callable wrappers, in-memory access-token cache with generation-counter invalidation, Spotify URL/URI parsing, search + play helpers. `getValidAccessToken` returns a discriminated `AccessTokenResult` distinguishing transient backend failures from needs-consent.
- `utils/spotifyPlaybackSdk.ts` — Singleton loader for `https://sdk.scdn.co/spotify-player.js` with `onError` + 15s timeout so blocked CDNs surface as failures the player can fall back from.
- `utils/spotifyPremiumNotice.ts` — per-user "don't show again" preference (localStorage).
- `components/spotify/SpotifyCallback.tsx` — Popup callback page at `/spotify-callback`; `postMessage`s the code back to the opener and closes itself.
- `components/spotify/SpotifyPremiumDialog.tsx` — The Premium-required modal. Portalled to `document.body` so it isn't clipped by the settings panel's `will-change: transform`.
- `hooks/useSpotifyAuth.ts` — Module-level singleton state with subscriber set, so the Player and Settings panel observe the same connection state. Per-uid keying on the in-flight initial probe + uid checks at every step of `connect()` prevent cross-user credential writes during a sign-in switch.
- `components/widgets/MusicWidget/PersonalSpotifyPanel.tsx` — Settings UI (Connect/Disconnect, status, URL paste + live search dropdown).
- `components/widgets/MusicWidget/PersonalSpotifyPlayer.tsx` — Front-face Web Playback SDK player. Falls back to the embed iframe on ANY unrecoverable SDK failure (script load failure, init/auth/account/connect errors, premium-required at play time).
- `components/widgets/MusicWidget/Widget.tsx` — Top-level dispatch between curated and personal modes (each mounts a separate component so hooks stay unconditional).

### Types & routing
- `MusicConfig` gains `source`, `personalSpotifyUrl`, `personalSpotifyLabel`, `personalSpotifyThumbnail`. Defaults to `'curated'` for backward compatibility — existing dashboards unaffected.
- `App.tsx` routes `/spotify-callback` to the popup-only callback page (no providers, no auth, no Firestore listeners).

## Required setup before this can be enabled in prod

1. **Register a Spotify app** at https://developer.spotify.com/dashboard.
2. Add redirect URIs on the Spotify app:
   - `https://spartboard.web.app/spotify-callback`
   - `http://localhost:3000/spotify-callback` (for dev)
3. Set `VITE_SPOTIFY_CLIENT_ID` in `.env.local` (and CI/deploy env).
4. Set **all three** Firebase Functions secrets:
   ```
   firebase functions:secrets:set SPOTIFY_OAUTH_CLIENT_ID         # same value as VITE_SPOTIFY_CLIENT_ID
   firebase functions:secrets:set SPOTIFY_OAUTH_CLIENT_SECRET     # from the Spotify dashboard
   firebase functions:secrets:set SPOTIFY_OAUTH_REFRESH_TOKEN_KEY # any strong random string (encrypts refresh tokens at rest)
   ```
5. Deploy the new callables:
   ```
   firebase deploy --only functions:exchangeSpotifyAuthCode,functions:refreshSpotifyAccessToken,functions:revokeSpotifyAuth
   ```

Until step 3 lands, the Connect button surfaces a clear "VITE_SPOTIFY_CLIENT_ID is not configured" message instead of silently failing. Until step 4 lands, the callables will fail at runtime with a missing-secret error.

## Test plan

- [ ] **Backward compat**: existing Music widgets default to `source: 'curated'` and behave exactly as before
- [ ] Open Music widget settings → Source toggle visible with Curated/My Spotify options
- [ ] Click "My Spotify" → Premium dialog appears (and is centered on the viewport, not the settings panel)
- [ ] Cancel → reverts source back to Curated
- [ ] Continue → triggers OAuth popup; Spotify consent page loads
- [ ] After consent: account email + Premium/Free badge visible in settings AND front-face player updates without remount
- [ ] **Premium account**: paste a Spotify track URL → widget front face shows track + working play/pause
- [ ] **Premium account**: search "lofi hip hop" → results appear; clicking one populates the URL field
- [ ] **Free account**: connect → widget front face renders the embed iframe (30-sec preview)
- [ ] **Free account with `spotify:track:...` URI**: front face still renders embed (not blank)
- [ ] Premium downgraded mid-session → next play attempt falls back to embed
- [ ] Disconnect button works; reconnecting re-fetches profile; revoke failure surfaces a warning instead of falsely flipping to disconnected
- [ ] Sign out → state clears; sign in as a different user → no leakage of previous Spotify session
- [ ] "Don't show this again" → Premium dialog stays dismissed on next connect attempt
- [ ] Refresh token persists across page reloads (silent reconnect on mount)
- [ ] Curated-stations path still works untouched (no regressions in YouTube/Spotify station playback)

https://claude.ai/code/session_01RF93aLU2thmM8Y9TdpaPn1