### PR TITLE
fix(parseGeminiJson): use depth counter instead of lastIndexOf for closing brace

### DIFF
--- a/functions/src/parseGeminiJson.test.ts
+++ b/functions/src/parseGeminiJson.test.ts
@@ -45,4 +45,14 @@ describe('parseGeminiJson', () => {
   it('throws on genuinely malformed JSON', () => {
     expect(() => parseGeminiJson('{not json at all}')).toThrow();
   });
+
+  it('parses correctly when trailing explanation contains closing-brace characters', () => {
+    // Regression: lastIndexOf('}') was used to find the slice end, so any `}`
+    // in the trailing prose (JSON notation, template literals, CSS rules, etc.)
+    // caused the slice to extend past the JSON boundary, producing a string
+    // that JSON.parse rejects even though the embedded JSON is valid.
+    const raw =
+      '{"foo":"bar","items":[1,2]}\n\nNote: use {curly braces} in JSON objects.';
+    expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'bar', items: [1, 2] });
+  });
 });

--- a/functions/src/parseGeminiJson.ts
+++ b/functions/src/parseGeminiJson.ts
@@ -18,12 +18,48 @@ export const parseGeminiJson = <T>(raw: string): T => {
     .replace(/```\s*$/i, '')
     .trim();
 
+  // Walk forward from the first `{` counting brace depth to find the
+  // *matching* closing brace for the outermost JSON object. Using
+  // `lastIndexOf('}')` is incorrect: any `}` in trailing prose
+  // (explanations, CSS examples, JSON notation) would extend the slice past
+  // the JSON boundary and cause JSON.parse to throw even though the embedded
+  // JSON is valid.
   const firstBrace = fenced.indexOf('{');
-  const lastBrace = fenced.lastIndexOf('}');
-  const slice =
-    firstBrace !== -1 && lastBrace > firstBrace
-      ? fenced.slice(firstBrace, lastBrace + 1)
-      : fenced;
+  let slice = fenced;
+  if (firstBrace !== -1) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let closingPos = -1;
+    for (let i = firstBrace; i < fenced.length; i++) {
+      const ch = fenced[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === '\\' && inString) {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            closingPos = i;
+            break;
+          }
+        }
+      }
+    }
+    if (closingPos !== -1) {
+      slice = fenced.slice(firstBrace, closingPos + 1);
+    }
+  }
 
   return JSON.parse(slice) as T;
 };


### PR DESCRIPTION
## Root Cause

`functions/src/parseGeminiJson.ts` used `fenced.lastIndexOf('}')` to find the end of the JSON object slice. This is a linear backward scan — it finds the **rightmost** `}` in the entire string with no understanding of nesting depth, string literals, or escaping.

Gemini commonly appends explanations that contain `}` characters (CSS rule examples, JSON notation like `"use {curly braces}"`, template variable examples). When any such `}` appears after the JSON closes, `lastIndexOf` resolves to it, extending the slice past the JSON boundary and causing `JSON.parse` to throw `"Unexpected non-whitespace character after JSON"` — even though the embedded JSON is perfectly valid.

## Fix Summary

Replaced the `lastIndexOf` call with a balanced-brace depth counter that scans forward from the first `{`:
- Increments depth on `{`, decrements on `}`
- Stops when depth returns to 0 (the matching close of the outermost object)
- Correctly tracks string literals (toggling on unescaped `"`) and respects backslash escape sequences, so `}` inside a JSON string value does not affect the depth count

File: `functions/src/parseGeminiJson.ts`

## Band-Aid Rejected

A regex like `/\{.*\}/s` or a heuristic suffix-strip would fail on nested objects and strings containing `}`. The only correct approach is a scanner that understands the JSON structure.

## Regression Test

New 8th test case in `functions/src/parseGeminiJson.test.ts`:

```ts
it('parses correctly when trailing explanation contains closing-brace characters', () => {
  const raw = '{"foo":"bar","items":[1,2]}\n\nNote: use {curly braces} in JSON objects.';
  expect(parseGeminiJson<Sample>(raw)).toEqual({ foo: 'bar', items: [1, 2] });
});
```

**Before fix:** `SyntaxError: Unexpected non-whitespace character after JSON at position 29`.  
**After fix:** 291/291 function tests pass (`pnpm -C functions run test`), full validate green.

## Risk

**contained** — single utility function in `functions/`. No shared state, no Firestore schema changes, no impact on client-side code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELSMJoJBRwx6ACbvWTvLcX)_