### PR TITLE
fix(boards-modal): make Duplicate feel instant and prevent click-spam

### DIFF
--- a/components/boardsModal/BoardCard.tsx
+++ b/components/boardsModal/BoardCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Star, Pin, Folder, Copy, Share2 } from 'lucide-react';
+import { Star, Pin, Folder, Copy, Share2, Loader2 } from 'lucide-react';
 import { useDraggable } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
 import type { Dashboard } from '@/types';
@@ -17,6 +17,10 @@ interface BoardCardProps {
   // header Collection already) or when the Board is at root.
   collectionBadge?: { name: string; color?: string } | null;
   canShare: boolean;
+  // True while a duplicate of this board is in-flight. Disables the
+  // Duplicate button and swaps its icon for a spinner so rapid clicks
+  // don't queue multiple copies.
+  isDuplicating?: boolean;
   onClick: () => void;
   onToggleSelect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
@@ -29,6 +33,7 @@ export const BoardCard: React.FC<BoardCardProps> = ({
   isSelected,
   collectionBadge,
   canShare,
+  isDuplicating = false,
   onClick,
   onToggleSelect,
   onContextMenu,
@@ -181,13 +186,20 @@ export const BoardCard: React.FC<BoardCardProps> = ({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
+            if (isDuplicating) return;
             onDuplicate();
           }}
           onPointerDown={(e) => e.stopPropagation()}
+          disabled={isDuplicating}
+          aria-busy={isDuplicating}
           aria-label={t('boardsModal.duplicate', { defaultValue: 'Duplicate' })}
-          className="p-1 rounded text-slate-300 hover:text-slate-700 hover:bg-slate-100 transition"
+          className="p-1 rounded text-slate-300 hover:text-slate-700 hover:bg-slate-100 transition disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-slate-300"
         >
-          <Copy className="w-3.5 h-3.5" />
+          {isDuplicating ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Copy className="w-3.5 h-3.5" />
+          )}
         </button>
         <button
           type="button"

--- a/components/boardsModal/BoardGrid.tsx
+++ b/components/boardsModal/BoardGrid.tsx
@@ -19,6 +19,11 @@ interface BoardGridProps {
   ) => void;
   onDuplicateBoard: (id: string) => void;
   onDuplicateCollection: (id: string) => void;
+  // Probe functions from `useBusyIdSet` — return true while the
+  // corresponding duplicate is in-flight, so the per-card spinner +
+  // disabled state can render.
+  isBoardDuplicating: (id: string) => boolean;
+  isCollectionDuplicating: (id: string) => boolean;
   onShareBoard: (board: Dashboard) => void;
   onShareCollection: (collection: Collection) => void;
 }
@@ -35,6 +40,8 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
   onContextMenu,
   onDuplicateBoard,
   onDuplicateCollection,
+  isBoardDuplicating,
+  isCollectionDuplicating,
   onShareBoard,
   onShareCollection,
 }) => {
@@ -123,6 +130,7 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
                       childBoardsCount={counts.boards}
                       isSelected={selectedIds.has(c.id)}
                       canShare={canShare}
+                      isDuplicating={isCollectionDuplicating(c.id)}
                       onClick={() => onSelectCollection(c.id)}
                       onToggleSelect={() => onToggleSelect(c.id)}
                       onContextMenu={(e) =>
@@ -158,6 +166,7 @@ export const BoardGrid: React.FC<BoardGridProps> = ({
                           : null
                       }
                       canShare={canShare}
+                      isDuplicating={isBoardDuplicating(b.id)}
                       onClick={() => onOpenBoard(b.id)}
                       onToggleSelect={() => onToggleSelect(b.id)}
                       onContextMenu={(e) =>

--- a/components/boardsModal/BoardsModal.tsx
+++ b/components/boardsModal/BoardsModal.tsx
@@ -20,6 +20,7 @@ import { SaveAsTemplateModal } from '@/components/admin/SaveAsTemplateModal';
 import { CreateFromTemplateModal } from './CreateFromTemplateModal';
 import { CollectionColorPicker } from './CollectionColorPicker';
 import { useBoardsModalDnd } from './useBoardsModalDnd';
+import { useBusyIdSet } from '@/hooks/useBusyIdSet';
 import type { Collection, Dashboard } from '@/types';
 
 // Lightweight target shape for the color picker — covers both flows
@@ -70,6 +71,12 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
   >(activeDashboard?.collectionId ?? null);
   const [search, setSearch] = useState('');
   const multi = useMultiSelect();
+  // Per-id busy tracking for the Duplicate buttons. Gives a synchronous
+  // rapid-click guard (the underlying ref is checked before the React
+  // state update commits) plus a snapshot that drives the spinner +
+  // disabled-state re-render on each card.
+  const boardDuplicateBusy = useBusyIdSet();
+  const collectionDuplicateBusy = useBusyIdSet();
   const {
     sensors,
     handleDragStart,
@@ -548,8 +555,16 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
               onToggleSelect={multi.toggle}
               onOpenBoard={handleOpenBoard}
               onContextMenu={handleContextMenu}
-              onDuplicateBoard={(id) => void duplicateDashboard(id)}
-              onDuplicateCollection={(id) => void duplicateCollection(id)}
+              onDuplicateBoard={(id) =>
+                void boardDuplicateBusy.run(id, () => duplicateDashboard(id))
+              }
+              onDuplicateCollection={(id) =>
+                void collectionDuplicateBusy.run(id, () =>
+                  duplicateCollection(id)
+                )
+              }
+              isBoardDuplicating={boardDuplicateBusy.isBusy}
+              isCollectionDuplicating={collectionDuplicateBusy.isBusy}
               onShareBoard={(b) => setShareTarget(b)}
               onShareCollection={(c) => setShareCollectionTarget(c)}
             />
@@ -581,7 +596,11 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
                 );
                 if (next?.trim()) await renameDashboard(board.id, next.trim());
               }}
-              onDuplicate={() => void duplicateDashboard(board.id)}
+              onDuplicate={() =>
+                void boardDuplicateBusy.run(board.id, () =>
+                  duplicateDashboard(board.id)
+                )
+              }
               onSetDefault={() => {
                 // Action toasts on failure; .catch prevents the rethrow
                 // from surfacing as an unhandled rejection in the console.

--- a/components/boardsModal/CollectionCard.tsx
+++ b/components/boardsModal/CollectionCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Folder, Copy, Share2 } from 'lucide-react';
+import { Folder, Copy, Share2, Loader2 } from 'lucide-react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
 import type { Collection } from '@/types';
@@ -11,6 +11,10 @@ interface CollectionCardProps {
   childBoardsCount: number;
   isSelected: boolean;
   canShare: boolean;
+  // True while a duplicate of this collection is in-flight. Disables the
+  // Duplicate button and swaps its icon for a spinner so rapid clicks
+  // don't queue multiple copies.
+  isDuplicating?: boolean;
   onClick: () => void;
   onToggleSelect: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
@@ -24,6 +28,7 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
   childBoardsCount,
   isSelected,
   canShare,
+  isDuplicating = false,
   onClick,
   onToggleSelect,
   onContextMenu,
@@ -177,17 +182,24 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
           type="button"
           onClick={(e) => {
             e.stopPropagation();
+            if (isDuplicating) return;
             onDuplicate();
           }}
           onPointerDown={(e) => e.stopPropagation()}
+          disabled={isDuplicating}
+          aria-busy={isDuplicating}
           aria-label={t('collectionMenu.duplicate', {
             defaultValue: 'Duplicate Collection',
           })}
-          className={`p-1 rounded hover:text-slate-700 hover:bg-slate-100 transition ${
+          className={`p-1 rounded hover:text-slate-700 hover:bg-slate-100 transition disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent ${
             collection.color ? 'text-slate-500' : 'text-slate-300'
           }`}
         >
-          <Copy className="w-3.5 h-3.5" />
+          {isDuplicating ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Copy className="w-3.5 h-3.5" />
+          )}
         </button>
       </div>
     </div>

--- a/components/boardsModal/CollectionCard.tsx
+++ b/components/boardsModal/CollectionCard.tsx
@@ -192,7 +192,9 @@ export const CollectionCard: React.FC<CollectionCardProps> = ({
             defaultValue: 'Duplicate Collection',
           })}
           className={`p-1 rounded hover:text-slate-700 hover:bg-slate-100 transition disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent ${
-            collection.color ? 'text-slate-500' : 'text-slate-300'
+            collection.color
+              ? 'text-slate-500 disabled:hover:text-slate-500'
+              : 'text-slate-300 disabled:hover:text-slate-300'
           }`}
         >
           {isDuplicating ? (

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -59,6 +59,7 @@ import {
 } from '../utils/dashboardPII';
 import { migrateBoardForCollections } from '../utils/collectionsMigration';
 import { pickInitialBoard } from '../utils/pickInitialBoard';
+import { sanitizeBoardSnapshot } from '../utils/dashboardSanitize';
 import { logError } from '../utils/logError';
 import { useRosters } from '../hooks/useRosters';
 import { useGoogleDrive } from '../hooks/useGoogleDrive';
@@ -3495,12 +3496,30 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       // Deep-clone so widget configs / arrays aren't shared by reference
       // between the original and the optimistic copy (Firestore snapshot
       // will later reconcile with the same id — same shape).
+      //
+      // Sanitize first to strip host-specific linkage fields:
+      //   - `driveFileId` would cause `saveDashboard` → `exportDashboard`
+      //     to PATCH the SOURCE's Drive file with the copy's contents.
+      //   - `linkedShareId` / `linkedShareRole` / `linkedShareHostName` /
+      //     `linkedShareEnded` would falsely enroll the copy in the
+      //     source's live-share linkage.
+      //   - `thumbnailUrl`, `sharedGroups`, `annotationOverlay`,
+      //     `isDefault`, `isPinned`, `updatedAt`, `collectionId` are
+      //     also stripped — see `sanitizeBoardSnapshot` for the why.
+      //
+      // We re-apply `collectionId` so the copy stays in the same
+      // Collection as the source (the typical user expectation for
+      // single-board duplicate). `updatedAt` is stamped to `Date.now()`
+      // so the optimistic card shows a "just edited" date instead of
+      // inheriting the source's last-edit timestamp while we wait for
+      // Firestore to ack.
       const duplicated: Dashboard = {
-        ...structuredClone(dashboard),
+        ...sanitizeBoardSnapshot(structuredClone(dashboard)),
         id: crypto.randomUUID(),
         name: `${dashboard.name} (Copy)`,
-        isDefault: false,
+        collectionId: dashboard.collectionId,
         createdAt: Date.now(),
+        updatedAt: Date.now(),
         order: maxOrder + 1,
       };
 
@@ -3562,11 +3581,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       // Deep-clone each board so widget configs and arrays aren't shared by
       // reference between the original and the duplicate. Mirrors the pattern
       // in `importSharedCollection` and `duplicateWidget` (same file).
+      //
+      // `sanitizeBoardSnapshot` strips host-specific linkage (driveFileId,
+      // linkedShare*, thumbnailUrl, sharedGroups, annotationOverlay,
+      // isDefault, isPinned, updatedAt, collectionId) so the copy doesn't
+      // PATCH the source's Drive file or inherit live-share state. We
+      // then reassign `collectionId` to the new Collection and stamp
+      // `updatedAt` so the optimistic card shows a "just edited" date.
       const clones: Dashboard[] = children.map((dash, i) => ({
-        ...structuredClone(dash),
+        ...sanitizeBoardSnapshot(structuredClone(dash)),
         id: crypto.randomUUID(),
-        isDefault: false,
         createdAt: Date.now(),
+        updatedAt: Date.now(),
         order: maxOrder + 1 + i,
         collectionId: newCollectionId,
       }));

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3492,8 +3492,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         0
       );
 
+      // Deep-clone so widget configs / arrays aren't shared by reference
+      // between the original and the optimistic copy (Firestore snapshot
+      // will later reconcile with the same id — same shape).
       const duplicated: Dashboard = {
-        ...dashboard,
+        ...structuredClone(dashboard),
         id: crypto.randomUUID(),
         name: `${dashboard.name} (Copy)`,
         isDefault: false,
@@ -3501,11 +3504,19 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         order: maxOrder + 1,
       };
 
+      // Optimistic insert — the new card appears in the modal immediately.
+      // Mirrors the pattern in `renameDashboard` below. The Firestore
+      // snapshot listener will later arrive with the same id and reconcile
+      // silently (no flicker, same shape).
+      setDashboards((prev) => [...prev, duplicated]);
+
       try {
         await saveDashboard(duplicated);
         addToast(`Board "${dashboard.name}" duplicated`);
       } catch (err) {
         console.error('Duplicate failed:', err);
+        // Revert the optimistic insert so the user doesn't see a ghost row.
+        setDashboards((prev) => prev.filter((d) => d.id !== duplicated.id));
         addToast('Duplicate failed', 'error');
       }
     },
@@ -3551,20 +3562,32 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       // Deep-clone each board so widget configs and arrays aren't shared by
       // reference between the original and the duplicate. Mirrors the pattern
       // in `importSharedCollection` and `duplicateWidget` (same file).
+      const clones: Dashboard[] = children.map((dash, i) => ({
+        ...structuredClone(dash),
+        id: crypto.randomUUID(),
+        isDefault: false,
+        createdAt: Date.now(),
+        order: maxOrder + 1 + i,
+        collectionId: newCollectionId,
+      }));
+
+      // Optimistic insert — all child duplicates appear in the modal
+      // immediately. The Firestore snapshot will reconcile silently with
+      // the same ids. Per-child failures revert their row below.
+      setDashboards((prev) => [...prev, ...clones]);
+
       const results = await Promise.allSettled(
-        children.map((dash, i) =>
-          saveDashboard({
-            ...structuredClone(dash),
-            id: crypto.randomUUID(),
-            isDefault: false,
-            createdAt: Date.now(),
-            order: maxOrder + 1 + i,
-            collectionId: newCollectionId,
-          })
-        )
+        clones.map((clone) => saveDashboard(clone))
       );
 
-      const failed = results.filter((r) => r.status === 'rejected').length;
+      const failedIds = clones
+        .filter((_, i) => results[i].status === 'rejected')
+        .map((c) => c.id);
+      if (failedIds.length > 0) {
+        setDashboards((prev) => prev.filter((d) => !failedIds.includes(d.id)));
+      }
+
+      const failed = failedIds.length;
       if (failed === 0) {
         addToast(`Collection "${source.name}" duplicated`);
       } else if (failed === children.length) {

--- a/tests/DashboardContext_duplicateDashboard.test.tsx
+++ b/tests/DashboardContext_duplicateDashboard.test.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect } from 'react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
+import { DashboardProvider } from '../context/DashboardContext';
+import { useDashboard } from '../context/useDashboard';
+import type { Dashboard } from '../types';
+
+/**
+ * duplicateDashboard: optimistic insert, rollback-on-failure, and
+ * linkage-field sanitization.
+ *
+ * Three behaviors are pinned here because they regress silently:
+ *
+ * 1. The optimistic local insert renders the new "(Copy)" Board before
+ *    `saveDashboard` resolves — that's the perceived-speed fix. If a
+ *    refactor reverts to awaiting Firestore, the modal goes back to
+ *    feeling slow.
+ *
+ * 2. On `saveDashboard` rejection the optimistic row is removed. Without
+ *    this, a Drive/Firestore failure leaves a ghost row that disappears
+ *    on the next snapshot and confuses the user.
+ *
+ * 3. `sanitizeBoardSnapshot` strips host-specific linkage fields
+ *    (`driveFileId`, `linkedShareId`, `linkedShareRole`,
+ *    `linkedShareHostName`, `linkedShareEnded`, `thumbnailUrl`,
+ *    `sharedGroups`, `annotationOverlay`, `isDefault`, `isPinned`). The
+ *    real bug being defended against: if `driveFileId` is inherited,
+ *    `saveDashboard` PATCHes the SOURCE's Drive file with the duplicate's
+ *    contents, silently corrupting the original.
+ */
+
+const mockUser = {
+  uid: 'owner-uid',
+  displayName: 'Owner',
+  email: 'owner@example.com',
+};
+
+vi.mock('../context/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    isAdmin: false,
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    refreshGoogleToken: vi.fn().mockResolvedValue('mock-token'),
+    profileLoaded: true,
+  }),
+}));
+
+const mockSaveDashboard = vi.fn().mockResolvedValue(undefined);
+type SubscribeCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+
+// Module-level seed read INSIDE the subscribe mock. Mirrors the proven
+// pattern in `DashboardContext_sharing.test.tsx` — the mock closure
+// re-reads this variable on each call, so individual tests can swap it
+// before render without re-creating the mock.
+let initialDashboardsSeed: Dashboard[] = [];
+const mockSubscribeToDashboards = vi.fn((cb: SubscribeCb) => {
+  cb(initialDashboardsSeed, false);
+  return () => undefined;
+});
+
+vi.mock('../hooks/useFirestore', () => ({
+  useFirestore: () => ({
+    saveDashboard: mockSaveDashboard,
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboards: mockSubscribeToDashboards,
+    shareDashboard: vi.fn().mockResolvedValue('mock-share-id'),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+    mirrorSharedBoard: vi.fn().mockResolvedValue(undefined),
+    subscribeToSharedBoard: vi.fn(() => () => undefined),
+    joinSharedBoard: vi.fn().mockResolvedValue(undefined),
+    leaveSharedBoard: vi.fn().mockResolvedValue(undefined),
+    stopSharingBoard: vi.fn().mockResolvedValue(undefined),
+    rosters: [],
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    activeRosterId: null,
+  }),
+}));
+
+vi.mock('../hooks/useRosters', () => ({
+  useRosters: () => ({
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn().mockResolvedValue('new-collection-id'),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-share-id'),
+    shareSubstituteCollection: vi.fn().mockResolvedValue('mock-sub-share-id'),
+    loadSharedCollection: vi.fn().mockResolvedValue(null),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+const SOURCE_ID = 'source-board-id';
+
+// A source Board that carries every host-specific linkage field we need
+// to make sure does NOT leak into the duplicate. If the assertions below
+// pass, `sanitizeBoardSnapshot` is doing its job inside `duplicateDashboard`.
+function makeLinkedSource(): Dashboard {
+  return {
+    id: SOURCE_ID,
+    name: 'My Board',
+    background: 'bg-slate-800',
+    widgets: [],
+    createdAt: 1700000000000,
+    updatedAt: 1700000999999,
+    isPinned: true,
+    isDefault: true,
+    driveFileId: 'source-drive-file-id',
+    thumbnailUrl: 'https://storage.example/source-thumb.png',
+    linkedShareId: 'source-share-id',
+    linkedShareRole: 'owner',
+    linkedShareHostName: 'Source Host',
+    linkedShareEnded: false,
+    sharedGroups: [{ id: 'g1', name: 'Group 1' }],
+    collectionId: 'source-collection-id',
+  };
+}
+
+/**
+ * Renders the provider with a probe that captures `duplicateDashboard`
+ * and the live `dashboards` array so tests can drive the action and
+ * read optimistic state in the same render tree.
+ */
+async function renderWithCaptured(source: Dashboard): Promise<{
+  duplicate: (id: string) => Promise<void>;
+  getDashboards: () => Dashboard[];
+}> {
+  // Seed the subscription with the source Board so the provider's
+  // `dashboards` state contains it before the test calls duplicate.
+  initialDashboardsSeed = [source];
+
+  // Mirror the capture pattern from `DashboardContext_sharing.test.tsx`:
+  // an effect captures the latest provider handles into module-scoped
+  // mutables, and the caller `waitFor`s until they're populated. The
+  // effect re-runs whenever `duplicateDashboard` / `dashboards`
+  // identity changes (e.g. when the seeded source lands in state).
+  let capturedDuplicate: ((id: string) => Promise<void>) | null = null;
+  let capturedDashboards: Dashboard[] = [];
+
+  const Probe: React.FC = () => {
+    const { duplicateDashboard, dashboards } = useDashboard();
+    useEffect(() => {
+      capturedDuplicate = duplicateDashboard;
+      capturedDashboards = dashboards;
+    }, [duplicateDashboard, dashboards]);
+    return <div>Test App</div>;
+  };
+  render(
+    <DashboardProvider>
+      <Probe />
+    </DashboardProvider>
+  );
+
+  // Wait for the seeded source to land and the duplicate handle to
+  // populate before returning.
+  await waitFor(() => {
+    expect(capturedDuplicate).not.toBeNull();
+    expect(capturedDashboards.some((d) => d.id === source.id)).toBe(true);
+  });
+
+  return {
+    duplicate: (id: string) =>
+      act(async () => {
+        const fn = capturedDuplicate;
+        if (!fn) throw new Error('duplicateDashboard not captured');
+        await fn(id);
+      }),
+    getDashboards: () => capturedDashboards,
+  };
+}
+
+describe('DashboardContext.duplicateDashboard', () => {
+  beforeEach(() => {
+    // Reset only what we care about — don't `vi.clearAllMocks()`, which
+    // in this test surface clears mock.calls on EVERY mocked function
+    // including the `vi.mock('../hooks/...')` factory returns, and the
+    // provider hits a stripped surface on the second test's render.
+    mockSaveDashboard.mockReset();
+    mockSaveDashboard.mockResolvedValue(undefined);
+    mockSubscribeToDashboards.mockClear();
+    initialDashboardsSeed = [];
+    window.history.pushState({}, '', '/');
+  });
+
+  afterEach(() => {
+    // testing-library doesn't auto-cleanup in this project's setup, so the
+    // provider from the previous test would otherwise hang around and the
+    // next `render()` would mount alongside it — which manifests as the
+    // new Probe never rendering (the old tree intercepts effects).
+    cleanup();
+  });
+
+  it('inserts the duplicate into local state and saves it (happy path)', async () => {
+    const source = makeLinkedSource();
+    const { duplicate, getDashboards } = await renderWithCaptured(source);
+
+    await duplicate(SOURCE_ID);
+
+    // Both the source AND the copy are present after duplicate resolves —
+    // the optimistic insert happens before the await on saveDashboard, so
+    // even on the happy path the local list contains both rows by the time
+    // we observe it. (The dedicated rollback test below pins the reverse:
+    // a rejected save removes the optimistic row, which is only meaningful
+    // if the optimistic row exists in the first place.)
+    const copy = getDashboards().find((d) => d.id !== SOURCE_ID);
+    expect(copy).toBeDefined();
+    expect(copy?.name).toBe('My Board (Copy)');
+    expect(mockSaveDashboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('strips host-specific linkage fields when building the duplicate', async () => {
+    const source = makeLinkedSource();
+    const { duplicate } = await renderWithCaptured(source);
+    await duplicate(SOURCE_ID);
+
+    expect(mockSaveDashboard).toHaveBeenCalledTimes(1);
+    const saved = mockSaveDashboard.mock.calls[0]?.[0] as Dashboard;
+
+    // ID, name, and createdAt are fresh.
+    expect(saved.id).not.toBe(SOURCE_ID);
+    expect(saved.name).toBe('My Board (Copy)');
+    expect(saved.createdAt).not.toBe(source.createdAt);
+
+    // CRITICAL: linkage fields stripped. The big one is `driveFileId` —
+    // inheriting it would PATCH the source's Drive file on save.
+    expect(saved.driveFileId).toBeUndefined();
+    expect(saved.linkedShareId).toBeUndefined();
+    expect(saved.linkedShareRole).toBeUndefined();
+    expect(saved.linkedShareHostName).toBeUndefined();
+    expect(saved.linkedShareEnded).toBeUndefined();
+    expect(saved.thumbnailUrl).toBeUndefined();
+    expect(saved.sharedGroups).toBeUndefined();
+    expect(saved.isPinned).toBeUndefined();
+    expect(saved.isDefault).toBeUndefined();
+
+    // Collection membership is preserved (typical user expectation for
+    // single-board duplicate — the copy stays next to the source).
+    expect(saved.collectionId).toBe('source-collection-id');
+
+    // updatedAt is stamped fresh so the optimistic row shows a "just
+    // edited" date instead of inheriting the source's last-edit ts.
+    expect(saved.updatedAt).not.toBe(source.updatedAt);
+    expect(typeof saved.updatedAt).toBe('number');
+  });
+
+  it('reverts the optimistic insert when saveDashboard rejects', async () => {
+    mockSaveDashboard.mockRejectedValue(new Error('Firestore write failed'));
+
+    const source = makeLinkedSource();
+    const { duplicate, getDashboards } = await renderWithCaptured(source);
+    await duplicate(SOURCE_ID);
+
+    // After rejection only the source remains — the optimistic row is gone.
+    await waitFor(() => {
+      const copy = getDashboards().find((d) => d.id !== SOURCE_ID);
+      expect(copy).toBeUndefined();
+    });
+    expect(getDashboards()).toHaveLength(1);
+    expect(getDashboards()[0]?.id).toBe(SOURCE_ID);
+  });
+});


### PR DESCRIPTION
## Summary

Sidebar → **Boards & Collections** → Duplicate had two bad UX symptoms:

1. **No feedback** — the button stayed styled normally, no spinner, no toast, so users couldn't tell anything was happening.
2. **Slow** — the new card didn't appear in the grid until Firestore + Drive (PII supplement) finished round-tripping.

Net effect: users clicked Duplicate 3–5 times waiting for something to happen, and after ~5 s **all** of those copies appeared at once.

## Changes

- **Optimistic local insert** in `duplicateDashboard` and `duplicateCollection` (`context/DashboardContext.tsx`). The new Board (or each child Board of a duplicated Collection) is added to local state immediately, so it renders in the modal in ~1 frame. The Firestore snapshot reconciles silently with the same id. On save failure the optimistic row is reverted and the existing error toast fires.
- **Busy state + spinner** on the Duplicate icon on `BoardCard` and `CollectionCard`. Wired through `useBusyIdSet` in `BoardsModal` (same hook the Quiz / VideoActivity / MiniApp / GuidedLearning library managers already use for their duplicate-kebab plumbing). The hook's synchronous ref-check is the rapid-double-click guard, so the second click is a no-op — users can no longer queue multiple copies.
- Drive/PII semantics inside `saveDashboard` are deliberately **untouched** — the strict "abort on PII Drive failure" contract is preserved.

## Test plan

- [ ] Open Sidebar → Boards & Collections.
- [ ] Click Duplicate on a Board card. Verify the icon flips to a spinner, the button is disabled, and a "(Copy)" card appears in the grid immediately.
- [ ] Spam-click Duplicate on the same Board. Verify only one duplicate is created.
- [ ] Wait for completion → success toast appears, spinner stops, no row flicker.
- [ ] Reload the page → the duplicate persists (Firestore actually wrote, not just local state).
- [ ] Duplicate a Collection that contains several Boards. Verify the collection card appears, then the child Board duplicates appear together.
- [ ] Failure path: with Drive scope revoked (or offline), duplicate a Board that contains PII (e.g. roster names in a custom widget). Verify the optimistic row is removed and the error toast fires.
- [ ] `pnpm run type-check` ✅
- [ ] `pnpm run lint` ✅
- [ ] `pnpm run format:check` ✅

https://claude.ai/code/session_01KT6D11Yfo68ZKBXSHjLU8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT6D11Yfo68ZKBXSHjLU8x)_