### PR TITLE
feat(boards-modal): inline Share + Duplicate icons on Board and Collection cards

### DIFF
--- a/components/boardsModal/BoardCard.tsx
+++ b/components/boardsModal/BoardCard.tsx
@@ -135,9 +135,9 @@ export const BoardCard: React.FC<BoardCardProps> = ({
       <div className="text-xxs text-slate-400 mb-1 pr-20">
         {widgetCount} widgets · edited {lastEdited}
       </div>
-      {collectionBadge &&
-        (collectionBadge.color ? (
-          <div className="pr-20">
+      {collectionBadge && (
+        <div className="pr-20">
+          {collectionBadge.color ? (
             <div
               className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-xxs font-bold max-w-full"
               style={{
@@ -148,15 +148,14 @@ export const BoardCard: React.FC<BoardCardProps> = ({
               <Folder className="w-2.5 h-2.5 flex-shrink-0" />
               <span className="truncate">{collectionBadge.name}</span>
             </div>
-          </div>
-        ) : (
-          <div className="pr-20">
+          ) : (
             <div className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-slate-100 text-xxs text-slate-600 max-w-full">
               <Folder className="w-2.5 h-2.5 flex-shrink-0" />
               <span className="truncate">{collectionBadge.name}</span>
             </div>
-          </div>
-        ))}
+          )}
+        </div>
+      )}
 
       {/* Always-visible action row — touch-discoverable surface for the
           actions teachers need at-a-glance (share, duplicate, pin).

--- a/components/boardsModal/BoardCard.tsx
+++ b/components/boardsModal/BoardCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Star, Pin, Folder } from 'lucide-react';
+import { Star, Pin, Folder, Copy, Share2 } from 'lucide-react';
 import { useDraggable } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
 import type { Dashboard } from '@/types';
@@ -16,18 +16,24 @@ interface BoardCardProps {
   // null when in a Collection-scoped view (every Board there shares the
   // header Collection already) or when the Board is at root.
   collectionBadge?: { name: string; color?: string } | null;
+  canShare: boolean;
   onClick: () => void;
   onToggleSelect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
+  onDuplicate: () => void;
+  onShare: () => void;
 }
 
 export const BoardCard: React.FC<BoardCardProps> = ({
   board,
   isSelected,
   collectionBadge,
+  canShare,
   onClick,
   onToggleSelect,
   onContextMenu,
+  onDuplicate,
+  onShare,
 }) => {
   const { unpinBoard, pinBoard } = useDashboard();
   const { t } = useTranslation();
@@ -123,49 +129,91 @@ export const BoardCard: React.FC<BoardCardProps> = ({
           {board.name}
         </div>
       </div>
-      <div className="text-xxs text-slate-400 mb-1">
+      {/* Reserve right-side runway for the absolute-positioned action row
+          below. Without this padding the metadata + collection badge run
+          under the Share/Duplicate/Pin icons on narrower cards. */}
+      <div className="text-xxs text-slate-400 mb-1 pr-20">
         {widgetCount} widgets · edited {lastEdited}
       </div>
       {collectionBadge &&
         (collectionBadge.color ? (
-          <div
-            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-xxs font-bold max-w-full"
-            style={{
-              backgroundColor: collectionBadge.color,
-              color: pickReadableForeground(collectionBadge.color),
-            }}
-          >
-            <Folder className="w-2.5 h-2.5 flex-shrink-0" />
-            <span className="truncate">{collectionBadge.name}</span>
+          <div className="pr-20">
+            <div
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-xxs font-bold max-w-full"
+              style={{
+                backgroundColor: collectionBadge.color,
+                color: pickReadableForeground(collectionBadge.color),
+              }}
+            >
+              <Folder className="w-2.5 h-2.5 flex-shrink-0" />
+              <span className="truncate">{collectionBadge.name}</span>
+            </div>
           </div>
         ) : (
-          <div className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-slate-100 text-xxs text-slate-600 max-w-full">
-            <Folder className="w-2.5 h-2.5 flex-shrink-0" />
-            <span className="truncate">{collectionBadge.name}</span>
+          <div className="pr-20">
+            <div className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-slate-100 text-xxs text-slate-600 max-w-full">
+              <Folder className="w-2.5 h-2.5 flex-shrink-0" />
+              <span className="truncate">{collectionBadge.name}</span>
+            </div>
           </div>
         ))}
 
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          // Action toasts + rolls back on failure; .catch keeps the
-          // rethrow from surfacing as an unhandled rejection.
-          const op = board.isPinned ? unpinBoard(board.id) : pinBoard(board.id);
-          op.catch(() => undefined);
-        }}
-        onPointerDown={(e) => e.stopPropagation()}
-        aria-label={
-          board.isPinned
-            ? t('boardsModal.unpin', { defaultValue: 'Unpin' })
-            : t('boardsModal.pin', { defaultValue: 'Pin' })
-        }
-        className="absolute bottom-2 right-2 p-1 rounded text-slate-300 hover:text-amber-500 hover:bg-amber-50 transition"
-      >
-        <Pin
-          className={`w-3.5 h-3.5 ${board.isPinned ? 'fill-amber-500 text-amber-500' : ''}`}
-        />
-      </button>
+      {/* Always-visible action row — touch-discoverable surface for the
+          actions teachers need at-a-glance (share, duplicate, pin).
+          Right-click context menu still lists these too. Each button stops
+          propagation on click + pointerdown so it doesn't trigger card-open
+          or dnd-kit drag-start. */}
+      <div className="absolute bottom-2 right-2 flex items-center gap-0.5">
+        {canShare && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onShare();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            aria-label={t('boardsModal.share', { defaultValue: 'Share' })}
+            className="p-1 rounded text-slate-300 hover:text-brand-blue-primary hover:bg-brand-blue-lighter transition"
+          >
+            <Share2 className="w-3.5 h-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={t('boardsModal.duplicate', { defaultValue: 'Duplicate' })}
+          className="p-1 rounded text-slate-300 hover:text-slate-700 hover:bg-slate-100 transition"
+        >
+          <Copy className="w-3.5 h-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            // Action toasts + rolls back on failure; .catch keeps the
+            // rethrow from surfacing as an unhandled rejection.
+            const op = board.isPinned
+              ? unpinBoard(board.id)
+              : pinBoard(board.id);
+            op.catch(() => undefined);
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={
+            board.isPinned
+              ? t('boardsModal.unpin', { defaultValue: 'Unpin' })
+              : t('boardsModal.pin', { defaultValue: 'Pin' })
+          }
+          className="p-1 rounded text-slate-300 hover:text-amber-500 hover:bg-amber-50 transition"
+        >
+          <Pin
+            className={`w-3.5 h-3.5 ${board.isPinned ? 'fill-amber-500 text-amber-500' : ''}`}
+          />
+        </button>
+      </div>
     </div>
   );
 };

--- a/components/boardsModal/BoardGrid.tsx
+++ b/components/boardsModal/BoardGrid.tsx
@@ -9,6 +9,7 @@ interface BoardGridProps {
   collections: Collection[];
   boards: Dashboard[];
   selectedIds: ReadonlySet<string>;
+  canShare: boolean;
   onSelectCollection: (id: string | null) => void;
   onToggleSelect: (id: string) => void;
   onOpenBoard: (id: string) => void;
@@ -16,6 +17,10 @@ interface BoardGridProps {
     e: React.MouseEvent,
     target: { type: 'board' | 'collection'; id: string }
   ) => void;
+  onDuplicateBoard: (id: string) => void;
+  onDuplicateCollection: (id: string) => void;
+  onShareBoard: (board: Dashboard) => void;
+  onShareCollection: (collection: Collection) => void;
 }
 
 export const BoardGrid: React.FC<BoardGridProps> = ({
@@ -23,10 +28,15 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
   collections,
   boards,
   selectedIds,
+  canShare,
   onSelectCollection,
   onToggleSelect,
   onOpenBoard,
   onContextMenu,
+  onDuplicateBoard,
+  onDuplicateCollection,
+  onShareBoard,
+  onShareCollection,
 }) => {
   const { t } = useTranslation();
 
@@ -112,11 +122,14 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
                       childCollectionsCount={counts.folders}
                       childBoardsCount={counts.boards}
                       isSelected={selectedIds.has(c.id)}
+                      canShare={canShare}
                       onClick={() => onSelectCollection(c.id)}
                       onToggleSelect={() => onToggleSelect(c.id)}
                       onContextMenu={(e) =>
                         onContextMenu(e, { type: 'collection', id: c.id })
                       }
+                      onDuplicate={() => onDuplicateCollection(c.id)}
+                      onShare={() => onShareCollection(c)}
                     />
                   );
                 })}
@@ -144,11 +157,14 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
                           ? { name: parent.name, color: parent.color }
                           : null
                       }
+                      canShare={canShare}
                       onClick={() => onOpenBoard(b.id)}
                       onToggleSelect={() => onToggleSelect(b.id)}
                       onContextMenu={(e) =>
                         onContextMenu(e, { type: 'board', id: b.id })
                       }
+                      onDuplicate={() => onDuplicateBoard(b.id)}
+                      onShare={() => onShareBoard(b)}
                     />
                   );
                 })}

--- a/components/boardsModal/BoardsModal.tsx
+++ b/components/boardsModal/BoardsModal.tsx
@@ -52,6 +52,7 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
     unpinBoard,
     renameDashboard,
     duplicateDashboard,
+    duplicateCollection,
     setDefaultDashboard,
     addToast,
     collectionsApi: {
@@ -542,10 +543,15 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
               collections={filteredCollections}
               boards={filteredBoards}
               selectedIds={multi.selectedIds}
+              canShare={canShare}
               onSelectCollection={setSelectedCollectionId}
               onToggleSelect={multi.toggle}
               onOpenBoard={handleOpenBoard}
               onContextMenu={handleContextMenu}
+              onDuplicateBoard={(id) => void duplicateDashboard(id)}
+              onDuplicateCollection={(id) => void duplicateCollection(id)}
+              onShareBoard={(b) => setShareTarget(b)}
+              onShareCollection={(c) => setShareCollectionTarget(c)}
             />
           </div>
           <DragOverlay dropAnimation={null}>{dragPreview}</DragOverlay>

--- a/components/boardsModal/CollectionCard.tsx
+++ b/components/boardsModal/CollectionCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Folder } from 'lucide-react';
+import { Folder, Copy, Share2 } from 'lucide-react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
 import type { Collection } from '@/types';
@@ -10,9 +10,12 @@ interface CollectionCardProps {
   childCollectionsCount: number;
   childBoardsCount: number;
   isSelected: boolean;
+  canShare: boolean;
   onClick: () => void;
   onToggleSelect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
+  onDuplicate: () => void;
+  onShare: () => void;
 }
 
 export const CollectionCard: React.FC<CollectionCardProps> = ({
@@ -20,9 +23,12 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
   childCollectionsCount,
   childBoardsCount,
   isSelected,
+  canShare,
   onClick,
   onToggleSelect,
   onContextMenu,
+  onDuplicate,
+  onShare,
 }) => {
   const { t } = useTranslation();
 
@@ -135,11 +141,54 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
         {collection.name}
       </div>
       <div
-        className={`text-xxs ${textColor ? '' : 'text-slate-400'}`}
+        className={`text-xxs pr-14 ${textColor ? '' : 'text-slate-400'}`}
         style={textColor ? { color: textColor, opacity: 0.6 } : undefined}
       >
         {childCollectionsCount > 0 && `${childCollectionsCount} folders · `}
         {childBoardsCount} boards
+      </div>
+
+      {/* Always-visible action row — touch-discoverable surface for Share
+          + Duplicate. Right-click context menu still lists these too. Each
+          button stops propagation on click + pointerdown so it doesn't
+          trigger card-open or dnd-kit drag-start. On tinted Collections
+          the default text-slate-300 washes out — bump to slate-500 inline
+          so the icons stay legible against the color tint. */}
+      <div className="absolute bottom-2 right-2 flex items-center gap-0.5">
+        {canShare && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onShare();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+            aria-label={t('collectionMenu.share', {
+              defaultValue: 'Share Collection',
+            })}
+            className={`p-1 rounded hover:text-brand-blue-primary hover:bg-brand-blue-lighter transition ${
+              collection.color ? 'text-slate-500' : 'text-slate-300'
+            }`}
+          >
+            <Share2 className="w-3.5 h-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={t('collectionMenu.duplicate', {
+            defaultValue: 'Duplicate Collection',
+          })}
+          className={`p-1 rounded hover:text-slate-700 hover:bg-slate-100 transition ${
+            collection.color ? 'text-slate-500' : 'text-slate-300'
+          }`}
+        >
+          <Copy className="w-3.5 h-3.5" />
+        </button>
       </div>
     </div>
   );

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -133,6 +133,9 @@ const mockDashboard: DashboardContextValue = {
   duplicateDashboard: async () => {
     /* mock */
   },
+  duplicateCollection: async () => {
+    /* mock */
+  },
   renameDashboard: async () => {
     /* mock */
   },

--- a/components/subs/SubsDashboardProvider.tsx
+++ b/components/subs/SubsDashboardProvider.tsx
@@ -260,6 +260,7 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       saveCurrentDashboard: NOOP_ASYNC,
       deleteDashboard: NOOP_ASYNC as (id: string) => Promise<void>,
       duplicateDashboard: NOOP_ASYNC as (id: string) => Promise<void>,
+      duplicateCollection: NOOP_ASYNC as (id: string) => Promise<void>,
       renameDashboard: NOOP_ASYNC as (
         id: string,
         name: string

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3512,6 +3512,73 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     [user, dashboards, saveDashboard, addToast]
   );
 
+  // Flat clone: copies the Collection's metadata (name, parent, color) and
+  // each direct child Board into the new Collection. Sub-Collections are
+  // intentionally NOT recursed — keeps the operation bounded and predictable.
+  const duplicateCollection = useCallback(
+    async (id: string) => {
+      if (!user) {
+        addToast('Must be signed in to duplicate', 'error');
+        return;
+      }
+
+      const source = collections.find((c) => c.id === id);
+      if (!source) return;
+
+      let newCollectionId: string;
+      try {
+        newCollectionId = await collectionsApi.createCollection(
+          `${source.name} (Copy)`,
+          source.parentCollectionId ?? null,
+          source.color ? { color: source.color } : undefined
+        );
+      } catch (err) {
+        console.error('Duplicate collection failed:', err);
+        addToast('Failed to duplicate collection', 'error');
+        return;
+      }
+
+      const children = dashboards.filter((d) => d.collectionId === id);
+      if (children.length === 0) {
+        addToast(`Collection "${source.name}" duplicated`);
+        return;
+      }
+
+      const maxOrder = dashboards.reduce(
+        (m, db) => Math.max(m, db.order ?? 0),
+        0
+      );
+      const results = await Promise.allSettled(
+        children.map((dash, i) =>
+          saveDashboard({
+            ...dash,
+            id: crypto.randomUUID(),
+            isDefault: false,
+            createdAt: Date.now(),
+            order: maxOrder + 1 + i,
+            collectionId: newCollectionId,
+          })
+        )
+      );
+
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed === 0) {
+        addToast(`Collection "${source.name}" duplicated`);
+      } else if (failed === children.length) {
+        addToast(
+          `Collection duplicated but ${failed} board(s) failed to copy`,
+          'error'
+        );
+      } else {
+        addToast(
+          `Collection duplicated — ${failed} of ${children.length} board(s) failed`,
+          'error'
+        );
+      }
+    },
+    [user, dashboards, collections, collectionsApi, saveDashboard, addToast]
+  );
+
   const renameDashboard = useCallback(
     async (id: string, name: string) => {
       if (!user) {
@@ -4915,6 +4982,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       saveCurrentDashboard,
       deleteDashboard,
       duplicateDashboard,
+      duplicateCollection,
       renameDashboard,
       loadDashboard,
       reorderDashboards,
@@ -5035,6 +5103,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       saveCurrentDashboard,
       deleteDashboard,
       duplicateDashboard,
+      duplicateCollection,
       renameDashboard,
       loadDashboard,
       reorderDashboards,

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3533,7 +3533,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           source.color ? { color: source.color } : undefined
         );
       } catch (err) {
-        console.error('Duplicate collection failed:', err);
+        logError('DashboardContext.duplicateCollection', err, { id });
         addToast('Failed to duplicate collection', 'error');
         return;
       }
@@ -3548,10 +3548,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         (m, db) => Math.max(m, db.order ?? 0),
         0
       );
+      // Deep-clone each board so widget configs and arrays aren't shared by
+      // reference between the original and the duplicate. Mirrors the pattern
+      // in `importSharedCollection` and `duplicateWidget` (same file).
       const results = await Promise.allSettled(
         children.map((dash, i) =>
           saveDashboard({
-            ...dash,
+            ...structuredClone(dash),
             id: crypto.randomUUID(),
             isDefault: false,
             createdAt: Date.now(),
@@ -3566,12 +3569,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         addToast(`Collection "${source.name}" duplicated`);
       } else if (failed === children.length) {
         addToast(
-          `Collection duplicated but ${failed} board(s) failed to copy`,
+          `Collection "${source.name}" duplicated, but all ${failed} board(s) failed to copy`,
           'error'
         );
       } else {
         addToast(
-          `Collection duplicated — ${failed} of ${children.length} board(s) failed`,
+          `Collection "${source.name}" duplicated, but ${failed} of ${children.length} board(s) failed to copy`,
           'error'
         );
       }

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -144,6 +144,12 @@ export interface DashboardContextValue {
   saveCurrentDashboard: () => Promise<void>;
   deleteDashboard: (id: string) => Promise<void>;
   duplicateDashboard: (id: string) => Promise<void>;
+  /**
+   * Flat clone: creates a new Collection (same parent, color) with `(Copy)`
+   * suffix and duplicates each direct child Board into it. Sub-Collections
+   * are NOT recursed — keeps the write bounded and predictable.
+   */
+  duplicateCollection: (id: string) => Promise<void>;
   renameDashboard: (id: string, name: string) => Promise<void>;
   loadDashboard: (id: string) => void;
   reorderDashboards: (ids: string[]) => Promise<void>;


### PR DESCRIPTION
## Summary

After the May 2026 BoardsModal redesign (commit `5eebffb`), the **Duplicate** and **Share** actions for both Boards and Collections lived only in the right-click context menus — invisible to teachers on tablets and projector touchscreens, which is the primary classroom surface. This PR restores one-tap discoverable access without removing the existing context-menu path.

## Changes

### Board cards (`components/boardsModal/BoardCard.tsx`)
- New `Share2` icon (gated on `canAccessFeature('dashboard-sharing')`) + `Copy` icon sit in a compact bottom-right action row alongside the existing Pin button.
- Each button stops propagation on `onClick` and `onPointerDown` so it doesn't trigger card-open or dnd-kit drag-start.
- Metadata and collection-badge rows get `pr-20` runway so they don't bleed under the icons on narrower cards.

### Collection cards (`components/boardsModal/CollectionCard.tsx`)
- Same Share + Duplicate row in the bottom-right (no Pin on Collections).
- On tinted Collections the default `text-slate-300` washes out — bumped to `text-slate-500` inline when `collection.color` is set so the icons stay legible.
- Subtitle gets `pr-14` runway.

### `duplicateCollection` (new, `context/DashboardContext.tsx`)
- Flat clone: creates a new Collection with `(Copy)` suffix, same parent, same color.
- Each **direct** child Board is duplicated into the new Collection.
- Sub-Collections are intentionally **not** recursed — keeps the write bounded and predictable; teachers can re-run on sub-folders if needed.
- Uses `Promise.allSettled` so partial failures are reported with counts instead of swallowed.
- Stub providers (`StudentContexts`, `SubsDashboardProvider`) carry NOOP implementations for type compliance.

### Plumbing
- `DashboardContextValue` interface extended with `duplicateCollection: (id: string) => Promise<void>`.
- `BoardGrid` threads `canShare`, `onDuplicateBoard`, `onDuplicateCollection`, `onShareBoard`, `onShareCollection` through to cards.
- `BoardsModal` wires the new BoardGrid props using existing `duplicateDashboard`, the new `duplicateCollection`, and existing `setShareTarget`/`setShareCollectionTarget` state setters. The existing context-menu path and `ShareLinkCreatorModal`/`ShareCollectionLinkCreatorModal` are unchanged.

## Test plan

- [ ] `pnpm dev`, open BoardsModal from BoardNavFAB → "Manage all boards…" (or sidebar direct-open).
- [ ] Click Copy icon on a board card → toast "Board '{name}' duplicated", `(Copy)` board appears.
- [ ] Click Share icon on a board card → `ShareLinkCreatorModal` opens with the board pre-selected. Close it cleanly.
- [ ] Click Copy icon on a collection card with several boards → new `{name} (Copy)` collection with same color appears, each direct child board copied in; sub-collections **not** copied.
- [ ] Click Share icon on a collection card → `ShareCollectionLinkCreatorModal` opens with that collection + its boards.
- [ ] Drag a card body → still drags. Click an icon → no card-open, no drag-start.
- [ ] Right-click → context menu still works and still lists Duplicate + Share.
- [ ] Toggle `feature_permissions/dashboard-sharing` off → Share icon disappears on both card types; Duplicate stays.
- [ ] Touch device / DevTools mobile emulation → each icon taps cleanly.
- [ ] `pnpm run validate` → green (type-check, lint, format-check, 2835 unit tests).

## Out of scope

- Recursive sub-collection duplication (user picked flat scope).
- Multi-select bulk duplicate/share from the header.
- New i18n entries beyond inline `defaultValue` — keys can be added to `locales/*/translation.json` in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSGS9s8k66i2f3zqa43obb)_