### PR TITLE
unify(D1): replace hand-rolled empty state in NextUp/Widget with ScaledEmptyState

### DIFF
--- a/components/widgets/NextUp/Widget.tsx
+++ b/components/widgets/NextUp/Widget.tsx
@@ -20,6 +20,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { ListOrdered, RefreshCcw } from 'lucide-react';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { useDialog } from '@/context/useDialog';
 
 const SESSIONS_COLLECTION = 'nextup_sessions';
@@ -292,24 +293,11 @@ export const NextUpWidget: React.FC<WidgetComponentProps> = ({ widget }) => {
     return (
       <WidgetLayout
         content={
-          <div className="flex flex-col items-center justify-center h-full text-slate-400 p-6 text-center">
-            <ListOrdered
-              className="mb-4 opacity-20"
-              style={{
-                width: 'min(48px, 12cqmin)',
-                height: 'min(48px, 12cqmin)',
-              }}
-            />
-            <p
-              className="font-medium"
-              style={{ fontSize: 'min(14px, 3.5cqmin)' }}
-            >
-              Queue is not active
-            </p>
-            <p className="mt-1" style={{ fontSize: 'min(10px, 2.5cqmin)' }}>
-              Flip to settings to start a session
-            </p>
-          </div>
+          <ScaledEmptyState
+            icon={ListOrdered}
+            title="Queue is not active"
+            subtitle="Flip to settings to start a session"
+          />
         }
       />
     );


### PR DESCRIPTION
## Canonical Form
`<ScaledEmptyState icon={X} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx`

## Instances Unified
**`components/widgets/NextUp/Widget.tsx`** — 1 hand-rolled empty state replaced.

The "Queue is not active" zero-session state was a bespoke `<div className="flex flex-col items-center justify-center h-full ...">` with manually-specified `min(48px, 12cqmin)` icon sizing and custom font sizes. Replaced with `<ScaledEmptyState icon={ListOrdered} title="Queue is not active" subtitle="Flip to settings to start a session" />`.

## Enforcement Added
None beyond the existing `ScaledEmptyState` component — its existence is the canonical enforcement mechanism. The hand-rolled anti-pattern was one-off drift, not a systemic pattern.

## Behavior-Preservation Evidence
- Same icon (`ListOrdered`), same title, same subtitle — visually identical concept
- `ScaledEmptyState` uses `cqmin` units internally; the only visual diff is icon slightly larger (`15cqmin` vs `12cqmin`) and title slightly larger (`4cqmin` vs `3.5cqmin`) — both improvements toward the correct size hierarchy per CLAUDE.md
- No state, no side effects, no data path changes

## Investigated But Not Changed
- `SmartNotebook/Library.tsx` — already uses `ScaledEmptyState` ✓
- `GuidedLearning/Widget.tsx:778` — view-only share results screen with action button; intentional variation analogous to D1-E1 (adding to exceptions)
- `GuidedLearningManager.tsx` — already uses `ScaledEmptyState` ✓

## Risk Tag
**mechanical** — pure component substitution, same visual concept, no behavioral change.

https://claude.ai/code/session_01DscSiiWf3izZNyRVdQeUr1

---
_Generated by [Claude Code](https://claude.ai/code/session_01DscSiiWf3izZNyRVdQeUr1)_