### PR TITLE
fix(quiz): preserve student answers + recover from PIN pop-out lockout

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1011,9 +1011,11 @@ const ActiveQuiz: React.FC<{
   // picks up exactly where the student left off.
   const [writtenAnswer, setWrittenAnswer] = useState<string>('');
   const writtenAnswerRef = useRef<string>('');
-  const writtenAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
+  // Per-question draft autosave timer. Originally written-response-only;
+  // now coalesces autosaves for every answer type (MC, FIB, Matching,
+  // Ordering, short, essay) because dropping non-written answers on tab
+  // close was the primary source of the reported quiz data loss.
+  const draftAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Which question id the current `writtenAnswer` belongs to. Used by the
   // autosave effect to refuse writes during the single render between
   // `currentQuestion.id` advancing (student-paced submit-and-advance) and
@@ -1250,62 +1252,114 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
-  // Written-response autosave. Debounced 500ms to mirror the PLC notes
-  // editor pattern; flushed synchronously on unmount, visibility-hidden,
-  // and when the teacher pauses the session so a student can resume on
-  // a new day without losing typing. Submit/advance also persists the
-  // final state, so the debounce is purely a write-rate optimization.
+  // Per-question draft autosave for every answer type. Originally
+  // written-response-only — MC/FIB/Matching/Ordering used to only write
+  // on explicit Submit, so a tab close mid-attempt silently dropped the
+  // student's answers (the bug the user reported as "sporadic data
+  // loss"). The 500 ms debounce mirrors the PLC notes editor pattern;
+  // Submit/advance still writes the final state, so the debounce is
+  // purely a write-rate optimization.
+  //
+  // Matching/Ordering live in `structuredAnswerRef` (a ref so drag-and-
+  // drop doesn't re-render this whole component on every move), so they
+  // schedule their own autosave from the StructuredQuestionInput's
+  // `onAnswerChange` callback via `scheduleDraftAutosave` below. This
+  // effect covers the state-driven types (MC, FIB, short, essay).
   useEffect(() => {
     const qid = currentQuestion?.id;
-    const isWritten =
-      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
-    if (!isWritten || !qid) return;
+    const type = currentQuestion?.type;
+    if (!qid || !type) return;
     if (submitted) return;
 
-    // Race guard: if `currentQuestion.id` has advanced (student-paced
-    // submit-and-advance) but `hydrateAnswerControls` hasn't yet replaced
-    // `writtenAnswer` with the new question's saved value, the draft we
-    // see here is still from the previous question. Refuse to write —
-    // the next render after hydration will re-evaluate this effect with
-    // the correct draft.
-    if (writtenAnswerQuestionIdRef.current !== qid) return;
-
-    // Skip the initial-hydration call: if the editor's seeded value
-    // matches the saved response, there's nothing to write.
-    if (writtenAnswer === (savedAnswerForCurrent ?? '')) return;
-
-    if (writtenAutosaveTimer.current) {
-      clearTimeout(writtenAutosaveTimer.current);
+    let draft: string | null = null;
+    if (type === 'short' || type === 'essay') {
+      // Race guard: if `currentQuestion.id` has advanced (student-paced
+      // submit-and-advance) but `hydrateAnswerControls` hasn't yet
+      // replaced `writtenAnswer` with the new question's saved value,
+      // the draft we see here is still from the previous question.
+      // Refuse to write — the next render after hydration will
+      // re-evaluate with the correct draft.
+      if (writtenAnswerQuestionIdRef.current !== qid) return;
+      draft = writtenAnswer;
+    } else if (type === 'MC') {
+      draft = draftMcAnswer;
+    } else if (type === 'FIB') {
+      draft = fibAnswer;
+    } else {
+      // Matching/Ordering autosave via scheduleDraftAutosave from the
+      // structured input's onAnswerChange; not driven by this effect.
+      return;
     }
-    const draft = writtenAnswer;
-    writtenAutosaveTimer.current = setTimeout(() => {
+
+    if (draft === null) return;
+    // Skip empties (nothing to save yet — student hasn't chosen/typed).
+    // Empty-string drafts ARE meaningful for written types (the student
+    // may have just cleared the editor — that's a real edit worth
+    // persisting). For MC null already covered above; for FIB an empty
+    // string is "no answer yet" so skip.
+    if (type === 'FIB' && draft === '') return;
+    // Skip the initial-hydration call: if the seeded value matches what
+    // was already saved, there's nothing to write.
+    if (draft === (savedAnswerForCurrent ?? '')) return;
+
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
+    const snapshot = draft;
+    draftAutosaveTimer.current = setTimeout(() => {
       void onAnswerRef
-        .current(qid, draft, undefined, { isDraft: true })
+        .current(qid, snapshot, undefined, { isDraft: true })
         .catch((err: unknown) => {
-          logError('QuizStudentApp.writtenAutosave', err, {
+          logError('QuizStudentApp.draftAutosave', err, {
             questionId: qid,
+            questionType: type,
           });
         });
     }, 500);
 
     return () => {
-      if (writtenAutosaveTimer.current) {
-        clearTimeout(writtenAutosaveTimer.current);
+      if (draftAutosaveTimer.current) {
+        clearTimeout(draftAutosaveTimer.current);
       }
     };
   }, [
     writtenAnswer,
+    draftMcAnswer,
+    fibAnswer,
     currentQuestion?.id,
     currentQuestion?.type,
     submitted,
     savedAnswerForCurrent,
   ]);
 
-  // Flush pending written-response autosave on unmount and on the
-  // visibility-hidden / pause transitions so a closed tab or a teacher
-  // pause never loses in-flight typing. The synchronous Firestore write
-  // can't be awaited inside a unload handler, but kicking it off before
-  // the page tears down is the best-effort flush we can do.
+  // Imperative draft autosave for ref-driven types (Matching/Ordering)
+  // whose value updates don't flow through React state. Called from the
+  // child StructuredQuestionInput's `onAnswerChange` on every drag/drop
+  // so the same 500 ms debounce window coalesces rapid placements.
+  const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
+    if (myResponseStatusRef.current === 'completed') return;
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
+    draftAutosaveTimer.current = setTimeout(() => {
+      void onAnswerRef
+        .current(qid, answer, undefined, { isDraft: true })
+        .catch((err: unknown) => {
+          logError('QuizStudentApp.draftAutosave', err, {
+            questionId: qid,
+            questionType: 'structured',
+          });
+        });
+    }, 500);
+  }, []);
+
+  // Flush pending draft autosave for the current question on unmount,
+  // visibility-hidden, beforeunload, and on the teacher pause event. The
+  // synchronous Firestore write can't be awaited inside an unload
+  // handler, but kicking it off before the page tears down is the best-
+  // effort flush we can do. Covers every answer type — without this the
+  // 500 ms debounce window is enough for tab-close to lose the last
+  // typed character / clicked option / dropped chip.
   useEffect(() => {
     const flush = () => {
       // Bail if the response has already been finalized. The cleanup
@@ -1313,24 +1367,45 @@ const ActiveQuiz: React.FC<{
       // flipping to `'completed'` — without this guard, the flush would
       // re-write the answer with `status: 'draft'`, downgrading the
       // parent doc from `'completed'` back to `'in-progress'` and
-      // breaking the teacher's results view ("0 finished", "in
-      // progress" badge, score distribution empty).
+      // breaking the teacher's results view.
       if (myResponseStatusRef.current === 'completed') return;
       const qid = currentQuestionRef.current?.id;
       const type = currentQuestionRef.current?.type;
-      if (type !== 'short' && type !== 'essay') return;
-      if (!qid) return;
-      const draft = writtenAnswerRef.current;
+      if (!qid || !type) return;
+
+      let draft: string | null = null;
+      switch (type) {
+        case 'short':
+        case 'essay':
+          draft = writtenAnswerRef.current;
+          break;
+        case 'MC':
+          draft = draftMcAnswerRef.current;
+          break;
+        case 'FIB':
+          draft = fibAnswerRef.current;
+          break;
+        case 'Matching':
+        case 'Ordering':
+          draft = structuredAnswerRef.current;
+          break;
+        default:
+          return;
+      }
+      if (draft === null) return;
+      if (type === 'FIB' && draft === '') return;
       if (draft === (savedAnswerForCurrent ?? '')) return;
-      if (writtenAutosaveTimer.current) {
-        clearTimeout(writtenAutosaveTimer.current);
-        writtenAutosaveTimer.current = null;
+
+      if (draftAutosaveTimer.current) {
+        clearTimeout(draftAutosaveTimer.current);
+        draftAutosaveTimer.current = null;
       }
       void onAnswerRef
         .current(qid, draft, undefined, { isDraft: true })
         .catch((err: unknown) => {
-          logError('QuizStudentApp.writtenAutosaveFlush', err, {
+          logError('QuizStudentApp.draftFlush', err, {
             questionId: qid,
+            questionType: type,
           });
         });
     };
@@ -1338,8 +1413,10 @@ const ActiveQuiz: React.FC<{
       if (document.visibilityState === 'hidden') flush();
     };
     // Custom event from `ActiveQuiz.handleAutoSubmit` so a strike-3
-    // auto-submit lands the latest essay draft before completing the
-    // response. Internal-only event name; not part of any public API.
+    // auto-submit lands the latest draft (of any type) before completing
+    // the response. Name preserved for backwards compatibility with the
+    // existing `dispatchEvent('spartboard:quiz:flush-written')` call;
+    // semantically it now flushes whichever type is active.
     document.addEventListener('visibilitychange', onVisibilityChange);
     document.addEventListener('spartboard:quiz:flush-written', flush);
     window.addEventListener('beforeunload', flush);
@@ -1969,6 +2046,9 @@ const ActiveQuiz: React.FC<{
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
               structuredAnswerRef.current = answer;
+              // Persist the placement as a draft so a tab close before
+              // Submit doesn't lose the student's in-progress pairings.
+              scheduleDraftAutosave(currentQuestion.id, answer);
             }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1257,6 +1257,16 @@ const ActiveQuiz: React.FC<{
     if (!autoSubmitTriggeredFor) return;
     const question = currentQuestionRef.current;
     if (!question || question.id !== autoSubmitTriggeredFor) return;
+    // Cancel any pending draft autosave for the same question — same
+    // rationale as handleSubmit/handleSubmitAndAdvance. Without this
+    // clear, the question-change watcher will later fire the captured
+    // draft with `isDraft: true`, downgrading the just-auto-submitted
+    // answer's status back to 'draft' on the next advance.
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+      draftAutosaveTimer.current = null;
+    }
+    pendingDraftRef.current = null;
     // Pull from the type-appropriate live ref so a half-completed
     // matching/ordering answer is preserved on timeout instead of
     // submitting the empty string.
@@ -1347,25 +1357,20 @@ const ActiveQuiz: React.FC<{
     pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
+      // Only clear the timer here. We CAN'T flush from this cleanup
+      // even when the question has advanced: React commits cleanups
+      // BEFORE the ref-sync effect at L1205 updates
+      // `currentQuestionRef.current` to the new id, so any condition
+      // like `currentQuestionRef.current?.id !== capturedQid` would
+      // always read stale (equal) refs and never fire. The actual
+      // flush-on-advance happens in the question-change watcher at
+      // L1418, which runs AFTER the ref-sync. handleSubmit /
+      // handleSubmitAndAdvance / the timer-expiry auto-submit effect
+      // all explicitly null `pendingDraftRef.current` so the watcher
+      // skips already-submitted answers.
       if (draftAutosaveTimer.current) {
         clearTimeout(draftAutosaveTimer.current);
         draftAutosaveTimer.current = null;
-      }
-      // Flush only when (a) this same effect's scheduled write is still
-      // the latest pending draft AND (b) the question has advanced.
-      // handleSubmit/handleSubmitAndAdvance synchronously null out
-      // `pendingDraftRef` before submitting, so if our captured write
-      // has been superseded by an explicit submit we skip the flush —
-      // otherwise we'd double-fire submitAnswer and downgrade the
-      // just-submitted answer's status from 'submitted' to 'draft'.
-      const pending = pendingDraftRef.current;
-      if (
-        pending &&
-        pending.qid === capturedQid &&
-        currentQuestionRef.current?.id !== capturedQid
-      ) {
-        writeNow();
-        pendingDraftRef.current = null;
       }
     };
   }, [
@@ -1391,6 +1396,15 @@ const ActiveQuiz: React.FC<{
     // onAnswerChange, the resulting draft write would silently
     // un-submit the question and drop it from the teacher's results.
     if (submittedRef.current) return;
+    // Saved-equal guard: StructuredQuestionInput's mount effect re-emits
+    // the saved answer on every remount. Without this short-circuit
+    // each question advance triggers a redundant 500ms-debounced write
+    // (cost) AND overwrites pendingDraftRef.qid to the new question
+    // before the question-change watcher can flush the outgoing
+    // question's still-pending draft — silently dropping it. Mirrors
+    // the state-driven effect's `draft === savedAnswerForCurrent`
+    // short-circuit.
+    if (answer === (savedAnswerForCurrentRef.current ?? '')) return;
     if (draftAutosaveTimer.current) {
       clearTimeout(draftAutosaveTimer.current);
     }
@@ -1436,13 +1450,17 @@ const ActiveQuiz: React.FC<{
   // typed character / clicked option / dropped chip.
   useEffect(() => {
     const flush = () => {
-      // Bail if the response has already been finalized. The cleanup
-      // flush runs on unmount, which is triggered by `myResponse.status`
-      // flipping to `'completed'` — without this guard, the flush would
-      // re-write the answer with `status: 'draft'`, downgrading the
-      // parent doc from `'completed'` back to `'in-progress'` and
-      // breaking the teacher's results view.
+      // Bail if the response has already been finalized at the doc
+      // level (last-question submit / completeQuiz), OR if the current
+      // question was just explicitly submitted locally. The doc-level
+      // check covers the post-completeQuiz unmount path; the
+      // `submittedRef` check covers the per-question-submit + tab-close
+      // race where the listener hasn't yet propagated the just-submitted
+      // answer back into savedAnswerForCurrent, so the saved-equal
+      // bail-out below would otherwise fail and re-write the answer as
+      // a draft — downgrading the just-submitted answer.
       if (myResponseStatusRef.current === 'completed') return;
+      if (submittedRef.current) return;
       const qid = currentQuestionRef.current?.id;
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
@@ -3125,7 +3143,11 @@ const QuizSubmittedWaitScreen: React.FC<{
   >;
   pin: string;
 }> = ({ session, myResponse, pin }) => {
-  const autoSubmitted = (myResponse.tabSwitchWarnings ?? 0) >= 3;
+  // Local variable name avoids shadowing `QuizResponse.autoSubmitted`
+  // (the cron-set flag for idle-finalized responses). This banner is
+  // tab-switch-specific; the cron-finalized case has no banner yet
+  // (deferred UI surface).
+  const tabSwitchAutoSubmitted = (myResponse.tabSwitchWarnings ?? 0) >= 3;
   const scoreSuffix = getScoreSuffix(session);
 
   return (
@@ -3152,7 +3174,7 @@ const QuizSubmittedWaitScreen: React.FC<{
         </p>
       </div>
 
-      {autoSubmitted && (
+      {tabSwitchAutoSubmitted && (
         <div className="max-w-sm mb-6 p-3 bg-amber-500/20 border border-amber-500/40 rounded-xl text-amber-200 text-sm">
           Auto-submitted because you left the quiz tab 3 times.
         </div>

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1178,6 +1178,25 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
+  // Mirror of the per-question `submitted` state so the imperative
+  // autosave path (Matching/Ordering's onAnswerChange) can refuse to
+  // schedule a draft write for an already-submitted question. Without
+  // this, back-navigating to a submitted structured question and
+  // triggering onAnswerChange (e.g., StructuredQuestionInput's mount
+  // effect re-emits the saved answer) downgrades the answer from
+  // `status: 'submitted'` to `status: 'draft'`, vanishing it from the
+  // teacher's results view.
+  const submittedRef = useRef(false);
+  submittedRef.current = submitted;
+  // Pending draft tracker for question-change flushes. Both the state-
+  // driven autosave effect AND scheduleDraftAutosave populate this when
+  // they schedule a write; a watcher on `currentQuestion?.id` calls
+  // `write()` synchronously when the question advances, flushing the
+  // outgoing question's last edit before the new question's autosave
+  // path clobbers the shared timer slot.
+  const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
+    null
+  );
   // Live serialized answer for Matching/Ordering, written by the child
   // StructuredQuestionInput on every drag/tap so timer auto-submit can
   // capture partial placements instead of submitting the empty string.
@@ -1301,34 +1320,52 @@ const ActiveQuiz: React.FC<{
     }
 
     if (draft === null) return;
-    // Skip empties (nothing to save yet — student hasn't chosen/typed).
-    // Empty-string drafts ARE meaningful for written types (the student
-    // may have just cleared the editor — that's a real edit worth
-    // persisting). For MC null already covered above; for FIB an empty
-    // string is "no answer yet" so skip.
-    if (type === 'FIB' && draft === '') return;
     // Skip the initial-hydration call: if the seeded value matches what
-    // was already saved, there's nothing to write.
+    // was already saved, there's nothing to write. This also handles
+    // the "FIB: empty draft + no prior save" case (both sides reduce
+    // to '') without short-circuiting on empty draft alone — which
+    // would have silently dropped a deliberate clear of a previously-
+    // saved FIB answer.
     if (draft === (savedAnswerForCurrent ?? '')) return;
 
     if (draftAutosaveTimer.current) {
       clearTimeout(draftAutosaveTimer.current);
     }
     const snapshot = draft;
-    draftAutosaveTimer.current = setTimeout(() => {
+    const capturedQid = qid;
+    const writeNow = () => {
       void onAnswerRef
-        .current(qid, snapshot, undefined, { isDraft: true })
+        .current(capturedQid, snapshot, undefined, { isDraft: true })
         .catch((err: unknown) => {
           logError('QuizStudentApp.draftAutosave', err, {
-            questionId: qid,
+            questionId: capturedQid,
             questionType: type,
           });
         });
-    }, 500);
+    };
+    draftAutosaveTimer.current = setTimeout(writeNow, 500);
+    pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
       if (draftAutosaveTimer.current) {
         clearTimeout(draftAutosaveTimer.current);
+        draftAutosaveTimer.current = null;
+      }
+      // Flush only when (a) this same effect's scheduled write is still
+      // the latest pending draft AND (b) the question has advanced.
+      // handleSubmit/handleSubmitAndAdvance synchronously null out
+      // `pendingDraftRef` before submitting, so if our captured write
+      // has been superseded by an explicit submit we skip the flush —
+      // otherwise we'd double-fire submitAnswer and downgrade the
+      // just-submitted answer's status from 'submitted' to 'draft'.
+      const pending = pendingDraftRef.current;
+      if (
+        pending &&
+        pending.qid === capturedQid &&
+        currentQuestionRef.current?.id !== capturedQid
+      ) {
+        writeNow();
+        pendingDraftRef.current = null;
       }
     };
   }, [
@@ -1347,10 +1384,17 @@ const ActiveQuiz: React.FC<{
   // so the same 500 ms debounce window coalesces rapid placements.
   const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
     if (myResponseStatusRef.current === 'completed') return;
+    // Per-question guard: don't downgrade an already-submitted answer
+    // back to draft. Back-navigation in student-paced mode can land on
+    // a previously-submitted Matching/Ordering question; if
+    // StructuredQuestionInput's mount effect (or a stray drag) calls
+    // onAnswerChange, the resulting draft write would silently
+    // un-submit the question and drop it from the teacher's results.
+    if (submittedRef.current) return;
     if (draftAutosaveTimer.current) {
       clearTimeout(draftAutosaveTimer.current);
     }
-    draftAutosaveTimer.current = setTimeout(() => {
+    const writeNow = () => {
       void onAnswerRef
         .current(qid, answer, undefined, { isDraft: true })
         .catch((err: unknown) => {
@@ -1359,8 +1403,29 @@ const ActiveQuiz: React.FC<{
             questionType: 'structured',
           });
         });
-    }, 500);
+    };
+    draftAutosaveTimer.current = setTimeout(writeNow, 500);
+    pendingDraftRef.current = { qid, write: writeNow };
   }, []);
+
+  // Question-change watcher: if a draft is pending for the OUTGOING
+  // question when the user advances, flush it synchronously before
+  // the new question's autosave path clobbers the shared timer slot.
+  // The state-driven effect's cleanup also flushes when its own deps
+  // caused the cleanup, but Matching/Ordering pending saves are
+  // scheduled imperatively (not in a tracked effect), so this watcher
+  // is the only path that flushes them on advance.
+  useEffect(() => {
+    const pending = pendingDraftRef.current;
+    if (pending && pending.qid !== currentQuestion?.id) {
+      if (draftAutosaveTimer.current) {
+        clearTimeout(draftAutosaveTimer.current);
+        draftAutosaveTimer.current = null;
+      }
+      pending.write();
+      pendingDraftRef.current = null;
+    }
+  }, [currentQuestion?.id]);
 
   // Flush pending draft autosave for the current question on unmount,
   // visibility-hidden, beforeunload, and on the teacher pause event. The
@@ -1402,11 +1467,12 @@ const ActiveQuiz: React.FC<{
           return;
       }
       if (draft === null) return;
-      if (type === 'FIB' && draft === '') return;
       // Use the ref-synced live value rather than the closure-captured
       // `savedAnswerForCurrent`, which was frozen at mount because this
-      // effect has [] deps. See the ref declaration above for full
-      // rationale.
+      // effect has [] deps. The saved-equal check handles the "never
+      // typed" empty case (saved null, draft '') without short-
+      // circuiting on empty draft alone — which would have silently
+      // dropped a deliberate clear of a previously-saved FIB answer.
       if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
@@ -1507,6 +1573,17 @@ const ActiveQuiz: React.FC<{
 
   const handleSubmit = async (answer: string) => {
     if (submitting || submitted) return;
+    // Cancel any pending draft autosave so the flush-on-question-change
+    // path doesn't double-fire submitAnswer with `isDraft: true` after
+    // we explicitly submit. Without this clear, the autosave timer
+    // captured the same (qid, answer) and its cleanup-on-advance fires
+    // a redundant write that DOWNGRADES the just-submitted answer's
+    // status back to 'draft'.
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+      draftAutosaveTimer.current = null;
+    }
+    pendingDraftRef.current = null;
     setSubmitting(true);
     setSubmitted(true);
     setSelectedAnswer(answer);
@@ -1613,6 +1690,13 @@ const ActiveQuiz: React.FC<{
     // Self-paced revisits are intentional re-submissions — let them through
     // even when `submitted=true`. Teacher-paced still locks after first submit.
     if (submitted && !isStudentPaced) return;
+    // Cancel any pending draft autosave (see handleSubmit for the
+    // double-fire-downgrade rationale).
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+      draftAutosaveTimer.current = null;
+    }
+    pendingDraftRef.current = null;
     advancingRef.current = true;
     setSubmitting(true);
     setSaveError(null);

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1065,6 +1065,15 @@ const ActiveQuiz: React.FC<{
         (a) => a.questionId === currentQuestion.id
       )?.answer ?? null)
     : null;
+  // Synchronize `savedAnswerForCurrent` into a ref from the render body so
+  // the draft-flush effect (deps: []) compares against the live value
+  // instead of the mount-time closure capture. Without this, a student who
+  // types and triggers a save before closing the tab would see the flush
+  // compare draft against null (initial saved value) instead of the actually
+  // persisted draft — almost always benign because most diffs are nonzero,
+  // but a flush-after-no-edit would still spuriously re-write.
+  const savedAnswerForCurrentRef = useRef<string | null>(null);
+  savedAnswerForCurrentRef.current = savedAnswerForCurrent;
 
   // Hydrate the answer controls from any saved answer so a previously-
   // answered question shows the student's prior choice. For MC we set
@@ -1394,7 +1403,11 @@ const ActiveQuiz: React.FC<{
       }
       if (draft === null) return;
       if (type === 'FIB' && draft === '') return;
-      if (draft === (savedAnswerForCurrent ?? '')) return;
+      // Use the ref-synced live value rather than the closure-captured
+      // `savedAnswerForCurrent`, which was frozen at mount because this
+      // effect has [] deps. See the ref declaration above for full
+      // rationale.
+      if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
         clearTimeout(draftAutosaveTimer.current);
@@ -1426,10 +1439,10 @@ const ActiveQuiz: React.FC<{
       window.removeEventListener('beforeunload', flush);
       flush();
     };
-    // savedAnswerForCurrent is intentionally not a dep — we flush against
-    // whatever the current saved value is at flush time, not on every
-    // change of saved state.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Event listeners register once; the live state needed by `flush`
+    // (current question, draft values, saved-answer baseline) is read
+    // fresh at flush time via refs synced in the render body, so this
+    // effect has no React-tracked deps.
   }, []);
 
   // Watch for teacher revealing answers after student already submitted.

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -1724,7 +1724,24 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                         onRemoveStudent(rowKey)
                                       )
                                         .then(() => setConfirmRemove(null))
-                                        .catch(() => undefined);
+                                        .catch((err: unknown) => {
+                                          // Surface the new "must be
+                                          // signed in" auth-bail
+                                          // message (and any other
+                                          // failure) so the teacher
+                                          // sees actionable feedback
+                                          // instead of a silent no-op.
+                                          logError(
+                                            'QuizLiveMonitor.removeStudent',
+                                            err
+                                          );
+                                          addToast(
+                                            err instanceof Error
+                                              ? err.message
+                                              : 'Could not remove student — try again or check your connection.',
+                                            'error'
+                                          );
+                                        });
                                     }
                                   : undefined
                               }
@@ -2155,7 +2172,24 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                                         onRemoveStudent(rowKey)
                                       )
                                         .then(() => setConfirmRemove(null))
-                                        .catch(() => undefined);
+                                        .catch((err: unknown) => {
+                                          // Surface the new "must be
+                                          // signed in" auth-bail
+                                          // message (and any other
+                                          // failure) so the teacher
+                                          // sees actionable feedback
+                                          // instead of a silent no-op.
+                                          logError(
+                                            'QuizLiveMonitor.removeStudent',
+                                            err
+                                          );
+                                          addToast(
+                                            err instanceof Error
+                                              ? err.message
+                                              : 'Could not remove student — try again or check your connection.',
+                                            'error'
+                                          );
+                                        });
                                     }
                                   : undefined
                               }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -290,6 +290,14 @@
         { "fieldPath": "buildingId", "order": "ASCENDING" },
         { "fieldPath": "expiresAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "responses",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "lastWriteAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -2156,18 +2156,19 @@ service cloud.firestore {
           // Tags are written by the teacher on sync, never by the
           // student.
           request.resource.data.get('preSyncVersion', 0) == 0 &&
-          // Field whitelist: a student creating a fresh response may
-          // only write the schema fields the join path actually emits.
-          // Without this, a malicious join payload could include
-          // `autoSubmitted: true` (cron-only signal), `unlocked: true`
-          // (teacher-only), forged `grading.*` (teacher-only), etc.
-          // The UPDATE rule already enforces an allowlist; this
-          // closes the symmetric CREATE-side hole.
-          request.resource.data.keys().hasOnly([
-            'studentUid', 'joinedAt', 'lastWriteAt', 'status', 'answers',
-            'score', 'submittedAt', 'completedAttempts', 'preSyncVersion',
-            'pin', 'classPeriod', 'classId'
-          ]) &&
+          // Block forgery of teacher-only / cron-only fields at create
+          // time. A malicious join payload could otherwise include
+          // `autoSubmitted: true` (cron signal), `unlocked: true`
+          // (teacher signal — would trip the rejoin resume-unlocked
+          // branch), `unlockedAt`, or forged `grading.*` (teacher
+          // grading data). Explicitly deny these rather than maintain
+          // an exhaustive allowlist — the UPDATE rule already has a
+          // hasOnly whitelist that's the source of truth for the
+          // student's mutable surface.
+          request.resource.data.get('autoSubmitted', null) == null &&
+          request.resource.data.get('unlocked', null) == null &&
+          request.resource.data.get('unlockedAt', null) == null &&
+          request.resource.data.get('grading', null) == null &&
           // studentRole users must be enrolled in the session's class
           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)

--- a/firestore.rules
+++ b/firestore.rules
@@ -2220,7 +2220,19 @@ service cloud.firestore {
            // (e.g. `somethingElse: 'hack'`) would land in `addedKeys` and
            // bypass the whitelist entirely.
            request.resource.data.diff(resource.data)
-             .affectedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt']) &&
+             .affectedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt', 'lastWriteAt']) &&
+           // `lastWriteAt` is the idle-auto-submit cutoff field. Students
+           // stamp it on every answer write so the scheduled cleanup
+           // function can find stale-in-progress responses. Monotonic
+           // (only stay same or increase) so a confused/buggy client
+           // can't roll the timestamp backward and prematurely trigger
+           // an idle auto-submit. Server-side clock skew is not bounded
+           // here — forgery has no practical attack value (a student
+           // who forges a future timestamp just stays in the joined
+           // bucket longer; tab-switch protections still finalize them).
+           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastWriteAt']) ||
+            (request.resource.data.lastWriteAt is number &&
+             request.resource.data.lastWriteAt >= resource.data.get('lastWriteAt', 0))) &&
            // Students may only ever CLEAR the unlock flag (write `false`)
            // — never set it to true. The teacher's unlock action sets
            // `unlocked: true`; `completeQuiz` clears it back to false
@@ -2270,6 +2282,37 @@ service cloud.firestore {
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
+      }
+
+      // Archived responses — copies of student responses that the teacher
+      // removed (which used to be a hard delete). Live response is gone
+      // so the deterministic key is free for a fresh rejoin; the archive
+      // preserves partial answers so the teacher can recover them and so
+      // the dev (and admins) can fetch attempts that never reached
+      // submit. Students never read archived responses — privacy from
+      // classmates and from themselves (no use case where they would
+      // need to). Idle auto-submit does NOT archive — those land back
+      // in /responses with `autoSubmitted: true`.
+      match /archived_responses/{responseKey} {
+        function sessionTeacherUidArch() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.teacherUid;
+        }
+        allow read: if request.auth != null && (
+          request.auth.uid == sessionTeacherUidArch() || isAdmin()
+        );
+        // Only the session teacher can write the archive, and only as
+        // themselves (no proxy writes). archivedAt + archivedBy must be
+        // present on create; archiveReason is constrained to a known
+        // small set so a future log query can bucket by reason.
+        allow create: if request.auth != null &&
+          request.auth.uid == sessionTeacherUidArch() &&
+          request.resource.data.archivedBy == request.auth.uid &&
+          request.resource.data.archivedAt is number &&
+          request.resource.data.get('archiveReason', '') in
+            ['teacher-removed', 'session-ended', 'idle-auto-submit-failed'];
+        // Archive is otherwise immutable from the client. Future
+        // cleanup (delete after N days) will run via admin SDK only.
+        allow update, delete: if isAdmin();
       }
 
       // View tracking for view-only Share links. Each pageview by a student

--- a/firestore.rules
+++ b/firestore.rules
@@ -2134,6 +2134,11 @@ service cloud.firestore {
         // the cross-auth-type paths are now closed.
         allow create: if request.auth != null &&
           request.resource.data.studentUid == request.auth.uid &&
+          // `lastWriteAt` must be server-stamped (`serverTimestamp()`
+          // from the SDK resolves to `request.time` at rule evaluation
+          // time). Forbidding client-stamped values here closes the
+          // CREATE-side hole symmetric to the UPDATE rule below.
+          request.resource.data.lastWriteAt == request.time &&
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // Students cannot forge prior completions
@@ -2221,18 +2226,18 @@ service cloud.firestore {
            // bypass the whitelist entirely.
            request.resource.data.diff(resource.data)
              .affectedKeys().hasOnly(['answers', 'status', 'submittedAt', 'tabSwitchWarnings', 'completedAttempts', 'classPeriod', 'score', 'preSyncVersion', 'unlocked', 'resultsTabWarnings', 'resultsLockedOut', 'resultsLockedOutAt', 'lastWriteAt']) &&
-           // `lastWriteAt` is the idle-auto-submit cutoff field. Students
-           // stamp it on every answer write so the scheduled cleanup
-           // function can find stale-in-progress responses. Monotonic
-           // (only stay same or increase) so a confused/buggy client
-           // can't roll the timestamp backward and prematurely trigger
-           // an idle auto-submit. Server-side clock skew is not bounded
-           // here — forgery has no practical attack value (a student
-           // who forges a future timestamp just stays in the joined
-           // bucket longer; tab-switch protections still finalize them).
+           // `lastWriteAt` is the idle-auto-submit cutoff field. Must
+           // be server-stamped (`serverTimestamp()` from the SDK, which
+           // resolves to `request.time` at rule evaluation), NOT a
+           // client `Date.now()`. Equality with `request.time` enforces
+           // server stamping: any client that passes a raw Timestamp
+           // or a number is rejected. This closes the clock-skew
+           // failure modes — past-clock devices can't get force-
+           // finalized on the next sweep, future-clock devices can't
+           // evade idle auto-submit indefinitely, and multi-tab
+           // students with drifting clocks can't lock themselves out.
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['lastWriteAt']) ||
-            (request.resource.data.lastWriteAt is number &&
-             request.resource.data.lastWriteAt >= resource.data.get('lastWriteAt', 0))) &&
+            request.resource.data.lastWriteAt == request.time) &&
            // Students may only ever CLEAR the unlock flag (write `false`)
            // — never set it to true. The teacher's unlock action sets
            // `unlocked: true`; `completeQuiz` clears it back to false
@@ -2300,12 +2305,16 @@ service cloud.firestore {
         allow read: if request.auth != null && (
           request.auth.uid == sessionTeacherUidArch() || isAdmin()
         );
-        // Only the session teacher can write the archive, and only as
-        // themselves (no proxy writes). archivedAt + archivedBy must be
-        // present on create; archiveReason is constrained to a known
-        // small set so a future log query can bucket by reason.
+        // The session teacher OR an admin can archive a response. The
+        // delete rule on the parent /responses doc has always allowed
+        // both — without symmetric allowance here, an admin removing a
+        // student would have the archive create rejected and the whole
+        // batch (including the delete) rolls back. archivedBy must be
+        // the writer's own auth.uid (no proxy writes), and the
+        // archiveReason is constrained to a small set so a future log
+        // query can bucket by reason.
         allow create: if request.auth != null &&
-          request.auth.uid == sessionTeacherUidArch() &&
+          (request.auth.uid == sessionTeacherUidArch() || isAdmin()) &&
           request.resource.data.archivedBy == request.auth.uid &&
           request.resource.data.archivedAt is number &&
           request.resource.data.get('archiveReason', '') in

--- a/firestore.rules
+++ b/firestore.rules
@@ -2156,6 +2156,18 @@ service cloud.firestore {
           // Tags are written by the teacher on sync, never by the
           // student.
           request.resource.data.get('preSyncVersion', 0) == 0 &&
+          // Field whitelist: a student creating a fresh response may
+          // only write the schema fields the join path actually emits.
+          // Without this, a malicious join payload could include
+          // `autoSubmitted: true` (cron-only signal), `unlocked: true`
+          // (teacher-only), forged `grading.*` (teacher-only), etc.
+          // The UPDATE rule already enforces an allowlist; this
+          // closes the symmetric CREATE-side hole.
+          request.resource.data.keys().hasOnly([
+            'studentUid', 'joinedAt', 'lastWriteAt', 'status', 'answers',
+            'score', 'submittedAt', 'completedAttempts', 'preSyncVersion',
+            'pin', 'classPeriod', 'classId'
+          ]) &&
           // studentRole users must be enrolled in the session's class
           passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)

--- a/firestore.rules
+++ b/firestore.rules
@@ -2134,11 +2134,15 @@ service cloud.firestore {
         // the cross-auth-type paths are now closed.
         allow create: if request.auth != null &&
           request.resource.data.studentUid == request.auth.uid &&
-          // `lastWriteAt` must be server-stamped (`serverTimestamp()`
-          // from the SDK resolves to `request.time` at rule evaluation
-          // time). Forbidding client-stamped values here closes the
-          // CREATE-side hole symmetric to the UPDATE rule below.
-          request.resource.data.lastWriteAt == request.time &&
+          // If `lastWriteAt` is supplied, it must be server-stamped
+          // (`serverTimestamp()` from the SDK resolves to `request.time`
+          // at rule evaluation). Optional to keep the rule tolerant of
+          // legacy joins / test fixtures that don't carry the field;
+          // the worst case is the doc never appears in the idle
+          // auto-submit sweep (teacher-visible, manually cleanable) —
+          // not data loss.
+          (request.resource.data.get('lastWriteAt', null) == null ||
+           request.resource.data.lastWriteAt == request.time) &&
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // Students cannot forge prior completions

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -52,7 +52,7 @@ interface QuizAnswer {
 
 interface QuizResponseDoc {
   status?: string;
-  lastWriteAt?: number;
+  lastWriteAt?: admin.firestore.Timestamp;
   completedAttempts?: number;
   answers?: QuizAnswer[];
 }
@@ -66,7 +66,14 @@ export const finalizeIdleQuizAttempts = onSchedule(
   },
   async () => {
     const db = admin.firestore();
-    const cutoff = Date.now() - IDLE_THRESHOLD_MS;
+    // lastWriteAt is a server-stamped Firestore Timestamp (see
+    // `firestore.rules` for the request.time == lastWriteAt
+    // enforcement). The cutoff must be a Timestamp too, otherwise
+    // the inequality query against a Timestamp-typed field returns
+    // zero rows (Firestore strict type comparison).
+    const cutoff = admin.firestore.Timestamp.fromMillis(
+      Date.now() - IDLE_THRESHOLD_MS
+    );
 
     const stale = await db
       .collectionGroup('responses')
@@ -92,20 +99,38 @@ export const finalizeIdleQuizAttempts = onSchedule(
       if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
 
       const data = (docSnap.data() ?? {}) as QuizResponseDoc;
-      const answers = Array.isArray(data.answers) ? data.answers : [];
+      // Defensive: filter out any null/non-object answer entries so
+      // a legacy/aborted-write doc doesn't propagate sparse entries
+      // through the auto-finalized response (the teacher results
+      // surface previously never saw these because the student
+      // never clicked Submit; auto-finalization could force them
+      // through and crash render code that assumes
+      // `answer.questionId` exists).
+      const answers = (Array.isArray(data.answers) ? data.answers : []).filter(
+        (a): a is QuizAnswer => a !== null && typeof a === 'object'
+      );
       // Promote any pending drafts to submitted so the teacher's
       // results view counts them as the student's final answers.
       const finalAnswers = answers.map((a) =>
-        a && a.status === 'draft' ? { ...a, status: 'submitted' } : a
+        a.status === 'draft' ? { ...a, status: 'submitted' } : a
       );
 
-      batch.update(docSnap.ref, {
+      // Don't consume an attempt slot for a student who joined but
+      // never wrote a single answer — they'd otherwise hit the cap
+      // without seeing a question. The doc still flips to
+      // `completed` with `autoSubmitted: true` so it falls out of
+      // the live "joined" bucket; teachers can review and (if
+      // needed) clear the row via removeStudent.
+      const update: Record<string, unknown> = {
         status: 'completed',
         submittedAt: finalizedAt,
-        completedAttempts: (data.completedAttempts ?? 0) + 1,
         autoSubmitted: true,
         answers: finalAnswers,
-      });
+      };
+      if (finalAnswers.length > 0) {
+        update.completedAttempts = (data.completedAttempts ?? 0) + 1;
+      }
+      batch.update(docSnap.ref, update);
       batchOps++;
       finalized++;
 
@@ -120,7 +145,7 @@ export const finalizeIdleQuizAttempts = onSchedule(
     }
 
     console.log(
-      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (cutoff=${new Date(cutoff).toISOString()})`
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (cutoff=${cutoff.toDate().toISOString()})`
     );
   }
 );

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -1,0 +1,126 @@
+/**
+ * Hourly sweep that finalizes quiz responses that have been sitting in
+ * `joined` or `in-progress` past the idle threshold. Addresses the
+ * "student joins, answers a few, never submits — work is lost" failure
+ * the user reported.
+ *
+ * What it does:
+ *   - Queries `collectionGroup('responses')` for docs where status is
+ *     joined or in-progress and `lastWriteAt` is older than the cutoff.
+ *   - Promotes any draft answers to submitted, then flips the response
+ *     to `status: 'completed'` with `autoSubmitted: true` so the teacher
+ *     can distinguish auto-finalized rows from manually submitted ones
+ *     in the results view.
+ *   - Skips the cross-launch ledger increment intentionally — PIN-keyed
+ *     anonymous students don't have a ledger entry (uids rotate), and
+ *     SSO bookkeeping is non-trivial to do from server context without
+ *     re-reading the parent session + assignment. Teachers can use the
+ *     existing `unlockStudentAttempt` action if a refund is needed.
+ *
+ * Idempotency: once a doc flips to `completed` it falls out of the
+ * status filter, so a re-run of the same window is a no-op.
+ *
+ * Pre-feature responses written before `lastWriteAt` existed are
+ * skipped by the inequality query (Firestore semantics) — correct
+ * behavior; we don't want to retroactively auto-submit historical
+ * attempts.
+ */
+
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+
+/**
+ * Wall-clock minutes a response may sit idle in `joined`/`in-progress`
+ * before being auto-finalized. 90 minutes covers a full class period
+ * plus a tail; intentionally not per-assignment configurable in this
+ * pass to keep the change small (revisit if teachers ask for it).
+ */
+const IDLE_THRESHOLD_MINUTES = 90;
+const IDLE_THRESHOLD_MS = IDLE_THRESHOLD_MINUTES * 60 * 1000;
+
+/**
+ * Safety cap so a backlog (e.g. after a deploy or an outage) doesn't
+ * monopolise a single run. Firestore batches max at 500 ops; we leave
+ * headroom for the implicit ops the SDK adds.
+ */
+const MAX_FINALIZE_PER_RUN = 400;
+
+interface QuizAnswer {
+  questionId?: string;
+  status?: string;
+}
+
+interface QuizResponseDoc {
+  status?: string;
+  lastWriteAt?: number;
+  completedAttempts?: number;
+  answers?: QuizAnswer[];
+}
+
+export const finalizeIdleQuizAttempts = onSchedule(
+  {
+    schedule: 'every 60 minutes',
+    timeoutSeconds: 540,
+    memory: '512MiB',
+    region: 'us-central1',
+  },
+  async () => {
+    const db = admin.firestore();
+    const cutoff = Date.now() - IDLE_THRESHOLD_MS;
+
+    const stale = await db
+      .collectionGroup('responses')
+      .where('status', 'in', ['joined', 'in-progress'])
+      .where('lastWriteAt', '<', cutoff)
+      .limit(MAX_FINALIZE_PER_RUN)
+      .get();
+
+    if (stale.empty) {
+      console.log('[finalizeIdleQuizAttempts] no stale responses');
+      return;
+    }
+
+    const finalizedAt = Date.now();
+    let batch = db.batch();
+    let batchOps = 0;
+    let finalized = 0;
+
+    for (const docSnap of stale.docs) {
+      // Defense in depth: collectionGroup('responses') matches any path
+      // ending in /responses/{id}. We only want quiz responses; reject
+      // anything not under `quiz_sessions/{sid}/responses/{id}`.
+      if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
+
+      const data = (docSnap.data() ?? {}) as QuizResponseDoc;
+      const answers = Array.isArray(data.answers) ? data.answers : [];
+      // Promote any pending drafts to submitted so the teacher's
+      // results view counts them as the student's final answers.
+      const finalAnswers = answers.map((a) =>
+        a && a.status === 'draft' ? { ...a, status: 'submitted' } : a
+      );
+
+      batch.update(docSnap.ref, {
+        status: 'completed',
+        submittedAt: finalizedAt,
+        completedAttempts: (data.completedAttempts ?? 0) + 1,
+        autoSubmitted: true,
+        answers: finalAnswers,
+      });
+      batchOps++;
+      finalized++;
+
+      if (batchOps >= 400) {
+        await batch.commit();
+        batch = db.batch();
+        batchOps = 0;
+      }
+    }
+    if (batchOps > 0) {
+      await batch.commit();
+    }
+
+    console.log(
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (cutoff=${new Date(cutoff).toISOString()})`
+    );
+  }
+);

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -79,6 +79,11 @@ export const finalizeIdleQuizAttempts = onSchedule(
       .collectionGroup('responses')
       .where('status', 'in', ['joined', 'in-progress'])
       .where('lastWriteAt', '<', cutoff)
+      // Oldest-first so a sustained backlog doesn't starve the docs
+      // that have been waiting longest. Without an explicit order
+      // Firestore's default is by document key, which is effectively
+      // random for the responses subcollection.
+      .orderBy('lastWriteAt', 'asc')
       .limit(MAX_FINALIZE_PER_RUN)
       .get();
 
@@ -88,64 +93,90 @@ export const finalizeIdleQuizAttempts = onSchedule(
     }
 
     const finalizedAt = Date.now();
-    let batch = db.batch();
-    let batchOps = 0;
     let finalized = 0;
+    let skippedRaced = 0;
 
+    // Per-doc transactions instead of a single batch so a student who
+    // submits between our query read and the write isn't overwritten —
+    // each transaction re-reads the response and re-checks `status` +
+    // `lastWriteAt` before promoting drafts. The batch alternative
+    // would let one stale doc roll back finalizations for the entire
+    // run, OR (without a precondition) silently clobber a fresh
+    // submission with `autoSubmitted: true`. Per-doc txs trade some
+    // throughput for correctness; at the per-hour cadence and the
+    // 400-doc cap, the cost is bounded (~20s on a full sweep).
     for (const docSnap of stale.docs) {
       // Defense in depth: collectionGroup('responses') matches any path
       // ending in /responses/{id}. We only want quiz responses; reject
       // anything not under `quiz_sessions/{sid}/responses/{id}`.
       if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
 
-      const data = (docSnap.data() ?? {}) as QuizResponseDoc;
-      // Defensive: filter out any null/non-object answer entries so
-      // a legacy/aborted-write doc doesn't propagate sparse entries
-      // through the auto-finalized response (the teacher results
-      // surface previously never saw these because the student
-      // never clicked Submit; auto-finalization could force them
-      // through and crash render code that assumes
-      // `answer.questionId` exists).
-      const answers = (Array.isArray(data.answers) ? data.answers : []).filter(
-        (a): a is QuizAnswer => a !== null && typeof a === 'object'
-      );
-      // Promote any pending drafts to submitted so the teacher's
-      // results view counts them as the student's final answers.
-      const finalAnswers = answers.map((a) =>
-        a.status === 'draft' ? { ...a, status: 'submitted' } : a
-      );
+      try {
+        const result = await db.runTransaction(async (tx) => {
+          const freshSnap = await tx.get(docSnap.ref);
+          if (!freshSnap.exists) return 'gone' as const;
+          const fresh = (freshSnap.data() ?? {}) as QuizResponseDoc;
+          // Re-check the snapshot-read predicates inside the tx. A
+          // student submit (status → 'completed') or any subsequent
+          // answer write (lastWriteAt advanced past cutoff) between
+          // the query and the tx-read means this doc is no longer
+          // eligible.
+          if (fresh.status !== 'joined' && fresh.status !== 'in-progress') {
+            return 'raced-status' as const;
+          }
+          if (
+            fresh.lastWriteAt &&
+            fresh.lastWriteAt.toMillis() >= cutoff.toMillis()
+          ) {
+            return 'raced-write' as const;
+          }
 
-      // Don't consume an attempt slot for a student who joined but
-      // never wrote a single answer — they'd otherwise hit the cap
-      // without seeing a question. The doc still flips to
-      // `completed` with `autoSubmitted: true` so it falls out of
-      // the live "joined" bucket; teachers can review and (if
-      // needed) clear the row via removeStudent.
-      const update: Record<string, unknown> = {
-        status: 'completed',
-        submittedAt: finalizedAt,
-        autoSubmitted: true,
-        answers: finalAnswers,
-      };
-      if (finalAnswers.length > 0) {
-        update.completedAttempts = (data.completedAttempts ?? 0) + 1;
-      }
-      batch.update(docSnap.ref, update);
-      batchOps++;
-      finalized++;
+          // Defensive: filter out any null/non-object answer entries so
+          // a legacy/aborted-write doc doesn't propagate sparse entries
+          // through the auto-finalized response.
+          const answers = (
+            Array.isArray(fresh.answers) ? fresh.answers : []
+          ).filter((a): a is QuizAnswer => a !== null && typeof a === 'object');
+          // Promote any pending drafts to submitted so the teacher's
+          // results view counts them as the student's final answers.
+          const finalAnswers = answers.map((a) =>
+            a.status === 'draft' ? { ...a, status: 'submitted' } : a
+          );
 
-      if (batchOps >= 400) {
-        await batch.commit();
-        batch = db.batch();
-        batchOps = 0;
+          // Don't consume an attempt slot for a student who joined
+          // but never wrote a single answer — they'd otherwise hit
+          // the cap without seeing a question. The doc still flips
+          // to `completed` with `autoSubmitted: true` so it falls
+          // out of the live "joined" bucket; teachers can review
+          // and (if needed) clear the row via removeStudent.
+          const update: Record<string, unknown> = {
+            status: 'completed',
+            submittedAt: finalizedAt,
+            autoSubmitted: true,
+            answers: finalAnswers,
+          };
+          if (finalAnswers.length > 0) {
+            update.completedAttempts = (fresh.completedAttempts ?? 0) + 1;
+          }
+          tx.update(docSnap.ref, update);
+          return 'finalized' as const;
+        });
+        if (result === 'finalized') {
+          finalized++;
+        } else if (result === 'raced-status' || result === 'raced-write') {
+          skippedRaced++;
+        }
+      } catch (err) {
+        console.warn(
+          '[finalizeIdleQuizAttempts] tx failed',
+          docSnap.ref.path,
+          err
+        );
       }
-    }
-    if (batchOps > 0) {
-      await batch.commit();
     }
 
     console.log(
-      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (cutoff=${cutoff.toDate().toISOString()})`
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, cutoff=${cutoff.toDate().toISOString()})`
     );
   }
 );

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -95,6 +95,7 @@ export const finalizeIdleQuizAttempts = onSchedule(
     const finalizedAt = Date.now();
     let finalized = 0;
     let skippedRaced = 0;
+    let failed = 0;
 
     // Per-doc transactions instead of a single batch so a student who
     // submits between our query read and the write isn't overwritten —
@@ -149,11 +150,20 @@ export const finalizeIdleQuizAttempts = onSchedule(
           // to `completed` with `autoSubmitted: true` so it falls
           // out of the live "joined" bucket; teachers can review
           // and (if needed) clear the row via removeStudent.
+          //
+          // Also clear `unlocked`: if the cron finalizes a doc that
+          // was previously teacher-unlocked but the student never
+          // came back, leaving `unlocked: true` would trip the
+          // `existing.status === 'completed' && existing.unlocked`
+          // rejoin branch in useQuizSession (joinQuizSession resume-
+          // unlocked path) and grant another attempt without
+          // consuming a slot — silently bypassing the cap.
           const update: Record<string, unknown> = {
             status: 'completed',
             submittedAt: finalizedAt,
             autoSubmitted: true,
             answers: finalAnswers,
+            unlocked: false,
           };
           if (finalAnswers.length > 0) {
             update.completedAttempts = (fresh.completedAttempts ?? 0) + 1;
@@ -167,6 +177,7 @@ export const finalizeIdleQuizAttempts = onSchedule(
           skippedRaced++;
         }
       } catch (err) {
+        failed++;
         console.warn(
           '[finalizeIdleQuizAttempts] tx failed',
           docSnap.ref.path,
@@ -176,7 +187,19 @@ export const finalizeIdleQuizAttempts = onSchedule(
     }
 
     console.log(
-      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, cutoff=${cutoff.toDate().toISOString()})`
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, failed=${failed}, cutoff=${cutoff.toDate().toISOString()})`
     );
+
+    // If more than ~10% of attempts failed, escalate by throwing so the
+    // scheduler logs an error-level event and retries on the next tick.
+    // Lower the threshold once we have a baseline; for now this catches
+    // structural problems (e.g., a rule deploy gap, a malformed-doc
+    // backlog) without paging on isolated contention races.
+    const total = finalized + skippedRaced + failed;
+    if (total > 0 && failed * 10 > total) {
+      throw new Error(
+        `[finalizeIdleQuizAttempts] elevated failure rate: ${failed}/${total}`
+      );
+    }
   }
 );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -38,6 +38,7 @@ export { joinPlcAssignmentSyncGroup } from './plcAssignmentSyncJoin';
 export { joinPlcVideoActivitySyncGroup } from './plcVideoActivitySyncJoin';
 export { recomputeAdminAnalytics } from './adminAnalyticsSnapshot';
 export { expireSubShares } from './expireSubShares';
+export { finalizeIdleQuizAttempts } from './finalizeIdleQuizAttempts';
 export {
   exchangeGoogleAuthCode,
   refreshGoogleAccessToken,
@@ -4194,6 +4195,12 @@ export const pinLoginV1 = onCall(
         return s === 'waiting' || s === 'active' || s === 'paused';
       });
       if (!joinable) {
+        console.warn('[pinLoginV1] fallback', {
+          kind,
+          reason: 'no-joinable-session',
+          codeMatchCount: codeMatch.size,
+          period,
+        });
         return { matched: false, reason: 'no-joinable-session' };
       }
       sessionRef = joinable.ref;
@@ -4211,12 +4218,24 @@ export const pinLoginV1 = onCall(
 
     const sessionSnap = await sessionRef.get();
     if (!sessionSnap.exists) {
+      console.warn('[pinLoginV1] fallback', {
+        kind,
+        reason: 'session-not-found',
+        sessionId: sessionRef.id,
+        period,
+      });
       return { matched: false, reason: 'session-not-found' };
     }
     const sessionData = sessionSnap.data() ?? {};
     const teacherUid =
       typeof sessionData.teacherUid === 'string' ? sessionData.teacherUid : '';
     if (!teacherUid) {
+      console.warn('[pinLoginV1] fallback', {
+        kind,
+        reason: 'session-missing-teacher',
+        sessionId: sessionRef.id,
+        period,
+      });
       return { matched: false, reason: 'session-missing-teacher' };
     }
     const rosterIds = Array.isArray(sessionData.rosterIds)
@@ -4226,7 +4245,16 @@ export const pinLoginV1 = onCall(
       : [];
     if (rosterIds.length === 0) {
       // No roster on the session — can't bridge. Fall through to the
-      // legacy anonymous PIN flow on the client.
+      // legacy anonymous PIN flow on the client. Common for legacy
+      // PIN-only sessions; surface so we can spot a rostered session
+      // that lost its rosterIds via a bad write.
+      console.warn('[pinLoginV1] fallback', {
+        kind,
+        reason: 'no-rosters-on-session',
+        sessionId: sessionRef.id,
+        teacherUid,
+        period,
+      });
       return { matched: false, reason: 'no-rosters-on-session' };
     }
 
@@ -4280,6 +4308,21 @@ export const pinLoginV1 = onCall(
     }
 
     if (!matched) {
+      // The PIN+period tuple didn't resolve to any roster entry across
+      // the session's rosters. This is the most diagnostically valuable
+      // fallback — it usually means either (a) the teacher hasn't run
+      // commitRosterPinIndexV1 since the roster was last edited, or
+      // (b) the period the student entered doesn't match the roster's
+      // encoded period. Period is logged (not the PIN itself) so we can
+      // diff against the roster's period encoding.
+      console.warn('[pinLoginV1] fallback', {
+        kind,
+        reason: 'no-index-entry',
+        sessionId: sessionRef.id,
+        teacherUid,
+        rosterCount: rosterIds.length,
+        period,
+      });
       return { matched: false, reason: 'no-index-entry' };
     }
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -52,6 +52,17 @@ export type { QuizSessionOptions } from '../types';
 export const QUIZ_SESSIONS_COLLECTION = 'quiz_sessions';
 export const RESPONSES_COLLECTION = 'responses';
 /**
+ * Archive subcollection for responses removed by the teacher. Holds a
+ * copy of the original response doc plus archive metadata
+ * (`archivedAt`, `archivedBy`, `archiveReason`). The live doc is deleted
+ * so the deterministic key is freed for a fresh rejoin; the archive
+ * preserves partial answers for teacher recovery + dev queries beyond
+ * the 48h window the user asked for. Cleanup is intentionally not
+ * scheduled — retention is currently indefinite; revisit if storage
+ * cost becomes a concern.
+ */
+export const ARCHIVED_RESPONSES_COLLECTION = 'archived_responses';
+/**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
  * and accumulates a student's completed-attempt count across every session
  * the teacher creates for the same quiz. Without this collection, the
@@ -682,10 +693,32 @@ export const useQuizSessionTeacher = (
             )
           : null;
 
-      // Delete in a batch so the response and ledger reset are atomic
-      // from a UI perspective (no half-state where the response is
-      // gone but the cap still blocks rejoin).
+      // Archive the response before delete so partial answers survive
+      // the teacher's "remove" action. The deterministic key model means
+      // we can't soft-delete in place (the slot must be free for a fresh
+      // rejoin), so we stash a copy under `archived_responses` and then
+      // delete the live doc + ledger atomically. If `target` is missing
+      // (snapshot race), skip the archive and fall back to the original
+      // delete-only behavior — there's no in-memory copy to archive.
       const batch = writeBatch(db);
+      if (target) {
+        const archiveRef = doc(
+          db,
+          QUIZ_SESSIONS_COLLECTION,
+          sessionId,
+          ARCHIVED_RESPONSES_COLLECTION,
+          responseKey
+        );
+        // Strip the listener-only `_responseKey` tag before writing so
+        // the archive matches the original Firestore schema.
+        const { _responseKey: _, ...archivePayload } = target;
+        batch.set(archiveRef, {
+          ...archivePayload,
+          archivedAt: Date.now(),
+          archivedBy: auth.currentUser?.uid ?? null,
+          archiveReason: 'teacher-removed',
+        });
+      }
       batch.delete(responseRef);
       if (ledgerRef) batch.delete(ledgerRef);
       await batch.commit();
@@ -1293,12 +1326,43 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               },
               { matched: boolean; customToken?: string; reason?: string }
             >(functions, 'pinLoginV1');
-            const res = await callable({
-              kind: 'quiz',
-              code: normCode,
-              pin: sanitizedPin,
-              period: classPeriod,
-            });
+            const callBridge = () =>
+              callable({
+                kind: 'quiz',
+                code: normCode,
+                pin: sanitizedPin,
+                period: classPeriod,
+              });
+            // Retry once on transient errors (cold start, brief network
+            // blip, function deploy mid-call). The lockout the user
+            // reported on tab pop-out happens when the new tab's bridge
+            // call fails with a transient error, falls through to the
+            // anonymous flow, and then can't claim the existing response
+            // doc keyed by the first tab's HMAC pseudonym. Retrying
+            // here covers the common case without adding a second
+            // user-visible failure mode.
+            //
+            // Non-retryable codes (not-found, invalid-argument,
+            // permission-denied) are deterministic — re-running won't
+            // change the answer, so we surface them on the first try.
+            let res;
+            try {
+              res = await callBridge();
+            } catch (err) {
+              const code = getErrorCode(err);
+              const transient =
+                code === 'unavailable' ||
+                code === 'deadline-exceeded' ||
+                code === 'internal' ||
+                code === 'aborted';
+              if (!transient) throw err;
+              console.warn(
+                '[useQuizSession] pinLoginV1 bridge transient failure — retrying:',
+                { code }
+              );
+              await new Promise((r) => setTimeout(r, 300));
+              res = await callBridge();
+            }
             if (res.data.matched && res.data.customToken) {
               await signInWithCustomToken(auth, res.data.customToken);
               const refreshed = auth.currentUser;
@@ -1307,6 +1371,17 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
                 studentUid = refreshed.uid;
                 isAnonymous = refreshed.isAnonymous;
               }
+            } else {
+              // Bridge returned `matched: false` — log the reason so we
+              // can correlate client-side rejoin lockouts with the
+              // server-side fall-through cause (e.g. `no-index-entry`
+              // = roster pin_index out of date). Without this the
+              // anonymous fall-through is silent.
+              console.warn('[useQuizSession] pinLoginV1 bridge no-match:', {
+                reason: res.data.reason ?? 'unknown',
+                hasRoster: sessionHasRosters,
+                classPeriod,
+              });
             }
           } catch (err) {
             // The bridge is best-effort by design — falling through to
@@ -1609,6 +1684,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           const newResponse: QuizResponse = {
             studentUid,
             joinedAt: Date.now(),
+            // Seed `lastWriteAt` at join so a student who joins but
+            // never answers still ages into the idle auto-submit
+            // query (which uses an inequality filter — Firestore
+            // skips docs without the field).
+            lastWriteAt: Date.now(),
             status: 'joined',
             answers: [],
             score: null,
@@ -1711,8 +1791,15 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           getErrorCode(err) === 'permission-denied' &&
           auth.currentUser?.isAnonymous
         ) {
+          // Distinguish the "popped out into a new tab" case from a
+          // genuine PIN collision. Both look the same from Firestore's
+          // perspective (existing doc's studentUid ≠ ours), so we steer
+          // the student toward closing duplicate tabs first — that's the
+          // common case after our pinLoginV1 retry hardening above — and
+          // only escalate to "ask your teacher" if the student is sure
+          // they're not still open elsewhere.
           msg =
-            "Looks like that PIN has already joined this quiz. Ask your teacher to clear it for you, or double-check that you've selected the right class period.";
+            "It looks like you're already in this quiz on another tab or device. Close any other tabs you have this quiz open in and try again. If you're still stuck, ask your teacher to release your attempt.";
         } else if (getErrorCode(err) === 'permission-denied') {
           msg =
             "You can't join this quiz. Ask your teacher to make sure you're enrolled in the right class.";
@@ -1785,7 +1872,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           RESPONSES_COLLECTION,
           responseKey
         ),
-        { status: nextStatus, answers: updated }
+        // `lastWriteAt` is the idle-auto-submit Cloud Function's cutoff
+        // field: any joined/in-progress response whose `lastWriteAt` is
+        // older than the assignment's idle threshold gets finalized
+        // automatically. Stamped on every answer write (draft or
+        // submitted) — tab-switch warnings deliberately do NOT update
+        // it, so a student who toggles tabs without answering still
+        // ages out as expected.
+        {
+          status: nextStatus,
+          answers: updated,
+          lastWriteAt: Date.now(),
+        }
       );
     },
     []

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -695,10 +695,9 @@ export const useQuizSessionTeacher = (
         responseKey
       );
       if (!target) {
-        // Best-effort fetch; if it fails or returns no snapshot, fall
-        // through to delete-only behavior (preserves the pre-fix
-        // semantics for this rare race and avoids breaking tests
-        // whose mocks return undefined from getDoc).
+        // Best-effort fetch when the snapshot listener hasn't yet
+        // surfaced the response (rare race after a fresh mount). We
+        // need this to satisfy the archive contract for partial work.
         try {
           const fallbackSnap = await getDoc(responseRef);
           if (fallbackSnap?.exists?.()) {
@@ -707,8 +706,21 @@ export const useQuizSessionTeacher = (
               _responseKey: fallbackSnap.id,
             };
           }
-        } catch {
-          // ignore — fall through to delete-only.
+          // If the doc legitimately doesn't exist (already removed),
+          // fall through to a no-op delete — preserves the pre-fix
+          // delete-only semantics for this case.
+        } catch (err) {
+          // Don't silently swallow permission/transport errors — they
+          // mean the archive write will ALSO fail (same auth/network),
+          // so proceeding with the delete-only batch silently destroys
+          // the student's partial work. Log + rethrow so the caller
+          // toasts the error and the teacher can retry, rather than
+          // discovering later that the archive doesn't exist.
+          console.error(
+            '[useQuizSession] removeStudent fallback getDoc failed; aborting to preserve archive contract',
+            err
+          );
+          throw err;
         }
       }
 

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -28,7 +28,9 @@ import {
   increment,
   deleteField,
   runTransaction,
+  serverTimestamp,
   type DocumentSnapshot,
+  type FieldValue,
 } from 'firebase/firestore';
 import { db, auth, functions } from '@/config/firebase';
 import { signInAnonymously, signInWithCustomToken } from 'firebase/auth';
@@ -665,15 +667,24 @@ export const useQuizSessionTeacher = (
   const removeStudent = useCallback(
     async (responseKey: string) => {
       if (!sessionId) return;
+      // Auth must be present before we open the batch — the archive
+      // create rule requires `archivedBy == request.auth.uid`, so a
+      // mid-token-refresh null would cause the entire batch (including
+      // the delete) to roll back. Bail early with a clear error
+      // instead.
+      const writerUid = auth.currentUser?.uid;
+      if (!writerUid) {
+        throw new Error(
+          'You must be signed in to remove a student. Try refreshing the page.'
+        );
+      }
       // Look up the response in the snapshot-driven `responses` list to
       // recover the studentUid + quizId we need for the ledger reset
-      // (Phase 2). The teacher's existing UX for `removeStudent` is
-      // "free the student up to retake" — which today only freed the
-      // per-session counter. After Phase 2 the cross-launch ledger
-      // would still cap them, so the reset must clear the ledger entry
-      // too. Falls back to a response-only delete when the response
-      // isn't in the snapshot list (race with a stale UI click).
-      const target = responses.find(
+      // (Phase 2). If the snapshot listener hasn't propagated yet
+      // (teacher just opened the monitor), fall back to a direct
+      // `getDoc` so we still produce an archive — silently skipping
+      // the archive would defeat the data-preservation contract.
+      let target = responses.find(
         (r) => (r._responseKey ?? r.studentUid) === responseKey
       );
       const responseRef = doc(
@@ -683,6 +694,23 @@ export const useQuizSessionTeacher = (
         RESPONSES_COLLECTION,
         responseKey
       );
+      if (!target) {
+        // Best-effort fetch; if it fails or returns no snapshot, fall
+        // through to delete-only behavior (preserves the pre-fix
+        // semantics for this rare race and avoids breaking tests
+        // whose mocks return undefined from getDoc).
+        try {
+          const fallbackSnap = await getDoc(responseRef);
+          if (fallbackSnap?.exists?.()) {
+            target = {
+              ...(fallbackSnap.data() as QuizResponse),
+              _responseKey: fallbackSnap.id,
+            };
+          }
+        } catch {
+          // ignore — fall through to delete-only.
+        }
+      }
 
       const ledgerRef =
         target && session?.quizId
@@ -694,12 +722,12 @@ export const useQuizSessionTeacher = (
           : null;
 
       // Archive the response before delete so partial answers survive
-      // the teacher's "remove" action. The deterministic key model means
-      // we can't soft-delete in place (the slot must be free for a fresh
-      // rejoin), so we stash a copy under `archived_responses` and then
-      // delete the live doc + ledger atomically. If `target` is missing
-      // (snapshot race), skip the archive and fall back to the original
-      // delete-only behavior — there's no in-memory copy to archive.
+      // the teacher's "remove" action. The deterministic key model
+      // means we can't soft-delete in place (the slot must be free for
+      // a fresh rejoin), so we stash a copy under `archived_responses`
+      // and then delete the live doc + ledger atomically. If `target`
+      // is still missing after the fallback fetch (doc already gone),
+      // skip the archive — there's nothing left to preserve.
       const batch = writeBatch(db);
       if (target) {
         const archiveRef = doc(
@@ -715,7 +743,7 @@ export const useQuizSessionTeacher = (
         batch.set(archiveRef, {
           ...archivePayload,
           archivedAt: Date.now(),
-          archivedBy: auth.currentUser?.uid ?? null,
+          archivedBy: writerUid,
           archiveReason: 'teacher-removed',
         });
       }
@@ -774,6 +802,11 @@ export const useQuizSessionTeacher = (
         completedAttempts: refundedAttempts,
         unlocked: true,
         unlockedAt: Date.now(),
+        // Refresh lastWriteAt so the idle auto-submit Cloud Function
+        // doesn't immediately re-finalize this freshly-unlocked attempt
+        // on its next sweep. Without this, an unlock done >90 min after
+        // the original submit would be silently undone within the hour.
+        lastWriteAt: serverTimestamp(),
       });
       if (ledgerRef && ledgerSnap?.exists()) {
         const ledgerCurrent =
@@ -1519,6 +1552,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               status: 'in-progress',
               submittedAt: null,
               score: null,
+              // Refresh so idle auto-submit doesn't immediately
+              // re-finalize the resumed attempt (lastWriteAt would
+              // otherwise still point at the prior submit).
+              lastWriteAt: serverTimestamp(),
               ...(classPeriod && existing.classPeriod !== classPeriod
                 ? { classPeriod }
                 : {}),
@@ -1558,6 +1595,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
               score: null,
               submittedAt: null,
               preSyncVersion: 0,
+              // Refresh so the idle auto-submit cron doesn't destroy
+              // the fresh attempt — without this, a rejoin >90 min
+              // after the prior submit gets finalized on the next
+              // sweep with zero answers.
+              lastWriteAt: serverTimestamp(),
               ...(classPeriod && existing.classPeriod !== classPeriod
                 ? { classPeriod }
                 : {}),
@@ -1575,16 +1617,20 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           } else if (classPeriod && existing.classPeriod !== classPeriod) {
             // Backfill classPeriod on an in-flight response (e.g. student
             // joined before periods were configured or reloaded after a
-            // change).
-            await updateDoc(responseRef, { classPeriod }).catch(
-              (err: unknown) =>
-                logQuizJoinFirestoreError('update-backfill-period', err, {
-                  sessionId: sessionDoc.id,
-                  responseKey,
-                  studentUid,
-                  existingStudentUid: existing.studentUid,
-                  isAnonymous,
-                })
+            // change). Treat this as activity — refresh lastWriteAt so
+            // a long-running session doesn't trip the idle auto-submit
+            // on the next sweep just because of a backfill touch.
+            await updateDoc(responseRef, {
+              classPeriod,
+              lastWriteAt: serverTimestamp(),
+            }).catch((err: unknown) =>
+              logQuizJoinFirestoreError('update-backfill-period', err, {
+                sessionId: sessionDoc.id,
+                responseKey,
+                studentUid,
+                existingStudentUid: existing.studentUid,
+                isAnonymous,
+              })
             );
           }
         } else if (limit !== null && ledgerCompleted >= limit) {
@@ -1681,14 +1727,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           // the same `classPeriod` field so all downstream surfaces (period
           // dropdown, export sheet) read uniformly.
           const finalClassPeriod = classPeriod ?? resolvedPeriodName;
-          const newResponse: QuizResponse = {
+          const newResponse: Omit<QuizResponse, 'lastWriteAt'> & {
+            lastWriteAt: FieldValue;
+          } = {
             studentUid,
             joinedAt: Date.now(),
             // Seed `lastWriteAt` at join so a student who joins but
-            // never answers still ages into the idle auto-submit
-            // query (which uses an inequality filter — Firestore
-            // skips docs without the field).
-            lastWriteAt: Date.now(),
+            // never answers still ages into the idle auto-submit query.
+            // Server-stamped (not Date.now()) so a Chromebook with a
+            // skewed clock can't (a) seed a past timestamp and get
+            // force-finalized on the next sweep, or (b) seed a future
+            // timestamp to evade auto-submit indefinitely.
+            lastWriteAt: serverTimestamp(),
             status: 'joined',
             answers: [],
             score: null,
@@ -1746,6 +1796,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           if (existing.classPeriod !== resolvedPeriodName) {
             await updateDoc(responseRef, {
               classPeriod: resolvedPeriodName,
+              // Refresh — backfill is a rejoin action, the student is
+              // active. See the in-flight backfill branch above for
+              // the symmetric refresh.
+              lastWriteAt: serverTimestamp(),
             }).catch((err: unknown) =>
               logQuizJoinFirestoreError('update-backfill-class-period', err, {
                 sessionId: sessionDoc.id,
@@ -1878,11 +1932,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // automatically. Stamped on every answer write (draft or
         // submitted) — tab-switch warnings deliberately do NOT update
         // it, so a student who toggles tabs without answering still
-        // ages out as expected.
+        // ages out as expected. Server-stamped so client clock skew
+        // can't trigger spurious auto-submit or evade it.
         {
           status: nextStatus,
           answers: updated,
-          lastWriteAt: Date.now(),
+          lastWriteAt: serverTimestamp(),
         }
       );
     },

--- a/types.ts
+++ b/types.ts
@@ -2867,17 +2867,25 @@ export interface QuizResponse {
   pin?: string;
   joinedAt: number;
   /**
-   * Wall-clock ms of the student's most recent answer write (draft or
-   * submitted). Stamped on every `submitAnswer` call and at join time;
+   * Firestore server-stamped time of the student's most recent answer
+   * write (draft or submitted). Stamped on every `submitAnswer` call,
+   * at join time, and whenever a join/unlock path resets the response.
    * NOT touched by tab-switch warnings. Used by the scheduled idle
    * auto-submit Cloud Function to find responses that have been
    * sitting in `joined`/`in-progress` past the assignment's idle
-   * threshold. Optional on legacy responses written before the field
-   * existed — those are skipped by the inequality query, which is the
-   * correct behavior (don't retroactively auto-submit historical
-   * attempts).
+   * threshold.
+   *
+   * Server-stamped (Firestore Timestamp) — not a client `Date.now()` —
+   * so a Chromebook with a skewed clock can't (a) seed a past
+   * timestamp and get force-finalized on the next sweep, (b) seed a
+   * future timestamp to evade auto-submit indefinitely, or (c) trip
+   * the monotonic rule when two tabs disagree on the wall clock.
+   *
+   * Optional on legacy responses written before the field existed —
+   * those are skipped by the inequality query, which is the correct
+   * behavior (don't retroactively auto-submit historical attempts).
    */
-  lastWriteAt?: number;
+  lastWriteAt?: import('firebase/firestore').Timestamp;
   /**
    * Set by the idle auto-submit Cloud Function when a stale response
    * was finalized without the student clicking Submit. Lets the

--- a/types.ts
+++ b/types.ts
@@ -2866,6 +2866,25 @@ export interface QuizResponse {
    */
   pin?: string;
   joinedAt: number;
+  /**
+   * Wall-clock ms of the student's most recent answer write (draft or
+   * submitted). Stamped on every `submitAnswer` call and at join time;
+   * NOT touched by tab-switch warnings. Used by the scheduled idle
+   * auto-submit Cloud Function to find responses that have been
+   * sitting in `joined`/`in-progress` past the assignment's idle
+   * threshold. Optional on legacy responses written before the field
+   * existed — those are skipped by the inequality query, which is the
+   * correct behavior (don't retroactively auto-submit historical
+   * attempts).
+   */
+  lastWriteAt?: number;
+  /**
+   * Set by the idle auto-submit Cloud Function when a stale response
+   * was finalized without the student clicking Submit. Lets the
+   * teacher's results view differentiate "submitted intentionally"
+   * from "auto-submitted after timeout".
+   */
+  autoSubmitted?: boolean;
   status: QuizResponseStatus;
   answers: QuizResponseAnswer[];
   /**


### PR DESCRIPTION
## Summary

Three intertwined defects caused the reported sporadic data loss + pop-out lockout in live quiz sessions. All three are fixed here; a fourth change preserves removed-student partials for dev recovery.

### 1. MC/FIB/Matching/Ordering answers dropped on tab close
Only written-response questions had a per-keystroke autosave. Every other answer type stayed in React state and was only written to Firestore on the explicit Submit click — so closing the tab mid-attempt dropped everything the student had selected.

**Fix:** Generalized the existing 500 ms debounced draft autosave (`submitAnswer({ isDraft: true })`) to cover all answer types. Matching/Ordering schedule their save from the structured input's `onAnswerChange` so drag-and-drop placements persist without re-rendering the whole quiz. The visibility-hidden / beforeunload flush is generalized the same way.

### 2. Pop-out into a new tab triggered "PIN already joined" lockout
When the `pinLoginV1` bridge hit a transient error (cold start, brief network blip), the new tab fell back to anonymous, got a fresh rotating UID, and was denied write access to the existing response doc (keyed by the first tab's HMAC pseudonym). The student saw a hard "ask your teacher" error.

**Fix:** Bridge now retries once on transient codes (`unavailable`, `deadline-exceeded`, `internal`, `aborted`). Every fall-through path on both client and server now emits a structured warn-level log with the reason, so future occurrences are diagnosable. The user-facing copy points students at "close the other tab first" instead of leading with "ask your teacher".

### 3. Abandoned partial attempts were never finalized
A student who joined, answered a few, then walked away without submitting sat in `joined`/`in-progress` indefinitely. Their drafts now exist in Firestore (thanks to #1) but were stuck in limbo.

**Fix:** New `finalizeIdleQuizAttempts` scheduled function (hourly) promotes draft answers to submitted, marks the response `autoSubmitted: true`, and transitions status to `completed` once `lastWriteAt` is older than 90 minutes. `lastWriteAt` is stamped at join time and on every answer write (not on tab-switch counters, so an idle student isn't kept alive by background visibility events).

### 4. `removeStudent` no longer destroys partial work
The teacher's "Remove" action used to hard-delete the response doc + ledger entry. That now copies the doc to `/quiz_sessions/{sid}/archived_responses/{key}` first, so partial answers are recoverable for the 48h+ window the user asked for. Cleanup of archived_responses is intentionally not scheduled — retention is indefinite for now; revisit if storage cost becomes a concern.

## Files changed
- `components/quiz/QuizStudentApp.tsx` — generalized draft autosave + flush, added `scheduleDraftAutosave` for ref-driven types, wired matching/ordering `onAnswerChange`
- `hooks/useQuizSession.ts` — `removeStudent` archive-before-delete, `pinLoginV1` retry + reason logging, `lastWriteAt` stamping at join + submit, better lockout copy
- `functions/src/finalizeIdleQuizAttempts.ts` (new) — hourly scheduled idle auto-submit
- `functions/src/index.ts` — `pinLoginV1` fallback diagnostic logs + export
- `firestore.rules` — `archived_responses` subcollection rules + `lastWriteAt` whitelist (monotonic)
- `firestore.indexes.json` — composite `responses` (status, lastWriteAt) index for the idle query
- `types.ts` — `lastWriteAt`, `autoSubmitted` on `QuizResponse`

## Test plan
- [ ] Validation passes locally: `pnpm run validate` (✅ done — lint, type-check, format, 3698/3698 unit tests)
- [ ] Functions build: `cd functions && pnpm run build` (✅ done)
- [ ] Deploy to dev preview, then:
  - [ ] Start a live quiz, answer a few MC/FIB questions in a new browser, close the tab without submitting → confirm draft answers appear in the teacher's monitor + persist after rejoin
  - [ ] Same flow with matching/ordering — drag a few chips, close tab, rejoin → placements survive
  - [ ] Pop a quiz out of an iframe into a new window → confirm rejoin succeeds without the lockout dialog
  - [ ] Cloud Functions logs show structured warn-level entries when `pinLoginV1` falls back (matched:false with reason)
  - [ ] Manually advance `lastWriteAt` 100 minutes back on a test response and confirm `finalizeIdleQuizAttempts` flips it to `completed` with `autoSubmitted:true` on the next hourly run (or invoke directly via scheduler emulator)
  - [ ] Teacher removes a student → `/quiz_sessions/{sid}/archived_responses/{key}` doc exists with the student's prior answers + archive metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)