### PR TITLE
fix(i18n): add missing common.saved/success/error keys to DE, ES, FR locales

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -11,7 +11,10 @@
     "none": "Keine",
     "loading": "Laden...",
     "saving": "Speichern...",
+    "saved": "Gespeichert",
     "upload": "Hochladen",
+    "success": "Erfolg",
+    "error": "Fehler",
     "clearAll": "Alles löschen"
   },
   "boardNav": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -11,7 +11,10 @@
     "none": "Ninguno",
     "loading": "Cargando...",
     "saving": "Guardando...",
+    "saved": "Guardado",
     "upload": "Subir",
+    "success": "Éxito",
+    "error": "Error",
     "clearAll": "Borrar Todo"
   },
   "boardNav": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -11,7 +11,10 @@
     "none": "Aucun",
     "loading": "Chargement...",
     "saving": "Enregistrement...",
+    "saved": "Enregistré",
     "upload": "Télécharger",
+    "success": "Succès",
+    "error": "Erreur",
     "clearAll": "Tout effacer"
   },
   "boardNav": {

--- a/tests/i18n/commonLocales.test.ts
+++ b/tests/i18n/commonLocales.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test for missing common-namespace keys in non-English locales.
+ *
+ * The keys `common.saved`, `common.success`, and `common.error` were added to
+ * the EN locale but never propagated to DE, ES, or FR.  These keys are used
+ * directly by production components:
+ *
+ *   - `common.saved`   → StickerLibraryModal save-button label
+ *   - `common.error`   → DashboardView and Weather/Settings error toasts
+ *   - `common.success` → available for shared use
+ *
+ * Without these keys, i18next falls back to EN for German/Spanish/French
+ * users, silently displaying English text in otherwise localised UIs.
+ *
+ * This test loads each locale JSON directly so the assertion fires even
+ * before the i18next runtime resolves the missing fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+/** Keys in the `common` namespace that every locale must provide. */
+const REQUIRED_COMMON_KEYS = ['saved', 'success', 'error'] as const;
+
+type LocaleFile = typeof en;
+
+describe('EN locale — common namespace baseline', () => {
+  it('has all required common keys', () => {
+    for (const key of REQUIRED_COMMON_KEYS) {
+      expect(en.common, `en.common.${key} is missing from EN`).toHaveProperty(
+        key
+      );
+    }
+  });
+});
+
+describe.each([
+  { code: 'de', locale: de as unknown as LocaleFile },
+  { code: 'es', locale: es as unknown as LocaleFile },
+  { code: 'fr', locale: fr as unknown as LocaleFile },
+])('$code locale — common namespace parity with EN', ({ code, locale }) => {
+  it(`${code}: has all required common keys`, () => {
+    for (const key of REQUIRED_COMMON_KEYS) {
+      expect(locale.common, `${code}.common.${key} is missing`).toHaveProperty(
+        key
+      );
+    }
+  });
+});

--- a/tests/i18n/commonLocales.test.ts
+++ b/tests/i18n/commonLocales.test.ts
@@ -25,8 +25,6 @@ import fr from '@/locales/fr.json';
 /** Keys in the `common` namespace that every locale must provide. */
 const REQUIRED_COMMON_KEYS = ['saved', 'success', 'error'] as const;
 
-type LocaleFile = typeof en;
-
 describe('EN locale — common namespace baseline', () => {
   it('has all required common keys', () => {
     for (const key of REQUIRED_COMMON_KEYS) {
@@ -38,9 +36,9 @@ describe('EN locale — common namespace baseline', () => {
 });
 
 describe.each([
-  { code: 'de', locale: de as unknown as LocaleFile },
-  { code: 'es', locale: es as unknown as LocaleFile },
-  { code: 'fr', locale: fr as unknown as LocaleFile },
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
 ])('$code locale — common namespace parity with EN', ({ code, locale }) => {
   it(`${code}: has all required common keys`, () => {
     for (const key of REQUIRED_COMMON_KEYS) {


### PR DESCRIPTION
## Root Cause

`common.saved`, `common.success`, and `common.error` were added to `locales/en.json` but never propagated to the German (`de`), Spanish (`es`), or French (`fr`) locale files. Because i18next silently falls back to EN when a key is absent, the bug was invisible in production — but every non-EN user saw English text in affected UI surfaces:

- `StickerLibraryModal` — uses `t('common.saved')` for the save-button label
- `DashboardView` — uses `t('common.error')` for error toasts
- `Weather/Settings` — uses `t('common.error')` for weather fetch failures

## Fix

Added the three keys with correct translations to all three non-EN locales:

| Key | DE | ES | FR |
|---|---|---|---|
| `common.saved` | Gespeichert | Guardado | Enregistré |
| `common.success` | Erfolg | Éxito | Succès |
| `common.error` | Fehler | Error | Erreur |

## Rejected Band-Aid

Adding `{ defaultValue: 'Saved' }` at each `t('common.saved')` call site — that would mask the gap at three specific locations without fixing the locale files, leaving the same problem for every future consumer of those keys.

## Regression Test

`tests/i18n/commonLocales.test.ts` — 4 tests:
1. EN baseline: has all three required keys (sanity check)
2. DE: has all three keys
3. ES: has all three keys
4. FR: has all three keys

The test loads each locale JSON directly (not via i18next), so the i18next fallback cannot hide the failure.

**Verified:** 3 of 4 tests FAIL on `dev-paul` (DE/ES/FR keys missing). All 4 PASS on this branch.

## Risk

**Contained** — additive JSON changes only; no code changes. Existing 15 i18n tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0173okwGQ2FxqBQ3msDgw637)_