### PR TITLE
fix(text-widget): drag-select crosses paragraphs + list buttons work on inline-only content

### DIFF
--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -261,12 +261,8 @@ const WrittenResponseEditorInner: React.FC<
   const handleListToggle = (listTag: 'ul' | 'ol') => {
     if (disabled || !editorRef.current) return;
     editorRef.current.focus();
-    // Always wrap loose top-level content in `<p>` blocks first. The
-    // weaker `needsBlockNormalization` skips inline-only content (to
-    // avoid stray line-boxes for `<b>hi</b>`-style snippets), but
-    // `toggleList` collects from `editor.children` and silently no-ops
-    // when no element children exist. ensureTopLevelBlocks is a no-op
-    // when content already has blocks.
+    // `toggleList` collects from `editor.children` (excludes text
+    // nodes), so any loose top-level text must be wrapped first.
     ensureTopLevelBlocks(editorRef.current, { wrapTag: 'p' });
     toggleList(editorRef.current, listTag, 'p');
     handleInput();

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import { sanitizeQuizResponse } from '@/utils/security';
 import {
+  ensureTopLevelBlocks,
   needsBlockNormalization,
   normalizeEditorBlocks,
 } from '@/utils/contentEditableBlocks';
@@ -260,13 +261,13 @@ const WrittenResponseEditorInner: React.FC<
   const handleListToggle = (listTag: 'ul' | 'ol') => {
     if (disabled || !editorRef.current) return;
     editorRef.current.focus();
-    // Run normalization first so any in-progress mixed structure
-    // (Chrome's bare-first-line + <div>-wrapped-rest pattern after
-    // typing Enter) becomes uniform `<p>` blocks. Then the list
-    // toggle operates on a clean tree.
-    if (needsBlockNormalization(editorRef.current, { wrapTag: 'p' })) {
-      normalizeEditorBlocks(editorRef.current, { wrapTag: 'p' });
-    }
+    // Always wrap loose top-level content in `<p>` blocks first. The
+    // weaker `needsBlockNormalization` skips inline-only content (to
+    // avoid stray line-boxes for `<b>hi</b>`-style snippets), but
+    // `toggleList` collects from `editor.children` and silently no-ops
+    // when no element children exist. ensureTopLevelBlocks is a no-op
+    // when content already has blocks.
+    ensureTopLevelBlocks(editorRef.current, { wrapTag: 'p' });
     toggleList(editorRef.current, listTag, 'p');
     handleInput();
   };

--- a/components/widgets/TextWidget/FormattingToolbar.test.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.test.tsx
@@ -528,6 +528,56 @@ describe('FormattingToolbar', () => {
     document.body.removeChild(editor);
   });
 
+  it('wraps inline-only editor content in a list (the previously broken case)', () => {
+    // Before the fix the toolbar called `needsBlockNormalization` first
+    // and that helper deliberately skips inline-only content to avoid
+    // stray line-boxes. The list command then ran against an editor
+    // whose `children` was empty (text nodes aren't in `.children`),
+    // collected zero blocks, and silently did nothing. The fix routes
+    // through `ensureTopLevelBlocks` which always wraps loose content.
+    const editor = mockEditorRef.current;
+    if (!editor) throw new Error('mockEditorRef.current is null');
+    editor.innerHTML = 'hello world';
+    document.body.appendChild(editor);
+    const textNode = editor.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, textNode.length);
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    render(<FormattingToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTitle(/Bulleted List/));
+
+    expect(editor.querySelector('ul')).not.toBeNull();
+    expect(editor.querySelectorAll('li').length).toBe(1);
+    expect(editor.querySelector('li')?.textContent).toBe('hello world');
+    document.body.removeChild(editor);
+  });
+
+  it('wraps inline-only editor content in a numbered list as well', () => {
+    const editor = mockEditorRef.current;
+    if (!editor) throw new Error('mockEditorRef.current is null');
+    editor.innerHTML = '<b>Bold text</b>';
+    document.body.appendChild(editor);
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    render(<FormattingToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTitle(/Numbered List/));
+
+    expect(editor.querySelector('ol')).not.toBeNull();
+    expect(editor.querySelectorAll('li').length).toBe(1);
+    expect(editor.querySelector('li b')?.textContent).toBe('Bold text');
+    document.body.removeChild(editor);
+  });
+
   it('reflects list toggle state via aria-pressed', () => {
     // Mock queryCommandState to simulate the caret being inside a list.
     const queryCommandStateMock = vi.fn(

--- a/components/widgets/TextWidget/FormattingToolbar.test.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.test.tsx
@@ -528,13 +528,7 @@ describe('FormattingToolbar', () => {
     document.body.removeChild(editor);
   });
 
-  it('wraps inline-only editor content in a list (the previously broken case)', () => {
-    // Before the fix the toolbar called `needsBlockNormalization` first
-    // and that helper deliberately skips inline-only content to avoid
-    // stray line-boxes. The list command then ran against an editor
-    // whose `children` was empty (text nodes aren't in `.children`),
-    // collected zero blocks, and silently did nothing. The fix routes
-    // through `ensureTopLevelBlocks` which always wraps loose content.
+  it('wraps inline-only editor content in a bulleted list', () => {
     const editor = mockEditorRef.current;
     if (!editor) throw new Error('mockEditorRef.current is null');
     editor.innerHTML = 'hello world';
@@ -557,7 +551,7 @@ describe('FormattingToolbar', () => {
     document.body.removeChild(editor);
   });
 
-  it('wraps inline-only editor content in a numbered list as well', () => {
+  it('wraps a single inline element in a numbered list', () => {
     const editor = mockEditorRef.current;
     if (!editor) throw new Error('mockEditorRef.current is null');
     editor.innerHTML = '<b>Bold text</b>';

--- a/components/widgets/TextWidget/FormattingToolbar.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.tsx
@@ -32,10 +32,7 @@ import { IconButton } from '@/components/common/IconButton';
 import { FONT_COLORS } from '@/config/fonts';
 import { HIGHLIGHT_PALETTE, STICKY_NOTE_COLORS } from '@/config/colors';
 import { useDialog } from '@/context/useDialog';
-import {
-  needsBlockNormalization,
-  normalizeEditorBlocks,
-} from '@/utils/contentEditableBlocks';
+import { ensureTopLevelBlocks } from '@/utils/contentEditableBlocks';
 import { toggleList } from '@/utils/contentEditableLists';
 
 interface FormattingToolbarProps {
@@ -555,13 +552,15 @@ export const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
       ) {
         const editor = editorRef.current;
         if (!editor) return;
-        // Normalize first so the live mixed-bare-text-then-<div>
-        // structure that Chrome produces in fresh editors doesn't
-        // confuse the block collection. No-op for already-uniform
-        // structures.
-        if (needsBlockNormalization(editor)) {
-          normalizeEditorBlocks(editor);
-        }
+        // Always wrap loose top-level content in a block before toggling
+        // a list. `toggleList` collects from `editor.children`, which
+        // excludes text nodes — so an editor with inline-only content
+        // (e.g. a single typed line that never crossed Enter) has zero
+        // collectable blocks and the list command silently no-ops.
+        // The stronger ensureTopLevelBlocks always wraps inline content
+        // so toggleList has an <li> source; it's a no-op when content
+        // is already in blocks.
+        ensureTopLevelBlocks(editor);
         const listTag = command === 'insertUnorderedList' ? 'ul' : 'ol';
         // `paragraphTag: 'div'` matches TextWidget's persistence
         // shape (`sanitizeHtml` allows `<div>`).

--- a/components/widgets/TextWidget/FormattingToolbar.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.tsx
@@ -552,14 +552,8 @@ export const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
       ) {
         const editor = editorRef.current;
         if (!editor) return;
-        // Always wrap loose top-level content in a block before toggling
-        // a list. `toggleList` collects from `editor.children`, which
-        // excludes text nodes — so an editor with inline-only content
-        // (e.g. a single typed line that never crossed Enter) has zero
-        // collectable blocks and the list command silently no-ops.
-        // The stronger ensureTopLevelBlocks always wraps inline content
-        // so toggleList has an <li> source; it's a no-op when content
-        // is already in blocks.
+        // `toggleList` collects from `editor.children` (excludes text
+        // nodes), so any loose top-level text must be wrapped first.
         ensureTopLevelBlocks(editor);
         const listTag = command === 'insertUnorderedList' ? 'ul' : 'ol';
         // `paragraphTag: 'div'` matches TextWidget's persistence

--- a/components/widgets/TextWidget/Widget.test.tsx
+++ b/components/widgets/TextWidget/Widget.test.tsx
@@ -149,6 +149,35 @@ describe('TextWidget', () => {
     expect(ancestorPointerDown).not.toHaveBeenCalled();
   });
 
+  it('Ctrl+Shift+8 wraps inline-only editor content in a bulleted list', () => {
+    // Guards the keyboard shortcut path through `ensureTopLevelBlocks`.
+    // Inline-only content (single typed line, no Enter pressed) has
+    // zero element children, so the old `needsBlockNormalization`
+    // guard skipped wrapping and `toggleList` silently no-opped.
+    render(<TextWidget widget={mockWidget} />);
+    const editableDiv = screen
+      .getByText('Hello World')
+      .closest('div[contentEditable="true"]') as HTMLElement;
+    expect(editableDiv).not.toBeNull();
+
+    // Replace with bare inline-only content and select all of it.
+    editableDiv.innerHTML = 'list me';
+    const textNode = editableDiv.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, textNode.length);
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    fireEvent.keyDown(editableDiv, { key: '8', shiftKey: true, ctrlKey: true });
+
+    expect(editableDiv.querySelector('ul')).not.toBeNull();
+    expect(editableDiv.querySelectorAll('li').length).toBe(1);
+    expect(editableDiv.querySelector('li')?.textContent).toBe('list me');
+  });
+
   it('triggers hyperlink prompt on Control+K', async () => {
     mockShowPrompt.mockResolvedValue('https://test.com');
     render(<TextWidget widget={mockWidget} />);

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -289,9 +289,6 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               : null;
         if (listTag && editorRef.current) {
           e.preventDefault();
-          // ensureTopLevelBlocks (not needsBlockNormalization) so the
-          // shortcut works on inline-only editors too — see runCommand
-          // in FormattingToolbar.tsx for the same reasoning.
           ensureTopLevelBlocks(editorRef.current);
           toggleList(editorRef.current, listTag, 'div');
           handleInput();

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -13,6 +13,7 @@ import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { FormattingToolbar } from './FormattingToolbar';
 import { PLACEHOLDER_TEXT } from './constants';
 import {
+  ensureTopLevelBlocks,
   needsBlockNormalization,
   normalizeEditorBlocks,
 } from '@/utils/contentEditableBlocks';
@@ -288,9 +289,10 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               : null;
         if (listTag && editorRef.current) {
           e.preventDefault();
-          if (needsBlockNormalization(editorRef.current)) {
-            normalizeEditorBlocks(editorRef.current);
-          }
+          // ensureTopLevelBlocks (not needsBlockNormalization) so the
+          // shortcut works on inline-only editors too — see runCommand
+          // in FormattingToolbar.tsx for the same reasoning.
+          ensureTopLevelBlocks(editorRef.current);
           toggleList(editorRef.current, listTag, 'div');
           handleInput();
           return;

--- a/utils/contentEditableBlocks.test.ts
+++ b/utils/contentEditableBlocks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ensureTopLevelBlocks,
   needsBlockNormalization,
   normalizeEditorBlocks,
 } from './contentEditableBlocks';
@@ -214,5 +215,67 @@ describe('needsBlockNormalization', () => {
         wrapTag: 'p',
       })
     ).toBe(false);
+  });
+});
+
+describe('ensureTopLevelBlocks', () => {
+  it('wraps inline-only content (the case toggleList needs)', () => {
+    // The toolbar's list buttons silently did nothing on this shape
+    // because `collectSelectedBlocks` iterates `editor.children`, which
+    // excludes text nodes. ensureTopLevelBlocks is the helper that
+    // guarantees there's always at least one block element for the
+    // list command to convert into an <li>.
+    const editor = buildEditor('hello world');
+    ensureTopLevelBlocks(editor);
+    expect(editor.children.length).toBe(1);
+    expect(editor.children[0].tagName).toBe('DIV');
+    expect(editor.children[0].textContent).toBe('hello world');
+  });
+
+  it('wraps a single inline element (e.g. <b>headline</b>)', () => {
+    // Distinct from normalizeEditorBlocks, which deliberately skips
+    // this case to avoid stray line-boxes. For list operations, we
+    // need the wrap regardless.
+    const editor = buildEditor('<b>headline</b>');
+    ensureTopLevelBlocks(editor);
+    expect(editor.children.length).toBe(1);
+    expect(editor.children[0].tagName).toBe('DIV');
+    expect(editor.children[0].innerHTML).toBe('<b>headline</b>');
+  });
+
+  it('is a no-op when content already has block structure', () => {
+    const html = '<div>One</div><div>Two</div>';
+    const editor = buildEditor(html);
+    ensureTopLevelBlocks(editor);
+    expect(editor.innerHTML).toBe(html);
+  });
+
+  it('wraps with <p> when requested (WrittenResponseEditor mode)', () => {
+    const editor = buildEditor('hello world');
+    ensureTopLevelBlocks(editor, { wrapTag: 'p' });
+    expect(editor.children.length).toBe(1);
+    expect(editor.children[0].tagName).toBe('P');
+  });
+
+  it('handles the mixed bare-text-then-<div> case (Chrome default)', () => {
+    const editor = buildEditor('First<div>Second</div>');
+    ensureTopLevelBlocks(editor);
+    expect(editor.children.length).toBe(2);
+    expect(editor.children[0].textContent).toBe('First');
+    expect(editor.children[1].textContent).toBe('Second');
+  });
+
+  it('drops top-level <br> separators', () => {
+    const editor = buildEditor('a<br/>b');
+    ensureTopLevelBlocks(editor);
+    expect(editor.querySelector('br')).toBeNull();
+    expect(editor.children.length).toBe(2);
+    expect(editor.textContent).toBe('ab');
+  });
+
+  it('is a no-op on an empty editor', () => {
+    const editor = buildEditor('');
+    ensureTopLevelBlocks(editor);
+    expect(editor.innerHTML).toBe('');
   });
 });

--- a/utils/contentEditableBlocks.test.ts
+++ b/utils/contentEditableBlocks.test.ts
@@ -219,12 +219,7 @@ describe('needsBlockNormalization', () => {
 });
 
 describe('ensureTopLevelBlocks', () => {
-  it('wraps inline-only content (the case toggleList needs)', () => {
-    // The toolbar's list buttons silently did nothing on this shape
-    // because `collectSelectedBlocks` iterates `editor.children`, which
-    // excludes text nodes. ensureTopLevelBlocks is the helper that
-    // guarantees there's always at least one block element for the
-    // list command to convert into an <li>.
+  it('wraps a bare top-level text node', () => {
     const editor = buildEditor('hello world');
     ensureTopLevelBlocks(editor);
     expect(editor.children.length).toBe(1);
@@ -232,15 +227,33 @@ describe('ensureTopLevelBlocks', () => {
     expect(editor.children[0].textContent).toBe('hello world');
   });
 
-  it('wraps a single inline element (e.g. <b>headline</b>)', () => {
-    // Distinct from normalizeEditorBlocks, which deliberately skips
-    // this case to avoid stray line-boxes. For list operations, we
-    // need the wrap regardless.
+  it('wraps a single top-level inline element', () => {
+    // normalizeEditorBlocks deliberately skips this shape; ensure does not.
     const editor = buildEditor('<b>headline</b>');
     ensureTopLevelBlocks(editor);
     expect(editor.children.length).toBe(1);
     expect(editor.children[0].tagName).toBe('DIV');
     expect(editor.children[0].innerHTML).toBe('<b>headline</b>');
+  });
+
+  it('keeps text node identity after wrapping (caret/selection survival)', () => {
+    // Live Ranges anchored to a moved node's *parent* collapse per
+    // the DOM spec, but the text node itself survives intact — it's
+    // just reparented. `toggleList` re-reads `window.getSelection()`
+    // after the wrap and works with the live range's new (collapsed)
+    // position, so the only thing this helper has to guarantee is
+    // that the text characters are preserved verbatim and the node
+    // identity stays the same.
+    const editor = buildEditor('hello world');
+    const textNode = editor.firstChild as Text;
+
+    ensureTopLevelBlocks(editor);
+
+    expect(textNode.nodeValue).toBe('hello world');
+    expect(textNode.parentElement).toBe(editor.children[0]);
+    expect(editor.children[0].tagName).toBe('DIV');
+    expect(editor.children[0].childNodes.length).toBe(1);
+    expect(editor.children[0].firstChild).toBe(textNode);
   });
 
   it('is a no-op when content already has block structure', () => {

--- a/utils/contentEditableBlocks.ts
+++ b/utils/contentEditableBlocks.ts
@@ -138,21 +138,16 @@ export const normalizeEditorBlocks = (
   wrapTopLevelContent(editor, options?.wrapTag ?? 'div');
 };
 
-/** Stronger normalization for list operations: always wraps loose top-
- *  level text/inline content into a block, even when the editor is
- *  inline-only (e.g. a single text node "hello world" the user typed
- *  without pressing Enter).
+/** Like `normalizeEditorBlocks` but unconditional — wraps inline-only
+ *  content too. Use before list operations: `toggleList` collects from
+ *  `editor.children` (excludes text nodes), so loose top-level text
+ *  must first be wrapped in a block or the command silently no-ops.
  *
- *  `normalizeEditorBlocks` deliberately skips inline-only content to
- *  avoid adding stray line-boxes for cases like `<b>headline</b>`.
- *  But `toggleList` iterates `editor.children` to find blocks to wrap
- *  into `<li>`s, and `editor.children` excludes text nodes — so when
- *  the editor has only a bare text node at the top level, the list
- *  command silently does nothing. This helper forces the wrap so the
- *  list command always has a block to act on.
- *
- *  Same node-relocation semantics as `normalizeEditorBlocks`: only
- *  moves nodes, never clones, so live Range references survive.
+ *  Only moves nodes, never clones, so node identity is preserved. The
+ *  user's selection (a live Range) may collapse to the editor when its
+ *  startContainer's ancestor is reparented per the DOM spec; callers
+ *  that need the post-wrap range should re-read it from `window.
+ *  getSelection()` rather than relying on a saved Range object.
  */
 export const ensureTopLevelBlocks = (
   editor: HTMLDivElement,

--- a/utils/contentEditableBlocks.ts
+++ b/utils/contentEditableBlocks.ts
@@ -135,9 +135,36 @@ export const normalizeEditorBlocks = (
   options?: NormalizeOptions
 ): void => {
   if (!needsBlockNormalization(editor, options)) return;
+  wrapTopLevelContent(editor, options?.wrapTag ?? 'div');
+};
 
-  const wrapTag = options?.wrapTag ?? 'div';
+/** Stronger normalization for list operations: always wraps loose top-
+ *  level text/inline content into a block, even when the editor is
+ *  inline-only (e.g. a single text node "hello world" the user typed
+ *  without pressing Enter).
+ *
+ *  `normalizeEditorBlocks` deliberately skips inline-only content to
+ *  avoid adding stray line-boxes for cases like `<b>headline</b>`.
+ *  But `toggleList` iterates `editor.children` to find blocks to wrap
+ *  into `<li>`s, and `editor.children` excludes text nodes — so when
+ *  the editor has only a bare text node at the top level, the list
+ *  command silently does nothing. This helper forces the wrap so the
+ *  list command always has a block to act on.
+ *
+ *  Same node-relocation semantics as `normalizeEditorBlocks`: only
+ *  moves nodes, never clones, so live Range references survive.
+ */
+export const ensureTopLevelBlocks = (
+  editor: HTMLDivElement,
+  options?: NormalizeOptions
+): void => {
+  wrapTopLevelContent(editor, options?.wrapTag ?? 'div');
+};
 
+const wrapTopLevelContent = (
+  editor: HTMLDivElement,
+  wrapTag: 'div' | 'p'
+): void => {
   let pending: Node[] = [];
   const flushPending = (insertBefore: Node | null) => {
     if (pending.length === 0) return;

--- a/utils/contentEditableDragSelect.test.ts
+++ b/utils/contentEditableDragSelect.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installDragSelectEnhancer } from './contentEditableDragSelect';
+
+/**
+ * `caretPositionFromPoint` isn't implemented in jsdom, so we stub it
+ * before each test to return the editor's first text node at offset 0.
+ * That lets the installer's drag-start path run end-to-end and we can
+ * observe whether `e.preventDefault()` was called — the core gating
+ * behavior these tests guard.
+ */
+const stubCaretAt = (node: Node, offset: number) => {
+  type CaretAPI = {
+    caretPositionFromPoint: (
+      x: number,
+      y: number
+    ) => { offsetNode: Node; offset: number } | null;
+  };
+  (document as unknown as CaretAPI).caretPositionFromPoint = () => ({
+    offsetNode: node,
+    offset,
+  });
+};
+
+const setUserAgent = (ua: string) => {
+  Object.defineProperty(navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+};
+
+const setMatchMedia = (coarse: boolean) => {
+  window.matchMedia = vi.fn().mockImplementation((q: string) => ({
+    matches: q === '(pointer: coarse)' ? coarse : false,
+    media: q,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+};
+
+describe('installDragSelectEnhancer — preventDefault gating', () => {
+  let editor: HTMLDivElement;
+  let cleanup: (() => void) | undefined;
+  const originalUA = navigator.userAgent;
+  const originalMatchMedia = window.matchMedia;
+  const originalCaretAPI = (
+    document as unknown as { caretPositionFromPoint?: unknown }
+  ).caretPositionFromPoint;
+
+  let textNode: Text;
+
+  beforeEach(() => {
+    editor = document.createElement('div');
+    editor.contentEditable = 'true';
+    editor.innerHTML = '<div>Hello world</div>';
+    document.body.appendChild(editor);
+    const para = editor.querySelector('div');
+    if (!para?.firstChild) throw new Error('test fixture: missing text node');
+    textNode = para.firstChild as Text;
+    stubCaretAt(textNode, 0);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    document.body.removeChild(editor);
+    setUserAgent(originalUA);
+    window.matchMedia = originalMatchMedia;
+    (
+      document as unknown as { caretPositionFromPoint?: unknown }
+    ).caretPositionFromPoint = originalCaretAPI;
+  });
+
+  it('calls preventDefault on Chromium desktop (pointer: fine)', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    );
+    setMatchMedia(false);
+    cleanup = installDragSelectEnhancer(editor);
+
+    const evt = new MouseEvent('mousedown', {
+      button: 0,
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 10,
+    });
+    Object.defineProperty(evt, 'target', { value: textNode });
+    editor.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+  });
+
+  it('skips preventDefault on Firefox (no clamp bug)', () => {
+    setUserAgent(
+      'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0'
+    );
+    setMatchMedia(false);
+    cleanup = installDragSelectEnhancer(editor);
+
+    const evt = new MouseEvent('mousedown', {
+      button: 0,
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 10,
+    });
+    Object.defineProperty(evt, 'target', { value: textNode });
+    editor.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('skips preventDefault on Safari (no clamp bug)', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+    );
+    setMatchMedia(false);
+    cleanup = installDragSelectEnhancer(editor);
+
+    const evt = new MouseEvent('mousedown', {
+      button: 0,
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 10,
+    });
+    Object.defineProperty(evt, 'target', { value: textNode });
+    editor.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+  });
+
+  it('skips preventDefault on Chromium mobile (pointer: coarse)', () => {
+    // Chrome on Android — Chromium UA but touch primary input. Skipping
+    // here preserves virtual-keyboard / long-press selection handles.
+    setUserAgent(
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36'
+    );
+    setMatchMedia(true);
+    cleanup = installDragSelectEnhancer(editor);
+
+    const evt = new MouseEvent('mousedown', {
+      button: 0,
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 10,
+    });
+    Object.defineProperty(evt, 'target', { value: textNode });
+    editor.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+  });
+});

--- a/utils/contentEditableDragSelect.ts
+++ b/utils/contentEditableDragSelect.ts
@@ -1,40 +1,22 @@
 /**
- * Chrome bug workaround: drag-selection inside contenteditable refuses
- * to extend across block boundaries when the initial `mousedown` lands
- * on a text node.
+ * Chromium contenteditable bug workaround: drag-selection clamps to
+ * the anchor text node's block when mousedown lands on text, refusing
+ * to extend across block boundaries. (Padding-area clicks work fine
+ * — the anchor falls on the container instead.)
  *
- * Concrete symptom: in a multi-paragraph editor, if the user begins a
- * drag-selection by clicking on the first character of a line, the
- * selection clamps to that single block — even if the user drags the
- * pointer well past the next paragraph. Starting the same drag from
- * editor padding / whitespace (off any text node) works fine, because
- * the browser anchors the selection to the block container instead
- * of the text node.
+ * `preventDefault()` on mousedown is required because Chromium re-
+ * clamps any bubble-phase `setBaseAndExtent` override on the next
+ * pointer tick, so the only reliable fix is to suppress Chromium's
+ * default drag-selection algorithm entirely. That also blocks the
+ * automatic focus shift and caret placement, so both are re-done
+ * manually: `editor.focus({ preventScroll: true })` + an empty range
+ * at the click point.
  *
- * Prior attempts that listened for `mousemove` and called
- * `setBaseAndExtent` from a bubble-phase listener did not work in
- * Chromium: the browser's internal drag-selection logic clamps the
- * selection as part of mousedown's default action / native input
- * pipeline, and bubble-phase JS overrides get re-clamped on the next
- * pointer tick. The only reliable fix is to suppress Chromium's
- * default drag-selection algorithm entirely by calling
- * `e.preventDefault()` on the initial `mousedown`, then drive the
- * selection ourselves on `mousemove` / `mouseup`.
- *
- * `preventDefault` on mousedown also suppresses the browser's
- * automatic focus shift and caret placement, so we re-do both
- * manually:
- *   1. `editor.focus({ preventScroll: true })` so the editor's
- *      `onFocus` handler still fires and key events route correctly.
- *   2. `selection.removeAllRanges()` + `addRange(...)` to position
- *      the caret at the click point.
- *
- * Double-click word selection, triple-click paragraph selection,
- * shift-click range extension, and modifier-clicks all bypass the
- * enhancer so the browser's existing behavior keeps working for
- * those gestures. Click events still fire as normal (preventDefault
- * on mousedown doesn't suppress click), so links and form controls
- * inside the editor still respond.
+ * Multi-click gestures (`detail >= 2`), shift-click range extension,
+ * and modifier-clicks bypass the enhancer so the browser's existing
+ * behavior keeps working for those. Click events still fire normally
+ * (preventDefault on mousedown doesn't suppress click), so links and
+ * form controls inside the editor still respond.
  */
 
 interface CaretPosition {

--- a/utils/contentEditableDragSelect.ts
+++ b/utils/contentEditableDragSelect.ts
@@ -11,19 +11,30 @@
  * the browser anchors the selection to the block container instead
  * of the text node.
  *
- * This util installs a small drag-enhancer on a contenteditable
- * element. While the user is dragging the left mouse button, it
- * recomputes the selection on every `mousemove` using
- * `caretPositionFromPoint` and applies it via
- * `Selection.setBaseAndExtent`. That overrides Chrome's broken
- * text-node-anchored extension with a fresh selection computed from
- * the pointer's actual position — so the selection always reaches
- * wherever the pointer is, regardless of where the drag started.
+ * Prior attempts that listened for `mousemove` and called
+ * `setBaseAndExtent` from a bubble-phase listener did not work in
+ * Chromium: the browser's internal drag-selection logic clamps the
+ * selection as part of mousedown's default action / native input
+ * pipeline, and bubble-phase JS overrides get re-clamped on the next
+ * pointer tick. The only reliable fix is to suppress Chromium's
+ * default drag-selection algorithm entirely by calling
+ * `e.preventDefault()` on the initial `mousedown`, then drive the
+ * selection ourselves on `mousemove` / `mouseup`.
+ *
+ * `preventDefault` on mousedown also suppresses the browser's
+ * automatic focus shift and caret placement, so we re-do both
+ * manually:
+ *   1. `editor.focus({ preventScroll: true })` so the editor's
+ *      `onFocus` handler still fires and key events route correctly.
+ *   2. `selection.removeAllRanges()` + `addRange(...)` to position
+ *      the caret at the click point.
  *
  * Double-click word selection, triple-click paragraph selection,
- * shift-click range extension, and pure caret clicks (no drag) all
- * bypass the enhancer so the browser's existing behavior keeps
- * working for those gestures.
+ * shift-click range extension, and modifier-clicks all bypass the
+ * enhancer so the browser's existing behavior keeps working for
+ * those gestures. Click events still fire as normal (preventDefault
+ * on mousedown doesn't suppress click), so links and form controls
+ * inside the editor still respond.
  */
 
 interface CaretPosition {
@@ -59,14 +70,16 @@ const caretPositionFromPoint = (x: number, y: number): CaretPosition | null => {
  * Install the drag-select enhancer on a contenteditable element.
  * Returns a cleanup function that removes the installed listeners.
  *
- * Listens for `mousedown` on the editor (to capture the drag anchor)
- * and `mousemove` / `mouseup` on `document` so the drag continues to
+ * Listens for `mousedown` on the editor (to capture the drag anchor
+ * and suppress the browser's broken default drag-select), and
+ * `mousemove` / `mouseup` on `document` so the drag continues to
  * track even when the pointer leaves the editor's box.
  */
 export const installDragSelectEnhancer = (
   editor: HTMLElement
 ): (() => void) => {
   let anchor: CaretPosition | null = null;
+  let isDragging = false;
 
   const onMouseDown = (e: MouseEvent) => {
     // Left button only.
@@ -84,6 +97,13 @@ export const installDragSelectEnhancer = (
     if (!(target instanceof Node)) return;
     if (!editor.contains(target)) return;
 
+    // Don't intercept clicks on interactive descendants (links, form
+    // controls). preventDefault would suppress their default actions
+    // and break expected behavior like following a link.
+    if (target instanceof Element) {
+      if (target.closest('a, input, textarea, select, button')) return;
+    }
+
     const pos = caretPositionFromPoint(e.clientX, e.clientY);
     if (!pos) return;
     // Confirm the resolved caret position lives inside the editor —
@@ -91,15 +111,48 @@ export const installDragSelectEnhancer = (
     // outside (e.g. the editor's parent). Without this guard the
     // first `setBaseAndExtent` would throw `IndexSizeError`.
     if (!editor.contains(pos.node)) return;
+
+    // Suppress the browser's default drag-selection algorithm — the
+    // one that clamps to the anchor text node's block — so our own
+    // setBaseAndExtent on mousemove takes hold without being
+    // re-clamped on the next pointer tick.
+    e.preventDefault();
+
+    // preventDefault also blocks the automatic focus shift onto the
+    // editor and the automatic caret placement, so re-do both
+    // manually. Without this, the editor's `onFocus` never fires
+    // (the TextWidget needs it to mark the widget as selected and
+    // clear placeholder content) and the caret doesn't render.
+    if (document.activeElement !== editor) {
+      editor.focus({ preventScroll: true });
+    }
+
+    const sel = window.getSelection();
+    if (!sel) return;
+    try {
+      const range = document.createRange();
+      range.setStart(pos.node, pos.offset);
+      range.setEnd(pos.node, pos.offset);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch {
+      // setStart/setEnd can throw IndexSizeError if the offset is out
+      // of range for the node (rare race after a concurrent DOM
+      // mutation). Bail out — the next click will retry.
+      return;
+    }
+
     anchor = pos;
+    isDragging = true;
   };
 
   const onMouseMove = (e: MouseEvent) => {
-    if (!anchor) return;
+    if (!isDragging || !anchor) return;
     // `e.buttons` is 0 when no button is held. A mouseup may have
     // happened off-window without firing on our listener (e.g. the
     // user released over a portal'd modal that swallows events).
     if (e.buttons === 0) {
+      isDragging = false;
       anchor = null;
       return;
     }
@@ -119,6 +172,7 @@ export const installDragSelectEnhancer = (
   };
 
   const onMouseUp = () => {
+    isDragging = false;
     anchor = null;
   };
 

--- a/utils/contentEditableDragSelect.ts
+++ b/utils/contentEditableDragSelect.ts
@@ -2,21 +2,36 @@
  * Chromium contenteditable bug workaround: drag-selection clamps to
  * the anchor text node's block when mousedown lands on text, refusing
  * to extend across block boundaries. (Padding-area clicks work fine
- * — the anchor falls on the container instead.)
+ * — the anchor falls on the container instead.) Firefox and Safari
+ * extend correctly across blocks and do not need this workaround.
  *
- * `preventDefault()` on mousedown is required because Chromium re-
- * clamps any bubble-phase `setBaseAndExtent` override on the next
- * pointer tick, so the only reliable fix is to suppress Chromium's
- * default drag-selection algorithm entirely. That also blocks the
- * automatic focus shift and caret placement, so both are re-done
- * manually: `editor.focus({ preventScroll: true })` + an empty range
- * at the click point.
+ * Bubble-phase `setBaseAndExtent` overrides get re-clamped by Chromium
+ * on the next pointer tick, so the only reliable fix is to suppress
+ * Chromium's default drag-selection algorithm by calling
+ * `e.preventDefault()` on mousedown. That also blocks the automatic
+ * focus shift and caret placement, so both are re-done manually:
+ * `editor.focus({ preventScroll: true })` + an empty range at the
+ * click point.
+ *
+ * The `preventDefault` + manual focus path is gated to non-touch
+ * Chromium because:
+ *  - Firefox/Safari don't have the bug, so suppressing native behavior
+ *    only opens us up to regressions from the polyfill path.
+ *  - On touch, `mousedown` is synthesized from the tap chain;
+ *    `preventDefault` there can suppress the virtual keyboard,
+ *    long-press selection handles, and tap-to-caret on Android
+ *    WebView. The native touch-selection path doesn't suffer the
+ *    block-clamping bug, so let the browser handle it.
+ *
+ * The `anchor`/`isDragging` state machine still runs everywhere so
+ * `setBaseAndExtent` on `mousemove` continues to extend the selection
+ * — it just doesn't need to fight a non-existent re-clamp in
+ * non-Chromium / touch.
  *
  * Multi-click gestures (`detail >= 2`), shift-click range extension,
- * and modifier-clicks bypass the enhancer so the browser's existing
- * behavior keeps working for those. Click events still fire normally
- * (preventDefault on mousedown doesn't suppress click), so links and
- * form controls inside the editor still respond.
+ * and modifier-clicks bypass the enhancer entirely. Click events
+ * still fire normally (preventDefault on mousedown doesn't suppress
+ * click), so links and form controls inside the editor still respond.
  */
 
 interface CaretPosition {
@@ -57,9 +72,35 @@ const caretPositionFromPoint = (x: number, y: number): CaretPosition | null => {
  * `mousemove` / `mouseup` on `document` so the drag continues to
  * track even when the pointer leaves the editor's box.
  */
+/** True for Chromium-based browsers (Chrome, Edge, Opera, Brave, Arc,
+ *  Vivaldi, …) on non-touch devices. Only those need the
+ *  preventDefault-driven workaround for the drag-select clamp bug; on
+ *  Firefox/Safari/mobile the native selection path works correctly
+ *  and suppressing it can break virtual-keyboard / touch-selection
+ *  affordances. */
+const needsPreventDefaultWorkaround = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent;
+  // Every Chromium fork carries "Chrome/" in the UA. We don't exclude
+  // Edge/Opera/etc. — they're all Blink and share the same bug.
+  if (!/Chrome\//.test(ua)) return false;
+  // Skip on touch primary input. `maxTouchPoints > 0` would over-fire
+  // on laptops with touchscreens; `pointer: coarse` is the actual
+  // signal for touch-first devices (phones, tablets).
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(pointer: coarse)').matches
+  ) {
+    return false;
+  }
+  return true;
+};
+
 export const installDragSelectEnhancer = (
   editor: HTMLElement
 ): (() => void) => {
+  const usePreventDefault = needsPreventDefaultWorkaround();
   let anchor: CaretPosition | null = null;
   let isDragging = false;
 
@@ -94,34 +135,32 @@ export const installDragSelectEnhancer = (
     // first `setBaseAndExtent` would throw `IndexSizeError`.
     if (!editor.contains(pos.node)) return;
 
-    // Suppress the browser's default drag-selection algorithm — the
-    // one that clamps to the anchor text node's block — so our own
-    // setBaseAndExtent on mousemove takes hold without being
-    // re-clamped on the next pointer tick.
-    e.preventDefault();
+    if (usePreventDefault) {
+      // Suppress Chromium's default drag-selection algorithm — the
+      // one that clamps to the anchor text node's block — so our own
+      // setBaseAndExtent on mousemove isn't re-clamped on the next
+      // pointer tick. Also blocks the automatic focus shift and caret
+      // placement, so both are re-done manually below.
+      e.preventDefault();
 
-    // preventDefault also blocks the automatic focus shift onto the
-    // editor and the automatic caret placement, so re-do both
-    // manually. Without this, the editor's `onFocus` never fires
-    // (the TextWidget needs it to mark the widget as selected and
-    // clear placeholder content) and the caret doesn't render.
-    if (document.activeElement !== editor) {
-      editor.focus({ preventScroll: true });
-    }
+      if (document.activeElement !== editor) {
+        editor.focus({ preventScroll: true });
+      }
 
-    const sel = window.getSelection();
-    if (!sel) return;
-    try {
-      const range = document.createRange();
-      range.setStart(pos.node, pos.offset);
-      range.setEnd(pos.node, pos.offset);
-      sel.removeAllRanges();
-      sel.addRange(range);
-    } catch {
-      // setStart/setEnd can throw IndexSizeError if the offset is out
-      // of range for the node (rare race after a concurrent DOM
-      // mutation). Bail out — the next click will retry.
-      return;
+      const sel = window.getSelection();
+      if (!sel) return;
+      try {
+        const range = document.createRange();
+        range.setStart(pos.node, pos.offset);
+        range.setEnd(pos.node, pos.offset);
+        sel.removeAllRanges();
+        sel.addRange(range);
+      } catch {
+        // setStart/setEnd throws IndexSizeError if the offset is out
+        // of range (rare race after a concurrent DOM mutation). Bail
+        // out — the next click will retry.
+        return;
+      }
     }
 
     anchor = pos;


### PR DESCRIPTION
## Summary

Two long-standing bugs in the TextWidget editor:

### 1. Drag-select clamped to a single paragraph

Chrome's contenteditable drag-selection algorithm anchors to the clicked text node and refuses to extend across block boundaries when the mousedown target is text. (Clicks on the editor's padding worked fine because the anchor falls on the container — exactly the user's reported workaround.)

The prior workaround in `installDragSelectEnhancer` called `setBaseAndExtent` from a bubble-phase mousemove listener, but Chromium re-clamps the selection on each pointer tick as part of mousedown's default action, so the override gets undone.

**The fix:** call `e.preventDefault()` on the initial mousedown, suppressing Chromium's default drag-select entirely, and drive focus, caret placement, and extension manually. Interactive descendants (links, form controls) are excluded so their click defaults still fire.

### 2. Bulleted/numbered list buttons did nothing on inline-only editors

`toggleList` collects blocks from `editor.children`, which excludes text nodes. For an editor whose content is a single typed line (no Enter pressed yet) — i.e. one bare text node at the top level — there are zero collectable blocks and the list command silently no-ops.

The toolbar previously called `needsBlockNormalization` first, but that helper deliberately skips inline-only content to avoid stray line-boxes for cases like `<b>headline</b>`.

**The fix:** add a stronger `ensureTopLevelBlocks` helper that always wraps loose top-level content into a block, and route the toolbar's list button and the `Ctrl+Shift+7/8` shortcut through it. WrittenResponseEditor gets the same fix since it has the same toggleList flow.

## Files

- `utils/contentEditableDragSelect.ts` — rewrite enhancer with `preventDefault` + manual focus/caret management
- `utils/contentEditableBlocks.ts` — add `ensureTopLevelBlocks` helper (shares wrap logic with `normalizeEditorBlocks`)
- `components/widgets/TextWidget/FormattingToolbar.tsx` — route lists through `ensureTopLevelBlocks`
- `components/widgets/TextWidget/Widget.tsx` — same fix for the Ctrl+Shift+7/8 keyboard shortcut
- `components/quiz/WrittenResponseEditor.tsx` — same fix for the `<p>`-tag editor

## Test plan

- [x] Unit tests for `ensureTopLevelBlocks` (7 new cases in `utils/contentEditableBlocks.test.ts`)
- [x] Unit tests for inline-only list toggle in `FormattingToolbar.test.tsx` (2 new cases)
- [x] All 2762 existing unit tests still pass
- [x] `pnpm run lint`, `pnpm run type-check`, `pnpm run format:check` all clean
- [x] Verified drag-select crosses paragraphs in a standalone reproduction page with Playwright (clicking on bare text node, dragging across multiple `<div>` blocks)
- [x] Verified inline-only `<b>Bold text</b>` content gets wrapped in `<ol><li>...</li></ol>` when numbered-list button is clicked
- [ ] Reporter to verify in production: click on any paragraph text, drag up or down across multiple paragraphs — selection should follow the pointer
- [ ] Reporter to verify in production: highlight inline-only text, click bullet/numbered list buttons — list should be created

https://claude.ai/code/session_01ADgNurgXTXgMNsqSj5xTJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADgNurgXTXgMNsqSj5xTJk)_