### PR TITLE
fix(security): escape &amp; before HTML entities in sanitizePrompt to close entity-bypass injection

### DIFF
--- a/functions/src/sanitize.test.ts
+++ b/functions/src/sanitize.test.ts
@@ -27,4 +27,20 @@ describe('sanitizePrompt', () => {
     expect(sanitizePrompt(undefined)).toBe('');
     expect(sanitizePrompt(null as unknown as string)).toBe('');
   });
+
+  it('escapes & before applying entity replacements so pre-formed entities cannot bypass sanitization', () => {
+    // Regression: without escaping `&` first, a user who types `&#123;` gets
+    // `&#123;` in the output — which is the HTML entity for `{`, defeating the
+    // curly-brace sanitization. The AI prompt ultimately sees `{` again.
+    //
+    // Correct behaviour: `&` is escaped to `&amp;` first, so `&#123;` becomes
+    // `&amp;#123;` — a literal ampersand + hash + digits, not a curly brace.
+    expect(sanitizePrompt('&#123;injected&#125;')).toBe(
+      '&amp;#123;injected&amp;#125;'
+    );
+    // Same bypass via tag entities.
+    expect(sanitizePrompt('&lt;script&gt;')).toBe('&amp;lt;script&amp;gt;');
+    // Plain & in ordinary text must also be escaped.
+    expect(sanitizePrompt('fish & chips')).toBe('fish &amp; chips');
+  });
 });

--- a/functions/src/sanitize.ts
+++ b/functions/src/sanitize.ts
@@ -5,14 +5,24 @@
  */
 export const sanitizePrompt = (text?: string): string => {
   if (typeof text !== 'string' || text.length === 0) return '';
-  return text
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\{/g, '&#123;')
-    .replace(/\}/g, '&#125;')
-    .replace(/\[/g, '&#91;')
-    .replace(/\]/g, '&#93;')
-    .replace(/`/g, '&#96;')
-    .replace(/[\r\n]+/g, ' ')
-    .trim();
+  return (
+    text
+      // Escape `&` FIRST so any `&` the user typed becomes `&amp;` before we
+      // introduce our own HTML entity sequences. Without this step a user can
+      // smuggle `{` / `<` / etc. through by pre-typing the entity code: the
+      // input `&#123;` would survive all subsequent replacements unchanged and
+      // the AI ultimately sees a curly brace again. Escaping `&` → `&amp;`
+      // first means `&#123;` becomes `&amp;#123;` — a literal string of
+      // printable characters with no structural meaning in HTML or JSON.
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\{/g, '&#123;')
+      .replace(/\}/g, '&#125;')
+      .replace(/\[/g, '&#91;')
+      .replace(/\]/g, '&#93;')
+      .replace(/`/g, '&#96;')
+      .replace(/[\r\n]+/g, ' ')
+      .trim()
+  );
 };

--- a/functions/src/sanitize.ts
+++ b/functions/src/sanitize.ts
@@ -3,26 +3,25 @@
  * Escapes characters used for prompt injection (like tags, delimiters, and control sequences)
  * and flattens all whitespace (newlines and carriage returns) into single spaces.
  */
+const ESCAPE_MAP: Record<string, string> = {
+  // `&` is escaped here too: a single-pass replacement on the source string
+  // naturally prevents double-escaping (the `&` inside the inserted `&lt;`
+  // etc. is never re-evaluated), so a pre-typed `&#123;` survives as the
+  // literal string `&amp;#123;` with no structural meaning in HTML or JSON.
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '{': '&#123;',
+  '}': '&#125;',
+  '[': '&#91;',
+  ']': '&#93;',
+  '`': '&#96;',
+};
+
 export const sanitizePrompt = (text?: string): string => {
   if (typeof text !== 'string' || text.length === 0) return '';
-  return (
-    text
-      // Escape `&` FIRST so any `&` the user typed becomes `&amp;` before we
-      // introduce our own HTML entity sequences. Without this step a user can
-      // smuggle `{` / `<` / etc. through by pre-typing the entity code: the
-      // input `&#123;` would survive all subsequent replacements unchanged and
-      // the AI ultimately sees a curly brace again. Escaping `&` → `&amp;`
-      // first means `&#123;` becomes `&amp;#123;` — a literal string of
-      // printable characters with no structural meaning in HTML or JSON.
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/\{/g, '&#123;')
-      .replace(/\}/g, '&#125;')
-      .replace(/\[/g, '&#91;')
-      .replace(/\]/g, '&#93;')
-      .replace(/`/g, '&#96;')
-      .replace(/[\r\n]+/g, ' ')
-      .trim()
-  );
+  return text
+    .replace(/[&<>{}[\]`]/g, (ch) => ESCAPE_MAP[ch])
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
 };


### PR DESCRIPTION
## Root cause

`sanitizePrompt` in `functions/src/sanitize.ts` escaped `{`, `<`, `>`, `[`, `]`, and `` ` `` as HTML entities, but never escaped `&` itself. Since every entity sequence it emits begins with `&`, a user who pre-typed the entity code directly bypassed sanitization entirely:

- Input `&#123;injected&#125;` → output `&#123;injected&#125;` (unchanged — the AI prompt received `{injected}`)
- Input `&lt;script&gt;` → output `&lt;script&gt;` (unchanged — semantically `<script>`)

## Fix

Added `.replace(/&/g, '&amp;')` as the **first** replacement in the chain. Any `&` the user typed becomes `&amp;` before our entity sequences are introduced, so `&#123;` becomes `&amp;#123;` — a literal string of printable characters with no structural meaning in HTML or JSON.

## Rejected band-aid

A regex to detect and reject already-encoded entities — that creates a denylist (fragile, needs updating with each new entity) and would break legitimate user input like `fish & chips`. Escaping `&` first is the correct, composable solution.

## Regression test

`functions/src/sanitize.test.ts` — new test `'escapes & before applying entity replacements so pre-formed entities cannot bypass sanitization'`:
- `sanitizePrompt('&#123;injected&#125;')` → `'&amp;#123;injected&amp;#125;'`
- `sanitizePrompt('&lt;script&gt;')` → `'&amp;lt;script&amp;gt;'`
- `sanitizePrompt('fish & chips')` → `'fish &amp; chips'`

Test FAILS on `dev-paul` baseline (first assertion: received `'&#123;injected&#125;'`), PASSES on this branch. All 299 function tests (298 pre-existing + 1 new) pass.

## Risk tag

**contained** — single-function change in `sanitize.ts`; all existing inputs unaffected (prior test inputs contained no `&`, so the new first replacement is a no-op for them).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6TyuZzhXYCsuwYdvbQ81q)_