### PR TITLE
fix(quiz,va): restore strict tab-switch detection on URL-bar / chrome clicks

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -74,6 +74,7 @@ import { usePreviewMode } from '@/hooks/usePreviewMode';
 import { ResultsWatermark } from './ResultsWatermark';
 import { ResultsTabWarningModal } from './ResultsTabWarningModal';
 import { useResultsTabWarnings } from '@/hooks/useResultsTabWarnings';
+import { useFocusLossPoll } from '@/hooks/useFocusLossPoll';
 import {
   getScoreSuffix,
   isGamificationActive,
@@ -908,6 +909,20 @@ const ActiveQuiz: React.FC<{
     myResponse?.status,
     myResponse?.unlocked,
   ]);
+
+  // Modern Chrome/Firefox don't fire `window.blur` when focus shifts to
+  // the URL bar, bookmark dropdowns, or other browser-chrome targets, so
+  // the listeners above miss those interactions. `document.hasFocus()`
+  // still flips false in all those cases — `useFocusLossPoll` watches the
+  // `true → false` edge on a 250 ms timer and dispatches a synthetic
+  // `blur` so the existing `handleVisibilityChange` listener owns the
+  // full response logic in one place (guard checks, debounce, increment,
+  // modal). See `hooks/useFocusLossPoll.ts` for the snapshot-race the
+  // first-mount-only seed protects against.
+  useFocusLossPoll({
+    enabled: tabWarningsEnabled,
+    onFocusLoss: () => window.dispatchEvent(new Event('blur')),
+  });
 
   // For student-paced mode, the student maintains their own local index
   const [localIndex, setLocalIndex] = useState(0);

--- a/components/videoActivity/VideoActivityStudentApp.tsx
+++ b/components/videoActivity/VideoActivityStudentApp.tsx
@@ -36,6 +36,7 @@ import { VideoPlayer } from './VideoPlayer';
 import { QuestionOverlay } from './QuestionOverlay';
 import { TeacherPreviewBanner } from '@/components/student/TeacherPreviewBanner';
 import { usePreviewMode } from '@/hooks/usePreviewMode';
+import { useFocusLossPoll } from '@/hooks/useFocusLossPoll';
 
 /**
  * Resolve the SSO student's class period from the session's
@@ -545,6 +546,25 @@ const JoinAndPlay: React.FC<JoinAndPlayProps> = ({
     myResponse?.unlocked,
     sessionId,
   ]);
+
+  // Modern Chrome/Firefox don't fire `window.blur` when focus shifts to
+  // the URL bar, bookmark dropdowns, or other browser-chrome targets, so
+  // the listeners above miss those interactions. `document.hasFocus()`
+  // still flips false in all those cases — `useFocusLossPoll` watches the
+  // `true → false` edge on a 250 ms timer and dispatches a synthetic
+  // `blur` so the existing `handleVisibilityChange` listener owns the
+  // full response logic in one place. The poll is gated by the same
+  // conditions as the listener effect; without them, a focus loss
+  // outside an active session would still fire.
+  const focusPollEnabled =
+    tabWarningsEnabled &&
+    joinStatus === 'joined' &&
+    session?.status === 'active' &&
+    !isViewOnly;
+  useFocusLossPoll({
+    enabled: focusPollEnabled,
+    onFocusLoss: () => window.dispatchEvent(new Event('blur')),
+  });
 
   // ── Invalid / missing session ID ──────────────────────────────────────────
 

--- a/hooks/useFocusLossPoll.ts
+++ b/hooks/useFocusLossPoll.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from 'react';
+
+interface UseFocusLossPollArgs {
+  /**
+   * Polling is only attached while this is true. Toggling false tears
+   * the interval down; toggling true again starts a fresh interval but
+   * preserves the previously-observed focus state so a focus loss that
+   * spans the disable→enable window is still detected on the next tick.
+   */
+  enabled: boolean;
+  /** Default 250 ms — fast enough to catch a quick URL-bar visit. */
+  intervalMs?: number;
+  /**
+   * Invoked once per `true → false` focus-state edge observed by the
+   * poll. The hook does NOT pass any arguments; the caller already
+   * knows the meaningful state.
+   */
+  onFocusLoss: () => void;
+}
+
+/**
+ * Polls `document.hasFocus()` on an interval and invokes `onFocusLoss`
+ * on each `true → false` edge.
+ *
+ * Why a poll instead of just listening to `window.blur`?
+ * Modern Chrome and Firefox no longer fire `window.blur` when focus
+ * shifts to the URL bar, bookmark dropdowns, devtools, or other
+ * browser-chrome targets — the focus shift stays inside the browser's
+ * own chrome. `document.hasFocus()` still flips false in all those
+ * cases, so a poll watching the `true → false` edge restores the
+ * stricter detection without depending on which event the browser
+ * chose to dispatch.
+ *
+ * The seed is gated to first-call only, surviving subsequent re-renders
+ * driven by external state churn (e.g. Firestore snapshot listeners
+ * whose `myResponse.status` change tears the calling effect down and
+ * rebuilds it). Re-seeding on every render would silently swallow a
+ * focus loss that happened while the snapshot was in flight — the
+ * re-seed would land at `false` while focus was already lost, the
+ * next tick would see `false → false`, and the edge would be missed.
+ */
+export function useFocusLossPoll({
+  enabled,
+  intervalMs = 250,
+  onFocusLoss,
+}: UseFocusLossPollArgs): void {
+  // "Latest ref" for the callback so the interval closure always
+  // invokes the freshest function without restarting on every render.
+  // Per `useDebouncedCallback`'s precedent, refs that mirror a value
+  // are assigned in the render body; the eslint rule is disabled
+  // locally because the interval callback always defers to a later
+  // task, so the assignment is guaranteed to land first.
+  const onFocusLossRef = useRef<() => void>(onFocusLoss);
+  // eslint-disable-next-line react-hooks/refs
+  onFocusLossRef.current = onFocusLoss;
+
+  // Persists across re-renders AND effect re-runs. See module-level
+  // doc for the snapshot-race this guards against.
+  const prevHadFocusRef = useRef<boolean>(true);
+  const seededRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (enabled === false) return undefined;
+    if (typeof document === 'undefined') return undefined;
+
+    if (!seededRef.current) {
+      seededRef.current = true;
+      prevHadFocusRef.current = document.hasFocus();
+    }
+
+    const id = window.setInterval(() => {
+      const nowHasFocus = document.hasFocus();
+      if (prevHadFocusRef.current && !nowHasFocus) {
+        onFocusLossRef.current();
+      }
+      prevHadFocusRef.current = nowHasFocus;
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [enabled, intervalMs]);
+}

--- a/tests/hooks/useFocusLossPoll.test.ts
+++ b/tests/hooks/useFocusLossPoll.test.ts
@@ -4,9 +4,9 @@ import { useFocusLossPoll } from '@/hooks/useFocusLossPoll';
 
 /**
  * The hook detects focus loss via a `document.hasFocus()` poll. jsdom's
- * implementation always returns `true`, so we override it through the
- * descriptor so individual tests can flip the return value mid-run.
- * The afterEach restores the original to keep these tests hermetic.
+ * implementation always returns `true`, so we spy on it with vitest and
+ * stub the return value per-test. `vi.restoreAllMocks()` in afterEach
+ * un-installs the spy so the tests stay hermetic.
  */
 function setHasFocus(value: boolean): void {
   vi.spyOn(document, 'hasFocus').mockReturnValue(value);

--- a/tests/hooks/useFocusLossPoll.test.ts
+++ b/tests/hooks/useFocusLossPoll.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFocusLossPoll } from '@/hooks/useFocusLossPoll';
+
+/**
+ * The hook detects focus loss via a `document.hasFocus()` poll. jsdom's
+ * implementation always returns `true`, so we override it through the
+ * descriptor so individual tests can flip the return value mid-run.
+ * The afterEach restores the original to keep these tests hermetic.
+ */
+function setHasFocus(value: boolean): void {
+  vi.spyOn(document, 'hasFocus').mockReturnValue(value);
+}
+
+describe('useFocusLossPoll', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('fires onFocusLoss on a true → false edge', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    renderHook(() =>
+      useFocusLossPoll({ enabled: true, intervalMs: 100, onFocusLoss })
+    );
+
+    // Initial poll seeds prev = true. Now lose focus and tick once.
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire on subsequent false → false ticks', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    renderHook(() =>
+      useFocusLossPoll({ enabled: true, intervalMs: 100, onFocusLoss })
+    );
+
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+
+    // Several more ticks while focus stays lost — no further fires.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire on focus regain', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    renderHook(() =>
+      useFocusLossPoll({ enabled: true, intervalMs: 100, onFocusLoss })
+    );
+
+    // Lose then immediately regain focus before the next tick.
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+
+    setHasFocus(true);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    // The false → true transition is silent. Still one call.
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires again on a new edge after focus returns', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    renderHook(() =>
+      useFocusLossPoll({ enabled: true, intervalMs: 100, onFocusLoss })
+    );
+
+    // First edge.
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+
+    // Return.
+    setHasFocus(true);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // Second edge.
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not poll when enabled is false', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    renderHook(() =>
+      useFocusLossPoll({ enabled: false, intervalMs: 100, onFocusLoss })
+    );
+
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onFocusLoss).not.toHaveBeenCalled();
+  });
+
+  it('clears the interval on unmount', () => {
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    const { unmount } = renderHook(() =>
+      useFocusLossPoll({ enabled: true, intervalMs: 100, onFocusLoss })
+    );
+
+    unmount();
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onFocusLoss).not.toHaveBeenCalled();
+  });
+
+  it('preserves edge detection when re-rendered during a focus-lost window', () => {
+    // Regression test for the snapshot-race the silent-failure-hunter
+    // surfaced on PR review. The inline version of this code re-seeded
+    // `prevHadFocus` on every effect re-run, so if a Firestore snapshot
+    // fired while focus was already lost (e.g. between a URL-bar click
+    // and the next poll tick), the seed dropped to `false` and the next
+    // tick saw `false → false` — silently swallowing the violation.
+    //
+    // With the seed gated to first-call-only, a re-render mid-focus-lost
+    // must NOT reset the previous-state tracker. The next tick still
+    // sees the true → false edge and fires.
+
+    setHasFocus(true);
+    const onFocusLoss = vi.fn();
+    let enabled = true;
+    const { rerender } = renderHook(() =>
+      useFocusLossPoll({ enabled, intervalMs: 100, onFocusLoss })
+    );
+
+    // Focus is lost between renders, before any poll tick fires.
+    setHasFocus(false);
+
+    // Simulate the snapshot-driven re-render of the parent component.
+    // The previous inline poll's effect would tear down and re-build
+    // here, re-seeding `prev` to the now-false state and burying the
+    // edge. The hook's gated seed must keep `prev = true` so the next
+    // tick still detects a transition.
+    rerender();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(1);
+
+    // Sanity: also covers re-renders triggered by the `enabled` flag
+    // bouncing (e.g. session.status flipping briefly). Toggle off then
+    // back on while focus stays lost; the next true→false edge after a
+    // refocus should still fire.
+    enabled = false;
+    rerender();
+    enabled = true;
+    rerender();
+
+    setHasFocus(true);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onFocusLoss).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the latest onFocusLoss closure (no stale callbacks)', () => {
+    setHasFocus(true);
+    const first = vi.fn();
+    const second = vi.fn();
+    let callback = first;
+    const { rerender } = renderHook(() =>
+      useFocusLossPoll({
+        enabled: true,
+        intervalMs: 100,
+        onFocusLoss: callback,
+      })
+    );
+
+    // Swap the callback BEFORE the edge fires.
+    callback = second;
+    rerender();
+
+    setHasFocus(false);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Active-quiz and active-video-activity tab-switch warning silently became more forgiving as Chrome/Firefox tightened `window.blur` — clicks into the URL bar, bookmark dropdowns, devtools, and other browser-chrome targets no longer dispatch the event, so the existing `visibilitychange` + `blur` listeners miss them. `document.hasFocus()` still flips false in all those cases.
- New `useFocusLossPoll` hook ([hooks/useFocusLossPoll.ts](hooks/useFocusLossPoll.ts)) polls `document.hasFocus()` every 250 ms and dispatches a synthetic `blur` on the `true → false` edge, so the existing `handleVisibilityChange` listener owns all the response logic (debounce, increment, modal, auto-submit, error path) in one place.
- Wired into both [QuizStudentApp.tsx](components/quiz/QuizStudentApp.tsx) and [VideoActivityStudentApp.tsx](components/videoActivity/VideoActivityStudentApp.tsx) under the same enable conditions the listener effect already uses.
- Results-view tab detection is **intentionally not changed** — a student briefly clicking the URL bar to share a published score shouldn't lock them out.

## The snapshot-race fix

The poll's previous-state ref is seeded to `document.hasFocus()` **only on the first call**, not on every render. The internal silent-failure-hunter review caught a race where a Firestore snapshot re-rendering the parent mid-focus-loss would re-seed the ref to `false` and silently swallow the next edge. The first-call gate plus a regression test ([tests/hooks/useFocusLossPoll.test.ts](tests/hooks/useFocusLossPoll.test.ts) case `preserves edge detection when re-rendered during a focus-lost window`) prevent that.

## Test plan

- [x] `pnpm run validate` — type-check + lint + format-check + vitest (2852 root + 290 functions, all green)
- [x] Preview boot smoke — `/quiz` loads cleanly with no console errors
- [ ] Manual: as a student in an active quiz, click the URL bar — the red "TAB SWITCH DETECTED" overlay should fire within ~250 ms
- [ ] Manual: same on `/activity` for a video-activity session
- [ ] Manual: in the published-results view, click the URL bar — should NOT fire (results-view detection unchanged)
- [ ] Manual: legitimate quiz interaction (clicking answers, typing in essay editor) does not falsely fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)