### PR TITLE
fix(specialist-schedule): guard isPast against parseTime returning -1

### DIFF
--- a/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
+++ b/components/widgets/SpecialistSchedule/SpecialistScheduleWidget.tsx
@@ -16,19 +16,12 @@ import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
 import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
 import { hexToRgba } from '@/utils/styles';
+import { parseTime, computeIsPast } from './utils';
 import {
   REFERENCE_VIEWPORT,
   computeWidgetPixelRect,
 } from '@/utils/proportionalLayout';
 import { SNAP_LAYOUT_CONSTANTS } from '@/utils/layoutMath';
-
-/** Parses an "HH:MM" time string and returns minutes since midnight, or -1 if invalid. */
-const parseTime = (t: string | undefined): number => {
-  if (!t || !t.includes(':')) return -1;
-  const [h, m] = t.split(':').map(Number);
-  if (isNaN(h) || isNaN(m)) return -1;
-  return h * 60 + m;
-};
 
 const formatTime = (time: string, format24: boolean): string => {
   if (!time.includes(':')) return time;
@@ -384,10 +377,12 @@ export const SpecialistScheduleWidget: React.FC<{ widget: WidgetData }> = ({
           >
             {currentItems.map((item, i) => {
               const isActive = i === activeIndex;
-              const isPast =
-                !isActive &&
-                parseTime(item.endTime ?? item.startTime) <
-                  now.getHours() * 60 + now.getMinutes();
+              const isPast = computeIsPast(
+                item.endTime,
+                item.startTime,
+                isActive,
+                now.getHours() * 60 + now.getMinutes()
+              );
               const bgColor = isPast
                 ? hexToRgba('#cbd5e1', cardOpacity)
                 : hexToRgba(cardColor, cardOpacity);

--- a/components/widgets/SpecialistSchedule/utils.ts
+++ b/components/widgets/SpecialistSchedule/utils.ts
@@ -27,8 +27,11 @@ export const computeIsPast = (
   nowMinutes: number
 ): boolean => {
   if (isActive) return false;
-  // Use || (not ??) so an empty-string endTime falls back to startTime,
-  // matching how endTime is treated elsewhere in the widget.
+  // Intentional `||` (not `??`): an empty-string endTime must also fall back
+  // to startTime, matching how endTime is treated elsewhere in the widget.
+  // parseTime would return -1 for '' anyway, but doing the fallback here
+  // preserves the valid startTime path.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveMinutes = parseTime(endTime || startTime);
   if (effectiveMinutes < 0) return false; // unparseable — do not flag as past
   return effectiveMinutes < nowMinutes;

--- a/components/widgets/SpecialistSchedule/utils.ts
+++ b/components/widgets/SpecialistSchedule/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Parses an "HH:MM" time string and returns minutes since midnight.
+ * Returns -1 if the string is missing, empty, or not a valid "HH:MM" value.
+ */
+export const parseTime = (t: string | undefined): number => {
+  if (!t || !t.includes(':')) return -1;
+  const [h, m] = t.split(':').map(Number);
+  if (isNaN(h) || isNaN(m)) return -1;
+  return h * 60 + m;
+};
+
+/**
+ * Determines whether a schedule item should be rendered as "past".
+ *
+ * Rules:
+ *   - An already-active item is never past.
+ *   - An item whose effective end time (endTime if present, otherwise
+ *     startTime) cannot be parsed is never past — rendering it as completed
+ *     when it has no valid time data would be misleading.
+ *   - Otherwise, the item is past when its effective end time is strictly
+ *     before the current minute count.
+ */
+export const computeIsPast = (
+  endTime: string | undefined,
+  startTime: string,
+  isActive: boolean,
+  nowMinutes: number
+): boolean => {
+  if (isActive) return false;
+  const effectiveMinutes = parseTime(endTime ?? startTime);
+  if (effectiveMinutes < 0) return false; // unparseable — do not flag as past
+  return effectiveMinutes < nowMinutes;
+};

--- a/components/widgets/SpecialistSchedule/utils.ts
+++ b/components/widgets/SpecialistSchedule/utils.ts
@@ -22,12 +22,14 @@ export const parseTime = (t: string | undefined): number => {
  */
 export const computeIsPast = (
   endTime: string | undefined,
-  startTime: string,
+  startTime: string | undefined,
   isActive: boolean,
   nowMinutes: number
 ): boolean => {
   if (isActive) return false;
-  const effectiveMinutes = parseTime(endTime ?? startTime);
+  // Use || (not ??) so an empty-string endTime falls back to startTime,
+  // matching how endTime is treated elsewhere in the widget.
+  const effectiveMinutes = parseTime(endTime || startTime);
   if (effectiveMinutes < 0) return false; // unparseable — do not flag as past
   return effectiveMinutes < nowMinutes;
 };

--- a/tests/components/widgets/SpecialistSchedule/utils.test.ts
+++ b/tests/components/widgets/SpecialistSchedule/utils.test.ts
@@ -63,14 +63,14 @@ describe('computeIsPast', () => {
     // Before the fix: parseTime(undefined ?? undefined) = parseTime(undefined) = -1
     // and -1 < 600 was true, so this returned true (bug).
     // After the fix: -1 < 0 guard short-circuits, returning false.
-    expect(
-      computeIsPast(
-        undefined,
-        undefined as unknown as string,
-        false,
-        NOW_MINUTES
-      )
-    ).toBe(false);
+    expect(computeIsPast(undefined, undefined, false, NOW_MINUTES)).toBe(false);
+  });
+
+  it('returns false when endTime is an empty string and startTime is valid future time', () => {
+    // Regression for `||` vs `??`: with `??`, '' would be passed to parseTime
+    // and return -1, hiding the valid startTime fallback. With `||`,
+    // the empty-string endTime is skipped and startTime drives the result.
+    expect(computeIsPast('', '11:00', false, NOW_MINUTES)).toBe(false);
   });
 
   it('returns false when startTime is an empty string (invalid time data)', () => {

--- a/tests/components/widgets/SpecialistSchedule/utils.test.ts
+++ b/tests/components/widgets/SpecialistSchedule/utils.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTime,
+  computeIsPast,
+} from '@/components/widgets/SpecialistSchedule/utils';
+
+describe('parseTime', () => {
+  it('parses a valid HH:MM string', () => {
+    expect(parseTime('08:30')).toBe(510);
+    expect(parseTime('00:00')).toBe(0);
+    expect(parseTime('13:45')).toBe(825);
+  });
+
+  it('returns -1 for undefined', () => {
+    expect(parseTime(undefined)).toBe(-1);
+  });
+
+  it('returns -1 for empty string', () => {
+    expect(parseTime('')).toBe(-1);
+  });
+
+  it('returns -1 for a string without a colon', () => {
+    expect(parseTime('0830')).toBe(-1);
+  });
+
+  it('returns -1 when hour or minute is NaN', () => {
+    expect(parseTime('ab:cd')).toBe(-1);
+  });
+});
+
+describe('computeIsPast', () => {
+  // 10:00 AM expressed as minutes since midnight
+  const NOW_MINUTES = 600;
+
+  it('returns false when the item is currently active', () => {
+    // Even if the time is clearly in the past, active items are never "past"
+    expect(computeIsPast('08:00', '07:00', true, NOW_MINUTES)).toBe(false);
+  });
+
+  it('returns true when endTime is before now', () => {
+    expect(computeIsPast('09:30', '08:00', false, NOW_MINUTES)).toBe(true);
+  });
+
+  it('returns true when endTime is absent and startTime is before now', () => {
+    // Falls back to startTime
+    expect(computeIsPast(undefined, '09:00', false, NOW_MINUTES)).toBe(true);
+  });
+
+  it('returns false when endTime is after now', () => {
+    expect(computeIsPast('10:30', '09:00', false, NOW_MINUTES)).toBe(false);
+  });
+
+  it('returns false when endTime equals now (not strictly before)', () => {
+    expect(computeIsPast('10:00', '09:00', false, NOW_MINUTES)).toBe(false);
+  });
+
+  it('returns false when endTime is undefined and startTime is after now', () => {
+    expect(computeIsPast(undefined, '11:00', false, NOW_MINUTES)).toBe(false);
+  });
+
+  // --- Regression: missing/invalid time must NOT cause isPast = true ---
+  it('returns false when both endTime and startTime are undefined (missing time data)', () => {
+    // Before the fix: parseTime(undefined ?? undefined) = parseTime(undefined) = -1
+    // and -1 < 600 was true, so this returned true (bug).
+    // After the fix: -1 < 0 guard short-circuits, returning false.
+    expect(
+      computeIsPast(
+        undefined,
+        undefined as unknown as string,
+        false,
+        NOW_MINUTES
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when startTime is an empty string (invalid time data)', () => {
+    // parseTime('') = -1 → should not be considered past
+    expect(computeIsPast(undefined, '', false, NOW_MINUTES)).toBe(false);
+  });
+
+  it('returns false when startTime is a malformed string', () => {
+    expect(computeIsPast(undefined, 'not-a-time', false, NOW_MINUTES)).toBe(
+      false
+    );
+  });
+
+  it('returns false at midnight (nowMinutes = 0) even when time is 00:00', () => {
+    // 00:00 means 0 minutes; 0 < 0 is false — item at midnight is not past at midnight
+    expect(computeIsPast('00:00', '00:00', false, 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root Cause

`SpecialistScheduleWidget.tsx` called `parseTime(item.endTime ?? item.startTime) < nowMinutes` to determine whether a schedule item should be rendered as "past" (green checkmark, strikethrough, greyed background). `parseTime` returns `-1` as a sentinel when the input is `undefined`, empty, or not a valid `HH:MM` string.

Because `nowMinutes` is always `>= 0`, the comparison `-1 < nowMinutes` is **always true**, so any schedule item with a missing or malformed time was unconditionally shown as completed — regardless of the actual time of day.

## Fix Summary

Extracted `parseTime` and a new `computeIsPast` function into `components/widgets/SpecialistSchedule/utils.ts`. `computeIsPast` short-circuits to `false` when `parseTime` returns `-1` (unparseable time). The widget now delegates to `computeIsPast` instead of inlining the comparison.

## Band-Aid Rejected

A one-line guard in the render loop (`t >= 0 && t < nowMinutes`) would fix the symptom but leave the logic inlined with no test coverage. Extracting to a pure utility function allows independent testing and makes the invariant explicit.

## Regression Test

`tests/components/widgets/SpecialistSchedule/utils.test.ts` — 15 tests covering `parseTime` (valid inputs, `undefined`, empty string, no colon, NaN segments) and `computeIsPast` (active-item guard, past/future endTime, absent endTime). Three regression cases explicitly verify that `startTime = undefined`, `startTime = ''`, and `startTime = 'not-a-time'` all return `false` — the buggy behaviour these were returning `true`.

**Before fix:** test fails.  
**After fix:** 15/15 pass, full validate green.

## Risk

**contained** — only `SpecialistScheduleWidget` display logic is affected. No Firestore or shared-state changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELSMJoJBRwx6ACbvWTvLcX)_