### PR TITLE
fix(random): restore button floors + size result text to displayed string

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "vite-dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "functions-emulator",

--- a/components/common/AbsentButton.tsx
+++ b/components/common/AbsentButton.tsx
@@ -63,24 +63,24 @@ export const AbsentButton: React.FC<AbsentButtonProps> = ({
         })}
         className={`relative flex items-center rounded-xl bg-white border border-slate-200 text-slate-500 hover:bg-slate-50 hover:text-brand-blue-primary transition-colors cursor-pointer ${className ?? ''}`.trim()}
         style={{
-          gap: 'min(6px, 1.5cqmin)',
-          padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
-          height: 'min(32px, 8cqmin)',
+          gap: 'clamp(5px, 1.5cqmin, 8px)',
+          padding: 'clamp(5px, 1.5cqmin, 8px) clamp(8px, 2.5cqmin, 14px)',
+          minHeight: 'clamp(26px, 8cqmin, 36px)',
         }}
       >
         <UserX
           className="shrink-0"
           style={{
-            width: 'min(14px, 4cqmin)',
-            height: 'min(14px, 4cqmin)',
+            width: 'clamp(12px, 4cqmin, 18px)',
+            height: 'clamp(12px, 4cqmin, 18px)',
           }}
         />
         {absentCount > 0 && (
           <span
             className="font-black bg-red-500 text-white rounded-full leading-none tabular-nums shrink-0"
             style={{
-              fontSize: 'min(10px, 3cqmin)',
-              padding: 'min(2px, 0.6cqmin) min(6px, 1.6cqmin)',
+              fontSize: 'clamp(9px, 3cqmin, 12px)',
+              padding: 'clamp(2px, 0.6cqmin, 3px) clamp(5px, 1.6cqmin, 8px)',
             }}
           >
             {absentCount}

--- a/components/common/ActiveClassChip.tsx
+++ b/components/common/ActiveClassChip.tsx
@@ -137,16 +137,22 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
   if (!activeRoster) return null;
 
   const iconSizeStyle = compact
-    ? { width: 'min(14px, 4cqmin)', height: 'min(14px, 4cqmin)' }
+    ? {
+        width: 'clamp(12px, 4cqmin, 18px)',
+        height: 'clamp(12px, 4cqmin, 18px)',
+      }
     : {
         width: 'clamp(14px, 3.6cqmin, 28px)',
         height: 'clamp(14px, 3.6cqmin, 28px)',
       };
   const labelFontStyle = compact
-    ? { fontSize: 'min(11px, 3.5cqmin)' }
+    ? { fontSize: 'clamp(10px, 3.5cqmin, 14px)' }
     : { fontSize: 'clamp(12px, 3cqmin, 20px)' };
   const chevronSizeStyle = compact
-    ? { width: 'min(12px, 3.5cqmin)', height: 'min(12px, 3.5cqmin)' }
+    ? {
+        width: 'clamp(10px, 3.5cqmin, 16px)',
+        height: 'clamp(10px, 3.5cqmin, 16px)',
+      }
     : {
         width: 'clamp(12px, 3cqmin, 22px)',
         height: 'clamp(12px, 3cqmin, 22px)',
@@ -184,9 +190,9 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
     : 'flex items-center bg-brand-blue-lighter rounded-full border border-brand-blue-light';
   const chipStyle: React.CSSProperties = compact
     ? {
-        gap: 'min(6px, 1.5cqmin)',
-        padding: 'min(6px, 1.5cqmin) min(10px, 2.5cqmin)',
-        height: 'min(32px, 8cqmin)',
+        gap: 'clamp(5px, 1.5cqmin, 8px)',
+        padding: 'clamp(5px, 1.5cqmin, 8px) clamp(8px, 2.5cqmin, 14px)',
+        minHeight: 'clamp(26px, 8cqmin, 36px)',
       }
     : {
         gap: 'clamp(6px, 2cqmin, 14px)',

--- a/components/widgets/random/GroupSizeStepper.tsx
+++ b/components/widgets/random/GroupSizeStepper.tsx
@@ -33,7 +33,7 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
       aria-label={title}
       title={title}
       className="flex items-stretch bg-white/80 border border-slate-200 rounded-full overflow-hidden shadow-sm flex-shrink-0"
-      style={{ height: 'min(48px, 9cqmin)' }}
+      style={{ height: 'clamp(40px, 9cqmin, 72px)' }}
     >
       <button
         type="button"
@@ -41,7 +41,7 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
         disabled={atMin}
         className="flex items-center justify-center text-slate-600 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         style={{
-          width: 'min(32px, 7cqmin)',
+          width: 'clamp(28px, 7cqmin, 48px)',
         }}
         aria-label={t('widgets.random.stepperDecrease', {
           name: title,
@@ -50,30 +50,30 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
       >
         <Minus
           style={{
-            width: 'min(14px, 3.5cqmin)',
-            height: 'min(14px, 3.5cqmin)',
+            width: 'clamp(12px, 3.5cqmin, 22px)',
+            height: 'clamp(12px, 3.5cqmin, 22px)',
           }}
         />
       </button>
       <div
         className="flex flex-col items-center justify-center"
         style={{
-          paddingLeft: 'min(4px, 0.5cqmin)',
-          paddingRight: 'min(4px, 0.5cqmin)',
-          minWidth: 'min(28px, 6cqmin)',
+          paddingLeft: 'clamp(4px, 0.5cqmin, 8px)',
+          paddingRight: 'clamp(4px, 0.5cqmin, 8px)',
+          minWidth: 'clamp(28px, 6cqmin, 44px)',
         }}
       >
         {label && (
           <span
             className="uppercase tracking-wider text-slate-400 font-bold leading-none"
-            style={{ fontSize: 'min(9px, 1.8cqmin)' }}
+            style={{ fontSize: 'clamp(9px, 1.8cqmin, 12px)' }}
           >
             {label}
           </span>
         )}
         <span
           className="font-bold font-mono text-slate-700 tabular-nums leading-tight"
-          style={{ fontSize: 'min(15px, 3.5cqmin)' }}
+          style={{ fontSize: 'clamp(14px, 3.5cqmin, 22px)' }}
         >
           {value}
         </span>
@@ -84,7 +84,7 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
         disabled={atMax}
         className="flex items-center justify-center text-slate-600 hover:bg-slate-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         style={{
-          width: 'min(32px, 7cqmin)',
+          width: 'clamp(28px, 7cqmin, 48px)',
         }}
         aria-label={t('widgets.random.stepperIncrease', {
           name: title,
@@ -93,8 +93,8 @@ export const GroupSizeStepper: React.FC<GroupSizeStepperProps> = ({
       >
         <Plus
           style={{
-            width: 'min(14px, 3.5cqmin)',
-            height: 'min(14px, 3.5cqmin)',
+            width: 'clamp(12px, 3.5cqmin, 22px)',
+            height: 'clamp(12px, 3.5cqmin, 22px)',
           }}
         />
       </button>

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -1383,17 +1383,61 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     [students]
   );
 
-  // 130/N cqw guarantees the N-char word fits (uppercase bold, ~0.65
-  // char-width ratio, 15 % safety margin). Derived dynamically so the
-  // guarantee holds for any word length, not just those in a lookup table.
-  // Capped at 40cqw for very short words and 4cqw as an absolute minimum.
-  // The cqh cap (20cqh) prevents vertical overflow in very wide-but-short
-  // widgets where a pure cqw value could produce an impossibly tall font.
+  // Size the result text to fit the CURRENTLY DISPLAYED string so short
+  // winners ("1.") fill the widget instead of being pinned to whatever the
+  // longest student name in the roster happens to be.
+  //
+  // Horizontal fit: 100/N cqw assumes ~0.85 char-width ratio for bold
+  // uppercase (Lexend) with ~15 % safety margin — wider than the historical
+  // 130/N which assumed 0.65 and let wide letters like R/E/A overflow.
+  // Multi-word strings wrap at spaces (white-space normal, no mid-word
+  // breaks) so the formula only needs to fit the longest single word.
+  //
+  // Caps: cqw cap raised to 80 so 1-2 char results ("1.", "X") can grow
+  // into available vertical space instead of being clipped by an artificially
+  // tight horizontal cap. cqh cap of 60 gives single-word results room to
+  // fill ~60 % of widget height while still allowing 2-line wrap on typical
+  // FirstName-LastName picks (60×2 = 120 cqh just clips, which is the
+  // wrap-fallback case and acceptable).
+  //
+  // Falls back to the 6-char "Ready?" placeholder length when displayResult
+  // is empty / not a string (e.g. Groups mode), so the formula stays defined.
+  const displayedWordLength = useMemo(() => {
+    if (typeof displayResult === 'string' && displayResult.length > 0) {
+      return displayResult
+        .trim()
+        .split(/\s+/)
+        .reduce((maxLen, word) => Math.max(maxLen, word.length), 0);
+    }
+    return 0;
+  }, [displayResult]);
   const resFontSize = useMemo(() => {
-    if (maxWordLength === 0) return 'min(26cqw, 20cqh)';
-    const cqwValue = Math.min(40, Math.max(4, Math.round(130 / maxWordLength)));
-    return `min(${cqwValue}cqw, 20cqh)`;
-  }, [maxWordLength]);
+    // Three regimes:
+    //   - Spinning: use the roster's worst-case word so the font is stable
+    //     across animation ticks (otherwise every random name swap retriggers
+    //     a font-size transition mid-spin).
+    //   - Settled winner: size to the actually-displayed string so short
+    //     winners ("1.") fill the widget.
+    //   - Placeholder ("Ready?"): always 6 chars — we don't fall back to
+    //     maxWordLength because a roster of short names (e.g. a 1-letter
+    //     "Q") would size the 6-char placeholder too large and overflow.
+    let effectiveLength: number;
+    if (isSpinning) {
+      effectiveLength = maxWordLength > 0 ? maxWordLength : 6;
+    } else if (displayedWordLength > 0) {
+      effectiveLength = displayedWordLength;
+    } else {
+      effectiveLength = 6;
+    }
+    // 75 = 100% width / (char_ratio ~1.13 with margin) — Lexend bold
+    // uppercase letters like R/E/A/D/Y run wider than typical sans-serif so
+    // the multiplier needs to be conservative or short words will overflow.
+    const cqwValue = Math.min(
+      80,
+      Math.max(4, Math.round(75 / effectiveLength))
+    );
+    return `min(${cqwValue}cqw, 60cqh)`;
+  }, [isSpinning, displayedWordLength, maxWordLength]);
 
   const renderSinglePick = () => {
     if (visualStyle === 'wheel' && students.length > 0) {
@@ -1539,9 +1583,10 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 disabled={isSpinning}
                 className="flex items-center rounded-xl bg-white border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-brand-blue-primary focus-visible:outline-offset-2"
                 style={{
-                  gap: 'min(6px, 1.5cqmin)',
-                  padding: 'min(6px, 1.5cqmin) min(12px, 2.5cqmin)',
-                  height: 'min(32px, 8cqmin)',
+                  gap: 'clamp(6px, 1.5cqmin, 10px)',
+                  padding:
+                    'clamp(6px, 1.5cqmin, 10px) clamp(10px, 2.5cqmin, 18px)',
+                  minHeight: 'clamp(32px, 8cqmin, 48px)',
                 }}
                 aria-label={t('widgets.random.modeChipAria', {
                   mode: currentModeLabel,
@@ -1555,13 +1600,13 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 <ModeIcon
                   className="text-brand-blue-primary shrink-0"
                   style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
+                    width: 'clamp(14px, 4cqmin, 22px)',
+                    height: 'clamp(14px, 4cqmin, 22px)',
                   }}
                 />
                 <span
                   className="font-black uppercase text-brand-blue-primary truncate min-w-0 tracking-widest"
-                  style={{ fontSize: 'min(13px, 3.5cqmin)' }}
+                  style={{ fontSize: 'clamp(13px, 3.5cqmin, 18px)' }}
                 >
                   {currentModeLabel}
                 </span>
@@ -1602,7 +1647,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             </div>
             <div
               className="flex items-center"
-              style={{ gap: 'min(6px, 1.5cqmin)' }}
+              style={{ gap: 'clamp(6px, 1.5cqmin, 10px)' }}
             >
               {/* AbsentButton is the canonical "remove a student" entry
                   point — only valid when a class roster is active, since
@@ -1720,9 +1765,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 })}
                 className="flex-1 min-w-0"
                 style={{
-                  height: 'min(48px, 9cqmin)',
-                  paddingLeft: 'min(14px, 2.5cqmin)',
-                  paddingRight: 'min(14px, 2.5cqmin)',
+                  height: 'clamp(40px, 10cqmin, 72px)',
+                  paddingLeft: 'clamp(10px, 3cqmin, 24px)',
+                  paddingRight: 'clamp(10px, 3cqmin, 24px)',
                 }}
                 title={t('widgets.random.launchJigsawHint', {
                   defaultValue: 'Show expert groups',
@@ -1730,15 +1775,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 icon={
                   <Sparkles
                     style={{
-                      width: 'min(18px, 4.5cqmin)',
-                      height: 'min(18px, 4.5cqmin)',
+                      width: 'clamp(16px, 4.5cqmin, 32px)',
+                      height: 'clamp(16px, 4.5cqmin, 32px)',
                     }}
                   />
                 }
               >
                 <span
                   className="font-black uppercase tracking-wider truncate"
-                  style={{ fontSize: 'min(12px, 2.8cqmin)' }}
+                  style={{ fontSize: 'clamp(11px, 3cqmin, 18px)' }}
                 >
                   {t('widgets.random.launchJigsawShort', {
                     defaultValue: 'Expert',
@@ -1767,9 +1812,9 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 })}
                 className="flex-1 min-w-0"
                 style={{
-                  height: 'min(48px, 9cqmin)',
-                  paddingLeft: 'min(14px, 2.5cqmin)',
-                  paddingRight: 'min(14px, 2.5cqmin)',
+                  height: 'clamp(40px, 10cqmin, 72px)',
+                  paddingLeft: 'clamp(10px, 3cqmin, 24px)',
+                  paddingRight: 'clamp(10px, 3cqmin, 24px)',
                 }}
                 title={t('widgets.random.launchHomeGroupHint', {
                   defaultValue: 'Return to home groups',
@@ -1777,15 +1822,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 icon={
                   <Home
                     style={{
-                      width: 'min(18px, 4.5cqmin)',
-                      height: 'min(18px, 4.5cqmin)',
+                      width: 'clamp(16px, 4.5cqmin, 32px)',
+                      height: 'clamp(16px, 4.5cqmin, 32px)',
                     }}
                   />
                 }
               >
                 <span
                   className="font-black uppercase tracking-wider truncate"
-                  style={{ fontSize: 'min(12px, 2.8cqmin)' }}
+                  style={{ fontSize: 'clamp(11px, 3cqmin, 18px)' }}
                 >
                   {t('widgets.random.launchHomeGroupShort', {
                     defaultValue: 'Home',
@@ -1800,8 +1845,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 disabled={isSpinning}
                 className="flex-shrink-0"
                 style={{
-                  width: 'min(48px, 9cqmin)',
-                  height: 'min(48px, 9cqmin)',
+                  width: 'clamp(40px, 10cqmin, 72px)',
+                  height: 'clamp(40px, 10cqmin, 72px)',
                   padding: 0,
                 }}
                 aria-label={isSpinning ? 'Picking' : 'Randomize'}
@@ -1810,8 +1855,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   <Shuffle
                     className={isSpinning ? 'animate-spin' : ''}
                     style={{
-                      width: 'min(22px, 5cqmin)',
-                      height: 'min(22px, 5cqmin)',
+                      width: 'clamp(20px, 5cqmin, 36px)',
+                      height: 'clamp(20px, 5cqmin, 36px)',
                     }}
                   />
                 }
@@ -1838,8 +1883,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     onClick={handleSendToScoreboard}
                     aria-label={t('widgets.random.sendToScoreboard')}
                     style={{
-                      width: 'min(48px, 9cqmin)',
-                      height: 'min(48px, 9cqmin)',
+                      width: 'clamp(40px, 10cqmin, 72px)',
+                      height: 'clamp(40px, 10cqmin, 72px)',
                       padding: 0,
                     }}
                     className="flex-shrink-0"
@@ -1847,8 +1892,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                     icon={
                       <Trophy
                         style={{
-                          width: 'min(22px, 5cqmin)',
-                          height: 'min(22px, 5cqmin)',
+                          width: 'clamp(20px, 5cqmin, 36px)',
+                          height: 'clamp(20px, 5cqmin, 36px)',
                         }}
                         className="text-amber-500"
                       />
@@ -1906,8 +1951,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                       defaultValue: 'Rotate groups',
                     })}
                     style={{
-                      width: 'min(48px, 9cqmin)',
-                      height: 'min(48px, 9cqmin)',
+                      width: 'clamp(40px, 10cqmin, 72px)',
+                      height: 'clamp(40px, 10cqmin, 72px)',
                       padding: 0,
                     }}
                     className="flex-shrink-0 ml-auto"
@@ -1919,8 +1964,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                       <RefreshCw
                         className={isRotating ? 'animate-spin' : ''}
                         style={{
-                          width: 'min(22px, 5cqmin)',
-                          height: 'min(22px, 5cqmin)',
+                          width: 'clamp(20px, 5cqmin, 36px)',
+                          height: 'clamp(20px, 5cqmin, 36px)',
                         }}
                       />
                     }
@@ -1934,8 +1979,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                 disabled={isSpinning}
                 className={`flex-shrink-0${mode === 'groups' && Array.isArray(displayResult) && displayResult.length > 1 ? '' : ' ml-auto'}`}
                 style={{
-                  width: 'min(48px, 9cqmin)',
-                  height: 'min(48px, 9cqmin)',
+                  width: 'clamp(40px, 10cqmin, 72px)',
+                  height: 'clamp(40px, 10cqmin, 72px)',
                   padding: 0,
                 }}
                 aria-label={isSpinning ? 'Picking' : 'Randomize'}
@@ -1944,8 +1989,8 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
                   <Shuffle
                     className={isSpinning ? 'animate-spin' : ''}
                     style={{
-                      width: 'min(22px, 5cqmin)',
-                      height: 'min(22px, 5cqmin)',
+                      width: 'clamp(20px, 5cqmin, 36px)',
+                      height: 'clamp(20px, 5cqmin, 36px)',
                     }}
                   />
                 }

--- a/tests/components/widgets/RandomWidget.test.tsx
+++ b/tests/components/widgets/RandomWidget.test.tsx
@@ -126,9 +126,11 @@ describe('RandomWidget', () => {
 
   describe('text scaling', () => {
     // Shorter words get a larger cqw value; longer words get a smaller one.
-    // Formula: round(130 / maxWordLength) cqw, capped at [4, 40].
-    // 'Alice'       →  5 chars → round(130/5)  = 26 → 'min(26cqw, 20cqh)'
-    // 'Christopher' → 11 chars → round(130/11) = 12 → 'min(12cqw, 20cqh)'
+    // When lastResult is set (settled winner), formula sizes based on the
+    // displayed string's longest word: round(75 / wordLength) cqw, capped at
+    // [4, 80], with a 60cqh vertical cap.
+    // 'Alice'       →  5 chars → round(75/5)  = 15 → 'min(15cqw, 60cqh)'
+    // 'Christopher' → 11 chars → round(75/11) =  7 → 'min(7cqw, 60cqh)'
 
     it('assigns a smaller font size for longer words than for shorter ones', () => {
       const shortWidget = {
@@ -164,8 +166,8 @@ describe('RandomWidget', () => {
         .getByTestId('random-flash')
         .getAttribute('data-font-size');
 
-      expect(shortFontSize).toBe('min(26cqw, 20cqh)');
-      expect(longFontSize).toBe('min(12cqw, 20cqh)');
+      expect(shortFontSize).toBe('min(15cqw, 60cqh)');
+      expect(longFontSize).toBe('min(7cqw, 60cqh)');
     });
 
     it('sizes font by the longest WORD, not the full name length', () => {
@@ -207,12 +209,13 @@ describe('RandomWidget', () => {
         .getAttribute('data-font-size');
 
       // Both rosters have a max word length of 11 → same font size
-      expect(multiFontSize).toBe('min(12cqw, 20cqh)');
-      expect(singleFontSize).toBe('min(12cqw, 20cqh)');
+      expect(multiFontSize).toBe('min(7cqw, 60cqh)');
+      expect(singleFontSize).toBe('min(7cqw, 60cqh)');
     });
 
     it('produces a valid font size for words longer than 18 characters', () => {
-      // 34-char word → round(130/34) = 4 (the minimum) → 'min(4cqw, 20cqh)'
+      // 34-char word → round(75/34) = 2 → clamped to the [4, 80] floor →
+      // 'min(4cqw, 60cqh)'
       const longWordWidget = {
         ...mockWidget,
         config: {
@@ -229,7 +232,7 @@ describe('RandomWidget', () => {
         .getByTestId('random-flash')
         .getAttribute('data-font-size');
 
-      expect(fontSize).toBe('min(4cqw, 20cqh)');
+      expect(fontSize).toBe('min(4cqw, 60cqh)');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes two compounding regressions in the Randomizer widget that made chips/buttons collapse and result text render tiny.

- **PR #1626's `min()` sweep had removed every minimum-size floor.** Reverted to `clamp(min, ideal, max)` so the mode chip, Pick button, GroupSizeStepper, ActiveClassChip (compact), and AbsentButton keep usable floors on small widgets.
- **Result-text formula now sizes for the *currently displayed* string**, not the roster's worst-case word. Short winners like "1." now fill available vertical space, multi-word names wrap (no mid-word breaks), and the longest word always fits horizontally.

## Formula details

Three regimes:

| State | Length used | Why |
|---|---|---|
| Spinning | roster max | Stable font during animation ticks |
| Settled winner | displayed string's longest word | Fills available space |
| Placeholder ("Ready?") | fixed 6 | Roster with 1-char student would otherwise oversize the placeholder |

Other tweaks:
- Horizontal: `75/N cqw` (was `130/N`) — Lexend bold uppercase runs wider than the original 0.65 char-ratio assumption.
- Caps: `80cqw` (was `40`), `60cqh` (was `20`) — short text can now grow into vertical space.

## Tooling

`.claude/launch.json` `vite-dev` now uses `autoPort: true` so worktree preview servers don't collide with the main `:3000`.

## Test plan

- [ ] Add a Randomizer in Pick One mode, leave roster empty → "Ready?" placeholder fits widget at any size
- [ ] Pick a name → result text fills widget (multi-word names wrap, longest word fits horizontally)
- [ ] Resize widget small (~250px wide) → chips and Pick button hold a usable floor
- [ ] Resize widget large (~800px wide) → chips/buttons hit their max cap, don't grow unbounded
- [ ] Verify groups/jigsaw modes — GroupSizeStepper +/- buttons remain tappable at small sizes
- [ ] `pnpm run validate` ✅ (already verified locally: type-check, lint, format, 3695 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)