### PR TITLE
docs(changelog): release entry for 2026-05-19 — Boards card actions and follow-up fixes

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,93 @@
 {
   "entries": [
     {
+      "version": "2026.05.19.3",
+      "date": "2026-05-19",
+      "title": "Boards card actions and follow-up fixes",
+      "overview": [
+        {
+          "type": "feature",
+          "subtitle": "Boards manager",
+          "items": [
+            {
+              "text": "Share and Duplicate icons now sit directly on every Board and Collection card — no more digging into the right-click menu on tablets and projector touchscreens."
+            },
+            {
+              "text": "Duplicate a whole Collection at once — name, color, and every board inside come along (sub-collections are left in place)."
+            }
+          ]
+        },
+        {
+          "type": "improvement",
+          "items": [
+            {
+              "text": "Duplicate feels instant: the new card appears in the grid immediately, the icon shows a spinner while the save finishes, and rapid clicks no longer create extra copies."
+            }
+          ]
+        },
+        {
+          "type": "fix",
+          "subtitle": "Sidebar modal follow-ups",
+          "items": [
+            {
+              "text": "The new Backgrounds modal now tracks built-in colors, patterns, and gradients in Recents (not just custom uploads)."
+            },
+            {
+              "text": "If a background upload is rejected, picking the same file again now works instead of appearing stuck."
+            },
+            {
+              "text": "Record and Magic can be removed from Quick Access slots again after they were chosen."
+            }
+          ]
+        },
+        {
+          "type": "fix",
+          "items": [
+            {
+              "text": "Quiz and Video Activity now catch students clicking into the browser's URL bar or bookmark dropdown — recent browser changes had quietly let some focus-loss events slip past."
+            },
+            {
+              "text": "Text Widget bullet and numbered list toolbar buttons now apply formatting on a fresh single-line block (keyboard shortcuts were unaffected)."
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "type": "feature",
+          "text": "Boards manager — Share and Duplicate icons now sit alongside Pin on every Board and Collection card, so the most common actions are one tap away on tablets and projector touchscreens. The Share icon honors your existing dashboard-sharing permission setting, and the right-click menu still works exactly the same way."
+        },
+        {
+          "type": "feature",
+          "text": "Duplicate a Collection — copy a whole Collection (name + color) along with every board inside it in one action. Sub-collections are left in place so the operation stays bounded; you can re-run Duplicate on any sub-folder you also want to copy."
+        },
+        {
+          "type": "improvement",
+          "text": "Duplicate (Boards and Collections) now feels instant — the new card appears in the grid immediately, the icon flips to a spinner while the save finishes in the background, and rapid taps no longer queue up multiple copies. If the save fails, the optimistic card is removed and the existing error toast still fires."
+        },
+        {
+          "type": "fix",
+          "text": "Quiz and Video Activity tab-switch detection now catches clicks into the browser's URL bar, bookmark dropdown, devtools, and other browser-chrome targets. Recent Chrome and Firefox changes had quietly stopped firing focus-loss events for those targets, so a few students could leave the tab without triggering the warning overlay. The published-results view is intentionally unchanged so a quick URL-bar click on a posted score doesn't lock students out."
+        },
+        {
+          "type": "fix",
+          "text": "Text Widget bullet-list and numbered-list toolbar buttons now apply the list formatting on a fresh single-line text block instead of just showing the button as active. Keyboard shortcuts (Ctrl+Shift+7 / Ctrl+Shift+8) were not affected."
+        },
+        {
+          "type": "fix",
+          "text": "Backgrounds modal — built-in colors, patterns, and gradients are now tracked in Recents alongside custom uploads, instead of only My Uploads showing up there."
+        },
+        {
+          "type": "fix",
+          "text": "Backgrounds upload — if a file is rejected (too large, Drive not ready, etc.), selecting the same file again now triggers a new upload attempt instead of silently doing nothing."
+        },
+        {
+          "type": "fix",
+          "text": "Quick Access Widgets modal — Record and Magic can now be removed from your slots once added. They were previously stranded in the selected list with no way to deselect."
+        }
+      ]
+    },
+    {
       "version": "2026.05.19.2",
       "date": "2026-05-19",
       "title": "Refreshed sidebar modals",


### PR DESCRIPTION
## Summary

Adds the "What's New" changelog entry for the dev-paul → main release PR (#1672), version **2026.05.19.3**. Merge this into `dev-paul` before merging #1672 so the entry ships with the release.

## What's covered

Walked every commit in `b5ded14..dev-paul` and pulled in only changes that are user-facing in the **currently-shipped** feature set:

**Features**
- Inline Share + Duplicate icons on Board and Collection cards (#1669)
- Duplicate-Collection action (whole-folder copy with all child boards)

**Improvements**
- Duplicate optimistic-insert UX + rapid-click guard (#1670)

**Fixes**
- Quiz / Video Activity tab-switch detection for URL-bar and browser-chrome clicks (#1671)
- Text Widget bullet/numbered list toolbar buttons on single-line blocks (#1668)
- Backgrounds modal: built-in colors/patterns/gradients now tracked in Recents
- Backgrounds modal: re-upload after rejection now works
- Quick Access Widgets: Record and Magic can be deselected

## What's intentionally omitted

**All personal-Spotify commits.** The feature was pulled from the 2026.05.19.2 entry (commit `e9b05ac`) because it's still gated behind Spotify's Premium-developer requirement and surfaces a 403 to end users. Adding it back here would advertise something teachers can't use. The Spotify-related diagnostic/fix commits in this batch (`8aa36b7`, `551121d`, `4768edf`, `42f74d9`, etc.) are still landing internal-only.

**Internal safety nets caught in review.** The `sanitizeBoardSnapshot` fix in #1670 prevents a duplicated board from inheriting the source's `driveFileId` (which could have overwritten the original). Since it was caught pre-production, teachers never saw the broken behavior — calling it out as a "fix" would just confuse them.

## Test plan

- [ ] Pull this into `dev-paul` (merge or rebase, your call), then visually verify on the dev preview: open the "What's New" panel and confirm the 2026.05.19.3 entry renders with the four overview themes and nine details bullets.
- [ ] Read the copy with fresh eyes — flag anything that sounds like dev-speak or overpromises.
- [ ] Merge into `dev-paul` **before** merging PR #1672 into main.

## Branch note

I tried to push the commit directly to `dev-paul` per the changelog routine, but the proxy rejected the push (403). Routing it through this PR onto `claude/beautiful-shannon-42AgQ` so a human can merge it into `dev-paul`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015b1KsgYxQwhkFnkAt48HNz)_