### PR TITLE
fix(canvas): remove onPointerLeave from AnnotationCanvas — pointer capture makes it harmful

### DIFF
--- a/components/common/AnnotationCanvas.test.tsx
+++ b/components/common/AnnotationCanvas.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { AnnotationCanvas } from './AnnotationCanvas';
 
 describe('AnnotationCanvas', () => {
@@ -103,5 +103,50 @@ describe('AnnotationCanvas', () => {
     fireEvent(canvas, upEvent);
 
     expect(stopPropagationSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Regression: pointerleave must NOT commit/abort a stroke mid-flight.
+   *
+   * Root cause: AnnotationCanvas attached `handleEnd` to `onPointerLeave`.
+   * Since `setPointerCapture` does not suppress `pointerleave` events (per
+   * the Pointer Events spec), a stroke is prematurely committed the instant
+   * the pointer exits the canvas bounds — even if the user hasn't released
+   * the button. This truncates fast strokes near canvas edges and causes
+   * `onPathsChange` to be called before the user intends to end the stroke.
+   *
+   * Fix: remove `onPointerLeave` from the canvas element entirely.
+   * `pointerup` and `pointercancel` (both registered) are sufficient because
+   * pointer capture guarantees those events reach the canvas regardless of
+   * where the pointer physically is.
+   */
+  it('does NOT commit an in-progress stroke when pointer leaves the canvas', () => {
+    const onPathsChange = vi.fn();
+    const { container } = render(
+      <AnnotationCanvas {...defaultProps} onPathsChange={onPathsChange} />
+    );
+    const canvas = container.querySelector('canvas');
+    if (!canvas) throw new Error('Canvas not found');
+
+    // Start a stroke and let React flush the state update
+    act(() => {
+      fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10 });
+    });
+
+    // Add a point mid-stroke (isDrawing is now true)
+    act(() => {
+      fireEvent.pointerMove(canvas, { clientX: 20, clientY: 20 });
+    });
+
+    // Simulate the pointer briefly leaving the canvas boundary without releasing.
+    // With `onPointerLeave={handleEnd}` present (the bug), this fires handleEnd
+    // while isDrawing=true, which calls onPathsChange prematurely.
+    act(() => {
+      fireEvent.pointerLeave(canvas);
+    });
+
+    // The stroke must NOT have been committed yet — onPathsChange should not
+    // have been called because the user has not released the pointer.
+    expect(onPathsChange).not.toHaveBeenCalled();
   });
 });

--- a/components/common/AnnotationCanvas.tsx
+++ b/components/common/AnnotationCanvas.tsx
@@ -145,7 +145,6 @@ export const AnnotationCanvas: React.FC<AnnotationCanvasProps> = ({
       onPointerMove={handleMove}
       onPointerUp={handleEnd}
       onPointerCancel={handleEnd}
-      onPointerLeave={handleEnd}
       style={{ touchAction: 'none' }}
     />
   );


### PR DESCRIPTION
## Root cause

`AnnotationCanvas.tsx` registered `onPointerLeave={handleEnd}` on the canvas element. The Pointer Events spec fires `pointerleave` even when the element has pointer capture — it fires whenever the pointer logically exits the element's bounds. So any fast stroke whose motion crossed the canvas edge mid-draw caused `handleEnd` to commit the stroke prematurely (while the pointer button was still held). Subsequent `pointerup` events were no-ops because `isDrawing` was already reset to `false`.

## Fix

Remove `onPointerLeave={handleEnd}`. The canvas already calls `setPointerCapture(e.pointerId)` in `handleStart` (line 102), which guarantees `pointerup` and `pointercancel` are routed back to the canvas element regardless of where the pointer physically moves. The `pointerleave` handler was both redundant and harmful.

## Rejected band-aid

Adding an `isDrawing` guard or `e.type` check inside `handleEnd` for the `pointerleave` path — that leaves the listener wired when it shouldn't be, and adds conditional logic that obscures intent. The correct fix is removing the handler entirely.

## Regression test

`components/common/AnnotationCanvas.test.tsx` — new test `'does NOT commit an in-progress stroke when pointer leaves the canvas'`:
- Fires `pointerDown` → `pointerMove` → `pointerLeave`
- Asserts `onPathsChange` is NOT called (stroke must still be in-progress)

Test FAILS on `dev-paul` baseline (stroke committed by `pointerleave`), PASSES on this branch. All 6 AnnotationCanvas tests, all 36 DraggableWindow tests, and all 79 layout tests pass.

## Risk tag

**contained** — one-line deletion in `AnnotationCanvas.tsx`; pointer capture was already the intended mechanism.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6TyuZzhXYCsuwYdvbQ81q)_