### PR TITLE
fix(grading): guard max-point accumulation against duplicate question IDs in video activity scorer

### DIFF
--- a/tests/utils/videoActivityGrading.test.ts
+++ b/tests/utils/videoActivityGrading.test.ts
@@ -348,4 +348,22 @@ describe('computeVideoActivityScorePct', () => {
     // First answer wins, no inflation from arrayUnion races
     expect(score).toBe(100);
   });
+
+  it('counts max points only once when questions array contains duplicate ids', () => {
+    // Duplicate question ids can appear in questions arrays if upstream data
+    // is corrupt (e.g. Drive-sync duplication, arrayUnion race on the template
+    // doc). The `seen` guard must protect `max` accumulation as well as answer
+    // crediting so that the denominator is not inflated and a correct answer
+    // still earns 100 %.
+    const score = computeVideoActivityScorePct(
+      [
+        q({ id: 'q1', type: 'MC', correctAnswer: 'a', points: 2 }),
+        q({ id: 'q1', type: 'MC', correctAnswer: 'a', points: 2 }), // duplicate
+      ],
+      [{ questionId: 'q1', answer: 'a' }] // one correct answer
+    );
+    // Without the fix: max = 4 (counted twice), earned = 2, score = 50.
+    // With the fix:    max = 2 (counted once),  earned = 2, score = 100.
+    expect(score).toBe(100);
+  });
 });

--- a/utils/videoActivityGrading.ts
+++ b/utils/videoActivityGrading.ts
@@ -140,11 +140,11 @@ export function computeVideoActivityScorePct(
   let earned = 0;
   let max = 0;
   for (const q of questions) {
-    max += q.points ?? 1;
     if (seen.has(q.id)) continue;
+    seen.add(q.id);
+    max += q.points ?? 1;
     const a = answers.find((x) => x.questionId === q.id);
     if (!a) continue;
-    seen.add(q.id);
     earned += gradeVideoActivityAnswer(q, a.answer).pointsEarned;
   }
   if (max === 0) return 0;


### PR DESCRIPTION
## Root cause

`computeVideoActivityScorePct` in `utils/videoActivityGrading.ts` accumulated `max += q.points ?? 1` **before** checking `seen.has(q.id)`, and only called `seen.add(q.id)` when an answer was found for the question. This meant:

- Duplicate question IDs (possible via Drive-sync duplication or `arrayUnion` races on the activity template doc) inflated the denominator once per duplicate.
- `earned` was credited only once (correct), but `max` was multiplied by the duplicate count.
- A student with a fully correct answer on a 2-point question appearing twice received `2/4 = 50%` instead of `2/2 = 100%`.

## Fix

Moved `seen.has(q.id)` check and `seen.add(q.id)` to the **top** of the loop body, before `max +=`, so both the denominator accumulation and the answer-crediting are protected by the same deduplication fence. The change is a 4-line reorder — no new logic.

## Rejected band-aid

Filtering duplicates from the `questions` array before entering the loop — that would silently discard data and doesn't address the architectural root cause: the `seen` guard must protect both the numerator and the denominator consistently.

## Regression test

`tests/utils/videoActivityGrading.test.ts` — new case `'counts max points only once when questions array contains duplicate ids'`:
- Passes a 2-question array where both entries have the same id and a 2-point value
- Passes one correct answer for that id
- Asserts `score === 100` (not `50`)

Test FAILS on `dev-paul` baseline (returns 50), PASSES on this branch. All 29 videoActivityGrading tests pass.

## Risk tag

**contained** — 4-line reorder inside a single pure function; all existing tests continue to pass unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6TyuZzhXYCsuwYdvbQ81q)_