### PR TITLE
fix(text-widget): normalize blocks before restoring selection in list toolbar

### DIFF
--- a/components/widgets/TextWidget/FormattingToolbar.test.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.test.tsx
@@ -572,6 +572,140 @@ describe('FormattingToolbar', () => {
     document.body.removeChild(editor);
   });
 
+  // Regression for PR #1668: the toolbar's `runCommand` used to call
+  // `restoreSelection()` BEFORE `ensureTopLevelBlocks()` on the list
+  // path. When the user had already clicked into the editor (so
+  // selectionchange populated savedRangeRef) and then clicked the list
+  // button, `ensureTopLevelBlocks` would reparent the loose text nodes
+  // — which can collapse the live Range that restoreSelection just
+  // installed in window.getSelection — and toggleList would silently
+  // no-op on an empty selection. The fix swaps the order so blocks are
+  // normalized first, then the saved selection is applied to the
+  // already-stable DOM. These tests exercise the realistic user flow
+  // (selectionchange fires before the button click), which the older
+  // tests above don't — they install the selection before the toolbar
+  // mounts, so savedRangeRef stays null and restoreSelection no-ops.
+  const renderToolbarWithCapturedSelection = (innerHTML: string) => {
+    const editor = document.createElement('div');
+    editor.innerHTML = innerHTML;
+    document.body.appendChild(editor);
+    const editorRef = {
+      current: editor,
+    } as React.RefObject<HTMLDivElement>;
+
+    render(<FormattingToolbar {...defaultProps} editorRef={editorRef} />);
+
+    // Mirror what the browser does when the user clicks into the editor:
+    // install a real range on the live selection, then fire the
+    // selectionchange event so the toolbar's captureSelection callback
+    // clones it into savedRangeRef.current.
+    const textNode = editor.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(textNode, 0);
+    range.setEnd(textNode, textNode.length);
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    sel.removeAllRanges();
+    sel.addRange(range);
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+
+    return { editor };
+  };
+
+  it('wraps inline-only content in a bulleted list when the selection was captured before the click', () => {
+    const { editor } = renderToolbarWithCapturedSelection('hello world');
+
+    fireEvent.click(screen.getByTitle(/Bulleted List/));
+
+    expect(editor.querySelector('ul')).not.toBeNull();
+    expect(editor.querySelectorAll('li').length).toBe(1);
+    expect(editor.querySelector('li')?.textContent).toBe('hello world');
+
+    document.body.removeChild(editor);
+  });
+
+  it('wraps inline-only content in a numbered list when the selection was captured before the click', () => {
+    const { editor } = renderToolbarWithCapturedSelection('hello world');
+
+    fireEvent.click(screen.getByTitle(/Numbered List/));
+
+    expect(editor.querySelector('ol')).not.toBeNull();
+    expect(editor.querySelectorAll('li').length).toBe(1);
+    expect(editor.querySelector('li')?.textContent).toBe('hello world');
+
+    document.body.removeChild(editor);
+  });
+
+  it('toggles a bulleted list off after toggling it on with the selection captured', () => {
+    const { editor } = renderToolbarWithCapturedSelection('hello world');
+
+    const bulletButton = screen.getByTitle(/Bulleted List/);
+    fireEvent.click(bulletButton);
+    expect(editor.querySelector('ul')).not.toBeNull();
+
+    // Re-capture selection so savedRangeRef reflects the post-toggle DOM
+    // (the text node is now inside an <li>). Without this, the saved
+    // range still points at the original loose text node, which is no
+    // longer in the document.
+    const li = editor.querySelector('li');
+    if (!li || !li.firstChild) throw new Error('li firstChild missing');
+    const range = document.createRange();
+    range.setStart(li.firstChild, 0);
+    range.setEnd(li.firstChild, (li.firstChild as Text).length);
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    sel.removeAllRanges();
+    sel.addRange(range);
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+
+    fireEvent.click(bulletButton);
+
+    expect(editor.querySelector('ul')).toBeNull();
+    expect(editor.querySelector('ol')).toBeNull();
+    expect(editor.textContent).toBe('hello world');
+
+    document.body.removeChild(editor);
+  });
+
+  it('normalizes blocks before installing the saved selection on the list path', () => {
+    // Stronger regression guard: even if jsdom doesn't collapse a live
+    // Range when its containers are reparented (real Chrome may, per the
+    // ensureTopLevelBlocks docstring), this test pins the operation order
+    // directly. If a future refactor re-introduces the
+    // `restoreSelection → ensureTopLevelBlocks` ordering, this fails
+    // regardless of the runtime's Range semantics.
+    const { editor } = renderToolbarWithCapturedSelection('hello world');
+
+    const events: string[] = [];
+    const sel = window.getSelection();
+    if (!sel) throw new Error('window.getSelection() unavailable');
+    const originalAddRange = sel.addRange.bind(sel);
+    sel.addRange = (r: Range) => {
+      events.push('addRange');
+      originalAddRange(r);
+    };
+    const originalInsertBefore = editor.insertBefore.bind(editor);
+    editor.insertBefore = <T extends Node>(node: T, ref: Node | null): T =>
+      (() => {
+        events.push('insertBefore');
+        return originalInsertBefore(node, ref);
+      })();
+
+    fireEvent.click(screen.getByTitle(/Bulleted List/));
+
+    const firstInsertBefore = events.indexOf('insertBefore');
+    const firstAddRange = events.indexOf('addRange');
+    expect(firstInsertBefore).toBeGreaterThanOrEqual(0);
+    expect(firstAddRange).toBeGreaterThanOrEqual(0);
+    expect(firstInsertBefore).toBeLessThan(firstAddRange);
+
+    document.body.removeChild(editor);
+  });
+
   it('reflects list toggle state via aria-pressed', () => {
     // Mock queryCommandState to simulate the caret being inside a list.
     const queryCommandStateMock = vi.fn(

--- a/components/widgets/TextWidget/FormattingToolbar.tsx
+++ b/components/widgets/TextWidget/FormattingToolbar.tsx
@@ -545,16 +545,24 @@ export const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
    *  directly and works across any selection shape. */
   const runCommand = useCallback(
     (command: string, value: string = '') => {
-      restoreSelection();
       if (
         command === 'insertUnorderedList' ||
         command === 'insertOrderedList'
       ) {
         const editor = editorRef.current;
         if (!editor) return;
-        // `toggleList` collects from `editor.children` (excludes text
-        // nodes), so any loose top-level text must be wrapped first.
+        // Normalize block structure BEFORE restoring the saved selection:
+        // `ensureTopLevelBlocks` reparents loose top-level text nodes into
+        // a wrapper `<div>`, which collapses a live Range that had just
+        // been installed in `window.getSelection()` — leaving `toggleList`
+        // with an empty selection so the button silently no-ops on
+        // inline-only content. The saved Range in `savedRangeRef`
+        // references the same text nodes (only moved, not cloned, per
+        // `ensureTopLevelBlocks`'s contract), so restoring it after the
+        // wrap puts the caret/highlight back where the user had it, now
+        // inside a stable block structure `toggleList` can act on.
         ensureTopLevelBlocks(editor);
+        restoreSelection();
         const listTag = command === 'insertUnorderedList' ? 'ul' : 'ol';
         // `paragraphTag: 'div'` matches TextWidget's persistence
         // shape (`sanitizeHtml` allows `<div>`).
@@ -567,6 +575,7 @@ export const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
         editor.dispatchEvent(new InputEvent('input', { bubbles: true }));
         return;
       }
+      restoreSelection();
       document.execCommand('styleWithCSS', false, 'true');
       document.execCommand(command, false, value);
       editorRef.current?.focus();


### PR DESCRIPTION
## Summary

- TextWidget's bullet-list / numbered-list toolbar buttons toggled their active state but produced no `<ul>` / `<ol>` in the DOM. Keyboard shortcuts (`Ctrl+Shift+8` / `Ctrl+Shift+7`) worked fine — the bug was specific to the toolbar click path.
- Root cause: `FormattingToolbar.runCommand` called `restoreSelection()` and then `ensureTopLevelBlocks(editor)`. The latter reparents loose top-level text nodes into a wrapper `<div>`, which collapses the live Range that `restoreSelection()` just installed in `window.getSelection()` (per the DOM mutation rules — and called out explicitly in `ensureTopLevelBlocks`'s docstring). `toggleList` then read an empty selection from `collectSelectedBlocks` and returned early.
- Fix: swap the order in the list branch — normalize blocks first, then restore the saved selection. The cloned Range in `savedRangeRef` references the same text nodes that `ensureTopLevelBlocks` moves (never clones), so reapplying it after the wrap puts the caret/highlight back where the user had it, inside a stable block structure that `toggleList` can act on. The non-list branch keeps the original `restoreSelection → execCommand` order, which is correct for commands that don't reparent nodes.

This was latent before #1663: the previous gated normalization was a no-op for already-wrapped content, so the restored Range survived. With #1663's unconditional `ensureTopLevelBlocks`, every toolbar click on inline-only content hit the bug.

## Test plan

- [ ] In a fresh TextWidget, type one line (no Enter), click the bullet-list button → verify a `<ul>` with one `<li>` is produced and the button is active.
- [ ] Click it again → verify the `<ul>` unwraps back to a `<div>` paragraph.
- [ ] Place caret in an empty TextWidget, click numbered-list, then type "one"/Enter/"two"/Enter/"three" → verify three numbered `<li>` items.
- [ ] Type three lines (Enter between each), drag-select across all three, click bullet-list → verify a single `<ul>` wrapping three `<li>`s (regression check on multi-block selection).
- [ ] `Ctrl+Shift+8` and `Ctrl+Shift+7` still work in all three scenarios above.
- [ ] `pnpm run lint` clean (verified locally).
- [ ] `pnpm run type-check` clean (verified locally).
- [ ] `pnpm run test` — all 2831 tests pass (verified locally).

https://claude.ai/code/session_019vNs7aWmTUzQfcSePFnrAs

---
_Generated by [Claude Code](https://claude.ai/code/session_019vNs7aWmTUzQfcSePFnrAs)_