### PR TITLE
fix: address PR #1690/#1691 review comments (DOMParser body + admin format24)

### DIFF
--- a/components/widgets/QRWidget/deriveSyncedUrl.ts
+++ b/components/widgets/QRWidget/deriveSyncedUrl.ts
@@ -13,7 +13,7 @@ const stripHtml = (html: string): string => {
     return result.replace(/[<>]/g, '');
   }
   const doc = new DOMParser().parseFromString(html, 'text/html');
-  return doc.body.textContent || '';
+  return doc.body?.textContent || '';
 };
 
 /**

--- a/utils/adminBuildingConfig.ts
+++ b/utils/adminBuildingConfig.ts
@@ -138,7 +138,7 @@ export const getAdminBuildingConfig = (
       break;
     case 'clock': {
       const validClockStyles = ['modern', 'lcd', 'minimal'] as const;
-      if (raw.format24 !== undefined) out.format24 = raw.format24;
+      if (typeof raw.format24 === 'boolean') out.format24 = raw.format24;
       if (raw.fontFamily) out.fontFamily = raw.fontFamily;
       if (raw.themeColor) out.themeColor = raw.themeColor;
       if (


### PR DESCRIPTION
## Summary

Two small hardening fixes pulled out of automated PR review comments on #1690 (dev-paul → main) and #1691.

### Changes

**`components/widgets/QRWidget/deriveSyncedUrl.ts`** — optional-chain `doc.body`
- Reviewer (gemini-code-assist on #1691) flagged that `doc.body.textContent` can crash if `DOMParser` is mocked or `body` is unexpectedly absent.
- Matches the existing defensive pattern in `components/widgets/MiniApp/components/MiniAppEditorModal.tsx:158` (`doc.body?.textContent?.trim() ?? ''`).

**`utils/adminBuildingConfig.ts`** — gate `format24` with `typeof === 'boolean'`
- Reviewer (copilot-pull-request-reviewer on #1691) flagged that this validation boundary lets a non-boolean Firestore value propagate.
- Matches the existing pattern on the sibling `glow` field two lines below (`if (typeof raw.glow === 'boolean') out.glow = raw.glow;`).

### Why a separate PR (not pushed directly to dev-paul)

The proxy in this automation environment returns HTTP 403 on direct pushes to `dev-paul`, so I opened this as its own PR against dev-paul instead.

### Verification

- `pnpm type-check` ✓
- `pnpm lint` ✓ (0 warnings, 0 errors)
- `pnpm run format:check` ✓
- `pnpm test tests/utils/adminBuildingConfig.test.ts components/widgets/QRWidget/Widget.test.tsx --run` ✓ (31 passed)

---
_Automated PR review follow-up — please verify before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPESXKmgqTCUdUjnbcMtN9)_