### PR TITLE
fix(quiz,admin): archive key collision + logError consistency (PR #1733 review)

### DIFF
--- a/components/admin/InstructionalRoutinesManager.tsx
+++ b/components/admin/InstructionalRoutinesManager.tsx
@@ -6,6 +6,7 @@ import { InstructionalRoutine } from '@/config/instructionalRoutines';
 import { ConfirmDialog } from '@/components/widgets/InstructionalRoutines/ConfirmDialog';
 import { getRoutineColorClasses } from '@/components/widgets/InstructionalRoutines/colorHelpers';
 import { useDashboard } from '@/context/useDashboard';
+import { logError } from '@/utils/logError';
 
 interface InstructionalRoutinesManagerProps {
   onClose: () => void;
@@ -154,7 +155,10 @@ export const InstructionalRoutinesManager: React.FC<
                   setEditingRoutine(null);
                   addToast('Routine saved to library', 'success');
                 } catch (error) {
-                  console.error('Failed to save routine:', error);
+                  logError('InstructionalRoutinesManager.saveRoutine', error, {
+                    routineId: editingRoutine.id,
+                    routineName: editingRoutine.name,
+                  });
                   addToast(
                     'Failed to save routine. Please try again.',
                     'error'
@@ -180,7 +184,10 @@ export const InstructionalRoutinesManager: React.FC<
               await deleteRoutine(deleteConfirm.routineId);
               addToast('Routine deleted successfully', 'success');
             } catch (error) {
-              console.error('Failed to delete routine:', error);
+              logError('InstructionalRoutinesManager.deleteRoutine', error, {
+                routineId: deleteConfirm.routineId,
+                routineName: deleteConfirm.routineName,
+              });
               addToast('Failed to delete routine. Please try again.', 'error');
             } finally {
               setDeleteConfirm(null);

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -742,21 +742,31 @@ export const useQuizSessionTeacher = (
       // skip the archive — there's nothing left to preserve.
       const batch = writeBatch(db);
       if (target) {
+        // Suffix the archive doc id with `archivedAt` so a student who
+        // rejoins (same deterministic responseKey) and is removed again
+        // doesn't collide with the prior archive. The archive rule only
+        // allows create — a colliding `set()` would be evaluated as
+        // update and rejected, breaking the entire removeStudent
+        // batch. Querying by `originalResponseKey` (a field on the
+        // archive doc) or by `archived_responses` collection-group +
+        // path filter recovers per-student history.
+        const archivedAt = Date.now();
         const archiveRef = doc(
           db,
           QUIZ_SESSIONS_COLLECTION,
           sessionId,
           ARCHIVED_RESPONSES_COLLECTION,
-          responseKey
+          `${responseKey}__${archivedAt}`
         );
         // Strip the listener-only `_responseKey` tag before writing so
         // the archive matches the original Firestore schema.
         const { _responseKey: _, ...archivePayload } = target;
         batch.set(archiveRef, {
           ...archivePayload,
-          archivedAt: Date.now(),
+          archivedAt,
           archivedBy: writerUid,
           archiveReason: 'teacher-removed',
+          originalResponseKey: responseKey,
         });
       }
       batch.delete(responseRef);


### PR DESCRIPTION
## Summary

Two Copilot findings on [#1733](https://github.com/OPS-PIvers/SpartBoard/pull/1733):

1. **Archive key collision on re-removal.** `removeStudent` archived under the deterministic `responseKey` (`pin-{period}-{pin}` or auth uid). A student who rejoins after removal reuses the same key — so the next removal hit the `archived_responses` rule's create-only constraint as an UPDATE and rolled back the entire batch (live response stuck in `responses/`). Suffix archive doc id with `archivedAt` so each removal lands a distinct doc; add `originalResponseKey` field on the archive for per-student history queries.

2. **InstructionalRoutinesManager logError consistency.** Two `console.error` call sites switched to `logError(scope, err, context)` matching the codebase pattern, with routine id/name as context.

## Test plan
- [x] `pnpm run lint` — clean
- [x] `pnpm run type-check` — clean
- [x] `pnpm run test` — 3719/3719 pass
- [ ] After deploy: remove a student → student rejoins → remove again → verify second archive lands at `archived_responses/{responseKey}__{ts2}` (not denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)