### PR TITLE
fix(smart-notebook): address PR #1702 review feedback

### DIFF
--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -69,10 +69,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     left: PANEL_MARGIN,
   });
 
-  // Pure-ish position calculator. Defined as a useCallback with its real deps
-  // so we can include it in the layout-effect's dep list without churn.
-  // `widgetRef` is stable (refs don't change identity) but we list it for
-  // completeness.
+  // Pure-ish position calculator. Lists only its real captured deps; the
+  // layout effect below adds `viewport` and `zoom` to its own dep list so
+  // the recompute fires when the window resizes or the dashboard zooms
+  // (both reshape the rect we read off `widgetRef.current` even though the
+  // function body doesn't reference those values directly).
   const updatePosition = useCallback(() => {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
@@ -119,13 +120,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setPosition({ top, left: Math.max(PANEL_MARGIN, (vw - pw) / 2) });
   }, [widget.x, widget.y, widget.w, widget.maximized, widgetRef]);
 
-  // Recompute on mount and whenever the widget position/size, viewport, or
-  // canvas zoom changes. getBoundingClientRect is not reactive, so any input
-  // that can alter the widget's screen rect must be in this dep list.
-  // `viewport` and `zoom` are listed because they change the rect we read
-  // off `widgetRef.current`; the function itself doesn't reference them.
-  // useLayoutEffect (not useEffect) so the position is applied before paint
-  // and the panel never flashes at the wrong spot.
+  // Recompute on mount and whenever the widget rect or any reactive input
+  // that reshapes it (viewport size, dashboard zoom) changes. useLayoutEffect
+  // (not useEffect) so the position is applied before paint and the panel
+  // never flashes at the wrong spot.
   //
   // Synchronous setState inside a layout effect is the React-recommended
   // pattern for DOM-measurement → render flows (you can't compute the rect
@@ -135,8 +133,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   useLayoutEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     updatePosition();
-    void viewport;
-    void zoom;
   }, [updatePosition, viewport, zoom]);
 
   // Animate in on mount (track both rAF handles for safe cleanup)

--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { IconButton } from '@/components/common/IconButton';
@@ -63,7 +69,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     left: PANEL_MARGIN,
   });
 
-  const updatePosition = () => {
+  // Pure-ish position calculator. Defined as a useCallback with its real deps
+  // so we can include it in the layout-effect's dep list without churn.
+  // `widgetRef` is stable (refs don't change identity) but we list it for
+  // completeness.
+  const updatePosition = useCallback(() => {
     const vw = window.innerWidth;
     const vh = window.innerHeight;
     const panelMaxH = vh * 0.8;
@@ -107,15 +117,27 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
 
     // Fallback: center horizontally
     setPosition({ top, left: Math.max(PANEL_MARGIN, (vw - pw) / 2) });
-  };
+  }, [widget.x, widget.y, widget.w, widget.maximized, widgetRef]);
 
   // Recompute on mount and whenever the widget position/size, viewport, or
   // canvas zoom changes. getBoundingClientRect is not reactive, so any input
   // that can alter the widget's screen rect must be in this dep list.
+  // `viewport` and `zoom` are listed because they change the rect we read
+  // off `widgetRef.current`; the function itself doesn't reference them.
+  // useLayoutEffect (not useEffect) so the position is applied before paint
+  // and the panel never flashes at the wrong spot.
+  //
+  // Synchronous setState inside a layout effect is the React-recommended
+  // pattern for DOM-measurement → render flows (you can't compute the rect
+  // in render — the DOM doesn't exist yet on first commit), so the
+  // `react-hooks/set-state-in-effect` rule's complaint is a false positive
+  // for this case.
   useLayoutEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     updatePosition();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widget.x, widget.y, widget.w, widget.maximized, viewport, zoom]);
+    void viewport;
+    void zoom;
+  }, [updatePosition, viewport, zoom]);
 
   // Animate in on mount (track both rAF handles for safe cleanup)
   useEffect(() => {

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -459,7 +459,7 @@ const PageThumbnail: React.FC<{
   liveObjects?: DrawableObject[];
   subcollectionMigrated?: boolean;
 }> = ({ page, liveObjects, subcollectionMigrated = false }) => {
-  const objects = liveObjects ?? page.objects;
+  const objects = liveObjects ?? page.objects ?? [];
   if (objects.length > 0) {
     const bboxes = objects.map((obj) => getBoundingBox(obj));
     const maxX = bboxes.reduce((m, b) => Math.max(m, b.x + b.w), 0);

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -8,7 +8,7 @@ import {
   Plus,
   Trash2,
 } from 'lucide-react';
-import { DrawingPage } from '@/types';
+import { DrawableObject, DrawingPage } from '@/types';
 import { getBoundingBox } from './hitTest';
 
 interface PageStripProps {
@@ -18,6 +18,15 @@ interface PageStripProps {
   onAddPage: () => void;
   onDeletePage: (index: number) => void;
   onRenamePage: (index: number, title: string) => void;
+  /** Live objects for the active page (subcollection-sourced post-migration).
+   *  Used to render an accurate thumbnail for the current page even when the
+   *  denormalized `pages[currentPage].objects` array is empty. */
+  activePageObjects?: DrawableObject[];
+  /** True once this widget's `pages[].objects[]` has been moved to the
+   *  Firestore subcollection. After migration, non-active pages have an empty
+   *  denormalized `objects[]` array — the thumbnail uses this flag to render
+   *  a "has content" placeholder instead of returning null. */
+  subcollectionMigrated?: boolean;
 }
 
 /**
@@ -58,6 +67,8 @@ export const PageStrip: React.FC<PageStripProps> = ({
   onAddPage,
   onDeletePage,
   onRenamePage,
+  activePageObjects,
+  subcollectionMigrated = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [anchor, setAnchor] = useState<{ bottom: number; left: number } | null>(
@@ -239,7 +250,16 @@ export const PageStrip: React.FC<PageStripProps> = ({
                             isActive ? 'ring-1 ring-brand-blue-light' : ''
                           }`}
                         >
-                          <PageThumbnail page={page} />
+                          <PageThumbnail
+                            page={page}
+                            // Hydrate the active page from the live
+                            // subcollection slice so its thumbnail is accurate
+                            // even when the denormalized cache is empty.
+                            liveObjects={
+                              isActive ? activePageObjects : undefined
+                            }
+                            subcollectionMigrated={subcollectionMigrated}
+                          />
                         </span>
                         {isEditing ? (
                           <InlineTitle
@@ -427,33 +447,57 @@ const InlineTitle: React.FC<{
  * outlined rect, projected from the implicit canvas size (largest extent of
  * any object) into the chip's dimensions. Deliberately a sketch — full
  * per-page renders cost too much to draw N pages on every keystroke.
+ *
+ * Post-migration caveat: once the widget's pages have moved to the Firestore
+ * subcollection, only the currently-loaded page knows its real `objects[]`
+ * (via the `liveObjects` prop). For non-active pages we fall back to a
+ * neutral "has content" placeholder — the alternative would be N extra
+ * Firestore reads per popover open, which isn't justified for a sketch.
  */
-const PageThumbnail: React.FC<{ page: DrawingPage }> = ({ page }) => {
-  if (page.objects.length === 0) return null;
-  const bboxes = page.objects.map((obj) => getBoundingBox(obj));
-  const maxX = bboxes.reduce((m, b) => Math.max(m, b.x + b.w), 0);
-  const maxY = bboxes.reduce((m, b) => Math.max(m, b.y + b.h), 0);
-  const W = Math.max(maxX, 1);
-  const H = Math.max(maxY, 1);
-  return (
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      preserveAspectRatio="xMidYMid meet"
-      className="absolute inset-0 w-full h-full"
-      aria-hidden="true"
-    >
-      {bboxes.map((b, i) => (
-        <rect
-          key={i}
-          x={b.x}
-          y={b.y}
-          width={Math.max(b.w, 1)}
-          height={Math.max(b.h, 1)}
-          fill="none"
-          stroke="rgba(226, 232, 240, 0.6)"
-          strokeWidth={Math.max(W, H) * 0.012}
-        />
-      ))}
-    </svg>
-  );
+const PageThumbnail: React.FC<{
+  page: DrawingPage;
+  liveObjects?: DrawableObject[];
+  subcollectionMigrated?: boolean;
+}> = ({ page, liveObjects, subcollectionMigrated = false }) => {
+  const objects = liveObjects ?? page.objects;
+  if (objects.length > 0) {
+    const bboxes = objects.map((obj) => getBoundingBox(obj));
+    const maxX = bboxes.reduce((m, b) => Math.max(m, b.x + b.w), 0);
+    const maxY = bboxes.reduce((m, b) => Math.max(m, b.y + b.h), 0);
+    const W = Math.max(maxX, 1);
+    const H = Math.max(maxY, 1);
+    return (
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="absolute inset-0 w-full h-full"
+        aria-hidden="true"
+      >
+        {bboxes.map((b, i) => (
+          <rect
+            key={i}
+            x={b.x}
+            y={b.y}
+            width={Math.max(b.w, 1)}
+            height={Math.max(b.h, 1)}
+            fill="none"
+            stroke="rgba(226, 232, 240, 0.6)"
+            strokeWidth={Math.max(W, H) * 0.012}
+          />
+        ))}
+      </svg>
+    );
+  }
+  // Post-migration non-active page: render a neutral filled rect so the chip
+  // doesn't look empty when the page may in fact have content we haven't
+  // loaded. Pre-migration empty pages fall through to null (no placeholder).
+  if (subcollectionMigrated) {
+    return (
+      <span
+        className="absolute inset-1 rounded-sm bg-white/10"
+        aria-hidden="true"
+      />
+    );
+  }
+  return null;
 };

--- a/components/widgets/DrawingWidget/TextEditorOverlay.tsx
+++ b/components/widgets/DrawingWidget/TextEditorOverlay.tsx
@@ -4,7 +4,10 @@ import { TextObject } from '@/types';
 interface TextEditorOverlayProps {
   /** The TextObject being edited. The overlay positions/styles itself from this. */
   object: TextObject;
-  /** Bounding rect of the canvas the object lives on, in CSS px on the page. */
+  /** Bounding rect of the canvas the object lives on, in viewport-relative
+   *  CSS px (i.e. the value returned by `getBoundingClientRect()` — no scroll
+   *  offsets applied). The overlay is `position: fixed`, so it consumes these
+   *  coordinates as-is. */
   canvasRect: DOMRect;
   /**
    * Internal canvas resolution. Object coordinates live in this space, so we
@@ -54,19 +57,20 @@ export const TextEditorOverlay: React.FC<TextEditorOverlayProps> = ({
   // Stash callbacks + object in refs so blur/keydown handlers always see the
   // latest closure without re-binding listeners (avoids missed commits if
   // React re-renders between an in-flight pointer event and the handler
-  // firing). The refs are synced via a deps-free `useEffect` so the
-  // `react-hooks/refs-during-render` rule doesn't flag the assignments;
-  // the lag of one render before the ref reflects a new prop value is
-  // immaterial here — the consumers (blur/keydown handlers) fire from
-  // event loops AFTER the render commits.
+  // firing). Refs are assigned during render — the consumers (blur/keydown
+  // handlers) fire from event loops after the render commits, so the
+  // synchronous assignment is exactly what they need. The `react-hooks/refs`
+  // rule flags this on principle, but the assignments are idempotent and the
+  // pattern is the standard "ref-as-latest-prop" trick.
   const onCommitRef = useRef(onCommit);
   const onCancelRef = useRef(onCancel);
   const objectRef = useRef(object);
-  useEffect(() => {
-    onCommitRef.current = onCommit;
-    onCancelRef.current = onCancel;
-    objectRef.current = object;
-  });
+  // eslint-disable-next-line react-hooks/refs
+  onCommitRef.current = onCommit;
+  // eslint-disable-next-line react-hooks/refs
+  onCancelRef.current = onCancel;
+  // eslint-disable-next-line react-hooks/refs
+  objectRef.current = object;
   // Guard so blur after a Cmd+Enter commit (which intentionally blurs the
   // editor) doesn't double-fire onCommit and clobber an upstream state reset.
   const finalizedRef = useRef(false);
@@ -75,9 +79,10 @@ export const TextEditorOverlay: React.FC<TextEditorOverlayProps> = ({
   const scaleX = canvasSize.width > 0 ? canvasRect.width / canvasSize.width : 1;
   const scaleY =
     canvasSize.height > 0 ? canvasRect.height / canvasSize.height : 1;
-  // Use page-level coords so the overlay sits over the canvas no matter
-  // where the parent container is scrolled. canvasRect already accounts for
-  // page scroll via getBoundingClientRect + scroll offsets at call site.
+  // The overlay is `position: fixed`, so coordinates are viewport-relative
+  // — exactly what `getBoundingClientRect()` returns at the call site. Do
+  // NOT add window.scrollX/Y here: that would double-shift the overlay when
+  // the page is scrolled.
   const leftPx = canvasRect.left + object.x * scaleX;
   const topPx = canvasRect.top + object.y * scaleY;
   const widthPx = object.w * scaleX;

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -369,9 +369,15 @@ export const DrawingWidget: React.FC<{
   // (post-migration) batch-delete its Firestore subcollection. Without the
   // subcollection cleanup, the page-meta doc and all its child object docs
   // would linger forever even though the page is gone from the dashboard.
+  //
+  // Destructure `forgetPage` so the callback below only re-creates when
+  // `forgetPage` itself changes (which is never — it's a stable useCallback
+  // in useCommandStack). Depending on the whole `commandStack` object would
+  // re-create this callback on every drawing stroke.
+  const { forgetPage } = commandStack;
   const handlePageRemoved = useCallback(
     (removedPageId: string) => {
-      commandStack.forgetPage(removedPageId);
+      forgetPage(removedPageId);
       if (!config.subcollectionMigrated) return;
       const uid = user?.uid;
       if (!uid || !dashboardId) return;
@@ -393,7 +399,7 @@ export const DrawingWidget: React.FC<{
       });
     },
     [
-      commandStack,
+      forgetPage,
       config.subcollectionMigrated,
       user?.uid,
       dashboardId,

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -50,6 +50,9 @@ import { STANDARD_COLORS } from '@/config/colors';
 import { DRAWING_DEFAULTS } from './constants';
 import { useDrawingCanvas } from './useDrawingCanvas';
 import { migrateDrawingConfig, nextZ } from '@/utils/migrateDrawingConfig';
+import { deleteDrawingPageSubcollection } from '@/utils/deleteDrawingPageSubcollection';
+import { db } from '@/config/firebase';
+import { logError } from '@/utils/logError';
 import type { DrawingPage } from '@/types';
 import { getBackgroundStyle } from './backgroundTemplates';
 import {
@@ -99,7 +102,7 @@ export const DrawingWidget: React.FC<{
   // when the widget switches to reading from the subcollection. We
   // render a non-interactive overlay until the migration finishes.
   const isMigratingSubcollection = drawingWidgetsMigrating.has(widget.id);
-  const { canAccessFeature } = useAuth();
+  const { user, canAccessFeature } = useAuth();
 
   // Defensive migration — the canonical migration happens during dashboard
   // hydration, but widgets constructed in tests or edge cases may still
@@ -278,7 +281,18 @@ export const DrawingWidget: React.FC<{
   // we compute the (added, updated, removed) sets and dispatch one mutator
   // per. setDoc / deleteDoc are async but we don't await — Firestore's
   // optimistic listener will surface the new state through the subscription
-  // anyway, and waiting would block the synchronous command-stack flow.
+  // anyway, and waiting would block the synchronous command-stack flow. On
+  // failure, the snapshot will revert the canvas to the pre-write state, so
+  // we surface an error toast so the user knows their change didn't persist.
+  const onSubWriteError = useCallback(
+    (err: unknown) => {
+      logError('DrawingWidget.subcollectionWrite', err, {
+        widgetId: widget.id,
+      });
+      addToast('Drawing change could not be saved.', 'error');
+    },
+    [addToast, widget.id]
+  );
   const writeObjects = useCallback(
     (next: DrawableObject[]) => {
       if (config.subcollectionMigrated) {
@@ -286,7 +300,7 @@ export const DrawingWidget: React.FC<{
         // 1000-object wipe ships as 3 batched commits instead of 1000
         // individual deletes.
         if (next.length === 0 && objects.length > 0) {
-          void subClearObjects();
+          subClearObjects().catch(onSubWriteError);
           return;
         }
         const prevById = new Map(objects.map((o) => [o.id, o]));
@@ -294,16 +308,16 @@ export const DrawingWidget: React.FC<{
         // Removed: in prev but not in next.
         for (const [id] of prevById) {
           if (!nextById.has(id)) {
-            void subRemoveObject(id);
+            subRemoveObject(id).catch(onSubWriteError);
           }
         }
         // Added or updated: walk next.
         for (const [id, obj] of nextById) {
           const prev = prevById.get(id);
           if (!prev) {
-            void subAddObject(obj);
+            subAddObject(obj).catch(onSubWriteError);
           } else if (prev !== obj) {
-            void subUpdateObject(obj);
+            subUpdateObject(obj).catch(onSubWriteError);
           }
         }
         return;
@@ -327,6 +341,7 @@ export const DrawingWidget: React.FC<{
       subUpdateObject,
       subRemoveObject,
       subClearObjects,
+      onSubWriteError,
     ]
   );
 
@@ -350,10 +365,47 @@ export const DrawingWidget: React.FC<{
     onObjectsChange: writeObjects,
   });
 
+  // When a page is deleted, drop the local command-stack history for it AND
+  // (post-migration) batch-delete its Firestore subcollection. Without the
+  // subcollection cleanup, the page-meta doc and all its child object docs
+  // would linger forever even though the page is gone from the dashboard.
+  const handlePageRemoved = useCallback(
+    (removedPageId: string) => {
+      commandStack.forgetPage(removedPageId);
+      if (!config.subcollectionMigrated) return;
+      const uid = user?.uid;
+      if (!uid || !dashboardId) return;
+      deleteDrawingPageSubcollection({
+        db,
+        uid,
+        dashboardId,
+        widgetId: widget.id,
+        pageId: removedPageId,
+      }).catch((err: unknown) => {
+        logError('DrawingWidget.deletePageSubcollection', err, {
+          widgetId: widget.id,
+          pageId: removedPageId,
+        });
+        addToast(
+          'Page deleted, but cleanup failed in the background.',
+          'error'
+        );
+      });
+    },
+    [
+      commandStack,
+      config.subcollectionMigrated,
+      user?.uid,
+      dashboardId,
+      widget.id,
+      addToast,
+    ]
+  );
+
   const pageNav = useDrawingPages({
     config: { ...config, pages, currentPage },
     updateConfig,
-    onPageRemoved: commandStack.forgetPage,
+    onPageRemoved: handlePageRemoved,
   });
 
   // Each create path (pen, shapes, image, text-first-commit) becomes a single
@@ -513,11 +565,9 @@ export const DrawingWidget: React.FC<{
     canvasRef,
   });
 
-  // Clear selection whenever the user switches off the Select tool. Without
-  // this, selection chrome lingers after the user clicks Pen/Rect/etc.
-  useEffect(() => {
-    if (activeTool !== 'select') clearSelection();
-  }, [activeTool, clearSelection]);
+  // Selection chrome is cleared by `setActiveTool` directly when leaving the
+  // Select tool — see the event-handler path below — so a state-sync effect
+  // here is unnecessary.
 
   // Clear selection + transform preview on page switch. Selection state is
   // page-scoped — a selected object id on page 1 has no meaning on page 2,
@@ -949,6 +999,10 @@ export const DrawingWidget: React.FC<{
   };
 
   const setActiveTool = (tool: ShapeTool) => {
+    // Leaving Select clears selection chrome so it doesn't linger after the
+    // user picks Pen/Rect/etc. Done synchronously in the handler — no
+    // useEffect needed because the event already knows the new tool.
+    if (tool !== 'select') clearSelection();
     updateWidget(widget.id, {
       config: { ...config, activeTool: tool } as DrawingConfig,
     });
@@ -1243,6 +1297,8 @@ export const DrawingWidget: React.FC<{
             onAddPage={pageNav.addPage}
             onDeletePage={pageNav.removePage}
             onRenamePage={pageNav.renamePage}
+            activePageObjects={objects}
+            subcollectionMigrated={config.subcollectionMigrated}
           />
         </div>
       </div>

--- a/components/widgets/DrawingWidget/useCommandStack.ts
+++ b/components/widgets/DrawingWidget/useCommandStack.ts
@@ -79,9 +79,7 @@ export const useCommandStack = ({
   // closure-captured `objects` and apply the SAME reverse twice while the
   // functional setStacks updater correctly chains past/future.
   //
-  // Refs assigned during render is the pattern CLAUDE.md recommends for
-  // keeping derived state in sync without an effect. The newer
-  // `react-hooks/refs` lint rule flags this on principle, but the pattern is
+  // The `react-hooks/refs` rule flags this on principle, but the pattern is
   // intentional and the assignments are idempotent (same input → same ref
   // value) so the StrictMode double-invoke is safe.
   const objectsRef = useRef<readonly DrawableObject[]>(objects);

--- a/components/widgets/DrawingWidget/useDrawingObjectsDoc.ts
+++ b/components/widgets/DrawingWidget/useDrawingObjectsDoc.ts
@@ -290,9 +290,24 @@ export const useDrawingObjectsDoc = ({
       if (!e) return;
       e.subscribers.delete(subscriber);
       e.refs -= 1;
-      // Eviction is deferred to the next subscribe — keeping the listener
-      // around for the LRU window costs only a handful of bytes and lets
-      // back-navigation reuse the cached data.
+      // Eviction within the LRU window is deferred to the next subscribe —
+      // keeping the listener around costs only a handful of bytes and lets
+      // back-navigation reuse the cached data. But if the entire widget has
+      // unmounted (no remaining refs across any page in this context), we
+      // must tear down all of its listeners so Firestore reads don't leak
+      // for the lifetime of the tab. Defer to a microtask so a back-to-back
+      // unmount + remount (e.g. a page switch) sees the new subscribe
+      // increment a ref BEFORE we check the total.
+      const ctxKey = subKey.contextKey;
+      queueMicrotask(() => {
+        const currentCm = activeSubsByContext.get(ctxKey);
+        if (!currentCm) return;
+        let totalRefs = 0;
+        for (const sub of currentCm.values()) totalRefs += sub.refs;
+        if (totalRefs > 0) return;
+        for (const sub of currentCm.values()) sub.unsubscribe();
+        activeSubsByContext.delete(ctxKey);
+      });
     };
   }, [uid, dashboardId, widgetId, pageId]);
 

--- a/components/widgets/SpecialistSchedule/utils.ts
+++ b/components/widgets/SpecialistSchedule/utils.ts
@@ -27,9 +27,10 @@ export const computeIsPast = (
   nowMinutes: number
 ): boolean => {
   if (isActive) return false;
-  // An empty-string endTime must fall back to startTime (matching how endTime
-  // is treated elsewhere in the widget); `??` alone wouldn't catch '', so
-  // test absence explicitly here.
+  // Empty-string endTime must fall back to startTime (matching how endTime
+  // is treated elsewhere in the widget). Explicit equality checks rather
+  // than `??` (which only catches null/undefined) or a truthy ternary
+  // (which the lint rule rewrites to `??`).
   const effective =
     endTime !== undefined && endTime !== '' ? endTime : startTime;
   const effectiveMinutes = parseTime(effective);

--- a/components/widgets/SpecialistSchedule/utils.ts
+++ b/components/widgets/SpecialistSchedule/utils.ts
@@ -27,12 +27,12 @@ export const computeIsPast = (
   nowMinutes: number
 ): boolean => {
   if (isActive) return false;
-  // Intentional `||` (not `??`): an empty-string endTime must also fall back
-  // to startTime, matching how endTime is treated elsewhere in the widget.
-  // parseTime would return -1 for '' anyway, but doing the fallback here
-  // preserves the valid startTime path.
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const effectiveMinutes = parseTime(endTime || startTime);
+  // An empty-string endTime must fall back to startTime (matching how endTime
+  // is treated elsewhere in the widget); `??` alone wouldn't catch '', so
+  // test absence explicitly here.
+  const effective =
+    endTime !== undefined && endTime !== '' ? endTime : startTime;
+  const effectiveMinutes = parseTime(effective);
   if (effectiveMinutes < 0) return false; // unparseable — do not flag as past
   return effectiveMinutes < nowMinutes;
 };

--- a/utils/deleteDrawingPageSubcollection.ts
+++ b/utils/deleteDrawingPageSubcollection.ts
@@ -1,0 +1,101 @@
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  writeBatch,
+  type Firestore,
+} from 'firebase/firestore';
+
+/**
+ * Phase 2 PR 2.6 — best-effort cleanup of a DrawingWidget page's Firestore
+ * subcollection when the page is deleted from the dashboard.
+ *
+ * Without this, `useDrawingPages.removePage` would only remove the page from
+ * the denormalized `pages[]` cache on the dashboard doc, leaving the
+ * page-meta doc and all of its child object docs orphaned at
+ *   /users/{uid}/dashboards/{dashboardId}/drawings/{widgetId}/pages/{pageId}
+ *   /users/{uid}/dashboards/{dashboardId}/drawings/{widgetId}/pages/{pageId}/objects/*
+ *
+ * Pseudo-atomicity: child object docs are batch-deleted FIRST in chunks of
+ * 450 ops, then the parent page-meta doc is removed. If a chunk commit
+ * fails midway, the parent still exists, so a re-run can resume — re-running
+ * the same id-set is idempotent (deleting an already-deleted doc is a no-op
+ * in Firestore).
+ *
+ * Errors are surfaced to the caller via the returned Promise; the
+ * DrawingWidget reports them through its standard error-toast path.
+ */
+
+const FIRESTORE_BATCH_LIMIT = 450;
+
+interface Options {
+  db: Firestore;
+  uid: string;
+  dashboardId: string;
+  widgetId: string;
+  pageId: string;
+}
+
+export const deleteDrawingPageSubcollection = async ({
+  db,
+  uid,
+  dashboardId,
+  widgetId,
+  pageId,
+}: Options): Promise<void> => {
+  const objectsCol = collection(
+    db,
+    'users',
+    uid,
+    'dashboards',
+    dashboardId,
+    'drawings',
+    widgetId,
+    'pages',
+    pageId,
+    'objects'
+  );
+
+  const snapshot = await getDocs(objectsCol);
+  const ids = snapshot.docs.map((d) => d.id);
+
+  for (let i = 0; i < ids.length; i += FIRESTORE_BATCH_LIMIT) {
+    const batch = writeBatch(db);
+    const slice = ids.slice(i, i + FIRESTORE_BATCH_LIMIT);
+    for (const id of slice) {
+      batch.delete(
+        doc(
+          db,
+          'users',
+          uid,
+          'dashboards',
+          dashboardId,
+          'drawings',
+          widgetId,
+          'pages',
+          pageId,
+          'objects',
+          id
+        )
+      );
+    }
+    await batch.commit();
+  }
+
+  // Parent page-meta doc last — its existence signals "children are present"
+  // for any future reader that uses it as a marker.
+  await deleteDoc(
+    doc(
+      db,
+      'users',
+      uid,
+      'dashboards',
+      dashboardId,
+      'drawings',
+      widgetId,
+      'pages',
+      pageId
+    )
+  );
+};

--- a/utils/deleteDrawingPageSubcollection.ts
+++ b/utils/deleteDrawingPageSubcollection.ts
@@ -64,21 +64,7 @@ export const deleteDrawingPageSubcollection = async ({
     const batch = writeBatch(db);
     const slice = ids.slice(i, i + FIRESTORE_BATCH_LIMIT);
     for (const id of slice) {
-      batch.delete(
-        doc(
-          db,
-          'users',
-          uid,
-          'dashboards',
-          dashboardId,
-          'drawings',
-          widgetId,
-          'pages',
-          pageId,
-          'objects',
-          id
-        )
-      );
+      batch.delete(doc(objectsCol, id));
     }
     await batch.commit();
   }

--- a/utils/migrateDrawingToSubcollection.ts
+++ b/utils/migrateDrawingToSubcollection.ts
@@ -92,8 +92,14 @@ export const migrateDrawingToSubcollection = async ({
   }
 
   // Build the flat write queue. Each entry is a (ref, payload) pair so we
-  // can chunk uniformly. Mixing page-doc writes with object writes in the
-  // same queue keeps ordering deterministic (page meta before its objects).
+  // can chunk uniformly.
+  //
+  // Pseudo-atomicity across batches: queue ALL object (child) writes BEFORE
+  // any page-meta (parent) writes. If a chunk commit fails partway through,
+  // the parent doc(s) for that page never landed, so a subsequent reader
+  // that uses the parent's existence as a "children are persisted" signal
+  // won't observe a half-migrated page. The setDoc / batch.set calls are
+  // idempotent on retry.
   type WriteOp =
     | {
         kind: 'page';
@@ -106,16 +112,17 @@ export const migrateDrawingToSubcollection = async ({
         objectId: string;
         payload: DrawableObject;
       };
-  const ops: WriteOp[] = [];
+  const pageOps: WriteOp[] = [];
+  const objectOps: WriteOp[] = [];
 
   for (const page of pages) {
-    ops.push({
+    pageOps.push({
       kind: 'page',
       pageId: page.id,
       payload: { background: page.background ?? 'blank' },
     });
     for (const obj of page.objects ?? []) {
-      ops.push({
+      objectOps.push({
         kind: 'object',
         pageId: page.id,
         objectId: obj.id,
@@ -123,6 +130,8 @@ export const migrateDrawingToSubcollection = async ({
       });
     }
   }
+  // Children first, parents last.
+  const ops: WriteOp[] = [...objectOps, ...pageOps];
 
   for (let i = 0; i < ops.length; i += FIRESTORE_BATCH_OP_LIMIT) {
     const batch = writeBatch(db);


### PR DESCRIPTION
## Summary

Addresses all 11 unresolved review comments on PR #1702. Targets `dev-paul` (the source branch of PR #1702) so the fixes merge into the open PR.

### Bugs

- **useDrawingObjectsDoc:** add microtask cleanup so listeners are torn down when the widget fully unmounts, not just on page switches (prevents leaking Firestore reads for closed widgets). _[Gemini high]_
- **migrateDrawingToSubcollection:** write child object docs before parent page-meta docs so a partial batch failure can't leave orphaned parents. _[Gemini high]_
- **Widget.tsx:** delete the page-meta doc + objects subcollection on page removal post-migration (otherwise orphaned forever). _[Gemini high]_
- **Widget.tsx:** surface a toast on subcollection write failures so a silently-reverted change is visible to the user. _[Claude review]_
- **PageStrip:** render a "has content" placeholder for non-active pages post-migration (denormalized `page.objects` is empty after migration, so thumbnails were permanently blank). Active page hydrates from the live subcollection slice. _[Claude review]_

### Refactors

- **Widget.tsx:** clear selection chrome inside `setActiveTool` instead of a state-sync `useEffect`. _[Claude review]_
- **TextEditorOverlay.tsx:** assign latest-prop refs in render body (no one-render lag) and fix the `canvasRect` doc/comment about scroll offsets — `getBoundingClientRect()` is viewport-relative and the overlay is `position: fixed`. _[Gemini medium / Copilot]_
- **SettingsPanel.tsx:** lift `updatePosition` into a stable `useCallback` so the layout effect can include it in its dep list instead of suppressing `exhaustive-deps`. _[Copilot]_
- **SpecialistSchedule/computeIsPast:** drop the `prefer-nullish-coalescing` suppression by treating empty string as absent explicitly. _[Copilot]_

### Notes

- The `react-hooks/refs` rule IS active via `eslint-plugin-react-hooks@7.0.1`'s `recommended` config (CLAUDE.md is stale on this point), so render-body ref assignments still need `// eslint-disable-next-line react-hooks/refs` suppressions. Kept them intact and clarified the comments.
- The `set-state-in-effect` suppression in SettingsPanel is the standard React pattern for "layout effect → measure DOM → setState before paint."

## Test plan

- [x] `pnpm run validate` — 3678 root + 291 functions tests pass, type-check + lint + format clean
- [ ] Manually verify drawing-widget page delete cleans up subcollection on a real Firestore project
- [ ] Manually verify the error toast surfaces when offline / Firestore write fails

https://claude.ai/code/session_01F49uFUisnzm3NLLvgEntFM

---
_Generated by [Claude Code](https://claude.ai/code/session_01F49uFUisnzm3NLLvgEntFM)_