### PR TITLE
fix(dup,quiz): address PR #1672 review feedback

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -920,7 +920,10 @@ const ActiveQuiz: React.FC<{
   // modal). See `hooks/useFocusLossPoll.ts` for the snapshot-race the
   // first-mount-only seed protects against.
   useFocusLossPoll({
-    enabled: tabWarningsEnabled,
+    enabled:
+      tabWarningsEnabled &&
+      session.status === 'active' &&
+      myResponse?.status !== 'completed',
     onFocusLoss: () => window.dispatchEvent(new Event('blur')),
   });
 

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3518,6 +3518,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         id: crypto.randomUUID(),
         name: `${dashboard.name} (Copy)`,
         collectionId: dashboard.collectionId,
+        isDefault: false,
         createdAt: Date.now(),
         updatedAt: Date.now(),
         order: maxOrder + 1,
@@ -3533,7 +3534,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         await saveDashboard(duplicated);
         addToast(`Board "${dashboard.name}" duplicated`);
       } catch (err) {
-        console.error('Duplicate failed:', err);
+        logError('DashboardContext.duplicateDashboard', err, {
+          id: dashboard.id,
+        });
         // Revert the optimistic insert so the user doesn't see a ghost row.
         setDashboards((prev) => prev.filter((d) => d.id !== duplicated.id));
         addToast('Duplicate failed', 'error');
@@ -3591,6 +3594,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       const clones: Dashboard[] = children.map((dash, i) => ({
         ...sanitizeBoardSnapshot(structuredClone(dash)),
         id: crypto.randomUUID(),
+        isDefault: false,
         createdAt: Date.now(),
         updatedAt: Date.now(),
         order: maxOrder + 1 + i,


### PR DESCRIPTION
## Summary

Addresses the unresolved review comments on PR #1672. The proxy in this environment rejects direct pushes to `dev-paul` (HTTP 403 — the same limitation noted in #1673), so this routes the fix through `claude/jolly-thompson-pejpC` for a human to merge into `dev-paul`.

## Changes

- **`logError` over `console.error`** in `duplicateDashboard` — matches the structured logging already used by `duplicateCollection` in the same provider (Copilot review comment).
- **Explicit `isDefault: false`** on the duplicated board and on each collection clone — `sanitizeBoardSnapshot` strips the field, leaving it `undefined`; setting it explicitly restores the prior implementation's semantics and keeps Firestore data consistent (Gemini review comments).
- **Gate the quiz focus-loss poll** on `session.status === 'active'` and `myResponse?.status !== 'completed'` so `useFocusLossPoll` stops polling / dispatching synthetic `blur` outside an active attempt, matching `handleVisibilityChange`'s own guards (Copilot review comment). The video-activity poll already has equivalent gating.

## Test plan

- [ ] `pnpm run validate` (type-check + lint + format-check pass locally)
- [ ] Merge into `dev-paul` so the fixes ship with #1672.

https://claude.ai/code/session_017Yrej2QvZMtddLsef3wrkg

---
_Generated by [Claude Code](https://claude.ai/code/session_017Yrej2QvZMtddLsef3wrkg)_