### PR TITLE
feat(admin): personal-spotify global feature gate with building scoping

### DIFF
--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -49,7 +49,7 @@ import { useStorage } from '@/hooks/useStorage';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { Toggle } from '../common/Toggle';
 import { Toast } from '../common/Toast';
-import { PermissionBuildingMultiSelect } from './PermissionBuildingMultiSelect';
+import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
 
 const GLOBAL_FEATURES: {
   id: GlobalFeature;
@@ -161,6 +161,17 @@ const ADMIN_ONLY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
     'share-link-tracking',
     'personal-spotify', // align with CANACCESSFEATURE_MISSING_DOC_DEFAULT (default-off)
   ]);
+
+/**
+ * Features that default to `enabled: false` for the in-memory permission
+ * object returned by getPermission(). MUST mirror runtime
+ * `canAccessFeature` missing-doc defaults that return false (currently
+ * just `personal-spotify` via CANACCESSFEATURE_MISSING_DOC_DEFAULT in
+ * context/AuthContext.tsx), so the admin UI display matches what
+ * end-users actually experience until a doc is saved.
+ */
+const DISABLED_BY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
+  new Set<GlobalFeature>(['personal-spotify']);
 
 /**
  * Widgets surfaced in the Assignment Modes admin section. All four widgets
@@ -547,7 +558,7 @@ export const GlobalPermissionsManager: React.FC = () => {
         featureId,
         accessLevel: defaultAccessLevel,
         betaUsers: [],
-        enabled: true,
+        enabled: !DISABLED_BY_DEFAULT_FEATURES.has(featureId),
         buildings: [],
         config: GEMINI_FEATURES.includes(featureId)
           ? { dailyLimit: defaultLimit, dailyLimitEnabled: true }

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -159,7 +159,11 @@ const ADMIN_ONLY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
   new Set<GlobalFeature>([
     'embed-mini-app',
     'share-link-tracking',
-    'personal-spotify', // align with CANACCESSFEATURE_MISSING_DOC_DEFAULT (default-off)
+    // personal-spotify intentionally omitted: DISABLED_BY_DEFAULT_FEATURES
+    // already gates it to enabled:false, so the accessLevel default is
+    // irrelevant until an admin explicitly saves the doc. Listing it here
+    // too would be misleading — the gate is off because enabled:false
+    // short-circuits, not because of the accessLevel.
   ]);
 
 /**

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -51,6 +51,7 @@ import { logError } from '@/utils/logError';
 import { Toggle } from '../common/Toggle';
 import { Toast } from '../common/Toast';
 import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
+import { FEATURE_DEFAULTS } from '@/config/featureDefaults';
 
 const GLOBAL_FEATURES: {
   id: GlobalFeature;
@@ -143,40 +144,6 @@ const GLOBAL_FEATURES: {
       'Let teachers connect their personal Spotify account in the Music widget. When off, Music shows only curated stations.',
   },
 ];
-
-/**
- * Features whose missing-permission default is `'admin'` instead of the
- * usual `'public'`. Both `getPermission` (the editor's persisted-or-default
- * resolver) and `filteredFeatures` (the toolbar filter's fallback) read
- * from this set so the fallback rule is defined once. Any divergence
- * between the two would silently mis-categorize a feature in the access-
- * level filter when no permission doc exists yet.
- *
- * Keep this aligned with the runtime-side defaults in `AuthContext` —
- * `canSeeShareTracking` likewise treats a missing 'share-link-tracking'
- * record as admin-only.
- */
-const ADMIN_ONLY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
-  new Set<GlobalFeature>([
-    'embed-mini-app',
-    'share-link-tracking',
-    // personal-spotify intentionally omitted: DISABLED_BY_DEFAULT_FEATURES
-    // already gates it to enabled:false, so the accessLevel default is
-    // irrelevant until an admin explicitly saves the doc. Listing it here
-    // too would be misleading — the gate is off because enabled:false
-    // short-circuits, not because of the accessLevel.
-  ]);
-
-/**
- * Features that default to `enabled: false` for the in-memory permission
- * object returned by getPermission(). MUST mirror runtime
- * `canAccessFeature` missing-doc defaults that return false (currently
- * just `personal-spotify` via CANACCESSFEATURE_MISSING_DOC_DEFAULT in
- * context/AuthContext.tsx), so the admin UI display matches what
- * end-users actually experience until a doc is saved.
- */
-const DISABLED_BY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
-  new Set<GlobalFeature>(['personal-spotify']);
 
 /**
  * Widgets surfaced in the Assignment Modes admin section. All four widgets
@@ -546,11 +513,7 @@ export const GlobalPermissionsManager: React.FC = () => {
   }, [loadPermissions]);
 
   const getPermission = (featureId: GlobalFeature): GlobalFeaturePermission => {
-    const defaultAccessLevel: AccessLevel = ADMIN_ONLY_DEFAULT_FEATURES.has(
-      featureId
-    )
-      ? 'admin'
-      : 'public';
+    const defaults = FEATURE_DEFAULTS[featureId];
 
     // Set smart default limits
     let defaultLimit = 20;
@@ -561,9 +524,9 @@ export const GlobalPermissionsManager: React.FC = () => {
     return (
       permissions.get(featureId) ?? {
         featureId,
-        accessLevel: defaultAccessLevel,
+        accessLevel: defaults.defaultAccessLevel,
         betaUsers: [],
-        enabled: !DISABLED_BY_DEFAULT_FEATURES.has(featureId),
+        enabled: defaults.defaultEnabled,
         buildings: [],
         config: GEMINI_FEATURES.includes(featureId)
           ? { dailyLimit: defaultLimit, dailyLimitEnabled: true }
@@ -693,13 +656,12 @@ export const GlobalPermissionsManager: React.FC = () => {
       a.label.localeCompare(b.label)
     );
     return sorted.filter((feature) => {
+      const defaults = FEATURE_DEFAULTS[feature.id];
       const perm = permissions.get(feature.id) ?? {
         featureId: feature.id,
-        accessLevel: (ADMIN_ONLY_DEFAULT_FEATURES.has(feature.id)
-          ? 'admin'
-          : 'public') as AccessLevel,
+        accessLevel: defaults.defaultAccessLevel,
         betaUsers: [] as string[],
-        enabled: true,
+        enabled: defaults.defaultEnabled,
         config: feature.id === 'gemini-functions' ? { dailyLimit: 20 } : {},
       };
       if (filterEnabled === 'on' && !perm.enabled) return false;

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -1036,6 +1036,22 @@ export const GlobalPermissionsManager: React.FC = () => {
           {filteredFeatures.map((feature) => {
             const permission = getPermission(feature.id);
             const isSaving = saving.has(feature.id);
+            // True when there's no persisted permission doc yet — the
+            // controls below are showing the synthetic default from
+            // `getPermission`. If an admin saves now, the defaults
+            // (including `enabled` and `accessLevel`) are what land in
+            // Firestore — for features that default to disabled, that
+            // means saving with no other changes leaves the feature
+            // off. Surface a banner so the admin understands.
+            const isSyntheticDefault = !permissions.has(feature.id);
+            const syntheticDefaultNotice = isSyntheticDefault ? (
+              <div className="px-4 py-2 bg-amber-50 border-b border-amber-200 text-xs text-amber-800">
+                <strong>No saved settings.</strong> The values below are
+                defaults; they&apos;ll be persisted to Firestore when you click
+                Save. For features that default to disabled, toggle{' '}
+                <em>Enabled</em> on before saving.
+              </div>
+            ) : null;
 
             if (effectiveViewMode === 'list') {
               return (
@@ -1043,6 +1059,7 @@ export const GlobalPermissionsManager: React.FC = () => {
                   key={feature.id}
                   className="bg-white border-2 border-slate-200 rounded-xl hover:border-brand-blue-light transition-colors overflow-hidden"
                 >
+                  {syntheticDefaultNotice}
                   <div className="flex items-center gap-4 p-3">
                     {/* Identity Section */}
                     <div className="flex items-center gap-3 w-56 xl:w-72 shrink-0">
@@ -1271,6 +1288,14 @@ export const GlobalPermissionsManager: React.FC = () => {
                 key={feature.id}
                 className="bg-white border-2 border-slate-200 rounded-2xl p-6 hover:border-brand-blue-light transition-all text-left"
               >
+                {isSyntheticDefault && (
+                  <div className="mb-4 px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 text-xs text-amber-800 leading-snug">
+                    <strong>No saved settings.</strong> The values below are
+                    defaults; they&apos;ll be persisted to Firestore when you
+                    click Save. For features that default to disabled, toggle{' '}
+                    <em>Enabled</em> on before saving.
+                  </div>
+                )}
                 <div className="flex items-center gap-4 mb-6">
                   <div className="bg-brand-blue-lighter p-3 rounded-xl text-brand-blue-primary">
                     <feature.icon className="w-6 h-6" />

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -42,12 +42,14 @@ import {
   Eye,
   ListChecks,
   PlayCircle,
+  Music2,
 } from 'lucide-react';
 import { useAuth } from '@/context/useAuth';
 import { useStorage } from '@/hooks/useStorage';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { Toggle } from '../common/Toggle';
 import { Toast } from '../common/Toast';
+import { PermissionBuildingMultiSelect } from './PermissionBuildingMultiSelect';
 
 const GLOBAL_FEATURES: {
   id: GlobalFeature;
@@ -131,6 +133,13 @@ const GLOBAL_FEATURES: {
     icon: Eye,
     description:
       'Show "N views" on view-only Share cards in the Quiz, Video Activity, Mini App, and Guided Learning archives. Each visible card fires a Firestore aggregation query when the dashboard tab regains focus — keep this Admin-only unless you specifically want every teacher to see open counts.',
+  },
+  {
+    id: 'personal-spotify',
+    label: 'Personal Spotify',
+    icon: Music2,
+    description:
+      'Let teachers connect their personal Spotify account in the Music widget. When off, Music shows only curated stations.',
   },
 ];
 
@@ -535,6 +544,7 @@ export const GlobalPermissionsManager: React.FC = () => {
         accessLevel: defaultAccessLevel,
         betaUsers: [],
         enabled: true,
+        buildings: [],
         config: GEMINI_FEATURES.includes(featureId)
           ? { dailyLimit: defaultLimit, dailyLimitEnabled: true }
           : {},
@@ -1148,6 +1158,17 @@ export const GlobalPermissionsManager: React.FC = () => {
                     </div>
                   </div>
 
+                  {/* Building Restriction */}
+                  <div className="border-t border-slate-100 bg-slate-50 p-4 text-left">
+                    <PermissionBuildingMultiSelect
+                      label="Restrict to buildings"
+                      selectedIds={permission.buildings ?? []}
+                      onChange={(buildings) =>
+                        updatePermission(feature.id, { buildings })
+                      }
+                    />
+                  </div>
+
                   {/* Beta Users Panel */}
                   {permission.accessLevel === 'beta' && (
                     <div className="border-t border-slate-100 bg-slate-50 p-4 text-left">
@@ -1418,6 +1439,17 @@ export const GlobalPermissionsManager: React.FC = () => {
                     }
                   />
                 )}
+
+                {/* Building Restriction */}
+                <div className="mb-6">
+                  <PermissionBuildingMultiSelect
+                    label="Restrict to buildings"
+                    selectedIds={permission.buildings ?? []}
+                    onChange={(buildings) =>
+                      updatePermission(feature.id, { buildings })
+                    }
+                  />
+                </div>
 
                 {/* Save Button */}
                 <button

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -47,6 +47,7 @@ import {
 import { useAuth } from '@/context/useAuth';
 import { useStorage } from '@/hooks/useStorage';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { logError } from '@/utils/logError';
 import { Toggle } from '../common/Toggle';
 import { Toast } from '../common/Toast';
 import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
@@ -608,8 +609,16 @@ export const GlobalPermissionsManager: React.FC = () => {
               (permission.config?.standardModel as string) || '(default)',
           });
         } catch (auditErr) {
-          // Non-blocking — don't fail the save if audit logging fails
-          console.error('Failed to write audit log:', auditErr);
+          // Non-blocking — don't fail the save if audit logging fails.
+          // Route through `logError` so the failure surfaces in structured
+          // logs / future Sentry, not just the local browser console. The
+          // save itself already succeeded; this is purely an audit-trail
+          // gap that ops needs to be able to see and triage.
+          logError(
+            'GlobalPermissionsManager.savePermission.auditLog',
+            auditErr,
+            { featureId, email: user?.email ?? null }
+          );
         }
       }
 

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -156,7 +156,11 @@ const GLOBAL_FEATURES: {
  * record as admin-only.
  */
 const ADMIN_ONLY_DEFAULT_FEATURES: ReadonlySet<GlobalFeature> =
-  new Set<GlobalFeature>(['embed-mini-app', 'share-link-tracking']);
+  new Set<GlobalFeature>([
+    'embed-mini-app',
+    'share-link-tracking',
+    'personal-spotify', // align with CANACCESSFEATURE_MISSING_DOC_DEFAULT (default-off)
+  ]);
 
 /**
  * Widgets surfaced in the Assignment Modes admin section. All four widgets

--- a/components/admin/PermissionBuildingMultiSelect.tsx
+++ b/components/admin/PermissionBuildingMultiSelect.tsx
@@ -78,6 +78,23 @@ export const PermissionBuildingMultiSelect: React.FC<Props> = ({
             </button>
           );
         })}
+        {/* Render orphan (deleted) building IDs so admins can clear them */}
+        {selectedIds
+          .filter((id) => !buildings.some((b) => b.id === id))
+          .map((id) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onChange(selectedIds.filter((b) => b !== id))}
+              aria-label={`Remove unknown building ${id}`}
+              aria-pressed="true"
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border border-dashed border-amber-400 bg-amber-50 text-amber-800 transition-colors hover:bg-amber-100"
+              title={`Building "${id}" no longer exists. Click to remove.`}
+            >
+              <X className="w-3 h-3" />
+              Unknown building ({id})
+            </button>
+          ))}
       </div>
     </div>
   );

--- a/components/admin/PermissionBuildingMultiSelect.tsx
+++ b/components/admin/PermissionBuildingMultiSelect.tsx
@@ -1,0 +1,84 @@
+/**
+ * Generic building multi-select for global feature permissions.
+ *
+ * Empty `selectedIds` displays an "All buildings" pill — the feature
+ * applies org-wide. Non-empty means the feature is restricted to users
+ * whose `selectedBuildings` overlap this list.
+ *
+ * Mirrors the chip styling of `BuildingSelector.tsx` (single-select) so
+ * the admin UI feels consistent. Unselected buildings render as
+ * outlined chips with a "+" affordance; selected buildings render as
+ * filled brand-blue chips with a "×" affordance.
+ */
+
+import React from 'react';
+import { Plus, X, Building2 } from 'lucide-react';
+import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+
+interface Props {
+  selectedIds: string[];
+  onChange: (next: string[]) => void;
+  /** Optional label shown above the control. */
+  label?: string;
+}
+
+export const PermissionBuildingMultiSelect: React.FC<Props> = ({
+  selectedIds,
+  onChange,
+  label,
+}) => {
+  const buildings = useAdminBuildings();
+  const selectedSet = new Set(selectedIds);
+
+  const toggle = (id: string): void => {
+    if (selectedSet.has(id)) {
+      onChange(selectedIds.filter((b) => b !== id));
+    } else {
+      onChange([...selectedIds, id]);
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {label && (
+        <p className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
+          {label}
+        </p>
+      )}
+      {selectedIds.length === 0 && (
+        <div className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-slate-100 text-slate-700 rounded-full text-xs font-semibold border border-slate-200">
+          <Building2 className="w-3 h-3" />
+          All buildings
+        </div>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {buildings.map((building) => {
+          const isSelected = selectedSet.has(building.id);
+          return (
+            <button
+              key={building.id}
+              type="button"
+              onClick={() => toggle(building.id)}
+              aria-label={
+                isSelected ? `Remove ${building.name}` : `Add ${building.name}`
+              }
+              aria-pressed={isSelected}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors ${
+                isSelected
+                  ? 'bg-brand-blue-primary text-white border-brand-blue-primary shadow-sm hover:bg-brand-blue-dark'
+                  : 'bg-white text-slate-600 border-slate-300 hover:bg-slate-50'
+              }`}
+            >
+              {isSelected ? (
+                <X className="w-3 h-3" />
+              ) : (
+                <Plus className="w-3 h-3" />
+              )}
+              {building.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/components/admin/PermissionBuildingMultiSelect.tsx
+++ b/components/admin/PermissionBuildingMultiSelect.tsx
@@ -13,7 +13,7 @@
 
 import React from 'react';
 import { Plus, X, Building2 } from 'lucide-react';
-import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+import { useAdminBuildingsState } from '@/hooks/useAdminBuildings';
 
 interface Props {
   selectedIds: string[];
@@ -27,7 +27,7 @@ export const PermissionBuildingMultiSelect: React.FC<Props> = ({
   onChange,
   label,
 }) => {
-  const buildings = useAdminBuildings();
+  const { buildings, isLoading } = useAdminBuildingsState();
   const selectedSet = new Set(selectedIds);
 
   const toggle = (id: string): void => {
@@ -78,23 +78,27 @@ export const PermissionBuildingMultiSelect: React.FC<Props> = ({
             </button>
           );
         })}
-        {/* Render orphan (deleted) building IDs so admins can clear them */}
-        {selectedIds
-          .filter((id) => !buildings.some((b) => b.id === id))
-          .map((id) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() => onChange(selectedIds.filter((b) => b !== id))}
-              aria-label={`Remove unknown building ${id}`}
-              aria-pressed="true"
-              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border border-dashed border-amber-400 bg-amber-50 text-amber-800 transition-colors hover:bg-amber-100"
-              title={`Building "${id}" no longer exists. Click to remove.`}
-            >
-              <X className="w-3 h-3" />
-              Unknown building ({id})
-            </button>
-          ))}
+        {/* Render orphan (deleted) building IDs so admins can clear them.
+            Suppressed while buildings are loading so a race between sign-in
+            and the first snapshot cannot render valid selections as "Unknown"
+            and prompt an anxious admin to delete them. */}
+        {!isLoading &&
+          selectedIds
+            .filter((id) => !buildings.some((b) => b.id === id))
+            .map((id) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onChange(selectedIds.filter((b) => b !== id))}
+                aria-label={`Remove unknown building ${id}`}
+                aria-pressed="true"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border border-dashed border-amber-400 bg-amber-50 text-amber-800 transition-colors hover:bg-amber-100"
+                title={`Building "${id}" no longer exists. Click to remove.`}
+              >
+                <X className="w-3 h-3" />
+                Unknown building ({id})
+              </button>
+            ))}
       </div>
     </div>
   );

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -76,6 +76,7 @@ const mockAuth: AuthContextType = {
   roleResolved: true,
   buildingIds: [],
   orgBuildings: [],
+  orgBuildingsLoaded: true,
   favoriteBackgrounds: [],
   recentBackgrounds: [],
   toggleFavoriteBackground: async () => {

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -431,6 +431,7 @@ describe('EmbedWidget', () => {
         roleResolved: true,
         buildingIds: [],
         orgBuildings: [],
+        orgBuildingsLoaded: true,
         favoriteBackgrounds: [],
         recentBackgrounds: [],
         toggleFavoriteBackground: vi.fn(),

--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { LayoutGrid, Music, Music2, Palette, Radio } from 'lucide-react';
 import { WidgetData, MusicConfig, MusicLayout, MusicSource } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
 import { useMusicStations } from '@/hooks/useMusicStations';
 import { Toggle } from '@/components/common/Toggle';
 import {
@@ -108,6 +109,8 @@ const SOURCE_OPTIONS: {
 
 export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget } = useDashboard();
+  const { canAccessFeature } = useAuth();
+  const canUsePersonal = canAccessFeature('personal-spotify');
   const config = widget.config as MusicConfig;
   const { stations, isLoading } = useMusicStations();
   const { layout = 'default', source = 'curated' } = config;
@@ -123,49 +126,51 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
   return (
     <div className="space-y-5">
-      {/* ── Source selector ── */}
-      <div className="space-y-2">
-        <SettingsLabel icon={Music2}>Source</SettingsLabel>
-        <div className="grid grid-cols-2 gap-2">
-          {SOURCE_OPTIONS.map((opt) => {
-            const isActive = source === opt.value;
-            const Icon = opt.icon;
-            return (
-              <button
-                key={opt.value}
-                type="button"
-                onClick={() =>
-                  updateWidget(widget.id, {
-                    config: {
-                      ...config,
-                      source: opt.value,
-                      // Disable Time-Tool sync when switching to Spotify-based source.
-                      ...(opt.value === 'personal' && config.syncWithTimeTool
-                        ? { syncWithTimeTool: false }
-                        : {}),
-                    },
-                  })
-                }
-                title={opt.description}
-                className={`flex items-center gap-2 p-3 rounded-xl border-2 transition-all text-left ${
-                  isActive
-                    ? 'border-green-500 bg-green-50 shadow-sm'
-                    : 'border-slate-100 hover:border-slate-300 bg-white'
-                }`}
-              >
-                <Icon
-                  className={`w-4 h-4 shrink-0 ${isActive ? 'text-green-700' : 'text-slate-500'}`}
-                />
-                <span
-                  className={`text-xs font-bold truncate ${isActive ? 'text-green-800' : 'text-slate-700'}`}
+      {/* ── Source selector (gated behind personal-spotify feature) ── */}
+      {canUsePersonal && (
+        <div className="space-y-2">
+          <SettingsLabel icon={Music2}>Source</SettingsLabel>
+          <div className="grid grid-cols-2 gap-2">
+            {SOURCE_OPTIONS.map((opt) => {
+              const isActive = source === opt.value;
+              const Icon = opt.icon;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() =>
+                    updateWidget(widget.id, {
+                      config: {
+                        ...config,
+                        source: opt.value,
+                        // Disable Time-Tool sync when switching to Spotify-based source.
+                        ...(opt.value === 'personal' && config.syncWithTimeTool
+                          ? { syncWithTimeTool: false }
+                          : {}),
+                      },
+                    })
+                  }
+                  title={opt.description}
+                  className={`flex items-center gap-2 p-3 rounded-xl border-2 transition-all text-left ${
+                    isActive
+                      ? 'border-green-500 bg-green-50 shadow-sm'
+                      : 'border-slate-100 hover:border-slate-300 bg-white'
+                  }`}
                 >
-                  {opt.label}
-                </span>
-              </button>
-            );
-          })}
+                  <Icon
+                    className={`w-4 h-4 shrink-0 ${isActive ? 'text-green-700' : 'text-slate-500'}`}
+                  />
+                  <span
+                    className={`text-xs font-bold truncate ${isActive ? 'text-green-800' : 'text-slate-700'}`}
+                  >
+                    {opt.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* ── Layout selector ── */}
       <div className="space-y-2 pt-1 border-t border-slate-100">
@@ -201,7 +206,7 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       </div>
 
       {/* ── Source-specific body ── */}
-      {source === 'personal' ? (
+      {source === 'personal' && canUsePersonal ? (
         <div className="pt-1 border-t border-slate-100">
           <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider pt-4 pb-2">
             Personal Spotify

--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -109,8 +109,13 @@ const SOURCE_OPTIONS: {
 
 export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { updateWidget } = useDashboard();
-  const { canAccessFeature } = useAuth();
-  const canUsePersonal = canAccessFeature('personal-spotify');
+  const { canAccessFeature, profileLoaded } = useAuth();
+  // While the profile is loading, optimistically show the source toggle (matches
+  // what gated-in users see). Only hide it once profileLoaded is true AND the
+  // gate explicitly denies — prevents a brief flicker that would unmount the
+  // settings UI for users who do have access.
+  const gateDenied = profileLoaded && !canAccessFeature('personal-spotify');
+  const canUsePersonal = !gateDenied;
   const config = widget.config as MusicConfig;
   const { stations, isLoading } = useMusicStations();
   const { layout = 'default', source = 'curated' } = config;

--- a/components/widgets/MusicWidget/Widget.tsx
+++ b/components/widgets/MusicWidget/Widget.tsx
@@ -13,6 +13,7 @@ import {
   YTPlayer,
 } from '@/utils/youtube';
 import { PersonalSpotifyPlayer } from './PersonalSpotifyPlayer';
+import { useAuth } from '@/context/useAuth';
 
 // ---------------------------------------------------------------------------
 // Shared play/pause overlay button
@@ -83,8 +84,16 @@ const PlayButton: React.FC<PlayButtonProps> = ({
  * widget. Splitting them this way keeps both branches' hooks unconditional.
  */
 export const MusicWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const source = (widget.config as MusicConfig).source ?? 'curated';
-  if (source === 'personal') {
+  const { canAccessFeature } = useAuth();
+  const canUsePersonal = canAccessFeature('personal-spotify');
+  const storedSource = (widget.config as MusicConfig).source ?? 'curated';
+  // When the gate is off, treat any stored `source: 'personal'` as curated.
+  // The stored config is preserved — re-enabling the gate restores personal
+  // playback without the user doing anything.
+  const effectiveSource =
+    canUsePersonal && storedSource === 'personal' ? 'personal' : 'curated';
+
+  if (effectiveSource === 'personal') {
     return <PersonalSpotifyPlayer widget={widget} />;
   }
   return <CuratedMusicWidget widget={widget} />;

--- a/components/widgets/MusicWidget/Widget.tsx
+++ b/components/widgets/MusicWidget/Widget.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Link, Music, Pause, Play, Radio } from 'lucide-react';
-import { WidgetData, MusicConfig, TimeToolConfig } from '@/types';
+import { WidgetData, MusicConfig, MusicSource, TimeToolConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { useMusicStations } from '@/hooks/useMusicStations';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -84,14 +84,16 @@ const PlayButton: React.FC<PlayButtonProps> = ({
  * widget. Splitting them this way keeps both branches' hooks unconditional.
  */
 export const MusicWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { canAccessFeature } = useAuth();
-  const canUsePersonal = canAccessFeature('personal-spotify');
-  const storedSource = (widget.config as MusicConfig).source ?? 'curated';
-  // When the gate is off, treat any stored `source: 'personal'` as curated.
-  // The stored config is preserved — re-enabling the gate restores personal
-  // playback without the user doing anything.
-  const effectiveSource =
-    canUsePersonal && storedSource === 'personal' ? 'personal' : 'curated';
+  const { canAccessFeature, profileLoaded } = useAuth();
+  const storedSource =
+    (widget.config as MusicConfig | undefined)?.source ?? 'curated';
+  // During the profile-load window, trust the stored source — users with
+  // access see no flicker, and the rare lost-access case briefly shows
+  // personal before being swapped to curated. We only "downgrade" to
+  // curated when profileLoaded is true AND the gate explicitly denies.
+  const gateDenied = profileLoaded && !canAccessFeature('personal-spotify');
+  const effectiveSource: MusicSource =
+    !gateDenied && storedSource === 'personal' ? 'personal' : 'curated';
 
   if (effectiveSource === 'personal') {
     return <PersonalSpotifyPlayer widget={widget} />;

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -83,6 +83,7 @@ const mockAuthContext = (
   roleResolved: true,
   buildingIds: [],
   orgBuildings: [],
+  orgBuildingsLoaded: true,
   favoriteBackgrounds: [],
   recentBackgrounds: [],
   toggleFavoriteBackground: async () => {

--- a/config/featureDefaults.ts
+++ b/config/featureDefaults.ts
@@ -1,0 +1,144 @@
+/**
+ * Single source of truth for global-feature defaults.
+ *
+ * Three concerns previously kept their own parallel lookups:
+ *
+ *   1. `canAccessFeature` (in `AuthContext`) — what does the runtime
+ *      gate return when no `global_permissions` doc exists yet?
+ *   2. `getPermission` / `filteredFeatures` (in
+ *      `GlobalPermissionsManager`) — what synthetic permission object
+ *      does the admin editor show before any doc is persisted?
+ *   3. The implicit assumption that those two stay aligned so an
+ *      admin sees the same enabled/accessLevel state as users do.
+ *
+ * Drift between those three lookups was the bug class we got tired
+ * of fixing one feature at a time. Funnel everything through
+ * `FEATURE_DEFAULTS` so adding a new `GlobalFeature` requires
+ * declaring its defaults in one place — and TypeScript refuses to
+ * compile the union extension until you do, because the table is
+ * typed as `Record<GlobalFeature, ...>` (NOT `Partial<...>`).
+ *
+ * @see context/AuthContext.tsx — consumes `missingDocPublic`.
+ * @see components/admin/GlobalPermissionsManager.tsx — consumes
+ *   `defaultAccessLevel` and `defaultEnabled` to build the synthetic
+ *   permission object.
+ */
+
+import type { AccessLevel, GlobalFeature } from '@/types';
+
+export interface FeatureDefault {
+  /** Access level used by the admin UI when no permission doc exists yet. */
+  defaultAccessLevel: AccessLevel;
+  /** Enabled value used by the admin UI when no permission doc exists yet. */
+  defaultEnabled: boolean;
+  /**
+   * When TRUE, `canAccessFeature(...)` returns true when no permission
+   * doc exists (default-public — the historical baseline). When FALSE,
+   * returns false (default-off).
+   *
+   * Use FALSE for features that depend on external configuration
+   * (OAuth secrets, redirect URIs, API keys) and would surface a
+   * broken UX if the code defaulted to enabled without an explicit
+   * admin opt-in. `personal-spotify` is the current example: shipping
+   * the code is not the same as shipping the OAuth setup.
+   */
+  missingDocPublic: boolean;
+}
+
+/**
+ * Required defaults for every global feature.
+ *
+ * The `Record<GlobalFeature, FeatureDefault>` (NOT `Partial`) is
+ * load-bearing: TypeScript will reject any new `GlobalFeature` union
+ * member that doesn't declare its defaults here. Keep this honest —
+ * don't add features to the union without adding a corresponding
+ * entry, even if the entry is just the "all public, all on" baseline.
+ *
+ * Note on `share-link-tracking`: `canAccessFeature('share-link-tracking')`
+ * returns the usual default-public behavior. `canSeeShareTracking()`
+ * is a separate gate that diverges to admin-only — see
+ * `AuthContextValue.ts` for why the divergence is intentional. This
+ * table covers the `canAccessFeature` path only.
+ */
+export const FEATURE_DEFAULTS: Record<GlobalFeature, FeatureDefault> = {
+  'live-session': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'gemini-functions': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'dashboard-sharing': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'dashboard-import': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'magic-layout': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'smart-paste': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'smart-poll': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'screen-recording': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'remote-control': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'embed-mini-app': {
+    defaultAccessLevel: 'admin',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'video-activity-audio-transcription': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'ai-file-context': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'org-admin-writes': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'assignment-modes': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'share-link-tracking': {
+    defaultAccessLevel: 'admin',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
+  'personal-spotify': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: false,
+    missingDocPublic: false,
+  },
+};

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1264,7 +1264,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           setSelectedBuildingsState(canonical);
         }
       } catch (e) {
-        console.warn('[AuthContext] Returning-user Firestore probe failed:', e);
+        // Promote from `console.warn` to structured logError so probe
+        // failures surface in production monitoring. The probe runs once
+        // per session and is the gate between "show setup wizard" and
+        // "land on dashboard" for users without a profile doc — a silent
+        // failure here is a regressed first-run UX we want to triage.
+        // Guard on `auth.currentUser` to avoid logging post-signout race
+        // failures where the probe was already in flight when the user
+        // signed out.
+        if (auth.currentUser) {
+          logError('AuthContext.returningUserProbe', e, {
+            uid: probeUid,
+          });
+        }
       }
     })();
   }, [user, profileLoaded, setupCompleted]);

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -53,6 +53,7 @@ import {
 import i18n from '../i18n';
 import { GoogleDriveService } from '../utils/googleDriveService';
 import { onDriveTokenChange } from '../utils/driveAuthErrors';
+import { reportGlobalPermissionsError } from '../utils/globalPermissionsErrors';
 import {
   refreshAccessTokenViaBackend,
   requestAndExchangeAuthCode,
@@ -916,13 +917,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         setGlobalPermissions(permissions);
       },
       (error) => {
-        // Log error with more context to help debugging if it persists
+        // Log unconditionally via `logError` so production monitoring
+        // sees snapshot failures (the old `console.error` was guarded on
+        // `auth.currentUser` and only landed in the dev console). The
+        // `code` is what we typically need to triage — permission-denied
+        // vs unavailable vs internal — so capture it as structured ctx.
         if (auth.currentUser) {
-          console.error(
-            `[AuthContext] Firestore Error (${error.code}):`,
-            error.message
-          );
+          logError('AuthContext.globalPermissions.onSnapshot', error, {
+            code: error.code,
+          });
         }
+        // Surface a toast ONCE per session so a teacher whose snapshot
+        // is broken doesn't silently see stale feature availability.
+        // The latch in `reportGlobalPermissionsError` keeps a retry
+        // storm from fanning out a queue of identical toasts.
+        reportGlobalPermissionsError();
       }
     );
 

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -195,6 +195,19 @@ const makeHybridBypassUser = (anonUser: User): User =>
     },
   });
 
+/**
+ * Per-feature default for `canAccessFeature` when no permission doc exists
+ * in `global_permissions`. Features not listed here default to `true`
+ * (public). Add an entry here when a feature must stay off until an admin
+ * explicitly seeds the doc — e.g. when it depends on external configuration
+ * (OAuth setup, API keys) that the code can't verify on its own.
+ */
+const CANACCESSFEATURE_MISSING_DOC_DEFAULT: Partial<
+  Record<GlobalFeature, boolean>
+> = {
+  'personal-spotify': false,
+};
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
@@ -1855,8 +1868,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         (p) => p.featureId === featureId
       );
 
-      // Public default for missing record — see resolvePermissionAccess docs.
-      if (!permission) return true;
+      // Per-feature override; defaults to public (`true`) for any feature
+      // not listed in CANACCESSFEATURE_MISSING_DOC_DEFAULT.
+      if (!permission) {
+        return CANACCESSFEATURE_MISSING_DOC_DEFAULT[featureId] ?? true;
+      }
       return resolvePermissionAccess(permission, user.email);
     },
     [user, globalPermissions, resolvePermissionAccess]

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1824,14 +1824,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         case 'admin':
           return false;
         case 'beta':
-          return isBetaUser(permission.betaUsers, userEmail);
+          if (!isBetaUser(permission.betaUsers, userEmail)) return false;
+          break;
         case 'public':
-          return true;
+          break;
         default:
           return false;
       }
+      // Building check applies only when explicitly restricted. An empty
+      // array or `undefined` means "no building restriction" — the feature
+      // applies to anyone who passed the access-level check above. When set,
+      // the user must have at least one of these buildings in their
+      // `selectedBuildings` (self-managed in General Settings).
+      if (permission.buildings && permission.buildings.length > 0) {
+        const allowed = new Set(permission.buildings);
+        const hasMatch = selectedBuildings.some((b) => allowed.has(b));
+        if (!hasMatch) return false;
+      }
+      return true;
     },
-    [isAdmin, isBetaUser]
+    [isAdmin, isBetaUser, selectedBuildings]
   );
 
   const canAccessFeature = useCallback(

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -60,6 +60,7 @@ import {
   revokeBackendRefreshToken,
 } from '../utils/googleOAuthRefresh';
 import { logError } from '../utils/logError';
+import { FEATURE_DEFAULTS } from '../config/featureDefaults';
 import { stripTransientKeys } from '../utils/widgetConfigPersistence';
 import { parseAssignmentModesConfig } from '../utils/assignmentModesConfig';
 import {
@@ -195,19 +196,6 @@ const makeHybridBypassUser = (anonUser: User): User =>
         : value;
     },
   });
-
-/**
- * Per-feature default for `canAccessFeature` when no permission doc exists
- * in `global_permissions`. Features not listed here default to `true`
- * (public). Add an entry here when a feature must stay off until an admin
- * explicitly seeds the doc — e.g. when it depends on external configuration
- * (OAuth setup, API keys) that the code can't verify on its own.
- */
-const CANACCESSFEATURE_MISSING_DOC_DEFAULT: Partial<
-  Record<GlobalFeature, boolean>
-> = {
-  'personal-spotify': false,
-};
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -1894,10 +1882,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         (p) => p.featureId === featureId
       );
 
-      // Per-feature override; defaults to public (`true`) for any feature
-      // not listed in CANACCESSFEATURE_MISSING_DOC_DEFAULT.
+      // Per-feature default from the single FEATURE_DEFAULTS table.
+      // `missingDocPublic: true` (the historical baseline) returns true
+      // when no doc exists; `false` keeps the feature off until an
+      // admin explicitly persists settings — used for features that
+      // depend on external config (OAuth, API keys) the code can't
+      // verify on its own.
       if (!permission) {
-        return CANACCESSFEATURE_MISSING_DOC_DEFAULT[featureId] ?? true;
+        return FEATURE_DEFAULTS[featureId].missingDocPublic;
       }
       return resolvePermissionAccess(permission, user.email);
     },

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -294,6 +294,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [resolvedForUser, setResolvedForUser] = useState<User | null>(null);
   const [buildingIds, setBuildingIds] = useState<string[]>([]);
   const [orgBuildings, setOrgBuildings] = useState<BuildingRecord[]>([]);
+  const [orgBuildingsLoaded, setOrgBuildingsLoaded] =
+    useState<boolean>(isAuthBypass);
   const [favoriteBackgrounds, setFavoriteBackgrounds] = useState<string[]>([]);
   const [recentBackgrounds, setRecentBackgrounds] = useState<string[]>([]);
   // Refs that always hold the latest list values so rapid callbacks don't close over stale state
@@ -936,6 +938,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     if (isAuthBypass) return;
     if (!user || !orgId) {
       setOrgBuildings([]);
+      setOrgBuildingsLoaded(true);
       return;
     }
 
@@ -946,12 +949,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
           (d) => ({ id: d.id, ...d.data() }) as BuildingRecord
         );
         setOrgBuildings(items);
+        setOrgBuildingsLoaded(true);
       },
       (err) => {
         console.error(
           `[AuthContext] org buildings snapshot error (${orgId}):`,
           err
         );
+        setOrgBuildingsLoaded(true);
       }
     );
     return unsub;
@@ -2028,6 +2033,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         roleResolved,
         buildingIds,
         orgBuildings,
+        orgBuildingsLoaded,
         favoriteBackgrounds,
         recentBackgrounds,
         toggleFavoriteBackground,

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -165,6 +165,14 @@ export interface AuthContextType {
    * Firestore listener instead of each opening its own.
    */
   orgBuildings: BuildingRecord[];
+  /**
+   * True once the first `orgBuildings` snapshot (or the explicit "no org"
+   * reset) has resolved. Consumers that need to distinguish a genuine empty
+   * result from an in-flight load (e.g. suppressing orphan building chips
+   * until the list is confirmed) should gate on this flag instead of checking
+   * `orgBuildings.length === 0`.
+   */
+  orgBuildingsLoaded: boolean;
   /** Background IDs the user has starred as favorites. */
   favoriteBackgrounds: string[];
   /** Background IDs recently applied, newest first, capped at 12. */

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -66,6 +66,7 @@ import { useDriveReconnected } from '../hooks/useDriveReconnected';
 import { useCollections } from '../hooks/useCollections';
 import { useSharedCollection } from '../hooks/useSharedCollection';
 import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
+import { setGlobalPermissionsErrorHandler } from '../utils/globalPermissionsErrors';
 import {
   setAiModelConfigFallbackHandler,
   resetAiModelConfigFallbackLatch,
@@ -637,6 +638,22 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     });
     return () => setDriveAuthErrorHandler(null);
   }, [addToast, refreshGoogleToken]);
+
+  // Register a one-time toast for `global_permissions` snapshot failures.
+  // AuthContext can't push toasts directly because DashboardContext (the
+  // toast queue owner) consumes AuthContext — same provider-ordering
+  // problem the Drive handler above solves. The latch lives in the
+  // util so retry storms don't fan out repeated toasts. Refresh is the
+  // user's only retry path; we don't try to auto-clear the latch.
+  useEffect(() => {
+    setGlobalPermissionsErrorHandler(() => {
+      addToast(
+        'Feature availability may not reflect current settings. Refresh to retry.',
+        'error'
+      );
+    });
+    return () => setGlobalPermissionsErrorHandler(null);
+  }, [addToast]);
 
   // Fire a toast (and clean the URL) when the user landed on /share-collection/
   // with no share ID. The initializer for hadEmptyShareCollectionUrl captures

--- a/docs/superpowers/plans/2026-05-18-personal-spotify-gate.md
+++ b/docs/superpowers/plans/2026-05-18-personal-spotify-gate.md
@@ -1,0 +1,1351 @@
+# Personal Spotify Global Feature Gate — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an admin gate (`'personal-spotify'`) that controls whether the per-teacher Spotify mode in the Music widget is visible, with `accessLevel` (admin/beta/public) + optional `buildings` scoping. When ungated for a user, the Music widget transparently renders curated stations and `source: 'personal'` config is preserved.
+
+**Architecture:** Extend the existing global-permission system. Add `'personal-spotify'` to `GlobalFeature` and an optional `buildings?: string[]` field to `GlobalFeaturePermission`. Extend the shared `resolvePermissionAccess` helper in AuthContext to enforce the building check (empty/undefined = no restriction). Add a per-feature default-policy map so `canAccessFeature('personal-spotify')` returns `false` when no permission doc exists (matches `canSeeShareTracking` precedent). Wire the admin UI into `GlobalPermissionsManager` with a new generic `PermissionBuildingMultiSelect` chip control. Gate the Music widget at two render-time surfaces: hide the source toggle in Settings, and short-circuit `source: 'personal'` to curated in the top-level widget dispatch.
+
+**Tech Stack:** React 19, TypeScript, Vitest + React Testing Library, Firebase Firestore, Tailwind CSS, lucide-react.
+
+**Spec:** `docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md`
+
+**Branch:** `feat/personal-spotify-gate` (stacked on `claude/spotify-widget-auth-NRZCZ`)
+
+---
+
+## File Structure
+
+**Modify:**
+
+- `types.ts` — extend `GlobalFeature` union (1 entry); add `buildings?: string[]` to `GlobalFeaturePermission`
+- `context/AuthContext.tsx` — extend `resolvePermissionAccess` (building check); add `MISSING_DOC_DEFAULT` map in `canAccessFeature`
+- `components/admin/GlobalPermissionsManager.tsx` — add `'personal-spotify'` to `GLOBAL_FEATURES`; render `<PermissionBuildingMultiSelect>` inside each feature row; persist `buildings` on save
+- `components/widgets/MusicWidget/Settings.tsx` — wrap source toggle in `canAccessFeature` gate
+- `components/widgets/MusicWidget/Widget.tsx` — compute `effectiveSource` that short-circuits `'personal'` → `'curated'` when ungated
+
+**Create:**
+
+- `components/admin/PermissionBuildingMultiSelect.tsx` — generic building-chip multi-select (empty = "All buildings" pill)
+- `tests/context/AuthContext.canAccessFeatureBuildings.test.tsx` — unit tests for the building check
+- `tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx` — unit tests for the missing-doc default
+- `tests/components/admin/PermissionBuildingMultiSelect.test.tsx` — component tests for the multi-select
+- `tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx` — component tests for Settings + Widget gating
+
+**Reference files (read for patterns, do not modify):**
+
+- `tests/context/AuthContext.canSeeShareTracking.test.tsx` — established test pattern for AuthContext (uses `Probe` + `mountAs` + `deliverGlobalPermissions` + `setAdmin`)
+- `tests/context/AuthContext.quizMonitorPrefs.test.tsx` — example of mocking `selectedBuildings` via the userProfile snapshot (`getDoc` mock returning `{ selectedBuildings: ['high'] }` for paths ending in `userProfile/profile`)
+- `components/admin/BuildingSelector.tsx` — existing single-select; informs the new multi-select's API + chip styling
+- `hooks/useAdminBuildings.ts` — building data source (used by both selectors)
+
+---
+
+## Task 1: Extend the types
+
+**Files:**
+
+- Modify: `types.ts`
+
+- [ ] **Step 1: Add `'personal-spotify'` to the `GlobalFeature` union**
+
+In `types.ts`, locate the `GlobalFeature` union (currently around line 5252-5267) and append `'personal-spotify'`:
+
+```ts
+export type GlobalFeature =
+  | 'live-session'
+  | 'gemini-functions'
+  | 'dashboard-sharing'
+  | 'dashboard-import'
+  | 'magic-layout'
+  | 'smart-paste'
+  | 'smart-poll'
+  | 'screen-recording'
+  | 'remote-control'
+  | 'embed-mini-app'
+  | 'video-activity-audio-transcription'
+  | 'ai-file-context'
+  | 'org-admin-writes'
+  | 'assignment-modes'
+  | 'share-link-tracking'
+  | 'personal-spotify';
+```
+
+- [ ] **Step 2: Add the optional `buildings?` field to `GlobalFeaturePermission`**
+
+In `types.ts`, locate `GlobalFeaturePermission` (around line 5269) and add the field:
+
+```ts
+export interface GlobalFeaturePermission {
+  featureId: GlobalFeature;
+  accessLevel: AccessLevel;
+  betaUsers: string[];
+  enabled: boolean;
+  /**
+   * Building IDs allowed access. Empty array or `undefined` means
+   * "no building restriction" — the feature applies org-wide.
+   * Non-empty array means: user must have at least one of these
+   * buildings in their `selectedBuildings` to pass the gate.
+   */
+  buildings?: string[];
+  config?: Record<string, unknown>;
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `pnpm run type-check`
+
+Expected: exit 0, no errors. (Optional field on an existing type does not break any caller.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add types.ts
+git commit -m "feat(types): add personal-spotify feature + optional buildings on GlobalFeaturePermission"
+```
+
+---
+
+## Task 2: Extend `resolvePermissionAccess` with the building check
+
+**Files:**
+
+- Create: `tests/context/AuthContext.canAccessFeatureBuildings.test.tsx`
+- Modify: `context/AuthContext.tsx` (around lines 1726-1745)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/context/AuthContext.canAccessFeatureBuildings.test.tsx`. Mirror the structure of `tests/context/AuthContext.canSeeShareTracking.test.tsx` but extend the mount helper to also deliver `selectedBuildings` via the userProfile `getDoc` mock (pattern from `AuthContext.quizMonitorPrefs.test.tsx` lines 124-147).
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { GlobalFeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: {
+  adminEmail: string | null;
+  selectedBuildings: string[];
+}): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => true,
+        data: () => ({ selectedBuildings: opts.selectedBuildings }),
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+
+function deliverGlobalPermissions(perms: GlobalFeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'global_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { id: string; data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ id: p.featureId, data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    return () => undefined;
+  });
+}
+
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  selectedBuildings: string[];
+  perms: GlobalFeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({
+    adminEmail: opts.isAdmin ? opts.email : null,
+    selectedBuildings: opts.selectedBuildings,
+  });
+  deliverGlobalPermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+    expect(ctxHolder.current?.profileLoaded).toBe(true);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessFeature buildings check', () => {
+  const baseFeature: Omit<GlobalFeaturePermission, 'buildings'> = {
+    featureId: 'personal-spotify',
+    accessLevel: 'public',
+    betaUsers: [],
+    enabled: true,
+  };
+
+  it('passes when buildings is undefined (no restriction)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [baseFeature],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('passes when buildings is an empty array (no restriction)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [{ ...baseFeature, buildings: [] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('passes when user has at least one of the allowed buildings', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [{ ...baseFeature, buildings: ['high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('fails when user has none of the allowed buildings', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['elementary'],
+      perms: [{ ...baseFeature, buildings: ['middle', 'high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('fails when user has no selected buildings and buildings is restricted', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: [],
+      perms: [{ ...baseFeature, buildings: ['middle'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('admin bypass wins over building restriction', async () => {
+    // Admins always pass once a record exists and is enabled — building
+    // restriction does not gate admins. Matches the existing accessLevel
+    // semantics where isAdmin short-circuits resolvePermissionAccess.
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      selectedBuildings: ['elementary'],
+      perms: [{ ...baseFeature, buildings: ['middle'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('disabled wins over a passing building match', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [{ ...baseFeature, enabled: false, buildings: ['high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — confirm they fail**
+
+Run: `pnpm vitest run tests/context/AuthContext.canAccessFeatureBuildings.test.tsx`
+
+Expected: most tests FAIL because the building check isn't implemented yet. The "buildings undefined" and "empty array" tests will likely already PASS (current behavior returns true). The "user has match" test will PASS by accident. The "no match," "no buildings," and "disabled" tests are the ones that exercise the new logic — focus on those failing.
+
+- [ ] **Step 3: Extend `resolvePermissionAccess` to check buildings**
+
+In `context/AuthContext.tsx`, locate `resolvePermissionAccess` (around line 1726) and add the building check after the access-level decision. Use `selectedBuildings` (already in scope as component state). Note: `isAdmin` short-circuits at line 1732 BEFORE any building check, so admins bypass building restrictions — that's by design and is asserted by the "admin bypass wins" test.
+
+Replace the existing function with:
+
+```ts
+const resolvePermissionAccess = useCallback(
+  (permission: GlobalFeaturePermission, userEmail: string | null): boolean => {
+    if (!permission.enabled) return false;
+    if (isAdmin) return true;
+    switch (permission.accessLevel) {
+      case 'admin':
+        return false;
+      case 'beta':
+        if (!isBetaUser(permission.betaUsers, userEmail)) return false;
+        break;
+      case 'public':
+        break;
+      default:
+        return false;
+    }
+    // Building check applies only when explicitly restricted. An empty
+    // array or `undefined` means "no building restriction" — the feature
+    // applies to anyone who passed the access-level check above. When set,
+    // the user must have at least one of these buildings in their
+    // `selectedBuildings` (self-managed in General Settings).
+    if (permission.buildings && permission.buildings.length > 0) {
+      const allowed = new Set(permission.buildings);
+      const hasMatch = selectedBuildings.some((b) => allowed.has(b));
+      if (!hasMatch) return false;
+    }
+    return true;
+  },
+  [isAdmin, isBetaUser, selectedBuildings]
+);
+```
+
+- [ ] **Step 4: Run the tests — confirm they pass**
+
+Run: `pnpm vitest run tests/context/AuthContext.canAccessFeatureBuildings.test.tsx`
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Run the existing canSeeShareTracking tests to confirm no regression**
+
+`canSeeShareTracking` also goes through `resolvePermissionAccess`. The added building check is gated behind `if (permission.buildings && length > 0)`, so any permission doc without buildings (all existing 15) behaves identically.
+
+Run: `pnpm vitest run tests/context/AuthContext.canSeeShareTracking.test.tsx`
+
+Expected: all tests PASS (no behavioral change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/context/AuthContext.canAccessFeatureBuildings.test.tsx context/AuthContext.tsx
+git commit -m "feat(auth): building-scope check in resolvePermissionAccess"
+```
+
+---
+
+## Task 3: Default-policy map for missing permission doc
+
+**Files:**
+
+- Create: `tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx`
+- Modify: `context/AuthContext.tsx` (`canAccessFeature` callback around line 1747)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx`. This test focuses on the missing-doc default for `'personal-spotify'`.
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { GlobalFeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: { adminEmail: string | null }): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => false,
+        data: () => undefined,
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+function deliverGlobalPermissions(perms: GlobalFeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'global_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { id: string; data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ id: p.featureId, data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    return () => undefined;
+  });
+}
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  perms: GlobalFeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({ adminEmail: opts.isAdmin ? opts.email : null });
+  deliverGlobalPermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessFeature("personal-spotify") missing-doc default', () => {
+  it('returns FALSE for non-admin when no permission doc exists', async () => {
+    // Default-off. Deploying without seeding the permission doc must
+    // leave teachers without the source toggle — protects misconfigured
+    // OAuth deployments from surfacing a broken Connect button.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('returns FALSE for admin when no permission doc exists', async () => {
+    // Admin bypass only applies once a permission record exists. Missing
+    // doc means "no policy has been set" — even admins get the closed
+    // default, so they have to seed the doc deliberately.
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('returns TRUE for other features when no permission doc exists (default-public unchanged)', async () => {
+    // The personal-spotify exception must not regress the default for
+    // other features. Pick an arbitrary one that has no special-default.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('gemini-functions')).toBe(true);
+  });
+
+  it('returns TRUE for non-admin when personal-spotify is enabled and public', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [
+        {
+          featureId: 'personal-spotify',
+          accessLevel: 'public',
+          betaUsers: [],
+          enabled: true,
+        },
+      ],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests — confirm they fail**
+
+Run: `pnpm vitest run tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx`
+
+Expected: the first two tests FAIL (current default returns `true` for missing docs). The last two PASS (existing behavior).
+
+- [ ] **Step 3: Add the per-feature default map in `canAccessFeature`**
+
+In `context/AuthContext.tsx`, locate `canAccessFeature` (around line 1747) and add the map at module top + the lookup inside the function:
+
+Add at the top of the file (after the existing imports, before the `AuthProvider` component):
+
+```ts
+/**
+ * Per-feature default for `canAccessFeature` when no permission doc exists
+ * in `global_permissions`. Features not listed here default to `true`
+ * (public). Add an entry here when a feature must stay off until an admin
+ * explicitly seeds the doc — e.g. when it depends on external configuration
+ * (OAuth setup, API keys) that the code can't verify on its own.
+ */
+const CANACCESSFEATURE_MISSING_DOC_DEFAULT: Partial<
+  Record<GlobalFeature, boolean>
+> = {
+  'personal-spotify': false,
+};
+```
+
+Then replace the `canAccessFeature` callback's missing-doc branch:
+
+```ts
+const canAccessFeature = useCallback(
+  (featureId: GlobalFeature): boolean => {
+    if (isAuthBypass) return true;
+    if (!user) return false;
+
+    const permission = globalPermissions.find((p) => p.featureId === featureId);
+
+    if (!permission) {
+      // Per-feature override; defaults to public (`true`) for any feature
+      // not listed in CANACCESSFEATURE_MISSING_DOC_DEFAULT.
+      return CANACCESSFEATURE_MISSING_DOC_DEFAULT[featureId] ?? true;
+    }
+    return resolvePermissionAccess(permission, user.email);
+  },
+  [user, globalPermissions, resolvePermissionAccess]
+);
+```
+
+- [ ] **Step 4: Run the tests — confirm they pass**
+
+Run: `pnpm vitest run tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx`
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Run all AuthContext tests for regression check**
+
+Run: `pnpm vitest run tests/context/`
+
+Expected: all tests PASS. The default-policy map only changes behavior for `'personal-spotify'`; all other features keep their existing defaults.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx context/AuthContext.tsx
+git commit -m "feat(auth): default-off for personal-spotify when permission doc missing"
+```
+
+---
+
+## Task 4: `PermissionBuildingMultiSelect` component
+
+**Files:**
+
+- Create: `components/admin/PermissionBuildingMultiSelect.tsx`
+- Create: `tests/components/admin/PermissionBuildingMultiSelect.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/components/admin/PermissionBuildingMultiSelect.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [
+    { id: 'elem', name: 'Elementary' },
+    { id: 'mid', name: 'Middle' },
+    { id: 'high', name: 'High School' },
+  ],
+}));
+
+describe('PermissionBuildingMultiSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an "All buildings" pill when selection is empty', () => {
+    render(
+      <PermissionBuildingMultiSelect selectedIds={[]} onChange={vi.fn()} />
+    );
+    expect(screen.getByText(/all buildings/i)).toBeInTheDocument();
+  });
+
+  it('renders a chip per selected building name', () => {
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem', 'high']}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Elementary')).toBeInTheDocument();
+    expect(screen.getByText('High School')).toBeInTheDocument();
+    expect(screen.queryByText('Middle')).not.toBeInTheDocument();
+  });
+
+  it('calls onChange with the new selection when an unselected building is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem']}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add middle/i }));
+    expect(onChange).toHaveBeenCalledWith(['elem', 'mid']);
+  });
+
+  it('calls onChange removing the building when a selected chip is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem', 'high']}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /remove elementary/i }));
+    expect(onChange).toHaveBeenCalledWith(['high']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `pnpm vitest run tests/components/admin/PermissionBuildingMultiSelect.test.tsx`
+
+Expected: FAIL with "Cannot find module '@/components/admin/PermissionBuildingMultiSelect'".
+
+- [ ] **Step 3: Implement `PermissionBuildingMultiSelect.tsx`**
+
+Create `components/admin/PermissionBuildingMultiSelect.tsx`:
+
+```tsx
+/**
+ * Generic building multi-select for global feature permissions.
+ *
+ * Empty `selectedIds` displays an "All buildings" pill — the feature
+ * applies org-wide. Non-empty means the feature is restricted to users
+ * whose `selectedBuildings` overlap this list.
+ *
+ * Mirrors the chip styling of `BuildingSelector.tsx` (single-select) so
+ * the admin UI feels consistent. Unselected buildings render as
+ * outlined chips with a "+" affordance; selected buildings render as
+ * filled brand-blue chips with a "×" affordance.
+ */
+
+import React from 'react';
+import { Plus, X, Building2 } from 'lucide-react';
+import { useAdminBuildings } from '@/hooks/useAdminBuildings';
+
+interface Props {
+  selectedIds: string[];
+  onChange: (next: string[]) => void;
+  /** Optional label shown above the control. */
+  label?: string;
+}
+
+export const PermissionBuildingMultiSelect: React.FC<Props> = ({
+  selectedIds,
+  onChange,
+  label,
+}) => {
+  const buildings = useAdminBuildings();
+  const selectedSet = new Set(selectedIds);
+
+  const toggle = (id: string): void => {
+    if (selectedSet.has(id)) {
+      onChange(selectedIds.filter((b) => b !== id));
+    } else {
+      onChange([...selectedIds, id]);
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {label && (
+        <p className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
+          {label}
+        </p>
+      )}
+      {selectedIds.length === 0 && (
+        <div className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-slate-100 text-slate-700 rounded-full text-xs font-semibold border border-slate-200">
+          <Building2 className="w-3 h-3" />
+          All buildings
+        </div>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {buildings.map((building) => {
+          const isSelected = selectedSet.has(building.id);
+          return (
+            <button
+              key={building.id}
+              type="button"
+              onClick={() => toggle(building.id)}
+              aria-label={
+                isSelected ? `Remove ${building.name}` : `Add ${building.name}`
+              }
+              aria-pressed={isSelected}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border transition-colors ${
+                isSelected
+                  ? 'bg-brand-blue-primary text-white border-brand-blue-primary shadow-sm hover:bg-brand-blue-dark'
+                  : 'bg-white text-slate-600 border-slate-300 hover:bg-slate-50'
+              }`}
+            >
+              {isSelected ? (
+                <X className="w-3 h-3" />
+              ) : (
+                <Plus className="w-3 h-3" />
+              )}
+              {building.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+Run: `pnpm vitest run tests/components/admin/PermissionBuildingMultiSelect.test.tsx`
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/admin/PermissionBuildingMultiSelect.tsx tests/components/admin/PermissionBuildingMultiSelect.test.tsx
+git commit -m "feat(admin): generic PermissionBuildingMultiSelect chip control"
+```
+
+---
+
+## Task 5: Wire `'personal-spotify'` into GlobalPermissionsManager
+
+**Files:**
+
+- Modify: `components/admin/GlobalPermissionsManager.tsx`
+
+This file is 1450 lines. Three precise patches in known locations:
+
+1. Add `Music2` to the lucide-react import + `'personal-spotify'` entry to the `GLOBAL_FEATURES` array.
+2. Update `getPermission` (lines 519-543) to default `buildings: []` so new docs always include the field.
+3. Render `<PermissionBuildingMultiSelect>` inside the per-feature row, wired to `updatePermission(featureId, { buildings: ... })` (existing function at line 545).
+
+The save path (`savePermission`, lines 559-604) needs **no changes** — it writes whatever `getPermission` returns, which will include `buildings` once steps 2-3 are in place.
+
+Manual smoke test at the end because GlobalPermissionsManager has no component tests in the repo.
+
+- [ ] **Step 1: Add the import + `GLOBAL_FEATURES` entry**
+
+In `components/admin/GlobalPermissionsManager.tsx`, add `Music2` to the lucide-react import block (near top of file). Check whether it's already there before adding.
+
+Then append to the `GLOBAL_FEATURES` array (defined near the top, after the imports):
+
+```ts
+{
+  id: 'personal-spotify',
+  label: 'Personal Spotify',
+  icon: Music2,
+  description:
+    "Let teachers connect their personal Spotify account in the Music widget. When off, Music shows only curated stations.",
+},
+```
+
+- [ ] **Step 2: Update `getPermission` default to include `buildings: []`**
+
+Locate `getPermission` at lines 519-543. The default object returned when no permission exists must include `buildings: []` so the persisted Firestore doc always has the field explicitly. Replace the returned default object:
+
+```ts
+return (
+  permissions.get(featureId) ?? {
+    featureId,
+    accessLevel: defaultAccessLevel,
+    betaUsers: [],
+    enabled: true,
+    buildings: [],
+    config: GEMINI_FEATURES.includes(featureId)
+      ? { dailyLimit: defaultLimit, dailyLimitEnabled: true }
+      : {},
+  }
+);
+```
+
+Existing permissions already loaded from Firestore (`permissions.get(featureId)`) keep their existing shape — `buildings` is undefined for the 15 legacy docs, which `resolvePermissionAccess` correctly treats as "no restriction." Only NEW docs get `buildings: []` on first save.
+
+- [ ] **Step 3: Import the multi-select component**
+
+Add near the other admin-component imports at the top of the file:
+
+```ts
+import { PermissionBuildingMultiSelect } from './PermissionBuildingMultiSelect';
+```
+
+- [ ] **Step 4: Render the multi-select inside the per-feature controls**
+
+Find where the per-feature controls (accessLevel radios, betaUsers, enabled toggle) are rendered. The repo uses inline JSX inside the manager component rather than a separate `FeatureRow` extracted component. Look for the section near where `updatePermission(feature.id, { accessLevel: ... })` and `updatePermission(feature.id, { enabled: ... })` are called.
+
+Place the multi-select directly below the existing controls (and above any feature-specific config like `<GeminiModelConfigSection>`):
+
+```tsx
+<PermissionBuildingMultiSelect
+  label="Restrict to buildings"
+  selectedIds={permission.buildings ?? []}
+  onChange={(buildings) => updatePermission(feature.id, { buildings })}
+/>
+```
+
+The file renders permission rows in both `'list'` and `'grid'` view modes — add the control in both places, or factor it into a small shared sub-component if the repeated JSX is awkward. Match the surrounding visual density (smaller text in the list view, more padding in the grid view).
+
+- [ ] **Step 5: Type-check + lint**
+
+```bash
+pnpm run type-check
+pnpm run lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 6: Smoke test in the browser**
+
+The dev server should still be running. Open `http://localhost:3000` (sign in as admin), then navigate to Admin Settings → Global Settings.
+
+Verify:
+
+1. "Personal Spotify" appears in the list with the Music2 icon and description.
+2. Click into it, set `enabled: true`, `accessLevel: 'admin'`, leave buildings empty. Save.
+3. Verify the Firestore doc at `/global_permissions/personal-spotify` has `buildings: []` (Firebase console).
+4. Re-edit, add one building to the multi-select, save.
+5. Verify the Firestore doc now has `buildings: ['<that-building-id>']`.
+6. Remove the building (click the × chip), save. Verify doc shows `buildings: []` again.
+
+If the doc updates correctly through all 6 steps, the wiring is correct.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/admin/GlobalPermissionsManager.tsx
+git commit -m "feat(admin): wire personal-spotify feature + building multi-select into Global Settings"
+```
+
+---
+
+## Task 6: Gate the Music widget Settings source toggle
+
+**Files:**
+
+- Create: `tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`
+- Modify: `components/widgets/MusicWidget/Settings.tsx`
+
+- [ ] **Step 1: Write the failing test (Settings half)**
+
+Create `tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`. We'll add Widget-half tests in Task 7 to the same file.
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MusicSettings } from '@/components/widgets/MusicWidget/Settings';
+import type { WidgetData } from '@/types';
+
+// Replace `useAuth` so we can flip `canAccessFeature` per test without
+// spinning up the full AuthProvider.
+const canAccessFeatureMock = vi.fn<(featureId: string) => boolean>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    canAccessFeature: canAccessFeatureMock,
+  }),
+}));
+
+// MusicSettings calls useDashboard().updateWidget; mock it minimally.
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ updateWidget: vi.fn() }),
+}));
+
+const baseWidget: WidgetData = {
+  id: 'w1',
+  type: 'music',
+  x: 0,
+  y: 0,
+  w: 300,
+  h: 200,
+  z: 1,
+  flipped: false,
+  minimized: false,
+  config: { source: 'curated' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canAccessFeatureMock.mockReset();
+});
+
+describe('MusicWidget Settings — personal Spotify gate', () => {
+  it('shows the Source toggle when canAccessFeature("personal-spotify") returns true', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(<MusicSettings widget={baseWidget} />);
+    expect(screen.getByText(/source/i)).toBeInTheDocument();
+    // The "My Spotify" option label should be reachable when the toggle is rendered.
+    expect(screen.getByText(/my spotify/i)).toBeInTheDocument();
+  });
+
+  it('hides the Source toggle entirely when canAccessFeature returns false', () => {
+    canAccessFeatureMock.mockReturnValue(false);
+    render(<MusicSettings widget={baseWidget} />);
+    expect(screen.queryByText(/source/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/my spotify/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+If the exported component from `Settings.tsx` is named something other than `MusicSettings`, adjust the import. Open `components/widgets/MusicWidget/Settings.tsx` to confirm the exported name and the JSX label for "Source" (currently rendered around lines 126-129 per earlier recon).
+
+- [ ] **Step 2: Run the test — confirm it fails**
+
+Run: `pnpm vitest run tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`
+
+Expected: the second test FAILS (Source toggle still renders even when ungated).
+
+- [ ] **Step 3: Gate the Source toggle in `Settings.tsx`**
+
+Open `components/widgets/MusicWidget/Settings.tsx`. Near the top, import `useAuth`:
+
+```ts
+import { useAuth } from '@/context/useAuth';
+```
+
+Inside the component, read the gate (place near the other hook calls):
+
+```ts
+const { canAccessFeature } = useAuth();
+const canUsePersonal = canAccessFeature('personal-spotify');
+```
+
+Wrap the entire Source-toggle block (the "── Source selector ──" section starting around line 126 and including the `SettingsLabel` + the option buttons) in a conditional:
+
+```tsx
+{
+  canUsePersonal && (
+    <>
+      {/* ── Source selector ── */}
+      <SettingsLabel icon={Music2}>Source</SettingsLabel>
+      {/* ...existing toggle JSX... */}
+    </>
+  );
+}
+```
+
+The Source-specific body below (the `{source === 'personal' ? ... : ...}` branch around line 204) does not need to change — when ungated, `source` will be forced to `'curated'` by Task 7's render-dispatch change, and even if a stored `source: 'personal'` reaches this body, the gate kept the user out of the panel so they never had a chance to render the personal settings UI. Defense-in-depth: also short-circuit to the curated body in Settings.tsx when ungated:
+
+```tsx
+{source === 'personal' && canUsePersonal ? (
+  // existing personal settings JSX (PersonalSpotifyPanel)
+) : (
+  // existing curated settings JSX
+)}
+```
+
+- [ ] **Step 4: Run the test — confirm it passes**
+
+Run: `pnpm vitest run tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx components/widgets/MusicWidget/Settings.tsx
+git commit -m "feat(music): gate personal Spotify source toggle in widget settings"
+```
+
+---
+
+## Task 7: Gate the Music widget render dispatch
+
+**Files:**
+
+- Modify: `components/widgets/MusicWidget/Widget.tsx`
+- Modify: `tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx` (append)
+
+- [ ] **Step 1: Read the current widget dispatch**
+
+Open `components/widgets/MusicWidget/Widget.tsx`. Identify the top-level branch that selects between curated and personal modes based on `config.source`. It will look approximately like:
+
+```tsx
+const source = widget.config.source ?? 'curated';
+return source === 'personal' ? <PersonalMode … /> : <CuratedMode … />;
+```
+
+- [ ] **Step 2: Add the failing tests (append to existing test file)**
+
+Append to `tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`:
+
+```tsx
+import { MusicWidget } from '@/components/widgets/MusicWidget/Widget';
+
+// PersonalSpotifyPlayer and the curated body each render something
+// distinctive we can assert on. Mock them to make the assertion trivial.
+vi.mock('@/components/widgets/MusicWidget/PersonalSpotifyPlayer', () => ({
+  PersonalSpotifyPlayer: () => <div data-testid="personal-player" />,
+}));
+// Use a vague match for the curated body; if the curated component has a
+// stable export name, prefer mocking that. Adjust this mock to whatever
+// component renders the curated front face in your widget code.
+
+describe('MusicWidget render dispatch — personal Spotify gate', () => {
+  it('renders the personal player when source=personal AND canAccessFeature is true', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'personal' } }} />
+    );
+    expect(screen.getByTestId('personal-player')).toBeInTheDocument();
+  });
+
+  it('renders the curated body when source=personal but canAccessFeature is false', () => {
+    canAccessFeatureMock.mockReturnValue(false);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'personal' } }} />
+    );
+    // The personal player must NOT be mounted — that's the transparent
+    // fallback the spec calls for.
+    expect(screen.queryByTestId('personal-player')).not.toBeInTheDocument();
+  });
+
+  it('renders the curated body when source=curated regardless of gate', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'curated' } }} />
+    );
+    expect(screen.queryByTestId('personal-player')).not.toBeInTheDocument();
+  });
+});
+```
+
+The `MusicWidget` import name might differ. Open `Widget.tsx` to confirm the exported component name and adjust.
+
+- [ ] **Step 3: Run the tests — confirm the gate test fails**
+
+Run: `pnpm vitest run tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`
+
+Expected: the "renders curated when source=personal but canAccessFeature is false" test FAILS because the widget currently honors `source: 'personal'` regardless of permissions.
+
+- [ ] **Step 4: Add the gate in `Widget.tsx`**
+
+In `components/widgets/MusicWidget/Widget.tsx`, import `useAuth` (if not already) and compute `effectiveSource`:
+
+```ts
+import { useAuth } from '@/context/useAuth';
+```
+
+Replace the dispatch logic:
+
+```tsx
+const { canAccessFeature } = useAuth();
+const canUsePersonal = canAccessFeature('personal-spotify');
+const storedSource = widget.config.source ?? 'curated';
+// When the gate is off, treat any stored `source: 'personal'` as curated.
+// The stored config is preserved — re-enabling the gate brings personal
+// playback back without the user doing anything.
+const effectiveSource =
+  canUsePersonal && storedSource === 'personal' ? 'personal' : 'curated';
+
+return effectiveSource === 'personal' ? (
+  <PersonalSpotifyPlayer widget={widget} />
+) : (
+  <CuratedPlayer widget={widget} />
+);
+```
+
+Use the actual component names from the existing dispatch (the names above are illustrative — read the file).
+
+- [ ] **Step 5: Run the tests — confirm they pass**
+
+Run: `pnpm vitest run tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx`
+
+Expected: all 5 tests in the file PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/widgets/MusicWidget/Widget.tsx tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
+git commit -m "feat(music): render-time gate for personal Spotify source in widget dispatch"
+```
+
+---
+
+## Task 8: Full validate + push + open PR
+
+- [ ] **Step 1: Run the full validation suite**
+
+```bash
+pnpm run validate
+```
+
+Expected: exit 0. This runs type-check, lint (`--max-warnings 0`), format-check, and tests. Per CLAUDE.md, this MUST pass before push or CI will block the PR.
+
+If anything fails: fix it before continuing. Do not `--no-verify` or skip hooks.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/personal-spotify-gate
+```
+
+- [ ] **Step 3: Open the stacked PR**
+
+```bash
+gh pr create --base claude/spotify-widget-auth-NRZCZ --title "feat(admin): personal-spotify global feature gate with building scoping" --body "$(cat <<'EOF'
+## Summary
+
+Adds an admin gate (`personal-spotify`) for the per-teacher Spotify mode introduced in #1662. Admins control rollout via Global Settings: enabled toggle, accessLevel (admin/beta/public), and optional buildings restriction. When ungated for a user, the Music widget transparently renders curated stations — `source: 'personal'` config is preserved across gate flips.
+
+**Stacked on #1662.** Rebase onto `dev-paul` when that PR squash-merges (per the stacked-PR rebase rule).
+
+### Why default-off when no permission doc exists
+
+Matches the `canSeeShareTracking` precedent. Personal Spotify depends on Firebase Functions secrets, Spotify dashboard redirect URIs, and an OAuth flow — if any are misconfigured, defaulting to ON would surface a broken Connect button to every teacher. Default-off forces explicit admin opt-in.
+
+### Generic `buildings?` field
+
+`buildings?: string[]` is a new optional field on `GlobalFeaturePermission`. Empty/undefined = "no restriction." It's centralised in `resolvePermissionAccess`, so any future global feature can opt in by setting the field — no per-feature code needed. The 15 existing global features are unaffected (field is optional).
+
+## Test plan
+
+- [ ] **Admin UI**: As an admin, navigate to Admin Settings → Global Settings. "Personal Spotify" appears in the list with the Music2 icon and description. Toggle `enabled: true`, `accessLevel: 'admin'`, leave buildings empty. Save.
+- [ ] **Default-off**: Sign in as a non-admin teacher with the permission doc deleted. Open a Music widget — Source toggle is absent; only curated stations render.
+- [ ] **Admin-only**: With `accessLevel: 'admin'`, non-admin teachers do not see the source toggle.
+- [ ] **Beta**: With `accessLevel: 'beta'` and a beta user's email in the list, that user sees the toggle.
+- [ ] **Public**: With `accessLevel: 'public'`, all signed-in teachers see the toggle.
+- [ ] **Building gate**: With `buildings: ['high']`, teachers whose `selectedBuildings` includes `'high'` see the toggle; others do not.
+- [ ] **Transparent fallback**: Configure a Music widget with `source: 'personal'` while gated in. Then revoke access (set `accessLevel: 'admin'` or remove from buildings). The same widget now renders curated; the stored `source: 'personal'` is preserved. Re-enable access — personal mode comes back without re-configuring.
+- [ ] **Admin bypass building**: Admins bypass building restriction (the existing admin bypass on accessLevel cascades through resolvePermissionAccess).
+- [ ] **No regression**: Existing 15 global features behave identically. Run `pnpm vitest run tests/context/` and confirm all AuthContext tests pass.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Verify CI is running**
+
+The push triggers PR validation (type-check + lint + format-check + build). Watch for green:
+
+```bash
+gh pr checks
+```
+
+Expected: all checks queued/passing within ~5 minutes. If anything fails, fix locally and push again.
+
+---
+
+## Self-review checklist (run by the implementer before declaring done)
+
+- [ ] **Spec coverage:** Every section of `docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md` has a corresponding task. Data model (Task 1) ✓ Gate enforcement (Tasks 2, 3) ✓ Admin UI (Tasks 4, 5) ✓ Music widget gating, all 3 surfaces (Tasks 6, 7) ✓ Testing (Tasks 2, 3, 4, 6, 7) ✓ Rollout note (PR body) ✓.
+- [ ] **No placeholders:** No "TBD", "TODO", "fill in" remain. Every code block in this plan is meant to be pasted with at most the name adjustments the step calls out.
+- [ ] **Type consistency:** `buildings?: string[]` used everywhere. `'personal-spotify'` is the exact feature id. `canAccessFeature`, `resolvePermissionAccess`, `selectedBuildings`, `useAdminBuildings`, `PermissionBuildingMultiSelect` — all names match across tasks.
+- [ ] **Out of scope respected:** No OAuth callable changes. No 15-feature backfill. No admin-managed building assignments. No drop-all-tokens admin action. No stored-config rewrites.

--- a/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
+++ b/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
@@ -55,10 +55,11 @@ canAccessFeature(featureId):
   permission = globalPermissions.find(featureId)
   if !permission         → false   (see "Defaults" below)
   if !permission.enabled → false
+  if isAdmin             → true   (short-circuit BEFORE per-level checks)
 
-  accessLevelOk = check accessLevel against user
-    admin   → isAdmin
-    beta    → isAdmin OR user.email in betaUsers
+  accessLevelOk = match accessLevel against user
+    admin   → false   (isAdmin already returned true above)
+    beta    → user.email in betaUsers
     public  → true
   if !accessLevelOk → false
 

--- a/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
+++ b/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
@@ -1,7 +1,7 @@
 # Personal Spotify Global Feature Gate
 
 **Date:** 2026-05-18
-**Status:** Design — approved, pending implementation plan
+**Status:** Implemented (PR #1665)
 **Related:** PR #1662 (per-teacher Spotify auth in Music widget)
 
 ## Problem

--- a/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
+++ b/docs/superpowers/specs/2026-05-18-personal-spotify-gate-design.md
@@ -1,0 +1,162 @@
+# Personal Spotify Global Feature Gate
+
+**Date:** 2026-05-18
+**Status:** Design — approved, pending implementation plan
+**Related:** PR #1662 (per-teacher Spotify auth in Music widget)
+
+## Problem
+
+PR #1662 ships per-teacher Spotify OAuth so any teacher can connect their personal Spotify account in the Music widget. There is no admin-level switch to control rollout — once deployed, every authenticated user who can access the Music widget can see the "My Spotify" source mode and trigger an OAuth popup.
+
+We need a gate so admins can:
+
+- Toggle the personal Spotify mode on/off org-wide
+- Roll it out by access level (admin only / beta testers / all teachers)
+- Optionally restrict access to specific buildings
+
+When the gate excludes a user — disabled, wrong access level, or wrong building — the personal Spotify UI must be **entirely hidden, as if it does not exist**. The Music widget continues to function with curated stations.
+
+## Out of scope
+
+- Admin-enforced building membership. The gate reads the user's self-managed `selectedBuildings`. A determined teacher can change their building selection to satisfy the gate; the OAuth callables themselves remain ungated server-side, so the worst case is the teacher sees the source toggle and connects their own Spotify account — no data leak.
+- Server-side enforcement of the gate in the OAuth callables. The 15 existing global features are UI-only gates; this feature follows that convention.
+- Backfilling building-gating to the existing 15 global features. None has been asked for.
+- A "drop all stored Spotify tokens" admin action. The existing per-user revoke is sufficient; a user re-enabling the gate just resumes their previous connection.
+- Rewriting any teacher's saved widget config. A `source: 'personal'` value persists across gate flips and reactivates when the gate is re-enabled.
+
+## Design
+
+### Data model (`types.ts`)
+
+Add `'personal-spotify'` to the `GlobalFeature` union.
+
+Add an optional `buildings?: string[]` field to `GlobalFeaturePermission`:
+
+```ts
+export interface GlobalFeaturePermission {
+  featureId: GlobalFeature;
+  accessLevel: AccessLevel;
+  betaUsers: string[];
+  enabled: boolean;
+  /** Building IDs allowed access. Empty/undefined = all buildings. */
+  buildings?: string[];
+  config?: Record<string, unknown>;
+}
+```
+
+The field is optional, so the 15 existing `/global_permissions/*` documents need no migration. Any future global feature can opt into building-gating by setting this field; the enforcement is centralized in `canAccessFeature`.
+
+### Gate enforcement (`AuthContext.canAccessFeature`)
+
+Update the existing `canAccessFeature(featureId)` to consult `permission.buildings` after the access-level check:
+
+```
+canAccessFeature(featureId):
+  permission = globalPermissions.find(featureId)
+  if !permission         → false   (see "Defaults" below)
+  if !permission.enabled → false
+
+  accessLevelOk = check accessLevel against user
+    admin   → isAdmin
+    beta    → isAdmin OR user.email in betaUsers
+    public  → true
+  if !accessLevelOk → false
+
+  if permission.buildings && permission.buildings.length > 0:
+    buildingOk = selectedBuildings.some(b => permission.buildings.includes(b))
+    if !buildingOk → false
+
+  return true
+```
+
+Two notes on the building check:
+
+1. Empty array OR `undefined` both mean "no building restriction" — admins can save the doc without ever picking a building and the feature applies org-wide.
+2. The intersection is "user is in ≥1 allowed building." A user in multiple buildings only needs one match.
+
+### Defaults — what happens when no permission doc exists
+
+For `'personal-spotify'`, missing-doc default is **`false` (gate off)**. This matches the precedent set by `canSeeShareTracking`:
+
+> Deploying this code without seeding the `global_permissions` doc leaves teachers unaffected.
+
+This is intentionally more conservative than the per-widget `canAccessWidget` default (which defaults to public). Rationale: the personal Spotify mode depends on Firebase Functions secrets, Spotify dashboard redirect URIs, and an OAuth flow. If any of these are misconfigured, defaulting to ON would surface a broken Connect button to every teacher. Default-off forces explicit opt-in by an admin who has verified setup.
+
+The default is enforced inside `canAccessFeature` itself via a small per-feature default-policy map (one entry: `'personal-spotify' → false`). Other global features keep their existing defaults — the map starts as a single entry and grows only when a feature wants non-default behavior. No new wrapper hook needed.
+
+### Admin UI (`components/admin/GlobalPermissionsManager.tsx`)
+
+Add `'personal-spotify'` to the `GLOBAL_FEATURES` array, using the `Music2` icon (already imported elsewhere) and a description like _"Let teachers connect their personal Spotify account in the Music widget. When off, Music shows only curated stations."_
+
+Add a building multi-select control that renders inside every feature row. The control is generic and only shown when the admin chooses to restrict to specific buildings; when empty it displays "All buildings" as a pill. The implementation plan will inspect `components/admin/BuildingSelector.tsx` and either reuse it directly or build a thin wrapper around the same `config/buildings.ts` data source so the building list stays consistent with the rest of the admin UI.
+
+Writing `buildings: []` on save is equivalent to omitting the field — both mean "no restriction." We store `[]` rather than omitting so the Firestore doc shape is explicit and predictable for any future tooling.
+
+### Music widget gating (3 small render-time changes)
+
+These three changes implement the "entirely hidden" requirement without touching any stored widget configs:
+
+1. **`components/widgets/MusicWidget/Settings.tsx`** — wrap the "Source" toggle in `canAccessFeature('personal-spotify') && ...`. When ungated, only the curated body renders; no toggle, no hint that another source exists.
+
+2. **`components/widgets/MusicWidget/Widget.tsx`** — at the top-level dispatch:
+
+   ```ts
+   const canPersonal = canAccessFeature('personal-spotify');
+   const effectiveSource =
+     canPersonal && config.source === 'personal' ? 'personal' : 'curated';
+   ```
+
+   A stored `source: 'personal'` is silently treated as curated when the gate is off. The widget never renders `PersonalSpotifyPanel` or `PersonalSpotifyPlayer` in that case. When the gate is re-enabled (or the user moves into an allowed building), the stored config takes effect again with no user action required.
+
+3. **`components/spotify/SpotifyCallback.tsx` route** — left as-is. The callback only `postMessage`s to its opener and closes itself; an ungated user cannot trigger a Connect that would lead them here.
+
+### What does NOT change
+
+- `functions/src/spotifyOAuth.ts` and the three deployed callables (`exchangeSpotifyAuthCode`, `refreshSpotifyAccessToken`, `revokeSpotifyAuth`) — left functional. Any user who calls them directly without the UI just writes/reads tokens under their own uid. Per existing global-feature convention, the gate is UI-only.
+- The 15 existing `/global_permissions/*` documents — the new `buildings` field is optional.
+- Any teacher's stored widget configs — never rewritten.
+
+## Rollout
+
+1. Deploy the type/UI/gate changes.
+2. In Global Settings, seed the `personal-spotify` permission doc:
+   - `enabled: true`
+   - `accessLevel: 'admin'` (start narrow — only admins see the source toggle)
+   - `buildings: []` (no building restriction, or a small pilot list)
+3. Verify in one admin account that the source toggle appears and the OAuth flow completes.
+4. Widen to `'beta'` with a small `betaUsers` list, then to `'public'` after testing.
+5. Until step 2 runs, the missing-doc default of `false` means no teacher sees the source toggle — safe state for production deploy without seeded permission.
+
+## Testing
+
+### Unit tests
+
+- `canAccessFeature` returns `false` when `permission.buildings` set and user's `selectedBuildings` has no overlap.
+- `canAccessFeature` returns `true` when `permission.buildings` is `[]` or `undefined` (no restriction) and the access-level check passes.
+- `canAccessFeature` returns `true` when `permission.buildings` has at least one of the user's selected buildings, AND access level passes.
+- `canAccessFeature('personal-spotify')` returns `false` when no permission doc exists (default-off precedent).
+
+### Component tests
+
+- `MusicWidget/Settings.tsx`: Source toggle is rendered when `canAccessFeature` returns true, hidden when false.
+- `MusicWidget/Widget.tsx`: With `config.source = 'personal'` and `canAccessFeature` returning false, renders the curated body (no `PersonalSpotifyPlayer` mounted).
+- `MusicWidget/Widget.tsx`: With `config.source = 'personal'` and `canAccessFeature` returning true, renders `PersonalSpotifyPlayer`.
+
+### Admin UI tests
+
+- `GlobalPermissionsManager`: Saving a permission with `buildings: []` and then with `buildings: ['b1', 'b2']` produces the correct Firestore doc shape (round-trips).
+
+### Out of scope for this spec's testing
+
+- OAuth callable changes (none).
+- Existing 15 global features' permission behavior (unchanged).
+
+## Open questions
+
+None at design time. All major decisions resolved during brainstorming:
+
+- Scope: personal Spotify source mode only (not all Spotify content, not the whole widget).
+- Building semantics: empty = all buildings; non-empty = restrict.
+- Fallback: render-time transparent fallback to curated, stored config preserved.
+- Default state: gate off when permission doc missing.
+- Building source: user-managed `selectedBuildings` (soft gate, acceptable for this app).

--- a/hooks/useAdminBuildings.ts
+++ b/hooks/useAdminBuildings.ts
@@ -43,3 +43,38 @@ export function useAdminBuildings(): Building[] {
     return orgBuildings.map(buildingRecordToBuilding);
   }, [orgBuildings]);
 }
+
+/**
+ * Like {@link useAdminBuildings} but also exposes a loading signal.
+ *
+ * `isLoading` is `true` during the window between sign-in and the first
+ * `orgBuildings` snapshot resolving. During this window the hook returns
+ * the `BUILDINGS` seed list as a placeholder — consumers that need to
+ * distinguish "definitive empty result" from "still loading" (e.g.
+ * {@link PermissionBuildingMultiSelect} suppressing orphan chips) should
+ * gate on `isLoading` instead of using the plain `useAdminBuildings()` hook.
+ *
+ * Does not break existing consumers of `useAdminBuildings`, which continues
+ * to return `Building[]` unchanged.
+ */
+export function useAdminBuildingsState(): {
+  buildings: Building[];
+  isLoading: boolean;
+} {
+  const auth = useContext(AuthContext);
+  const orgBuildings = auth?.orgBuildings;
+  // `orgBuildingsLoaded` flips to true after the first snapshot (or the
+  // "no org" reset). The seed fallback is returned in the loading window so
+  // the UI never shows blank, but consumers can suppress destructive actions
+  // (like removing orphan chips) until the list is confirmed.
+  const orgBuildingsLoaded = auth?.orgBuildingsLoaded ?? false;
+
+  const buildings = useMemo(() => {
+    if (!orgBuildings || orgBuildings.length === 0) {
+      return BUILDINGS;
+    }
+    return orgBuildings.map(buildingRecordToBuilding);
+  }, [orgBuildings]);
+
+  return { buildings, isLoading: !orgBuildingsLoaded };
+}

--- a/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
+++ b/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
@@ -65,4 +65,21 @@ describe('PermissionBuildingMultiSelect', () => {
     fireEvent.click(screen.getByRole('button', { name: /remove elementary/i }));
     expect(onChange).toHaveBeenCalledWith(['high']);
   });
+
+  it('renders orphan IDs as amber chips and removes them on click', () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem', 'deleted-bldg-99']}
+        onChange={onChange}
+      />
+    );
+    const orphanChip = screen.getByRole('button', {
+      name: /remove unknown building deleted-bldg-99/i,
+    });
+    expect(orphanChip).toBeInTheDocument();
+    expect(orphanChip).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(orphanChip);
+    expect(onChange).toHaveBeenCalledWith(['elem']);
+  });
 });

--- a/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
+++ b/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [
+    { id: 'elem', name: 'Elementary' },
+    { id: 'mid', name: 'Middle' },
+    { id: 'high', name: 'High School' },
+  ],
+}));
+
+describe('PermissionBuildingMultiSelect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders an "All buildings" pill when selection is empty', () => {
+    render(
+      <PermissionBuildingMultiSelect selectedIds={[]} onChange={vi.fn()} />
+    );
+    expect(screen.getByText(/all buildings/i)).toBeInTheDocument();
+  });
+
+  it('marks selected buildings as pressed and unselected as not pressed', () => {
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem', 'high']}
+        onChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /remove elementary/i })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: /remove high school/i })
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /add middle/i })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('calls onChange with the new selection when an unselected building is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem']}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add middle/i }));
+    expect(onChange).toHaveBeenCalledWith(['elem', 'mid']);
+  });
+
+  it('calls onChange removing the building when a selected chip is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['elem', 'high']}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /remove elementary/i }));
+    expect(onChange).toHaveBeenCalledWith(['high']);
+  });
+});

--- a/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
+++ b/tests/components/admin/PermissionBuildingMultiSelect.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { PermissionBuildingMultiSelect } from '@/components/admin/PermissionBuildingMultiSelect';
+import { useAdminBuildingsState } from '@/hooks/useAdminBuildings';
 
 vi.mock('@/hooks/useAdminBuildings', () => ({
   useAdminBuildings: () => [
@@ -9,6 +10,14 @@ vi.mock('@/hooks/useAdminBuildings', () => ({
     { id: 'mid', name: 'Middle' },
     { id: 'high', name: 'High School' },
   ],
+  useAdminBuildingsState: vi.fn(() => ({
+    buildings: [
+      { id: 'elem', name: 'Elementary' },
+      { id: 'mid', name: 'Middle' },
+      { id: 'high', name: 'High School' },
+    ],
+    isLoading: false,
+  })),
 }));
 
 describe('PermissionBuildingMultiSelect', () => {
@@ -81,5 +90,19 @@ describe('PermissionBuildingMultiSelect', () => {
     expect(orphanChip).toHaveAttribute('aria-pressed', 'true');
     fireEvent.click(orphanChip);
     expect(onChange).toHaveBeenCalledWith(['elem']);
+  });
+
+  it('suppresses orphan chips while buildings are loading', () => {
+    vi.mocked(useAdminBuildingsState).mockReturnValueOnce({
+      buildings: [],
+      isLoading: true,
+    });
+    render(
+      <PermissionBuildingMultiSelect
+        selectedIds={['orphan-id']}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/unknown building/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
+++ b/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
@@ -11,6 +11,11 @@ const canAccessFeatureMock = vi.fn<(featureId: string) => boolean>();
 vi.mock('@/context/useAuth', () => ({
   useAuth: () => ({
     canAccessFeature: canAccessFeatureMock,
+    // profileLoaded must be true so the optimistic-render gate logic in
+    // Widget.tsx and Settings.tsx can produce a definitive denial when
+    // canAccessFeature returns false. Without it, gateDenied is always false
+    // (profile hasn't "loaded") and the gate never fires in tests.
+    profileLoaded: true,
     selectedBuildings: [],
   }),
 }));

--- a/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
+++ b/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MusicSettings } from '@/components/widgets/MusicWidget/Settings';
+import { MusicWidget } from '@/components/widgets/MusicWidget/Widget';
 import type { WidgetData } from '@/types';
 
 // Replace `useAuth` so we can flip `canAccessFeature` per test without
@@ -22,6 +23,11 @@ vi.mock('@/context/useDashboard', () => ({
 // useMusicStations hits Firestore; mock it so tests stay unit-level.
 vi.mock('@/hooks/useMusicStations', () => ({
   useMusicStations: () => ({ stations: [], isLoading: false }),
+}));
+
+// PersonalSpotifyPlayer uses the Web Playback SDK; mock it to a simple sentinel.
+vi.mock('@/components/widgets/MusicWidget/PersonalSpotifyPlayer', () => ({
+  PersonalSpotifyPlayer: () => <div data-testid="personal-player" />,
 }));
 
 const baseWidget: WidgetData = {
@@ -56,5 +62,32 @@ describe('MusicWidget Settings — personal Spotify gate', () => {
     render(<MusicSettings widget={baseWidget} />);
     expect(screen.queryByText(/source/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/my spotify/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('MusicWidget render dispatch — personal Spotify gate', () => {
+  it('renders the personal player when source=personal AND canAccessFeature is true', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'personal' } }} />
+    );
+    expect(screen.getByTestId('personal-player')).toBeInTheDocument();
+  });
+
+  it('renders the curated body when source=personal but canAccessFeature is false', () => {
+    canAccessFeatureMock.mockReturnValue(false);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'personal' } }} />
+    );
+    // The personal player must NOT be mounted — transparent fallback per spec.
+    expect(screen.queryByTestId('personal-player')).not.toBeInTheDocument();
+  });
+
+  it('renders the curated body when source=curated regardless of gate', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(
+      <MusicWidget widget={{ ...baseWidget, config: { source: 'curated' } }} />
+    );
+    expect(screen.queryByTestId('personal-player')).not.toBeInTheDocument();
   });
 });

--- a/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
+++ b/tests/components/widgets/MusicWidget/personalSpotifyGate.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MusicSettings } from '@/components/widgets/MusicWidget/Settings';
+import type { WidgetData } from '@/types';
+
+// Replace `useAuth` so we can flip `canAccessFeature` per test without
+// spinning up the full AuthProvider.
+const canAccessFeatureMock = vi.fn<(featureId: string) => boolean>();
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    canAccessFeature: canAccessFeatureMock,
+    selectedBuildings: [],
+  }),
+}));
+
+// MusicSettings calls useDashboard().updateWidget; mock it minimally.
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ updateWidget: vi.fn() }),
+}));
+
+// useMusicStations hits Firestore; mock it so tests stay unit-level.
+vi.mock('@/hooks/useMusicStations', () => ({
+  useMusicStations: () => ({ stations: [], isLoading: false }),
+}));
+
+const baseWidget: WidgetData = {
+  id: 'w1',
+  type: 'music',
+  x: 0,
+  y: 0,
+  w: 300,
+  h: 200,
+  z: 1,
+  flipped: false,
+  minimized: false,
+  config: { source: 'curated' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canAccessFeatureMock.mockReset();
+});
+
+describe('MusicWidget Settings — personal Spotify gate', () => {
+  it('shows the Source toggle when canAccessFeature("personal-spotify") returns true', () => {
+    canAccessFeatureMock.mockReturnValue(true);
+    render(<MusicSettings widget={baseWidget} />);
+    expect(screen.getByText(/source/i)).toBeInTheDocument();
+    // The "My Spotify" option label should be reachable when the toggle is rendered.
+    expect(screen.getByText(/my spotify/i)).toBeInTheDocument();
+  });
+
+  it('hides the Source toggle entirely when canAccessFeature returns false', () => {
+    canAccessFeatureMock.mockReturnValue(false);
+    render(<MusicSettings widget={baseWidget} />);
+    expect(screen.queryByText(/source/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/my spotify/i)).not.toBeInTheDocument();
+  });
+});

--- a/tests/context/AuthContext.canAccessFeatureBuildings.test.tsx
+++ b/tests/context/AuthContext.canAccessFeatureBuildings.test.tsx
@@ -32,6 +32,11 @@ vi.mock('firebase/firestore', () => ({
   getDoc: vi.fn(),
   setDoc: vi.fn().mockResolvedValue(undefined),
   onSnapshot: vi.fn(() => () => undefined),
+  // Silences "No 'X' export defined on the firebase/firestore mock" stderr
+  // noise from the returning-user probe at AuthContext.tsx:~1217.
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn((c: unknown) => c),
+  limit: vi.fn(() => undefined),
 }));
 
 const ctxHolder: { current: AuthContextType | null } = { current: null };

--- a/tests/context/AuthContext.canAccessFeatureBuildings.test.tsx
+++ b/tests/context/AuthContext.canAccessFeatureBuildings.test.tsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { GlobalFeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: {
+  adminEmail: string | null;
+  selectedBuildings: string[];
+}): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => true,
+        data: () => ({ selectedBuildings: opts.selectedBuildings }),
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+
+function deliverGlobalPermissions(perms: GlobalFeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'global_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { id: string; data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ id: p.featureId, data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    return () => undefined;
+  });
+}
+
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  selectedBuildings: string[];
+  perms: GlobalFeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({
+    adminEmail: opts.isAdmin ? opts.email : null,
+    selectedBuildings: opts.selectedBuildings,
+  });
+  deliverGlobalPermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+    expect(ctxHolder.current?.profileLoaded).toBe(true);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessFeature buildings check', () => {
+  const baseFeature: Omit<GlobalFeaturePermission, 'buildings'> = {
+    featureId: 'personal-spotify',
+    accessLevel: 'public',
+    betaUsers: [],
+    enabled: true,
+  };
+
+  it('passes when buildings is undefined (no restriction)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [baseFeature],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('passes when buildings is an empty array (no restriction)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [{ ...baseFeature, buildings: [] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('passes when user has at least one of the allowed buildings', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [{ ...baseFeature, buildings: ['high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('fails when user has none of the allowed buildings', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['elementary'],
+      perms: [{ ...baseFeature, buildings: ['middle', 'high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('fails when user has no selected buildings and buildings is restricted', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: [],
+      perms: [{ ...baseFeature, buildings: ['middle'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('admin bypass wins over building restriction', async () => {
+    // Admins always pass once a record exists and is enabled — building
+    // restriction does not gate admins. Matches the existing accessLevel
+    // semantics where isAdmin short-circuits resolvePermissionAccess.
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      selectedBuildings: ['elementary'],
+      perms: [{ ...baseFeature, buildings: ['middle'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+
+  it('disabled wins over a passing building match', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [{ ...baseFeature, enabled: false, buildings: ['high'] }],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+});

--- a/tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx
+++ b/tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx
@@ -32,6 +32,11 @@ vi.mock('firebase/firestore', () => ({
   getDoc: vi.fn(),
   setDoc: vi.fn().mockResolvedValue(undefined),
   onSnapshot: vi.fn(() => () => undefined),
+  // Silences "No 'X' export defined on the firebase/firestore mock" stderr
+  // noise from the returning-user probe at AuthContext.tsx:~1217.
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn((c: unknown) => c),
+  limit: vi.fn(() => undefined),
 }));
 
 const ctxHolder: { current: AuthContextType | null } = { current: null };

--- a/tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx
+++ b/tests/context/AuthContext.canAccessFeaturePersonalSpotify.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { GlobalFeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: { adminEmail: string | null }): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => false,
+        data: () => undefined,
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+function deliverGlobalPermissions(perms: GlobalFeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'global_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { id: string; data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ id: p.featureId, data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    return () => undefined;
+  });
+}
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  perms: GlobalFeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({ adminEmail: opts.isAdmin ? opts.email : null });
+  deliverGlobalPermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessFeature("personal-spotify") missing-doc default', () => {
+  it('returns FALSE for non-admin when no permission doc exists', async () => {
+    // Default-off. Deploying without seeding the permission doc must
+    // leave teachers without the source toggle — protects misconfigured
+    // OAuth deployments from surfacing a broken Connect button.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('returns FALSE for admin when no permission doc exists', async () => {
+    // Admin bypass only applies once a permission record exists. Missing
+    // doc means "no policy has been set" — even admins get the closed
+    // default, so they have to seed the doc deliberately.
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(false);
+  });
+
+  it('returns TRUE for other features when no permission doc exists (default-public unchanged)', async () => {
+    // The personal-spotify exception must not regress the default for
+    // other features. Pick an arbitrary one that has no special-default.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('gemini-functions')).toBe(true);
+  });
+
+  it('returns TRUE for non-admin when personal-spotify is enabled and public', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [
+        {
+          featureId: 'personal-spotify',
+          accessLevel: 'public',
+          betaUsers: [],
+          enabled: true,
+        },
+      ],
+    });
+    expect(getCtx().canAccessFeature('personal-spotify')).toBe(true);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -5277,13 +5277,21 @@ export type GlobalFeature =
   | 'ai-file-context'
   | 'org-admin-writes'
   | 'assignment-modes'
-  | 'share-link-tracking';
+  | 'share-link-tracking'
+  | 'personal-spotify';
 
 export interface GlobalFeaturePermission {
   featureId: GlobalFeature;
   accessLevel: AccessLevel;
   betaUsers: string[];
   enabled: boolean;
+  /**
+   * Building IDs allowed access. Empty array or `undefined` means
+   * "no building restriction" — the feature applies org-wide.
+   * Non-empty array means: user must have at least one of these
+   * buildings in their `selectedBuildings` to pass the gate.
+   */
+  buildings?: string[];
   config?: Record<string, unknown>;
 }
 

--- a/utils/globalPermissionsErrors.ts
+++ b/utils/globalPermissionsErrors.ts
@@ -1,0 +1,57 @@
+/**
+ * Module-level dispatch for "global_permissions snapshot failed" errors.
+ *
+ * Modeled on `utils/driveAuthErrors.ts`. The toast is owned by
+ * `DashboardProvider` (which consumes the dashboard toast queue), while
+ * the failing snapshot lives in `AuthProvider`. Because Dashboard wraps
+ * Auth (Dashboard is *inside* Auth in the provider tree), Auth can't
+ * call into Dashboard directly — but a singleton dispatch is fine: the
+ * provider that owns the toast queue registers itself once, and the
+ * provider that detects the failure dispatches through this seam.
+ *
+ * The latch ensures we surface the error ONCE per session — the
+ * snapshot retries internally, and a constant stream of toasts would
+ * be more confusing than useful. If the underlying Firestore problem
+ * gets resolved (network back, rules deployed, etc.), the user can
+ * refresh; we don't try to auto-clear the latch.
+ *
+ * @see context/AuthContext.tsx — the dispatch site (snapshot error
+ *   callback for `global_permissions`).
+ * @see context/DashboardContext.tsx — registers the toast handler.
+ */
+
+type GlobalPermissionsErrorHandler = () => void;
+
+let handler: GlobalPermissionsErrorHandler | null = null;
+let latched = false;
+
+/** Register (or clear) the toast dispatcher. Called by `DashboardProvider`. */
+export const setGlobalPermissionsErrorHandler = (
+  next: GlobalPermissionsErrorHandler | null
+): void => {
+  handler = next;
+};
+
+/**
+ * Surface a "feature availability may be stale" toast. No-op if the
+ * latch is already set for this session, so a snapshot that retries
+ * five times in a row doesn't fan out five toasts.
+ *
+ * Returns `true` iff a toast was actually dispatched.
+ */
+export const reportGlobalPermissionsError = (): boolean => {
+  if (latched) return false;
+  if (!handler) return false;
+  handler();
+  latched = true;
+  return true;
+};
+
+/**
+ * Test-only: clear module-level state. Production code has no reason
+ * to reset the latch — it's a one-shot per page load.
+ */
+export const __resetGlobalPermissionsErrorsForTests = (): void => {
+  handler = null;
+  latched = false;
+};


### PR DESCRIPTION
## Summary

Adds an admin gate (`personal-spotify`) for the per-teacher Spotify mode introduced in #1662. Admins control rollout via Global Settings: enabled toggle, accessLevel (admin/beta/public), and optional buildings restriction. When ungated for a user, the Music widget transparently renders curated stations — `source: 'personal'` config is preserved across gate flips.

### Why default-off when no permission doc exists

Matches the `canSeeShareTracking` precedent. Personal Spotify depends on Firebase Functions secrets, Spotify dashboard redirect URIs, and an OAuth flow — if any are misconfigured, defaulting to ON would surface a broken Connect button to every teacher. Default-off forces explicit admin opt-in.

### Generic `buildings?` field

`buildings?: string[]` is a new optional field on `GlobalFeaturePermission`. Empty/undefined = "no restriction." It's centralised in `resolvePermissionAccess`, so any future global feature can opt in by setting the field — no per-feature code needed. The 15 existing global features are unaffected (field is optional).

## Test plan

- [ ] **Admin UI**: As an admin, navigate to Admin Settings → Global Settings. "Personal Spotify" appears in the list with the Music2 icon and description. Toggle `enabled: true`, `accessLevel: 'admin'`, leave buildings empty. Save.
- [ ] **Default-off**: Sign in as a non-admin teacher with the permission doc deleted. Open a Music widget — Source toggle is absent; only curated stations render.
- [ ] **Admin-only**: With `accessLevel: 'admin'`, non-admin teachers do not see the source toggle.
- [ ] **Beta**: With `accessLevel: 'beta'` and a beta user's email in the list, that user sees the toggle.
- [ ] **Public**: With `accessLevel: 'public'`, all signed-in teachers see the toggle.
- [ ] **Building gate**: With `buildings: ['high']`, teachers whose `selectedBuildings` includes `'high'` see the toggle; others do not.
- [ ] **Transparent fallback**: Configure a Music widget with `source: 'personal'` while gated in. Then revoke access (set `accessLevel: 'admin'` or remove from buildings). The same widget now renders curated; the stored `source: 'personal'` is preserved. Re-enable access — personal mode comes back without re-configuring.
- [ ] **Admin bypass building**: Admins bypass building restriction (the existing admin bypass on accessLevel cascades through resolvePermissionAccess).
- [ ] **No regression**: Existing 15 global features behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)