### PR TITLE
fix(settings-panel): position panel from screen rect not world coords

### DIFF
--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import { WidgetData, GlobalStyle } from '@/types';
 import { Z_INDEX } from '@/config/zIndex';
 import { UniversalStyleSettings } from '@/components/common/UniversalStyleSettings';
 import { useWindowSize } from '@/hooks/useWindowSize';
+import { useDashboard } from '@/context/useDashboard';
 
 interface SettingsPanelProps {
   widget: WidgetData;
@@ -38,6 +39,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const [isVisible, setIsVisible] = useState(false);
   const [activeTab, setActiveTab] = useState<'settings' | 'style'>('settings');
   const viewport = useWindowSize();
+  // Subscribe to zoom so the panel re-positions when the canvas zoom changes
+  // while open. Pan offset is intentionally local state in DashboardView (not
+  // in context) to avoid re-render cascades, so pan-while-open is not tracked
+  // here — the initial-open case is correctly handled by getBoundingClientRect.
+  const { zoom } = useDashboard();
 
   const transparency = widget.transparency ?? globalStyle.windowTransparency;
 
@@ -103,11 +109,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setPosition({ top, left: Math.max(PANEL_MARGIN, (vw - pw) / 2) });
   };
 
-  // Recompute on mount and whenever the widget position/size or viewport changes.
+  // Recompute on mount and whenever the widget position/size, viewport, or
+  // canvas zoom changes. getBoundingClientRect is not reactive, so any input
+  // that can alter the widget's screen rect must be in this dep list.
   useLayoutEffect(() => {
     updatePosition();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widget.x, widget.y, widget.w, widget.maximized, viewport]);
+  }, [widget.x, widget.y, widget.w, widget.maximized, viewport, zoom]);
 
   // Animate in on mount (track both rAF handles for safe cleanup)
   useEffect(() => {

--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { IconButton } from '@/components/common/IconButton';
@@ -47,23 +47,37 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     viewport.width - 2 * PANEL_MARGIN
   );
 
-  // Compute panel position from widget props + viewport (no DOM measurement)
-  const position = useMemo(() => {
-    const { width: vw, height: vh } = viewport;
+  // Compute panel position using the widget element's actual screen rect via
+  // getBoundingClientRect(). This is the only correct approach when the widget
+  // canvas has a CSS transform (zoom / pan) applied to it: widget.x/y are world
+  // coordinates, not viewport coordinates, so using them directly as `position:
+  // fixed` offsets produces a misaligned panel whenever zoom ≠ 1 or pan ≠ 0.
+  const [position, setPosition] = useState<{ top: number; left: number }>({
+    top: PANEL_MARGIN,
+    left: PANEL_MARGIN,
+  });
+
+  const updatePosition = () => {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
     const panelMaxH = vh * 0.8;
     const pw = Math.min(PANEL_WIDTH, vw - 2 * PANEL_MARGIN);
 
     // Maximized widgets: center the panel
     if (widget.maximized) {
-      return {
+      setPosition({
         top: Math.max(PANEL_MARGIN, (vh - panelMaxH) / 2),
         left: Math.max(PANEL_MARGIN, (vw - pw) / 2),
-      };
+      });
+      return;
     }
 
-    const widgetRight = widget.x + widget.w;
-    const widgetLeft = widget.x;
-    const widgetTop = widget.y;
+    // Use the live screen rect of the widget element, which accounts for any
+    // CSS transforms (zoom/pan surface) applied to ancestor elements.
+    const rect = widgetRef.current?.getBoundingClientRect();
+    const widgetLeft = rect?.left ?? widget.x;
+    const widgetTop = rect?.top ?? widget.y;
+    const widgetRight = rect != null ? rect.right : widget.x + widget.w;
 
     // Vertical: align top with widget, clamped to viewport
     const top = Math.max(
@@ -74,20 +88,25 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     // Try right side of widget
     const rightX = widgetRight + PANEL_MARGIN;
     if (rightX + pw + PANEL_MARGIN <= vw) {
-      return { top, left: rightX };
+      setPosition({ top, left: rightX });
+      return;
     }
 
     // Try left side of widget
     const leftX = widgetLeft - PANEL_MARGIN - pw;
     if (leftX >= PANEL_MARGIN) {
-      return { top, left: leftX };
+      setPosition({ top, left: leftX });
+      return;
     }
 
     // Fallback: center horizontally
-    return {
-      top,
-      left: Math.max(PANEL_MARGIN, (vw - pw) / 2),
-    };
+    setPosition({ top, left: Math.max(PANEL_MARGIN, (vw - pw) / 2) });
+  };
+
+  // Recompute on mount and whenever the widget position/size or viewport changes.
+  useLayoutEffect(() => {
+    updatePosition();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [widget.x, widget.y, widget.w, widget.maximized, viewport]);
 
   // Animate in on mount (track both rAF handles for safe cleanup)

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -14,15 +14,7 @@
 
 import React, { useRef } from 'react';
 import { render, screen, act } from '@testing-library/react';
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-  type MockInstance,
-} from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SettingsPanel } from '@/components/common/SettingsPanel';
 import { WidgetData, GlobalStyle } from '@/types';
 
@@ -36,6 +28,14 @@ vi.mock('@/components/common/WidgetBuildingToggle', () => ({
 
 vi.mock('@/components/common/UniversalStyleSettings', () => ({
   UniversalStyleSettings: () => null,
+}));
+
+// SettingsPanel now subscribes to useDashboard for zoom; tests do not render a
+// DashboardProvider, so stub the hook with stable defaults.
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    zoom: 1,
+  }),
 }));
 
 // ---------------------------------------------------------------------------
@@ -109,8 +109,6 @@ function findFixedAncestor(el: HTMLElement): HTMLElement | null {
 // ---------------------------------------------------------------------------
 
 describe('SettingsPanel', () => {
-  let getBCRSpy: MockInstance;
-
   beforeEach(() => {
     // rAF is used for the isVisible animation; run callbacks synchronously.
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -128,24 +126,22 @@ describe('SettingsPanel', () => {
   });
 
   afterEach(() => {
+    // vi.restoreAllMocks() also restores the getBCRSpy created in each test.
     vi.restoreAllMocks();
-    getBCRSpy?.mockRestore();
   });
 
   it('renders settings content inside the panel', () => {
-    getBCRSpy = vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockReturnValue({
-        left: 300,
-        top: 100,
-        right: 500,
-        bottom: 250,
-        width: 200,
-        height: 150,
-        x: 300,
-        y: 100,
-        toJSON: () => ({}),
-      });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 300,
+      top: 100,
+      right: 500,
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 300,
+      y: 100,
+      toJSON: () => ({}),
+    });
 
     act(() => {
       render(<Harness />);
@@ -170,19 +166,17 @@ describe('SettingsPanel', () => {
   it('positions the panel using getBoundingClientRect, not world coordinates', () => {
     // Mock getBoundingClientRect to return a screen rect that DIFFERS from the
     // widget's world coordinates — simulating a zoom/pan transform on the canvas.
-    getBCRSpy = vi
-      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockReturnValue({
-        left: 0,
-        top: 100,
-        right: 200, // ← screen right (differs from world right = 100+200 = 300)
-        bottom: 250,
-        width: 200,
-        height: 150,
-        x: 0,
-        y: 100,
-        toJSON: () => ({}),
-      });
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 100,
+      right: 200, // ← screen right (differs from world right = 100+200 = 300)
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
 
     act(() => {
       render(<Harness />);

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Regression test for SettingsPanel position calculation.
+ *
+ * BUG: The panel position used to be computed from `widget.x + widget.w`
+ * (world coordinates) as if they were viewport coordinates. When the board
+ * canvas has a CSS zoom/pan transform applied, the widget's actual screen
+ * position differs from its world coordinates. The panel therefore appeared
+ * at the wrong location whenever zoom ≠ 1 or pan ≠ 0.
+ *
+ * FIX: `updatePosition()` now calls `widgetRef.current.getBoundingClientRect()`
+ * so the panel is placed relative to the element's *actual* screen rect,
+ * which accounts for any ancestor CSS transforms.
+ */
+
+import React, { useRef } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
+import { SettingsPanel } from '@/components/common/SettingsPanel';
+import { WidgetData, GlobalStyle } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/components/common/WidgetBuildingToggle', () => ({
+  WidgetBuildingToggle: () => null,
+}));
+
+vi.mock('@/components/common/UniversalStyleSettings', () => ({
+  UniversalStyleSettings: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_WIDGET: WidgetData = {
+  id: 'w1',
+  type: 'clock',
+  // World coordinates — these intentionally differ from the screen coordinates
+  // returned by the mocked getBoundingClientRect() to simulate zoom/pan.
+  x: 100,
+  y: 100,
+  w: 200,
+  h: 150,
+  z: 1,
+  flipped: true,
+  config: {},
+};
+
+const MOCK_GLOBAL_STYLE: GlobalStyle = {
+  fontFamily: 'sans',
+  windowTransparency: 0.8,
+  windowBorderRadius: '2xl',
+  dockTransparency: 0.4,
+  dockBorderRadius: 'full',
+  dockTextColor: '#334155',
+  dockTextShadow: false,
+};
+
+// ---------------------------------------------------------------------------
+// Simple wrapper that exposes the inner widgetRef div
+// ---------------------------------------------------------------------------
+const Harness: React.FC<{ widgetOverrides?: Partial<WidgetData> }> = ({
+  widgetOverrides,
+}) => {
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const widget = { ...MOCK_WIDGET, ...widgetOverrides };
+
+  return (
+    <>
+      <div ref={widgetRef} data-testid="fake-widget" />
+      <SettingsPanel
+        widget={widget}
+        widgetRef={widgetRef}
+        settings={<div data-testid="settings-content">Settings</div>}
+        shouldRenderSettings
+        onClose={vi.fn()}
+        updateWidget={vi.fn()}
+        globalStyle={MOCK_GLOBAL_STYLE}
+        title="Test Widget"
+      />
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Helper: find the outermost fixed-position ancestor of an element
+// ---------------------------------------------------------------------------
+function findFixedAncestor(el: HTMLElement): HTMLElement | null {
+  let node: HTMLElement | null = el.parentElement;
+  while (node) {
+    if (node.style.position === 'fixed') return node;
+    node = node.parentElement;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SettingsPanel', () => {
+  let getBCRSpy: MockInstance;
+
+  beforeEach(() => {
+    // rAF is used for the isVisible animation; run callbacks synchronously.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      writable: true,
+    });
+    Object.defineProperty(window, 'innerHeight', {
+      value: 768,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getBCRSpy?.mockRestore();
+  });
+
+  it('renders settings content inside the panel', () => {
+    getBCRSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        left: 300,
+        top: 100,
+        right: 500,
+        bottom: 250,
+        width: 200,
+        height: 150,
+        x: 300,
+        y: 100,
+        toJSON: () => ({}),
+      });
+
+    act(() => {
+      render(<Harness />);
+    });
+
+    expect(screen.getByTestId('settings-content')).toBeInTheDocument();
+  });
+
+  /**
+   * Core regression: the panel left position must be derived from the element's
+   * actual screen rect (getBoundingClientRect), NOT from world coordinates.
+   *
+   * Setup:
+   *   - widget world position: x=100, w=200  →  world right = 300
+   *   - widget screen rect (after zoom/pan):  left=0, right=200
+   *
+   * Expected panel left (correct):   screenRect.right  + 12 = 200 + 12 = 212
+   * Buggy panel left (world coords): widget.x + widget.w + 12 = 100 + 200 + 12 = 312
+   *
+   * Viewport is 1024 wide; panel (width≤380) fits to the right of 200.
+   */
+  it('positions the panel using getBoundingClientRect, not world coordinates', () => {
+    // Mock getBoundingClientRect to return a screen rect that DIFFERS from the
+    // widget's world coordinates — simulating a zoom/pan transform on the canvas.
+    getBCRSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({
+        left: 0,
+        top: 100,
+        right: 200, // ← screen right (differs from world right = 100+200 = 300)
+        bottom: 250,
+        width: 200,
+        height: 150,
+        x: 0,
+        y: 100,
+        toJSON: () => ({}),
+      });
+
+    act(() => {
+      render(<Harness />);
+    });
+
+    const settingsContent = screen.getByTestId('settings-content');
+    const panelEl = findFixedAncestor(settingsContent);
+
+    expect(panelEl).not.toBeNull();
+    if (!panelEl) return;
+
+    const leftValue = parseFloat(panelEl.style.left);
+
+    // With the fix: left = screenRect.right + PANEL_MARGIN = 200 + 12 = 212
+    expect(leftValue).toBe(212);
+
+    // Explicitly confirm it is NOT the old (buggy) world-coordinate value:
+    // widget.x + widget.w + PANEL_MARGIN = 100 + 200 + 12 = 312
+    expect(leftValue).not.toBe(312);
+  });
+});


### PR DESCRIPTION
## Root Cause

`SettingsPanel` computed its `position: fixed` offset from `widget.x + widget.w` (world coordinates). These are canvas world-space values. The widget canvas has a CSS `transform: translate(pan.x, pan.y) scale(zoom)` applied by `DashboardView`. At default zoom=1 and pan=(0,0) the two coincide, so the bug is invisible — but as soon as the teacher zooms or pans the canvas, the panel renders at the wrong screen location.

`position: fixed` elements are positioned relative to the viewport, so they require **viewport (screen) coordinates**, not world coordinates.

## Fix Summary

Replaced the `useMemo` world-coord calculation with a `useState` position + `useLayoutEffect` that calls `widgetRef.current.getBoundingClientRect()`. `getBoundingClientRect()` returns the element's actual screen rect after all ancestor CSS transforms, giving the exact viewport coordinates needed. The effect re-runs on widget position/size/maximized changes and viewport resize to keep the panel in sync.

File: `components/common/SettingsPanel.tsx`

## Band-Aid Rejected

Manually inverting the canvas transform matrix (`world coords × 1/zoom + pan offset`) would work for the current implementation but is brittle — it requires reading zoom/pan from context, duplicates the transform logic from `DashboardView`, and breaks the moment any additional ancestor transform is added. `getBoundingClientRect()` is the browser's own computation of the same result.

## Regression Test

`tests/components/common/SettingsPanel.test.tsx` — 2 tests. The harness mocks `getBoundingClientRect` to return `right=200` (simulating a 0.5× zoom) while widget world coords give `right=300`. The test asserts:
- `left === 212` (screen right 200 + margin 12) — correct screen-coordinate result
- `left !== 312` (world right 300 + margin 12) — explicitly rejects the old buggy value

**Before fix:** `expected 312 to be 212` → fails.  
**After fix:** 2/2 pass, full validate green.

## Risk

**contained** — only `SettingsPanel` positioning logic. No state, Firestore, or other component changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELSMJoJBRwx6ACbvWTvLcX)_