### PR TITLE
Quiz safeguards, Scoreboard layout, Random widget chip + CI deploy-order fix

### DIFF
--- a/.github/scripts/wait-for-firestore-indexes.sh
+++ b/.github/scripts/wait-for-firestore-indexes.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Poll Firestore until every composite index is in state READY.
+#
+# Background: `firebase deploy --only firestore:indexes` returns success
+# once the index creation request is queued, NOT once the index finishes
+# building. Indexes can take seconds to tens of minutes to build
+# depending on collection size. If the new client bundle ships before
+# the index is ready, the first user to hit the query gets a
+# FAILED_PRECONDITION error.
+#
+# This script authenticates with the service account JSON pointed at by
+# GOOGLE_APPLICATION_CREDENTIALS, then polls `gcloud firestore indexes
+# composite list` until every entry reports state=READY (or a timeout
+# trips). It exits 0 on success, 1 on timeout.
+#
+# Usage: ./wait-for-firestore-indexes.sh <project-id>
+# Required env: GOOGLE_APPLICATION_CREDENTIALS pointing at a SA JSON
+# file with at least roles/datastore.viewer permissions.
+#
+# Timeout defaults to 10 minutes — long enough for typical builds on
+# small collections like the per-session quiz_sessions/*/responses
+# subcollection, short enough that a stuck deploy doesn't hold the
+# runner indefinitely.
+
+set -euo pipefail
+
+PROJECT_ID="${1:?usage: $0 <project-id>}"
+TIMEOUT_SECONDS="${WAIT_INDEXES_TIMEOUT:-600}"
+POLL_INTERVAL_SECONDS="${WAIT_INDEXES_POLL_INTERVAL:-15}"
+
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "ERROR: GOOGLE_APPLICATION_CREDENTIALS is not set" >&2
+  exit 1
+fi
+if [[ ! -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
+  echo "ERROR: GOOGLE_APPLICATION_CREDENTIALS points at a missing file: $GOOGLE_APPLICATION_CREDENTIALS" >&2
+  exit 1
+fi
+
+# gcloud is preinstalled on GitHub-hosted ubuntu runners. Authenticate
+# with the service account and target the project before polling.
+gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+echo "Waiting up to ${TIMEOUT_SECONDS}s for Firestore composite indexes on $PROJECT_ID to be READY..."
+
+while (( SECONDS < deadline )); do
+  # `gcloud firestore indexes composite list` lists all user-defined
+  # composite indexes for the (default) database. `--format='value(state)'`
+  # prints one state per line — possible values: CREATING, READY,
+  # NEEDS_REPAIR, DELETING.
+  if ! states=$(gcloud firestore indexes composite list --format='value(state)' 2>/dev/null); then
+    # Transient API blip — back off and retry rather than failing the
+    # deploy.
+    echo "  gcloud list query failed; retrying in ${POLL_INTERVAL_SECONDS}s..."
+    sleep "$POLL_INTERVAL_SECONDS"
+    continue
+  fi
+
+  if [[ -z "$states" ]]; then
+    echo "  no composite indexes returned yet; retrying in ${POLL_INTERVAL_SECONDS}s..."
+    sleep "$POLL_INTERVAL_SECONDS"
+    continue
+  fi
+
+  # Count anything that isn't READY. NEEDS_REPAIR is treated as a hard
+  # failure — a broken index won't fix itself by waiting.
+  not_ready=$(echo "$states" | grep -v '^READY$' || true)
+  if [[ -z "$not_ready" ]]; then
+    total=$(echo "$states" | wc -l | tr -d '[:space:]')
+    echo "All $total composite indexes are READY."
+    exit 0
+  fi
+
+  if echo "$not_ready" | grep -q '^NEEDS_REPAIR$'; then
+    echo "ERROR: one or more composite indexes are in NEEDS_REPAIR. Fix them in the Firebase console before redeploying." >&2
+    gcloud firestore indexes composite list --format='table(name,state)' >&2
+    exit 1
+  fi
+
+  pending=$(echo "$not_ready" | wc -l | tr -d '[:space:]')
+  echo "  $pending index(es) still building; sleeping ${POLL_INTERVAL_SECONDS}s..."
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+
+echo "ERROR: timed out after ${TIMEOUT_SECONDS}s waiting for Firestore composite indexes to be READY." >&2
+gcloud firestore indexes composite list --format='table(name,state)' >&2 || true
+exit 1

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -57,6 +57,26 @@ jobs:
       - name: Build project
         run: pnpm run build:all
 
+      # Deploy backend (rules, indexes, functions, storage) BEFORE hosting.
+      # Reason: a new Firestore composite index isn't usable until it
+      # finishes building, but `firebase deploy --only firestore` returns
+      # success as soon as the build is queued. If hosting went first, a
+      # query in the new client bundle that needs a not-yet-built index
+      # would fail with FAILED_PRECONDITION the moment a teacher hit the
+      # code path. Order: backend first, wait for indexes, hosting last.
+      - name: Create Service Account File
+        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > service-account.json
+
+      - name: Deploy Firebase Rules, Indexes, Functions, Storage
+        run: pnpm exec firebase deploy --only functions,firestore,storage --project spartboard --force
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
+
+      - name: Wait for Firestore composite indexes to be READY
+        run: ./.github/scripts/wait-for-firestore-indexes.sh spartboard
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
+
       - name: Deploy to Firebase Hosting (Live)
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
@@ -64,14 +84,6 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           projectId: spartboard
           channelId: live
-
-      - name: Create Service Account File
-        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > service-account.json
-
-      - name: Deploy Firebase Rules and Functions
-        run: pnpm exec firebase deploy --only functions,firestore,storage --project spartboard --force
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
 
       - name: Cleanup Service Account File
         if: always()

--- a/.github/workflows/firebase-dev-deploy.yml
+++ b/.github/workflows/firebase-dev-deploy.yml
@@ -71,8 +71,17 @@ jobs:
       - name: Create Service Account File
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > service-account.json
 
-      - name: Deploy Firebase Rules and Functions
+      - name: Deploy Firebase Rules, Indexes, Functions, Storage
         run: pnpm exec firebase deploy --only functions,firestore,storage --project spartboard --force
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
+
+      # `firebase deploy --only firestore` returns once index creation is
+      # queued, not when the build is ready. Wait here so the preview
+      # channel's client bundle can't run a query before its index is
+      # built — matches the production workflow's safety order.
+      - name: Wait for Firestore composite indexes to be READY
+        run: ./.github/scripts/wait-for-firestore-indexes.sh spartboard
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
 

--- a/components/widgets/Scoreboard/Settings.tsx
+++ b/components/widgets/Scoreboard/Settings.tsx
@@ -8,7 +8,7 @@ import {
   RandomGroup,
 } from '@/types';
 import { useDebounce } from '@/hooks/useDebounce';
-import { Plus, Trash2, Users, RefreshCw } from 'lucide-react';
+import { Plus, Trash2, Users, RefreshCw, LayoutGrid, List } from 'lucide-react';
 import { Button } from '@/components/common/Button';
 import { SCOREBOARD_COLORS as TEAM_COLORS } from '@/config/scoreboard';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
@@ -54,6 +54,12 @@ export const ScoreboardSettings: React.FC<{ widget: WidgetData }> = ({
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const config = widget.config as ScoreboardConfig;
   const teams = Array.isArray(config.teams) ? config.teams : [];
+  const layout = config.layout ?? 'cards';
+
+  const setLayout = (next: 'cards' | 'rows') => {
+    if (next === layout) return;
+    updateWidget(widget.id, { config: { ...config, layout: next } });
+  };
 
   // Find Random Widget
   const randomWidget = useMemo(
@@ -172,6 +178,44 @@ export const ScoreboardSettings: React.FC<{ widget: WidgetData }> = ({
 
   return (
     <div className="space-y-6">
+      <div>
+        <SettingsLabel>Layout</SettingsLabel>
+        <div
+          className="flex items-center bg-slate-200/80 rounded-lg p-0.5"
+          role="radiogroup"
+          aria-label="Scoreboard layout"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={layout === 'cards'}
+            onClick={() => setLayout('cards')}
+            className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-bold rounded-md transition-all ${
+              layout === 'cards'
+                ? 'bg-white text-slate-700 shadow-sm'
+                : 'text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            <LayoutGrid className="w-3.5 h-3.5" />
+            Cards
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={layout === 'rows'}
+            onClick={() => setLayout('rows')}
+            className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-bold rounded-md transition-all ${
+              layout === 'rows'
+                ? 'bg-white text-slate-700 shadow-sm'
+                : 'text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            <List className="w-3.5 h-3.5" />
+            List
+          </button>
+        </div>
+      </div>
+
       <div className="p-4 bg-indigo-50 border border-indigo-100 rounded-2xl flex flex-col gap-3">
         <div className="flex justify-between items-center">
           <div className="flex items-center gap-2 text-indigo-900">

--- a/components/widgets/Scoreboard/Widget.tsx
+++ b/components/widgets/Scoreboard/Widget.tsx
@@ -6,7 +6,7 @@ import {
   ScoreboardTeam,
   DEFAULT_GLOBAL_STYLE,
 } from '@/types';
-import { Trophy, LayoutGrid, List } from 'lucide-react';
+import { Trophy } from 'lucide-react';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { ScoreboardItem } from './components/ScoreboardItem';
 import { ScoreboardRowItem } from './components/ScoreboardRowItem';
@@ -55,15 +55,6 @@ export const ScoreboardWidget: React.FC<{ widget: WidgetData }> = ({
       layout === 'rows' ? [...teams].sort((a, b) => b.score - a.score) : teams,
     [teams, layout]
   );
-
-  const toggleLayout = useCallback(() => {
-    updateWidget(widget.id, {
-      config: {
-        ...config,
-        layout: layout === 'cards' ? 'rows' : 'cards',
-      },
-    });
-  }, [widget.id, updateWidget, config, layout]);
 
   // Keep a ref to the latest config to ensure handleUpdateScore is stable
   const configRef = useRef(config);
@@ -156,79 +147,38 @@ export const ScoreboardWidget: React.FC<{ widget: WidgetData }> = ({
                 className="opacity-40"
               />
             </div>
+          ) : layout === 'cards' ? (
+            <div
+              className="grid grid-cols-[repeat(auto-fit,minmax(min(120px,100%),1fr))] auto-rows-[1fr] h-full w-full bg-transparent overflow-y-auto custom-scrollbar"
+              style={{
+                gap: 'min(16px, 3.5cqmin)',
+                padding: 'min(16px, 3.5cqmin)',
+              }}
+            >
+              {teams.map((team) => (
+                <ScoreboardItem
+                  key={team.id}
+                  team={team}
+                  onUpdateScore={handleUpdateScore}
+                />
+              ))}
+            </div>
           ) : (
-            <div className="flex flex-col h-full w-full">
-              {layout === 'cards' ? (
-                <div
-                  className="grid grid-cols-[repeat(auto-fit,minmax(min(120px,100%),1fr))] auto-rows-[1fr] flex-1 w-full bg-transparent overflow-y-auto custom-scrollbar"
-                  style={{
-                    gap: 'min(16px, 3.5cqmin)',
-                    padding: 'min(16px, 3.5cqmin)',
-                  }}
-                >
-                  {teams.map((team) => (
-                    <ScoreboardItem
-                      key={team.id}
-                      team={team}
-                      onUpdateScore={handleUpdateScore}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div
-                  className="flex flex-col flex-1 w-full overflow-y-auto custom-scrollbar"
-                  style={{
-                    gap: 'min(4px, 1cqmin)',
-                    padding: 'min(8px, 2cqmin)',
-                  }}
-                >
-                  {sortedTeams.map((team, index) => (
-                    <ScoreboardRowItem
-                      key={team.id}
-                      team={team}
-                      rank={index + 1}
-                      onUpdateScore={handleUpdateScore}
-                    />
-                  ))}
-                </div>
-              )}
-              {/* Layout toggle — inline at bottom to avoid overlapping rows and resize handles */}
-              <div
-                className="flex justify-center border-t border-slate-200/30 shrink-0"
-                style={{ padding: 'min(4px, 1cqmin)' }}
-              >
-                <button
-                  onClick={toggleLayout}
-                  className="flex items-center bg-white/70 hover:bg-white/90 text-slate-500 hover:text-slate-700 backdrop-blur-sm rounded-lg transition-all active:scale-95"
-                  style={{
-                    gap: 'min(4px, 1cqmin)',
-                    padding: 'min(4px, 1cqmin) min(10px, 2.5cqmin)',
-                    fontSize: 'min(10px, 3cqmin)',
-                  }}
-                  aria-label={
-                    layout === 'cards'
-                      ? 'Switch to list view'
-                      : 'Switch to card view'
-                  }
-                >
-                  {layout === 'cards' ? (
-                    <List
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  ) : (
-                    <LayoutGrid
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  )}
-                  {layout === 'cards' ? 'List' : 'Grid'}
-                </button>
-              </div>
+            <div
+              className="flex flex-col h-full w-full overflow-y-auto custom-scrollbar"
+              style={{
+                gap: 'min(4px, 1cqmin)',
+                padding: 'min(8px, 2cqmin)',
+              }}
+            >
+              {sortedTeams.map((team, index) => (
+                <ScoreboardRowItem
+                  key={team.id}
+                  team={team}
+                  rank={index + 1}
+                  onUpdateScore={handleUpdateScore}
+                />
+              ))}
             </div>
           )}
         </div>

--- a/components/widgets/Scoreboard/components/ScoreboardItem.tsx
+++ b/components/widgets/Scoreboard/components/ScoreboardItem.tsx
@@ -125,40 +125,43 @@ export const ScoreboardItem = React.memo(
     return (
       <div
         className={`flex flex-col items-center justify-center ${colorClass} text-white rounded-2xl border border-white/20 shadow-sm relative group transition-all hover:shadow-md`}
-        style={{ containerType: 'size', padding: 'min(4px, 1cqmin)' }}
+        style={{
+          containerType: 'size',
+          padding: 'clamp(4px, 5cqmin, 24px)',
+        }}
       >
         <div
           className="font-black uppercase tracking-widest text-white text-center line-clamp-1 w-full"
           style={{
-            fontSize: 'min(15cqh, 80cqw)',
-            marginBottom: 'min(2cqh, 1cqmin)',
-            paddingLeft: 'min(8px, 2cqw)',
-            paddingRight: 'min(8px, 2cqw)',
+            fontSize: 'clamp(10px, 10cqmin, 48px)',
+            marginBottom: 'clamp(2px, 2cqmin, 12px)',
+            paddingLeft: 'clamp(2px, 2cqmin, 12px)',
+            paddingRight: 'clamp(2px, 2cqmin, 12px)',
           }}
         >
           {team.name}
         </div>
         <div
           className="flex items-center justify-center w-full flex-1 min-h-0"
-          style={{ gap: 'min(8px, 2cqmin)' }}
+          style={{ gap: 'clamp(4px, 4cqmin, 24px)' }}
         >
           <button
             onClick={() => onUpdateScore(team.id, -1)}
             aria-label="Decrease score"
             className={`bg-white ${buttonIconColor} rounded-lg shadow-sm hover:bg-slate-50 active:scale-95 transition-all shrink-0 flex items-center justify-center`}
-            style={{ padding: 'min(14px, 4cqmin)' }}
+            style={{ padding: 'clamp(4px, 6cqmin, 28px)' }}
           >
             <Minus
               style={{
-                width: 'min(28px, 12cqmin)',
-                height: 'min(28px, 12cqmin)',
+                width: 'clamp(12px, 14cqmin, 56px)',
+                height: 'clamp(12px, 14cqmin, 56px)',
               }}
             />
           </button>
           <div
             className="font-black text-white tabular-nums drop-shadow-sm flex-1 text-center min-w-0 leading-none"
             style={{
-              fontSize: 'min(70cqh, 22cqw)',
+              fontSize: 'clamp(16px, 45cqmin, 220px)',
             }}
           >
             {team.score}
@@ -167,12 +170,12 @@ export const ScoreboardItem = React.memo(
             onClick={() => onUpdateScore(team.id, 1)}
             aria-label="Increase score"
             className={`bg-white ${buttonIconColor} rounded-lg shadow-sm hover:bg-slate-50 active:scale-95 transition-all shrink-0 flex items-center justify-center`}
-            style={{ padding: 'min(14px, 4cqmin)' }}
+            style={{ padding: 'clamp(4px, 6cqmin, 28px)' }}
           >
             <Plus
               style={{
-                width: 'min(28px, 12cqmin)',
-                height: 'min(28px, 12cqmin)',
+                width: 'clamp(12px, 14cqmin, 56px)',
+                height: 'clamp(12px, 14cqmin, 56px)',
               }}
             />
           </button>

--- a/components/widgets/random/RandomClassContextButton.test.tsx
+++ b/components/widgets/random/RandomClassContextButton.test.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RandomClassContextButton } from './RandomClassContextButton';
+import { useDashboard } from '@/context/useDashboard';
+import { getLocalIsoDate } from '@/utils/localDate';
+import type { ClassRoster } from '@/types';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+
+const today = getLocalIsoDate();
+
+const makeRoster = (
+  id: string,
+  name: string,
+  studentCount = 20,
+  absentIds: string[] = []
+): ClassRoster => ({
+  id,
+  name,
+  driveFileId: null,
+  studentCount,
+  createdAt: 0,
+  students: Array.from({ length: studentCount }, (_, i) => ({
+    id: `${id}-s${i}`,
+    firstName: `First${i}`,
+    lastName: `Last${i}`,
+    pin: String(i + 1).padStart(2, '0'),
+  })),
+  absent:
+    absentIds.length > 0 ? { date: today, studentIds: absentIds } : undefined,
+});
+
+const noop = () => undefined;
+
+const mockUseDashboard = (
+  rosters: ClassRoster[],
+  activeRosterId: string | null,
+  setActiveRoster: ReturnType<typeof vi.fn> = vi.fn()
+) => {
+  (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    rosters,
+    activeRosterId,
+    setActiveRoster,
+  });
+  return setActiveRoster;
+};
+
+describe('RandomClassContextButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when there is no active roster', () => {
+    mockUseDashboard([], null);
+    const { container } = render(
+      <RandomClassContextButton
+        roster={null}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders an interactive button when a roster is active', () => {
+    const r = makeRoster('r1', 'Period 1');
+    mockUseDashboard([r], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    const button = screen.getByRole('button', {
+      name: /Active class: Period 1/i,
+    });
+    expect(button).toHaveAttribute('aria-haspopup', 'menu');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('shows an absent count badge when students are marked absent today', () => {
+    const r = makeRoster('r1', 'Period 1', 20, ['r1-s0', 'r1-s1', 'r1-s2']);
+    mockUseDashboard([r], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    // The badge is aria-hidden, so we match its text content directly inside
+    // the trigger. The accessible name carries the count for screen readers
+    // via the pluralized `triggerAriaWithAbsent_other` key in en.json.
+    expect(
+      screen.getByRole('button', { name: /3 students marked absent today/i })
+    ).toBeInTheDocument();
+  });
+
+  it('uses singular grammar in the aria-label when exactly one student is absent', () => {
+    const r = makeRoster('r1', 'Period 1', 20, ['r1-s0']);
+    mockUseDashboard([r], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /1 student marked absent today/i })
+    ).toBeInTheDocument();
+  });
+
+  it('omits absent phrasing from the aria-label in custom-names mode', () => {
+    const r = makeRoster('r1', 'Period 1', 20, ['r1-s0', 'r1-s1']);
+    const r2 = makeRoster('r2', 'Period 2');
+    mockUseDashboard([r, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="custom"
+        onOpenAbsentModal={noop}
+      />
+    );
+    // In custom mode the widget intentionally ignores roster absence — the
+    // accessible name should not announce "marked absent today" because no
+    // absent affordance is reachable from this chip.
+    const trigger = screen.getByRole('button', {
+      name: /Active class: Period 1/i,
+    });
+    expect(trigger.getAttribute('aria-label')).not.toMatch(/absent/i);
+  });
+
+  it('hides the absent-count badge when canMarkAbsent is false (stale state)', () => {
+    // Class roster with absent IDs but zero students — old AbsentButton
+    // returned null in this case; the new combined chip must not show a
+    // misleading red badge that the user cannot clear.
+    const r: ClassRoster = {
+      id: 'r1',
+      name: 'Period 1',
+      driveFileId: null,
+      studentCount: 0,
+      createdAt: 0,
+      students: [],
+      absent: { date: today, studentIds: ['ghost-1', 'ghost-2'] },
+    };
+    mockUseDashboard([r], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    // The badge text would be "2" if rendered — it must not appear.
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+  });
+
+  it('opens the popover and lists rosters as menuitemradio (multi-class)', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    mockUseDashboard([r1, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r1}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    const items = screen.getAllByRole('menuitemradio');
+    expect(items).toHaveLength(2);
+    const active = items.find((i) => i.getAttribute('aria-checked') === 'true');
+    expect(active?.textContent).toMatch(/Period 1/);
+  });
+
+  it('focuses the active roster (aria-checked) on open, not the first item', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    const r3 = makeRoster('r3', 'Period 3');
+    mockUseDashboard([r1, r2, r3], 'r3');
+    render(
+      <RandomClassContextButton
+        roster={r3}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 3/i })
+    );
+    const active = screen.getByRole('menuitemradio', {
+      checked: true,
+    });
+    expect(document.activeElement).toBe(active);
+  });
+
+  it('calls setActiveRoster when a different class is picked', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    const setActiveRoster = mockUseDashboard([r1, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r1}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Period 2/i }));
+    expect(setActiveRoster).toHaveBeenCalledWith('r2');
+  });
+
+  it('opens the absent modal via the popover action', () => {
+    const r = makeRoster('r1', 'Period 1');
+    mockUseDashboard([r], 'r1');
+    const onOpen = vi.fn();
+    render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="class"
+        onOpenAbsentModal={onOpen}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    // Mark Absent has role="menuitem" so AT navigates it via menu mode
+    // (alongside the menuitemradio class switchers).
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: /Mark absent students/i })
+    );
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the absent action in custom roster mode', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    mockUseDashboard([r1, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r1}
+        rosterMode="custom"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    // Class switcher still works in custom mode (teachers may switch back),
+    // but marking absent doesn't apply — that action belongs to class mode.
+    expect(
+      screen.queryByRole('menuitem', { name: /Mark absent students/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(2);
+  });
+
+  it('renders a static (non-interactive) chip when only one class exists and rosterMode is custom', () => {
+    const r = makeRoster('r1', 'Period 1');
+    mockUseDashboard([r], 'r1');
+    const { container } = render(
+      <RandomClassContextButton
+        roster={r}
+        rosterMode="custom"
+        onOpenAbsentModal={noop}
+      />
+    );
+    // No switch (single roster) and no absent action (custom mode) → the
+    // chip has nothing actionable behind it, so it renders as a static div
+    // rather than a button.
+    expect(
+      screen.queryByRole('button', { name: /Active class: Period 1/i })
+    ).not.toBeInTheDocument();
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/components/widgets/random/RandomClassContextButton.tsx
+++ b/components/widgets/random/RandomClassContextButton.tsx
@@ -1,0 +1,378 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Target, ChevronDown, UserX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useDashboard } from '@/context/useDashboard';
+import { Z_INDEX } from '@/config/zIndex';
+import type { ClassRoster } from '@/types';
+import { getLocalIsoDate } from '@/utils/localDate';
+
+interface RandomClassContextButtonProps {
+  /**
+   * The roster the Randomizer is currently pointed at, or null/undefined when
+   * no roster is active (e.g. custom-names mode). The component itself
+   * renders nothing in that case — keeps the header right side empty rather
+   * than showing a button with no class to represent.
+   */
+  roster: ClassRoster | null | undefined;
+  /**
+   * `'class'` enables the "Mark absent students" footer action inside the
+   * popover. Any other value (e.g. `'custom'`) suppresses it so the
+   * Randomizer never opens the absent modal against a roster it's ignoring.
+   */
+  rosterMode: 'class' | 'custom' | undefined;
+  /**
+   * Hoisted by RandomWidget so its empty-state branch can also open the
+   * modal. The button does not render the modal itself.
+   */
+  onOpenAbsentModal: () => void;
+}
+
+/**
+ * Randomizer-specific consolidation of `ActiveClassChip` + `AbsentButton`
+ * into a single icon-only chip with a popover containing the class name,
+ * the class switcher, and the absent-students action. Reduces header
+ * pressure at narrow widget widths where four labelled chips would crowd
+ * each other.
+ *
+ * Scope is intentionally Randomizer-only — Stations, SeatingChart, and
+ * LunchCount keep the separate chip pair. If the consolidation proves out
+ * here, lift it into a shared component.
+ */
+export const RandomClassContextButton: React.FC<
+  RandomClassContextButtonProps
+> = ({ roster, rosterMode, onOpenAbsentModal }) => {
+  const { t } = useTranslation();
+  const { rosters, activeRosterId, setActiveRoster } = useDashboard();
+
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
+
+  const today = getLocalIsoDate();
+  const absentCount =
+    rosterMode === 'class' && roster?.absent?.date === today
+      ? (roster.absent.studentIds?.length ?? 0)
+      : 0;
+
+  const canSwitchClass = rosters.length > 1;
+  const canMarkAbsent =
+    rosterMode === 'class' && !!roster && roster.students.length > 0;
+  const interactive = canSwitchClass || canMarkAbsent;
+
+  const openMenu = useCallback(() => {
+    if (!anchorRef.current) return;
+    setAnchorRect(anchorRef.current.getBoundingClientRect());
+    setOpen(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (popoverRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      closeMenu();
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu();
+    };
+    let animationFrameId = 0;
+    const handleReposition = () => {
+      cancelAnimationFrame(animationFrameId);
+      animationFrameId = requestAnimationFrame(() => {
+        if (anchorRef.current) {
+          setAnchorRect(anchorRef.current.getBoundingClientRect());
+        }
+      });
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKey);
+    window.addEventListener('resize', handleReposition);
+    window.addEventListener('scroll', handleReposition, true);
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKey);
+      window.removeEventListener('resize', handleReposition);
+      window.removeEventListener('scroll', handleReposition, true);
+    };
+  }, [open, closeMenu]);
+
+  // Move focus into the popover on open, back to the trigger on close —
+  // required for keyboard users since the popover is portaled to <body>.
+  // Prefer the currently-active menuitemradio so the menu opens oriented
+  // on the user's current selection (matches ActiveClassChip behavior).
+  const wasOpenRef = useRef(false);
+  useEffect(() => {
+    if (open) {
+      wasOpenRef.current = true;
+      const items = popoverRef.current?.querySelectorAll<HTMLElement>(
+        '[role="menuitemradio"], [role="menuitem"]'
+      );
+      if (items && items.length > 0) {
+        const list = Array.from(items);
+        const activeIdx = list.findIndex(
+          (item) => item.getAttribute('aria-checked') === 'true'
+        );
+        list[activeIdx >= 0 ? activeIdx : 0].focus();
+      }
+    } else if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      anchorRef.current?.focus();
+    }
+  }, [open]);
+
+  const handleMenuKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const items = popoverRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitemradio"], [role="menuitem"]'
+      );
+      if (!items || items.length === 0) return;
+      const list = Array.from(items);
+      const currentIdx = list.indexOf(
+        document.activeElement as HTMLButtonElement
+      );
+      let nextIdx = -1;
+      if (event.key === 'ArrowDown') {
+        nextIdx = currentIdx < 0 ? 0 : (currentIdx + 1) % list.length;
+      } else if (event.key === 'ArrowUp') {
+        nextIdx = currentIdx <= 0 ? list.length - 1 : currentIdx - 1;
+      } else if (event.key === 'Home') {
+        nextIdx = 0;
+      } else if (event.key === 'End') {
+        nextIdx = list.length - 1;
+      }
+      if (nextIdx >= 0) {
+        event.preventDefault();
+        list[nextIdx].focus();
+      }
+    },
+    []
+  );
+
+  // Auto-close if the chip's reason to exist disappears while open —
+  // otherwise the portal lingers without an anchor. Also close when the
+  // chip transitions to the non-interactive branch (no roster, no switch,
+  // no absent action), since that branch never attaches anchorRef and the
+  // focus-restore effect would dump focus on <body>.
+  if (open && (!roster || !interactive)) {
+    setOpen(false);
+  }
+
+  if (!roster) return null;
+
+  // Custom-names mode intentionally ignores roster absence — keep the
+  // accessible name focused on class identity in that case so screen
+  // readers don't announce a "0 marked absent today" phrase for a widget
+  // that doesn't track absences.
+  const triggerLabel =
+    rosterMode === 'class'
+      ? t('widgets.random.classContext.triggerAriaWithAbsent', {
+          defaultValue:
+            'Active class: {{name}}. {{count}} students marked absent today.',
+          name: roster.name,
+          count: absentCount,
+        })
+      : t('widgets.random.classContext.triggerAria', {
+          defaultValue: 'Active class: {{name}}',
+          name: roster.name,
+        });
+
+  const buttonClass =
+    'relative flex items-center justify-center rounded-xl bg-white border border-slate-200 transition-colors';
+  const buttonStyle: React.CSSProperties = {
+    padding: 'clamp(6px, 2cqmin, 14px)',
+    minHeight: 'clamp(32px, 8cqmin, 48px)',
+    minWidth: 'clamp(32px, 8cqmin, 48px)',
+  };
+  const iconStyle: React.CSSProperties = {
+    width: 'clamp(14px, 4cqmin, 22px)',
+    height: 'clamp(14px, 4cqmin, 22px)',
+  };
+
+  // Badge gated on canMarkAbsent (not just absentCount > 0): if a roster
+  // has stale absent IDs but students were removed mid-day, the absent
+  // action is unreachable — showing the badge would be a misleading
+  // notification with no UI to clear it.
+  const chipBody = (
+    <>
+      <Target className="text-brand-blue-primary shrink-0" style={iconStyle} />
+      {canMarkAbsent && absentCount > 0 && (
+        <span
+          className="absolute font-black bg-red-500 text-white rounded-full leading-none tabular-nums shrink-0 pointer-events-none"
+          style={{
+            top: 'clamp(-3px, -0.6cqmin, -2px)',
+            right: 'clamp(-3px, -0.6cqmin, -2px)',
+            fontSize: 'clamp(9px, 3cqmin, 12px)',
+            padding: 'clamp(2px, 0.6cqmin, 3px) clamp(5px, 1.6cqmin, 8px)',
+          }}
+          aria-hidden="true"
+        >
+          {absentCount}
+        </span>
+      )}
+    </>
+  );
+
+  if (!interactive) {
+    // Static branch: aria-label on a bare <div> is ignored by AT.
+    // role="img" lets the aria-label become the accessible name; a
+    // visually-hidden span backs it up via accessible-name-from-content
+    // for AT that ignores the role override.
+    return (
+      <div
+        className={buttonClass}
+        style={buttonStyle}
+        role="img"
+        aria-label={triggerLabel}
+      >
+        {chipBody}
+        <span className="sr-only">{triggerLabel}</span>
+      </div>
+    );
+  }
+
+  const POPOVER_MAX_WIDTH = 280;
+  const POPOVER_VIEWPORT_MARGIN = 8;
+  // Anchor under the trigger's left edge so the popover tracks the chip
+  // even when the widget is near the viewport edge (matches ActiveClassChip).
+  const popoverStyle: React.CSSProperties | null = anchorRect
+    ? {
+        position: 'fixed',
+        top: anchorRect.bottom + 6,
+        left: Math.max(
+          POPOVER_VIEWPORT_MARGIN,
+          Math.min(
+            anchorRect.left,
+            window.innerWidth - POPOVER_MAX_WIDTH - POPOVER_VIEWPORT_MARGIN
+          )
+        ),
+        zIndex: Z_INDEX.popover,
+      }
+    : null;
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        onClick={() => (open ? closeMenu() : openMenu())}
+        className={`${buttonClass} hover:bg-slate-50 cursor-pointer focus-visible:outline-2 focus-visible:outline-brand-blue-primary focus-visible:outline-offset-2`}
+        style={buttonStyle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={triggerLabel}
+      >
+        {chipBody}
+      </button>
+
+      {open &&
+        popoverStyle &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            role="menu"
+            aria-label={t('widgets.random.classContext.menuAria', {
+              defaultValue: 'Class context for Randomizer',
+            })}
+            onKeyDown={handleMenuKeyDown}
+            style={popoverStyle}
+            className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-150 min-w-[220px] max-w-[280px] bg-white rounded-xl shadow-xl border border-slate-200 overflow-hidden"
+          >
+            <div className="px-3 py-2.5 bg-slate-50 border-b border-slate-200 flex items-center gap-2">
+              <Target className="w-4 h-4 text-brand-blue-primary shrink-0" />
+              <span className="text-sm font-black text-brand-blue-primary tracking-wide truncate">
+                {roster.name}
+              </span>
+              {canSwitchClass && (
+                <ChevronDown
+                  className="ml-auto w-3.5 h-3.5 text-slate-400 shrink-0"
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+            {canSwitchClass && (
+              <div className="border-b border-slate-200">
+                <div className="px-3 pt-2 pb-1">
+                  <span className="text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                    {t('widgets.random.classContext.switchHeading', {
+                      defaultValue: 'Switch class',
+                    })}
+                  </span>
+                </div>
+                <div className="max-h-48 overflow-y-auto pb-1">
+                  {rosters.map((r) => {
+                    const isActive = r.id === activeRosterId;
+                    return (
+                      <button
+                        key={r.id}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={isActive}
+                        onClick={() => {
+                          if (!isActive) setActiveRoster(r.id);
+                          closeMenu();
+                        }}
+                        className={`w-full flex items-center justify-between px-3 py-2 text-left transition-colors ${
+                          isActive
+                            ? 'bg-brand-blue-lighter text-brand-blue-primary'
+                            : 'hover:bg-slate-50 text-slate-700'
+                        }`}
+                      >
+                        <span
+                          className={`text-sm truncate ${isActive ? 'font-black' : 'font-semibold'}`}
+                        >
+                          {r.name}
+                        </span>
+                        <span
+                          className={`text-[10px] font-bold tabular-nums ml-2 px-2 py-0.5 rounded-full shrink-0 ${
+                            isActive
+                              ? 'bg-white text-brand-blue-primary border border-brand-blue-light'
+                              : 'bg-slate-100 text-slate-500'
+                          }`}
+                        >
+                          {r.studentCount}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+            {canMarkAbsent && (
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  closeMenu();
+                  onOpenAbsentModal();
+                }}
+                className="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left text-slate-700 hover:bg-slate-50 transition-colors"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  <UserX className="w-4 h-4 text-slate-500 shrink-0" />
+                  <span className="text-sm font-semibold truncate">
+                    {t('widgets.random.classContext.markAbsentAction', {
+                      defaultValue: 'Mark absent students',
+                    })}
+                  </span>
+                </span>
+                {absentCount > 0 && (
+                  <span className="text-[10px] font-black bg-red-500 text-white rounded-full leading-none tabular-nums shrink-0 px-2 py-0.5">
+                    {absentCount}
+                  </span>
+                )}
+              </button>
+            )}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -371,6 +371,34 @@ describe('RandomWidget', () => {
         })
       );
     });
+
+    it('renders the remaining-students counter alongside the mode chip in single mode', () => {
+      // Counter used to live in a separate badge after the reset button.
+      // It now sits inside the mode chip's visual shell but as a SIBLING
+      // of the cycle <button>, so tapping the counter text does not cycle
+      // the mode. The aria-label on the button still includes the count
+      // for screen readers.
+      const widget = widgetWithMode('single');
+      (widget.config as RandomConfig).remainingStudents = ['Alice', 'Bob'];
+      render(<RandomWidget widget={widget} />);
+      const modeButton = screen.getByRole('button', {
+        name: /Operation mode: Pick One\. 2 students left/i,
+      });
+      expect(modeButton.textContent).toMatch(/PICK ONE/i);
+      // Counter is a sibling element within the chip shell — assert it
+      // exists in the header and not inside the cycle button.
+      expect(screen.getByText(/2 Left/i)).toBeInTheDocument();
+      expect(modeButton.textContent).not.toMatch(/Left/i);
+    });
+
+    it('hides the inline counter in non-single modes', () => {
+      render(<RandomWidget widget={widgetWithMode('shuffle')} />);
+      const modeButton = screen.getByRole('button', {
+        name: /Operation mode: Shuffle/i,
+      });
+      expect(modeButton.textContent).not.toMatch(/Left/i);
+      expect(screen.queryByText(/Left/i)).not.toBeInTheDocument();
+    });
   });
 
   it('sends groups to scoreboard when button is clicked (New Connection)', () => {

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -18,9 +18,8 @@ import {
   Student,
 } from '@/types';
 import { Button } from '@/components/common/Button';
-import { ActiveClassChip } from '@/components/common/ActiveClassChip';
-import { AbsentButton } from '@/components/common/AbsentButton';
 import { AbsentStudentsModal } from '@/components/common/AbsentStudentsModal';
+import { RandomClassContextButton } from './RandomClassContextButton';
 import {
   Users,
   RefreshCw,
@@ -1597,91 +1596,112 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               className="flex items-center"
               style={{ gap: 'clamp(6px, 2cqmin, 14px)' }}
             >
-              <button
-                type="button"
-                onClick={cycleMode}
-                disabled={isSpinning}
-                className="flex items-center rounded-xl bg-white border border-slate-200 hover:bg-slate-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-brand-blue-primary focus-visible:outline-offset-2"
+              {/* Mode chip + inline counter sit in one rounded shell, but the
+                  counter is a sibling of the actual cycle <button>, not a
+                  child — taps on "N Left" must NOT cycle the mode. The
+                  shared shell is a styled wrapper, the button only spans
+                  icon+label. */}
+              <div
+                className={`flex items-center rounded-xl bg-white border border-slate-200 ${
+                  isSpinning ? 'opacity-50' : ''
+                } transition-opacity`}
                 style={{
                   gap: 'clamp(6px, 1.5cqmin, 10px)',
                   padding:
                     'clamp(6px, 1.5cqmin, 10px) clamp(10px, 2.5cqmin, 18px)',
                   minHeight: 'clamp(32px, 8cqmin, 48px)',
                 }}
-                aria-label={t('widgets.random.modeChipAria', {
-                  mode: currentModeLabel,
-                  defaultValue: 'Operation mode: {{mode}}',
-                })}
-                title={t('widgets.random.modeChipTitle', {
-                  mode: currentModeLabel,
-                  defaultValue: 'Mode: {{mode}} — click to cycle',
-                })}
               >
-                <ModeIcon
-                  className="text-brand-blue-primary shrink-0"
-                  style={{
-                    width: 'clamp(14px, 4cqmin, 22px)',
-                    height: 'clamp(14px, 4cqmin, 22px)',
-                  }}
-                />
-                <span
-                  className="font-black uppercase text-brand-blue-primary truncate min-w-0 tracking-widest"
-                  style={{ fontSize: 'clamp(13px, 3.5cqmin, 18px)' }}
+                <button
+                  type="button"
+                  onClick={cycleMode}
+                  disabled={isSpinning}
+                  className="flex items-center bg-transparent border-0 p-0 m-0 hover:opacity-80 transition-opacity cursor-pointer disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-brand-blue-primary focus-visible:outline-offset-2 rounded"
+                  style={{ gap: 'clamp(6px, 1.5cqmin, 10px)' }}
+                  aria-label={
+                    mode === 'single' && remainingStudents.length > 0
+                      ? t('widgets.random.modeChipAriaWithCount', {
+                          mode: currentModeLabel,
+                          count: remainingStudents.length,
+                          defaultValue:
+                            'Operation mode: {{mode}}. {{count}} students left.',
+                        })
+                      : t('widgets.random.modeChipAria', {
+                          mode: currentModeLabel,
+                          defaultValue: 'Operation mode: {{mode}}',
+                        })
+                  }
+                  title={t('widgets.random.modeChipTitle', {
+                    mode: currentModeLabel,
+                    defaultValue: 'Mode: {{mode}} — click to cycle',
+                  })}
                 >
-                  {currentModeLabel}
-                </span>
-              </button>
-              {mode === 'single' && (
-                <>
-                  <button
-                    onClick={handleReset}
-                    disabled={
-                      isSpinning ||
-                      (remainingStudents.length === 0 && !displayResult)
-                    }
-                    className="hover:bg-slate-100 rounded-full text-slate-400 hover:text-brand-blue-primary transition-all disabled:opacity-30"
-                    style={{ padding: 'clamp(6px, 2cqmin, 14px)' }}
-                    title="Reset student pool"
+                  <ModeIcon
+                    className="text-brand-blue-primary shrink-0"
+                    style={{
+                      width: 'clamp(14px, 4cqmin, 22px)',
+                      height: 'clamp(14px, 4cqmin, 22px)',
+                    }}
+                  />
+                  <span
+                    className="font-black uppercase text-brand-blue-primary truncate min-w-0 tracking-widest"
+                    style={{ fontSize: 'clamp(13px, 3.5cqmin, 18px)' }}
                   >
-                    <RotateCcw
-                      style={{
-                        width: 'clamp(14px, 4cqmin, 28px)',
-                        height: 'clamp(14px, 4cqmin, 28px)',
-                      }}
-                    />
-                  </button>
-                  {remainingStudents.length > 0 && (
+                    {currentModeLabel}
+                  </span>
+                </button>
+                {mode === 'single' && remainingStudents.length > 0 && (
+                  <>
                     <span
-                      className="font-black text-slate-500 uppercase tracking-tight bg-slate-50 rounded border border-slate-200"
-                      style={{
-                        fontSize: 'clamp(10px, 2.6cqmin, 18px)',
-                        padding:
-                          'clamp(2px, 0.7cqmin, 6px) clamp(6px, 2cqmin, 14px)',
-                      }}
+                      aria-hidden="true"
+                      className="text-brand-blue-primary opacity-40 select-none shrink-0"
+                      style={{ fontSize: 'clamp(11px, 2.8cqmin, 14px)' }}
+                    >
+                      ·
+                    </span>
+                    <span
+                      className="font-black uppercase text-slate-500 tabular-nums tracking-wide shrink-0"
+                      style={{ fontSize: 'clamp(11px, 2.8cqmin, 14px)' }}
                     >
                       {remainingStudents.length} Left
                     </span>
-                  )}
-                </>
+                  </>
+                )}
+              </div>
+              {mode === 'single' && (
+                <button
+                  onClick={handleReset}
+                  disabled={
+                    isSpinning ||
+                    (remainingStudents.length === 0 && !displayResult)
+                  }
+                  className="hover:bg-slate-100 rounded-full text-slate-400 hover:text-brand-blue-primary transition-all disabled:opacity-30"
+                  style={{ padding: 'clamp(6px, 2cqmin, 14px)' }}
+                  title="Reset student pool"
+                >
+                  <RotateCcw
+                    style={{
+                      width: 'clamp(14px, 4cqmin, 28px)',
+                      height: 'clamp(14px, 4cqmin, 28px)',
+                    }}
+                  />
+                </button>
               )}
             </div>
             <div
               className="flex items-center"
               style={{ gap: 'clamp(6px, 1.5cqmin, 10px)' }}
             >
-              {/* AbsentButton is the canonical "remove a student" entry
-                  point — only valid when a class roster is active, since
-                  absence is stored on the roster doc. */}
-              {activeRoster && rosterMode === 'class' && (
-                <AbsentButton
-                  roster={activeRoster}
-                  onClick={() => setAbsentModalOpen(true)}
-                />
-              )}
-              {/* Class selector is always visible so teachers can pick or
-                  switch a class straight from the header, regardless of
-                  whether the widget started in custom-names mode. */}
-              <ActiveClassChip compact />
+              {/* Single icon-only chip combining class switch + absent
+                  attendance. Replaces the separate AbsentButton +
+                  ActiveClassChip pair to keep the header legible at narrow
+                  widths. Modal lifecycle stays hoisted on RandomWidget so
+                  the empty-state branch can also trigger it. */}
+              <RandomClassContextButton
+                roster={activeRoster}
+                rosterMode={rosterMode}
+                onOpenAbsentModal={() => setAbsentModalOpen(true)}
+              />
             </div>
           </div>
         }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -298,6 +298,14 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "lastWriteAt", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "responses",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "lastWriteAt", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -27,6 +27,7 @@
  */
 
 import { onSchedule } from 'firebase-functions/v2/scheduler';
+import { logger } from 'firebase-functions';
 import * as admin from 'firebase-admin';
 
 /**
@@ -39,11 +40,37 @@ const IDLE_THRESHOLD_MINUTES = 90;
 const IDLE_THRESHOLD_MS = IDLE_THRESHOLD_MINUTES * 60 * 1000;
 
 /**
- * Safety cap so a backlog (e.g. after a deploy or an outage) doesn't
- * monopolise a single run. Firestore batches max at 500 ops; we leave
- * headroom for the implicit ops the SDK adds.
+ * Hard cap on actual write transactions per run. Firestore batches max
+ * at 500 ops; we leave headroom for the implicit ops the SDK adds.
  */
 const MAX_FINALIZE_PER_RUN = 400;
+
+/**
+ * Read cap is intentionally larger than the write cap so abandoned
+ * paused/waiting/orphan responses (oldest by `lastWriteAt`, so they
+ * sort first) don't starve out genuinely-stale active responses.
+ * Without the gap, e.g. 400 always-older lobby ghosts would saturate
+ * the query every tick and the cron would never reach a real
+ * finalization candidate. Empirically a 4× headroom covers the
+ * accumulation of abandoned demo / never-started sessions across a
+ * school year; the per-tick cost is bounded (~1600 reads × $0.06/100k
+ * ≈ $0.001 per run worst case).
+ */
+const MAX_READ_PER_RUN = MAX_FINALIZE_PER_RUN * 4;
+
+/**
+ * Max age a 'waiting' session is allowed to keep blocking the sweep.
+ * 'waiting' sessions normally hold lobby joiners while the teacher
+ * advances to Q1; this PR intentionally skips them so a teacher who
+ * gets pulled into a meeting before starting doesn't return to find
+ * every student auto-submitted. But there is no organic end-state for
+ * an abandoned demo/practice session — without this bound the
+ * skipped-waiting bucket grows monotonically across a school year.
+ * 24h is comfortably past any plausible single-day "started but never
+ * advanced" case; older waiting sessions are treated as abandoned and
+ * their responses are finalized normally.
+ */
+const WAITING_ABANDONED_AGE_MS = 24 * 60 * 60 * 1000;
 
 interface QuizAnswer {
   questionId?: string;
@@ -55,6 +82,61 @@ interface QuizResponseDoc {
   lastWriteAt?: admin.firestore.Timestamp;
   completedAttempts?: number;
   answers?: QuizAnswer[];
+}
+
+interface QuizSessionDoc {
+  status?: string;
+  createdAt?: admin.firestore.Timestamp | number;
+}
+
+/**
+ * Extract the parent session id from a response doc path. Returns null
+ * for any path that doesn't match the expected `quiz_sessions/{sid}/
+ * responses/{rid}` shape — a single source of truth so the gather loop
+ * and the per-doc loop can't drift apart on what counts as a valid
+ * response path.
+ */
+function parseQuizResponsePath(path: string): string | null {
+  const segments = path.split('/');
+  if (segments.length < 4) return null;
+  if (segments[0] !== 'quiz_sessions') return null;
+  if (segments[2] !== 'responses') return null;
+  const sid = segments[1];
+  if (!sid) return null;
+  return sid;
+}
+
+/**
+ * Single-retry wrapper around `db.getAll`. The original PR landed a
+ * "degrade to pre-PR behavior on failure" fallback that, in practice,
+ * re-introduced the exact data-loss bug the PR was supposed to fix
+ * (sweep paused-session responses and force-finalize their students).
+ * A single retry catches transient deadline/network blips; if the
+ * retry also throws, we re-throw so Cloud Scheduler retries the
+ * entire run on the next tick — strictly safer than degrading.
+ */
+async function readSessionDocsWithRetry(
+  db: admin.firestore.Firestore,
+  refs: admin.firestore.DocumentReference[]
+): Promise<admin.firestore.DocumentSnapshot[]> {
+  try {
+    return await db.getAll(...refs);
+  } catch (err) {
+    logger.warn(
+      '[finalizeIdleQuizAttempts] parent session batch read failed; retrying once',
+      { err: String(err) }
+    );
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    try {
+      return await db.getAll(...refs);
+    } catch (err2) {
+      logger.error(
+        '[finalizeIdleQuizAttempts] parent session batch read failed twice; aborting run so Cloud Scheduler retries on the next tick',
+        { err: String(err2) }
+      );
+      throw err2;
+    }
+  }
 }
 
 export const finalizeIdleQuizAttempts = onSchedule(
@@ -84,7 +166,12 @@ export const finalizeIdleQuizAttempts = onSchedule(
       // Firestore's default is by document key, which is effectively
       // random for the responses subcollection.
       .orderBy('lastWriteAt', 'asc')
-      .limit(MAX_FINALIZE_PER_RUN)
+      // Read more than we'll write — see MAX_READ_PER_RUN. Skipped docs
+      // (paused / waiting / orphan parent) consume the read budget
+      // without consuming the write budget, so a larger read window
+      // ensures we still reach genuinely-stale active responses even
+      // when abandoned lobby sessions dominate the oldest tail.
+      .limit(MAX_READ_PER_RUN)
       .get();
 
     if (stale.empty) {
@@ -93,25 +180,29 @@ export const finalizeIdleQuizAttempts = onSchedule(
     }
 
     // Batch-read parent quiz_session docs so we can skip docs whose
-    // session isn't currently accepting work. Two skip categories:
+    // session isn't currently accepting work. Three skip categories:
     //
     //   - 'paused': teacher intentionally stopped (often end-of-day,
     //     intending to resume next class period). Without skipping,
     //     students get force-finalized with `autoSubmitted: true` 90
     //     min after pause, requiring per-student `unlockStudentAttempt`
     //     to recover the live attempt.
-    //   - 'waiting': session created but teacher hasn't advanced to Q1
-    //     yet (lobby state). Joined students sitting in the lobby
-    //     shouldn't be auto-submitted with 0 answers just because the
-    //     teacher got pulled into a meeting before starting. Also
-    //     covers the `resumeAssignment` branch that resumes a
-    //     never-started session back to 'waiting'.
+    //   - 'waiting' (recent): session created but teacher hasn't
+    //     advanced to Q1 yet (lobby state). Joined students sitting in
+    //     the lobby shouldn't be auto-submitted with 0 answers just
+    //     because the teacher got pulled into a meeting before
+    //     starting. Bounded by WAITING_ABANDONED_AGE_MS — older waiting
+    //     sessions are treated as abandoned and swept normally.
+    //   - 'orphan' (parent deleted or malformed): we don't sweep into
+    //     a missing parent; nothing reads the orphan response in the
+    //     live monitor anyway.
     //
     // 'active' and 'ended' sessions proceed to the per-doc tx as
     // before. `resumeAssignment` (hooks/useQuizAssignments.ts) batch-
-    // refreshes `lastWriteAt` on every joined/in-progress response when
-    // it flips status paused → active, so a resumed session's stale
-    // responses don't get instantly swept on the next tick.
+    // refreshes `lastWriteAt` on every joined/in-progress response
+    // BEFORE flipping status off 'paused', so the cron never sees
+    // stale-lastWriteAt + active at the same time for a legitimate
+    // resume.
     //
     // One Firestore read per unique sid, not per response — kept cheap
     // for the public-ed budget. The race-window between this batch
@@ -121,56 +212,69 @@ export const finalizeIdleQuizAttempts = onSchedule(
     // pause next tick and the rest are caught.
     const parentSessionIds = new Set<string>();
     for (const docSnap of stale.docs) {
-      if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
-      // Path shape: quiz_sessions/{sid}/responses/{rid}
-      const segments = docSnap.ref.path.split('/');
-      if (segments.length < 4 || segments[0] !== 'quiz_sessions') continue;
-      parentSessionIds.add(segments[1]);
+      const sid = parseQuizResponsePath(docSnap.ref.path);
+      if (sid) parentSessionIds.add(sid);
     }
     const sessionRefs = Array.from(parentSessionIds).map((sid) =>
       db.doc(`quiz_sessions/${sid}`)
     );
-    // `getAll` issues one network round-trip for N docs; returns docs in
-    // the same order as the input refs. Missing docs come back as
-    // `exists === false` snapshots, which we treat as "session gone" —
-    // a deleted parent session means orphan responses, which we skip
-    // (don't sweep into a missing parent; if the teacher deleted the
-    // whole session deliberately, the responses are already
-    // inaccessible from the live monitor).
+    // `getAll` issues one network round-trip for N docs. Missing docs
+    // come back as `exists === false` snapshots, which we treat as
+    // "session gone" — a deleted parent session means orphan responses,
+    // which we skip (don't sweep into a missing parent; if the teacher
+    // deleted the whole session deliberately, the responses are
+    // already inaccessible from the live monitor).
     //
-    // Availability fallback: if `getAll` itself throws (network blip,
-    // deadline exceeded), we proceed with an empty status map. That
-    // disables the new skip categories for this tick — the per-doc
-    // loop still runs and finalizes legitimate stale responses, which
-    // is the pre-PR behavior. Better to degrade to the old correctness
-    // than to abort the entire hourly sweep on a single transient
-    // failure.
-    const sessionStatusBySid = new Map<string, string | undefined>();
-    let parentReadFailed = false;
+    // Availability fallback: if `getAll` throws (network blip, deadline
+    // exceeded), retry once after a short backoff before falling
+    // through. If the retry also throws we ABORT the run instead of
+    // sweeping every doc as in the original PR — Cloud Scheduler will
+    // retry the entire run on the next tick, which is safer than the
+    // documented "degrade to pre-PR behavior" path: pre-PR behavior
+    // *is* the data-loss bug this function fixes, so degrading to it on
+    // a transient is exactly the regression we want to avoid for paused
+    // sessions whose teachers expect to resume next class period.
+    //
+    // We cache session metadata (status + createdAt) so the per-doc
+    // loop can apply the 'waiting' abandoned-age threshold without a
+    // second read.
+    interface CachedSession {
+      status: string | undefined;
+      createdAtMs: number | null;
+    }
+    const sessionMetaBySid = new Map<string, CachedSession>();
     if (sessionRefs.length > 0) {
-      try {
-        const sessionDocs = await db.getAll(...sessionRefs);
-        for (const sessionDoc of sessionDocs) {
-          if (!sessionDoc.exists) continue;
-          const status = (sessionDoc.data() ?? {}).status as string | undefined;
-          sessionStatusBySid.set(sessionDoc.id, status);
+      const sessionDocs = await readSessionDocsWithRetry(db, sessionRefs);
+      for (const sessionDoc of sessionDocs) {
+        if (!sessionDoc.exists) continue;
+        const data = (sessionDoc.data() ?? {}) as QuizSessionDoc;
+        const status =
+          typeof data.status === 'string' ? data.status : undefined;
+        let createdAtMs: number | null = null;
+        if (
+          data.createdAt &&
+          typeof (data.createdAt as { toMillis?: () => number }).toMillis ===
+            'function'
+        ) {
+          createdAtMs = (
+            data.createdAt as admin.firestore.Timestamp
+          ).toMillis();
+        } else if (typeof data.createdAt === 'number') {
+          createdAtMs = data.createdAt;
         }
-      } catch (err) {
-        parentReadFailed = true;
-        console.warn(
-          '[finalizeIdleQuizAttempts] parent session batch read failed; proceeding without skip data',
-          err
-        );
+        sessionMetaBySid.set(sessionDoc.id, { status, createdAtMs });
       }
     }
 
     const finalizedAt = Date.now();
+    const waitingAbandonedCutoffMs = finalizedAt - WAITING_ABANDONED_AGE_MS;
     let finalized = 0;
     let skippedRaced = 0;
     let skippedPaused = 0;
     let skippedWaiting = 0;
     let skippedOrphan = 0;
     let failed = 0;
+    let writeBudgetExhausted = false;
 
     // Per-doc transactions instead of a single batch so a student who
     // submits between our query read and the write isn't overwritten —
@@ -182,46 +286,58 @@ export const finalizeIdleQuizAttempts = onSchedule(
     // throughput for correctness; at the per-hour cadence and the
     // 400-doc cap, the cost is bounded (~20s on a full sweep).
     for (const docSnap of stale.docs) {
-      // Defense in depth: collectionGroup('responses') matches any path
-      // ending in /responses/{id}. We only want quiz responses; reject
-      // anything not under `quiz_sessions/{sid}/responses/{id}`.
-      if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
+      // Stop processing once we've used the write budget — additional
+      // docs read into `stale.docs` past this point are deferred to
+      // the next tick.
+      if (finalized + failed >= MAX_FINALIZE_PER_RUN) {
+        writeBudgetExhausted = true;
+        break;
+      }
+      // Defense in depth via the shared parser — anything not under
+      // `quiz_sessions/{sid}/responses/{id}` is rejected here in the
+      // same shape as the gather loop above.
+      const sid = parseQuizResponsePath(docSnap.ref.path);
+      if (!sid) continue;
 
-      const sid = docSnap.ref.path.split('/')[1];
-      // Skip docs whose parent session is paused or waiting:
+      // Skip docs whose parent session is paused or recently 'waiting':
       //   - paused: teacher intentionally stopped. Force-finalizing
       //     now would erase the live attempt with `autoSubmitted:
       //     true`. `resumeAssignment` refreshes lastWriteAt on every
-      //     joined/in-progress response so resumed sessions re-enter
-      //     the sweep on a fresh clock, not stamped to before-pause.
-      //   - waiting: session created but never started (teacher
-      //     hasn't advanced to Q1, or resumed a never-started
-      //     session). Joined-state lobby attendees would otherwise be
-      //     auto-submitted with 0 answers after the idle threshold.
+      //     joined/in-progress response BEFORE flipping status off
+      //     'paused', so the cron never sees stale-lastWriteAt +
+      //     not-paused at the same time for a legitimate resume.
+      //   - waiting (recent): session created but never started.
+      //     Joined-state lobby attendees would otherwise be auto-
+      //     submitted with 0 answers after the idle threshold.
+      //   - waiting (older than WAITING_ABANDONED_AGE_MS): treated as
+      //     abandoned and swept normally, so practice/demo sessions
+      //     can't accumulate as never-finalized lobby ghosts.
       //
-      // If parent batch read failed (parentReadFailed flag), the map
-      // is empty — `parentStatus` is undefined and `has(sid)` is
-      // false, so EVERY doc would fall through to the orphan-skip
-      // branch and nothing would get finalized. Bypass both skip
-      // branches in that case and fall back to pre-PR behavior of
-      // sweeping every doc.
-      if (!parentReadFailed) {
-        const parentStatus = sessionStatusBySid.get(sid);
-        if (parentStatus === 'paused') {
-          skippedPaused++;
-          continue;
-        }
-        if (parentStatus === 'waiting') {
+      // A parent session present in the map but with `status ===
+      // undefined` (legacy doc missing the field, or a partially-
+      // written doc) is treated as orphan rather than allowed to fall
+      // through — falling through would let a malformed parent take
+      // the auto-finalize path, which is the least-safe default.
+      const meta = sessionMetaBySid.get(sid);
+      if (!meta) {
+        skippedOrphan++;
+        continue;
+      }
+      if (meta.status === 'paused') {
+        skippedPaused++;
+        continue;
+      }
+      if (meta.status === 'waiting') {
+        const sessionAgeMs = meta.createdAtMs ?? finalizedAt; // missing createdAt → treat as new
+        if (sessionAgeMs > waitingAbandonedCutoffMs) {
           skippedWaiting++;
           continue;
         }
-        // Orphan response: parent session was deleted. Counted
-        // separately so the operational metric reflects that these
-        // aren't write failures — there's nothing to sweep into.
-        if (!sessionStatusBySid.has(sid)) {
-          skippedOrphan++;
-          continue;
-        }
+        // Old waiting session → fall through and finalize normally.
+      } else if (typeof meta.status !== 'string') {
+        // Malformed / legacy parent — treat as orphan.
+        skippedOrphan++;
+        continue;
       }
 
       try {
@@ -304,31 +420,42 @@ export const finalizeIdleQuizAttempts = onSchedule(
     // matching. New skip counters are appended after the original
     // parenthetical.
     console.log(
-      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, failed=${failed}, cutoff=${cutoff.toDate().toISOString()}) [paused=${skippedPaused}, waiting=${skippedWaiting}, orphan=${skippedOrphan}${parentReadFailed ? ', parentReadFailed=true' : ''}]`
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, failed=${failed}, cutoff=${cutoff.toDate().toISOString()}) [paused=${skippedPaused}, waiting=${skippedWaiting}, orphan=${skippedOrphan}, writeBudgetExhausted=${writeBudgetExhausted}]`
     );
 
-    // If more than ~10% of *attempted writes* failed, escalate by
-    // throwing so the scheduler logs an error-level event and retries
-    // on the next tick. The denominator deliberately excludes skip
-    // categories (raced / paused / waiting / orphan) — those aren't
-    // write attempts and including them would hide a structural
-    // problem: e.g. 380 raced + 20 failed (100% of attempted writes
-    // failing) would not have tripped the prior `total = finalized
-    // + raced + failed` denominator.
+    // Escalate on two distinct failure modes that the per-run
+    // failure-rate gate alone misses:
     //
-    // Minimum-attempts floor of 10: at low N a single transient
-    // contention failure (failed=1, finalized=0) would otherwise
-    // throw and trigger a Cloud Scheduler retry storm during quiet
-    // hours, e.g. a 3 AM tick where the only stale doc happens to
-    // have a transient tx failure. The threshold only kicks in once
-    // we have enough samples to distinguish structural problems
-    // from noise.
+    //   1. Sustained low-N total failure (e.g. 3 AM tick, 9 stale
+    //      docs, all 9 fail). The previous gate `attempted >= 10`
+    //      stayed silent forever; we now treat any 100% failure rate
+    //      as escalation-worthy regardless of count, with a small
+    //      grace floor for `failed === 1` so a single transient tx
+    //      blip can't page on its own.
+    //   2. Above-threshold rate at higher volume. Per-tick gate of
+    //      10% over a floor of 10 attempts; the comment defends
+    //      excluding skip categories from the denominator.
+    //
+    // logger.error gives Cloud Logging severity=ERROR so the default
+    // ERROR-severity alerts trip; we still throw so Cloud Scheduler
+    // also logs the failure and retries on the next tick.
     const attempted = finalized + failed;
     const ATTEMPTS_FLOOR = 10;
-    if (attempted >= ATTEMPTS_FLOOR && failed * 10 > attempted) {
-      throw new Error(
-        `[finalizeIdleQuizAttempts] elevated failure rate: ${failed}/${attempted}`
-      );
+    const isTotalFailure = failed >= 2 && finalized === 0;
+    const isElevatedRate =
+      attempted >= ATTEMPTS_FLOOR && failed * 10 > attempted;
+    if (isTotalFailure || isElevatedRate) {
+      const msg = `[finalizeIdleQuizAttempts] elevated failure rate: ${failed}/${attempted}`;
+      logger.error(msg, {
+        finalized,
+        failed,
+        skippedRaced,
+        skippedPaused,
+        skippedWaiting,
+        skippedOrphan,
+        writeBudgetExhausted,
+      });
+      throw new Error(msg);
     }
   }
 );

--- a/functions/src/finalizeIdleQuizAttempts.ts
+++ b/functions/src/finalizeIdleQuizAttempts.ts
@@ -92,9 +92,84 @@ export const finalizeIdleQuizAttempts = onSchedule(
       return;
     }
 
+    // Batch-read parent quiz_session docs so we can skip docs whose
+    // session isn't currently accepting work. Two skip categories:
+    //
+    //   - 'paused': teacher intentionally stopped (often end-of-day,
+    //     intending to resume next class period). Without skipping,
+    //     students get force-finalized with `autoSubmitted: true` 90
+    //     min after pause, requiring per-student `unlockStudentAttempt`
+    //     to recover the live attempt.
+    //   - 'waiting': session created but teacher hasn't advanced to Q1
+    //     yet (lobby state). Joined students sitting in the lobby
+    //     shouldn't be auto-submitted with 0 answers just because the
+    //     teacher got pulled into a meeting before starting. Also
+    //     covers the `resumeAssignment` branch that resumes a
+    //     never-started session back to 'waiting'.
+    //
+    // 'active' and 'ended' sessions proceed to the per-doc tx as
+    // before. `resumeAssignment` (hooks/useQuizAssignments.ts) batch-
+    // refreshes `lastWriteAt` on every joined/in-progress response when
+    // it flips status paused → active, so a resumed session's stale
+    // responses don't get instantly swept on the next tick.
+    //
+    // One Firestore read per unique sid, not per response — kept cheap
+    // for the public-ed budget. The race-window between this batch
+    // read and the per-doc tx below is bounded by the run duration
+    // (~20s on a full sweep): a teacher who pauses inside that window
+    // may still see some students finalized, but worst case they re-
+    // pause next tick and the rest are caught.
+    const parentSessionIds = new Set<string>();
+    for (const docSnap of stale.docs) {
+      if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
+      // Path shape: quiz_sessions/{sid}/responses/{rid}
+      const segments = docSnap.ref.path.split('/');
+      if (segments.length < 4 || segments[0] !== 'quiz_sessions') continue;
+      parentSessionIds.add(segments[1]);
+    }
+    const sessionRefs = Array.from(parentSessionIds).map((sid) =>
+      db.doc(`quiz_sessions/${sid}`)
+    );
+    // `getAll` issues one network round-trip for N docs; returns docs in
+    // the same order as the input refs. Missing docs come back as
+    // `exists === false` snapshots, which we treat as "session gone" —
+    // a deleted parent session means orphan responses, which we skip
+    // (don't sweep into a missing parent; if the teacher deleted the
+    // whole session deliberately, the responses are already
+    // inaccessible from the live monitor).
+    //
+    // Availability fallback: if `getAll` itself throws (network blip,
+    // deadline exceeded), we proceed with an empty status map. That
+    // disables the new skip categories for this tick — the per-doc
+    // loop still runs and finalizes legitimate stale responses, which
+    // is the pre-PR behavior. Better to degrade to the old correctness
+    // than to abort the entire hourly sweep on a single transient
+    // failure.
+    const sessionStatusBySid = new Map<string, string | undefined>();
+    let parentReadFailed = false;
+    if (sessionRefs.length > 0) {
+      try {
+        const sessionDocs = await db.getAll(...sessionRefs);
+        for (const sessionDoc of sessionDocs) {
+          if (!sessionDoc.exists) continue;
+          const status = (sessionDoc.data() ?? {}).status as string | undefined;
+          sessionStatusBySid.set(sessionDoc.id, status);
+        }
+      } catch (err) {
+        parentReadFailed = true;
+        console.warn(
+          '[finalizeIdleQuizAttempts] parent session batch read failed; proceeding without skip data',
+          err
+        );
+      }
+    }
+
     const finalizedAt = Date.now();
     let finalized = 0;
     let skippedRaced = 0;
+    let skippedPaused = 0;
+    let skippedWaiting = 0;
+    let skippedOrphan = 0;
     let failed = 0;
 
     // Per-doc transactions instead of a single batch so a student who
@@ -111,6 +186,43 @@ export const finalizeIdleQuizAttempts = onSchedule(
       // ending in /responses/{id}. We only want quiz responses; reject
       // anything not under `quiz_sessions/{sid}/responses/{id}`.
       if (!docSnap.ref.path.startsWith('quiz_sessions/')) continue;
+
+      const sid = docSnap.ref.path.split('/')[1];
+      // Skip docs whose parent session is paused or waiting:
+      //   - paused: teacher intentionally stopped. Force-finalizing
+      //     now would erase the live attempt with `autoSubmitted:
+      //     true`. `resumeAssignment` refreshes lastWriteAt on every
+      //     joined/in-progress response so resumed sessions re-enter
+      //     the sweep on a fresh clock, not stamped to before-pause.
+      //   - waiting: session created but never started (teacher
+      //     hasn't advanced to Q1, or resumed a never-started
+      //     session). Joined-state lobby attendees would otherwise be
+      //     auto-submitted with 0 answers after the idle threshold.
+      //
+      // If parent batch read failed (parentReadFailed flag), the map
+      // is empty — `parentStatus` is undefined and `has(sid)` is
+      // false, so EVERY doc would fall through to the orphan-skip
+      // branch and nothing would get finalized. Bypass both skip
+      // branches in that case and fall back to pre-PR behavior of
+      // sweeping every doc.
+      if (!parentReadFailed) {
+        const parentStatus = sessionStatusBySid.get(sid);
+        if (parentStatus === 'paused') {
+          skippedPaused++;
+          continue;
+        }
+        if (parentStatus === 'waiting') {
+          skippedWaiting++;
+          continue;
+        }
+        // Orphan response: parent session was deleted. Counted
+        // separately so the operational metric reflects that these
+        // aren't write failures — there's nothing to sweep into.
+        if (!sessionStatusBySid.has(sid)) {
+          skippedOrphan++;
+          continue;
+        }
+      }
 
       try {
         const result = await db.runTransaction(async (tx) => {
@@ -186,19 +298,36 @@ export const finalizeIdleQuizAttempts = onSchedule(
       }
     }
 
+    // Log field ordering: keep the original `finalized .. raced ..
+    // failed .. cutoff` adjacency so any pre-existing log-based
+    // metric / alert regex (`raced=(\d+), failed=(\d+)` etc.) keeps
+    // matching. New skip counters are appended after the original
+    // parenthetical.
     console.log(
-      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, failed=${failed}, cutoff=${cutoff.toDate().toISOString()})`
+      `[finalizeIdleQuizAttempts] finalized ${finalized} stale responses (raced=${skippedRaced}, failed=${failed}, cutoff=${cutoff.toDate().toISOString()}) [paused=${skippedPaused}, waiting=${skippedWaiting}, orphan=${skippedOrphan}${parentReadFailed ? ', parentReadFailed=true' : ''}]`
     );
 
-    // If more than ~10% of attempts failed, escalate by throwing so the
-    // scheduler logs an error-level event and retries on the next tick.
-    // Lower the threshold once we have a baseline; for now this catches
-    // structural problems (e.g., a rule deploy gap, a malformed-doc
-    // backlog) without paging on isolated contention races.
-    const total = finalized + skippedRaced + failed;
-    if (total > 0 && failed * 10 > total) {
+    // If more than ~10% of *attempted writes* failed, escalate by
+    // throwing so the scheduler logs an error-level event and retries
+    // on the next tick. The denominator deliberately excludes skip
+    // categories (raced / paused / waiting / orphan) — those aren't
+    // write attempts and including them would hide a structural
+    // problem: e.g. 380 raced + 20 failed (100% of attempted writes
+    // failing) would not have tripped the prior `total = finalized
+    // + raced + failed` denominator.
+    //
+    // Minimum-attempts floor of 10: at low N a single transient
+    // contention failure (failed=1, finalized=0) would otherwise
+    // throw and trigger a Cloud Scheduler retry storm during quiet
+    // hours, e.g. a 3 AM tick where the only stale doc happens to
+    // have a transient tx failure. The threshold only kicks in once
+    // we have enough samples to distinguish structural problems
+    // from noise.
+    const attempted = finalized + failed;
+    const ATTEMPTS_FLOOR = 10;
+    if (attempted >= ATTEMPTS_FLOOR && failed * 10 > attempted) {
       throw new Error(
-        `[finalizeIdleQuizAttempts] elevated failure rate: ${failed}/${total}`
+        `[finalizeIdleQuizAttempts] elevated failure rate: ${failed}/${attempted}`
       );
     }
   }

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -24,6 +24,7 @@ import {
   where,
   orderBy,
   serverTimestamp,
+  Timestamp,
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
@@ -919,22 +920,34 @@ export const useQuizAssignments = (
       const neverStarted =
         !!session &&
         (session.startedAt == null || session.currentQuestionIndex < 0);
-      await setStatus(
-        assignmentId,
-        'active',
-        neverStarted ? 'waiting' : 'active'
+
+      // Refresh `lastWriteAt` on every joined / in-progress response BEFORE
+      // flipping session status off 'paused'. Order matters: the hourly
+      // idle-finalize cron (functions/src/finalizeIdleQuizAttempts.ts) skips
+      // docs whose parent session is 'paused' or 'waiting'. If we flipped
+      // status to 'active' first, a cron tick landing between the flip and
+      // the response refresh would see status='active', stale `lastWriteAt`,
+      // and force-finalize every paused student — the exact failure this
+      // refresh is meant to prevent. Refreshing while still 'paused' is
+      // safe (cron skips paused anyway) and any failure here leaves the
+      // session paused, so a retry is clean.
+      //
+      // Filter to docs whose `lastWriteAt` is already inside the cron's
+      // idle window — fresh docs don't need touching, which avoids a write
+      // amplification when a teacher pauses/resumes rapidly. The 80-minute
+      // cutoff sits inside the cron's 90-minute idle threshold with a 10-
+      // minute safety margin, so any doc that *could* be swept by the next
+      // tick gets refreshed.
+      //
+      // Teacher branch in `firestore.rules` is unrestricted, so writing
+      // `lastWriteAt: serverTimestamp()` on student-owned response docs is
+      // allowed here. Batched so a typical 30-student session is one
+      // Firestore round-trip; sessions over the 500-op batch cap chunk
+      // into multiple batches.
+      const IDLE_REFRESH_CUTOFF_MS = 80 * 60 * 1000;
+      const refreshCutoff = Timestamp.fromMillis(
+        Date.now() - IDLE_REFRESH_CUTOFF_MS
       );
-      // Refresh `lastWriteAt` on every joined / in-progress response so the
-      // hourly idle-finalize cron (functions/src/finalizeIdleQuizAttempts.ts)
-      // doesn't force-finalize students who paused with the teacher and
-      // haven't had a chance to re-engage yet. Without this touch, a Friday
-      // pause + Monday resume would leave responses 48h+ stale; the cron
-      // tick after resume would auto-submit every paused student before
-      // they typed a single character. Teacher branch in `firestore.rules`
-      // is unrestricted, so writing `lastWriteAt: serverTimestamp()` on
-      // student-owned response docs is allowed here. Batched so a typical
-      // 30-student session is one Firestore round-trip; sessions over the
-      // 500-op batch cap chunk into multiple batches.
       const responsesSnap = await getDocs(
         query(
           collection(
@@ -943,7 +956,8 @@ export const useQuizAssignments = (
             assignmentId,
             RESPONSES_COLLECTION
           ),
-          where('status', 'in', ['joined', 'in-progress'])
+          where('status', 'in', ['joined', 'in-progress']),
+          where('lastWriteAt', '<', refreshCutoff)
         )
       );
       if (!responsesSnap.empty) {
@@ -961,6 +975,12 @@ export const useQuizAssignments = (
         }
         if (opsInBatch > 0) await batch.commit();
       }
+
+      await setStatus(
+        assignmentId,
+        'active',
+        neverStarted ? 'waiting' : 'active'
+      );
     },
     [userId, setStatus]
   );

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -23,6 +23,7 @@ import {
   query,
   where,
   orderBy,
+  serverTimestamp,
   updateDoc,
   writeBatch,
 } from 'firebase/firestore';
@@ -923,6 +924,43 @@ export const useQuizAssignments = (
         'active',
         neverStarted ? 'waiting' : 'active'
       );
+      // Refresh `lastWriteAt` on every joined / in-progress response so the
+      // hourly idle-finalize cron (functions/src/finalizeIdleQuizAttempts.ts)
+      // doesn't force-finalize students who paused with the teacher and
+      // haven't had a chance to re-engage yet. Without this touch, a Friday
+      // pause + Monday resume would leave responses 48h+ stale; the cron
+      // tick after resume would auto-submit every paused student before
+      // they typed a single character. Teacher branch in `firestore.rules`
+      // is unrestricted, so writing `lastWriteAt: serverTimestamp()` on
+      // student-owned response docs is allowed here. Batched so a typical
+      // 30-student session is one Firestore round-trip; sessions over the
+      // 500-op batch cap chunk into multiple batches.
+      const responsesSnap = await getDocs(
+        query(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            assignmentId,
+            RESPONSES_COLLECTION
+          ),
+          where('status', 'in', ['joined', 'in-progress'])
+        )
+      );
+      if (!responsesSnap.empty) {
+        const BATCH_LIMIT = 450; // headroom under the 500-op Firestore cap
+        let batch = writeBatch(db);
+        let opsInBatch = 0;
+        for (const respSnap of responsesSnap.docs) {
+          batch.update(respSnap.ref, { lastWriteAt: serverTimestamp() });
+          opsInBatch++;
+          if (opsInBatch >= BATCH_LIMIT) {
+            await batch.commit();
+            batch = writeBatch(db);
+            opsInBatch = 0;
+          }
+        }
+        if (opsInBatch > 0) await batch.commit();
+      }
     },
     [userId, setStatus]
   );

--- a/locales/en.json
+++ b/locales/en.json
@@ -655,7 +655,17 @@
         "jigsaw": "Jigsaw"
       },
       "modeChipAria": "Operation mode: {{mode}}",
+      "modeChipAriaWithCount_one": "Operation mode: {{mode}}. {{count}} student left.",
+      "modeChipAriaWithCount_other": "Operation mode: {{mode}}. {{count}} students left.",
       "modeChipTitle": "Mode: {{mode}} — click to cycle",
+      "classContext": {
+        "triggerAria": "Active class: {{name}}",
+        "triggerAriaWithAbsent_one": "Active class: {{name}}. {{count}} student marked absent today.",
+        "triggerAriaWithAbsent_other": "Active class: {{name}}. {{count}} students marked absent today.",
+        "menuAria": "Class context for Randomizer",
+        "switchHeading": "Switch class",
+        "markAbsentAction": "Mark absent students"
+      },
       "launchJigsaw": "Launch Jigsaw",
       "launchJigsawHint": "Show expert groups",
       "launchHomeGroup": "Launch Home Group",

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,42 @@
 {
   "entries": [
     {
+      "version": "2026.05.28.2",
+      "date": "2026-05-28",
+      "title": "Quiz auto-submit safeguards",
+      "overview": [
+        {
+          "type": "improvement",
+          "subtitle": "90-minute auto-submit safeguards",
+          "items": [
+            {
+              "text": "Pausing a live quiz now also pauses the 90-minute idle auto-submit, so you can hold a session over lunch, a fire drill, or until tomorrow's class without students being force-submitted while you're away."
+            },
+            {
+              "text": "Students sitting in the lobby of a quiz you haven't launched yet no longer get force-submitted with empty answers if you get pulled away before starting question 1."
+            },
+            {
+              "text": "Resuming a paused session gives every student a fresh 90-minute idle window, so a long pause never causes their work to auto-submit the moment they reconnect."
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "type": "improvement",
+          "text": "Live quiz — paused sessions are now exempt from the 90-minute idle auto-submit. If you pause a quiz at the end of a class period to resume the next day (or step out for lunch, a fire drill, or a hallway conversation), students' in-progress attempts are preserved instead of being force-submitted while the session is paused."
+        },
+        {
+          "type": "improvement",
+          "text": "Live quiz — lobby attendees are no longer force-submitted. If you create a quiz, students join the lobby, and you get pulled away before launching question 1, those students stay in the lobby with their join intact rather than being auto-finalized with 0 answers after 90 minutes."
+        },
+        {
+          "type": "improvement",
+          "text": "Live quiz — when you resume a paused session, the 90-minute idle clock restarts for every joined and in-progress student. Even if the pause lasted overnight, students get a full fresh window to keep working when they reconnect, instead of being immediately auto-submitted because their last activity was hours or days ago."
+        }
+      ]
+    },
+    {
       "version": "2026.05.28",
       "date": "2026-05-28",
       "title": "Quiz reliability, grading fixes, and translations",

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -3,7 +3,7 @@
     {
       "version": "2026.05.28.2",
       "date": "2026-05-28",
-      "title": "Quiz auto-submit safeguards",
+      "title": "Quiz safeguards, Scoreboard layout, and Random widget chip",
       "overview": [
         {
           "type": "improvement",
@@ -13,10 +13,28 @@
               "text": "Pausing a live quiz now also pauses the 90-minute idle auto-submit, so you can hold a session over lunch, a fire drill, or until tomorrow's class without students being force-submitted while you're away."
             },
             {
-              "text": "Students sitting in the lobby of a quiz you haven't launched yet no longer get force-submitted with empty answers if you get pulled away before starting question 1."
+              "text": "Students sitting in the lobby of a quiz you haven't launched yet no longer get force-submitted with empty answers if you get pulled away before starting question 1. Lobby sessions left untouched for more than 24 hours are treated as abandoned and finalized normally."
             },
             {
-              "text": "Resuming a paused session gives every student a fresh 90-minute idle window, so a long pause never causes their work to auto-submit the moment they reconnect."
+              "text": "Resuming a paused session gives every still-joined student a fresh 90-minute idle window, so a long pause never causes their work to auto-submit the moment they reconnect."
+            }
+          ]
+        },
+        {
+          "type": "improvement",
+          "subtitle": "Scoreboard layout",
+          "items": [
+            {
+              "text": "The Cards vs Rows layout toggle moved out of the Scoreboard's chrome and into the Settings panel, where it sits alongside team and color settings — easier to find when you're setting up a board for the first time."
+            }
+          ]
+        },
+        {
+          "type": "improvement",
+          "subtitle": "Random widget — class context chip",
+          "items": [
+            {
+              "text": "The active class chip and the Mark Absent button merged into a single icon-only chip with a popover. Click the target icon to see the class name, switch class, or mark absent students — frees up header room at narrow widget widths."
             }
           ]
         }
@@ -28,11 +46,19 @@
         },
         {
           "type": "improvement",
-          "text": "Live quiz — lobby attendees are no longer force-submitted. If you create a quiz, students join the lobby, and you get pulled away before launching question 1, those students stay in the lobby with their join intact rather than being auto-finalized with 0 answers after 90 minutes."
+          "text": "Live quiz — lobby attendees are no longer force-submitted while the session sits in the waiting state. If you create a quiz, students join the lobby, and you get pulled away before launching question 1, those students stay in the lobby with their join intact instead of being auto-finalized with 0 answers after 90 minutes. Lobby sessions that sit untouched for more than 24 hours are treated as abandoned and swept on the next cron pass, so old practice/demo sessions don't accumulate as never-finalized rows."
         },
         {
           "type": "improvement",
-          "text": "Live quiz — when you resume a paused session, the 90-minute idle clock restarts for every joined and in-progress student. Even if the pause lasted overnight, students get a full fresh window to keep working when they reconnect, instead of being immediately auto-submitted because their last activity was hours or days ago."
+          "text": "Live quiz — when you resume a paused session, the 90-minute idle clock restarts for every still-joined and in-progress student before the session flips back to active. Even if the pause lasted overnight, students get a full fresh window to keep working when they reconnect, instead of being immediately auto-submitted because their last activity was hours or days ago."
+        },
+        {
+          "type": "improvement",
+          "text": "Scoreboard widget — the Cards / Rows layout toggle moved from the widget header into the Settings panel as a labelled control. Existing scoreboards keep whichever layout they were already using; the header is now reserved for the score display itself."
+        },
+        {
+          "type": "improvement",
+          "text": "Random widget — the active class chip and the Mark Absent button merged into a single icon-only chip with a popover. The popover shows the class name, lets you switch class, and offers a Mark Absent Students action when the Randomizer is pointing at a real class roster (the action hides itself when you're in custom-names mode). Stations, Seating Chart, and Lunch Count keep their separate chips for now."
         }
       ]
     },

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -16,11 +16,13 @@ import type {
   SharedQuizAssignment,
 } from '@/types';
 
-// `deleteField()` returns a Firestore sentinel; the production code stores
-// the sentinel in the patch object and Firestore SDK interprets it on the
-// wire. For tests we use a unique branded marker so assertions can verify
-// the sentinel landed in the right field without depending on the real SDK.
+// `deleteField()` and `serverTimestamp()` return Firestore sentinels; the
+// production code stores the sentinel in the patch object and Firestore SDK
+// interprets it on the wire. For tests we use unique branded markers so
+// assertions can verify the sentinel landed in the right field without
+// depending on the real SDK.
 const DELETE_FIELD_SENTINEL = Symbol('test:deleteField()');
+const SERVER_TIMESTAMP_SENTINEL = Symbol('test:serverTimestamp()');
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
   deleteField: vi.fn(() => DELETE_FIELD_SENTINEL),
@@ -32,6 +34,7 @@ vi.mock('firebase/firestore', () => ({
   query: vi.fn(),
   where: vi.fn(),
   orderBy: vi.fn(),
+  serverTimestamp: vi.fn(() => SERVER_TIMESTAMP_SENTINEL),
   updateDoc: vi.fn(),
   writeBatch: vi.fn(),
 }));
@@ -154,6 +157,7 @@ function makePublicQuestions(n: number): QuizPublicQuestion[] {
 describe('useQuizAssignments - reopenAssignment', () => {
   const batchUpdate = vi.fn();
   const batchCommit = vi.fn();
+  const mockGetDocs = getDocs as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -170,6 +174,13 @@ describe('useQuizAssignments - reopenAssignment', () => {
       update: batchUpdate,
       commit: batchCommit,
     });
+    // `resumeAssignment` now batch-refreshes `lastWriteAt` on every
+    // joined/in-progress response so the idle-finalize cron doesn't
+    // force-finalize students on the next tick after resume. The
+    // reopen + resume tests don't seed any live responses, so an
+    // empty snapshot is the right default; tests that exercise the
+    // refresh behavior override this with their own mock.
+    mockGetDocs.mockResolvedValue({ empty: true, docs: [] });
   });
 
   function findSessionPatch(): Record<string, unknown> {
@@ -367,6 +378,62 @@ describe('useQuizAssignments - reopenAssignment', () => {
     if (!resumeSessionCall)
       throw new Error('expected resume batch.update on quiz_sessions/*');
     expect(resumeSessionCall[1]).toMatchObject({ status: 'waiting' });
+  });
+
+  it('resumeAssignment refreshes lastWriteAt on every joined/in-progress response so the idle-finalize cron does not force-finalize resumed students on the next tick', async () => {
+    // Regression shield for PR #1736 review finding: the cron
+    // (functions/src/finalizeIdleQuizAttempts.ts) skips parent-status
+    // 'paused' / 'waiting', but if a teacher pauses on Friday and
+    // resumes Monday, `session.status` flips to 'active' while every
+    // response's `lastWriteAt` is still 48h+ stale. Without this
+    // refresh, the very next hourly cron tick after resume force-
+    // finalizes every paused student with `autoSubmitted: true`
+    // before they have a chance to type. The refresh stamps
+    // `lastWriteAt: serverTimestamp()` on each joined/in-progress
+    // response so the cron's idle threshold restarts from now.
+    const session: Partial<QuizSession> = {
+      id: ASSIGNMENT_ID,
+      sessionMode: 'teacher',
+      status: 'paused',
+      currentQuestionIndex: 2,
+      totalQuestions: 5,
+      startedAt: 1000,
+    };
+    mockGetDoc.mockResolvedValueOnce({ data: () => session });
+
+    // Three live responses (2 joined, 1 in-progress) and one already-
+    // completed response that should NOT be touched.
+    const respRefs = {
+      r1: 'quiz_sessions/asg-1/responses/r1',
+      r2: 'quiz_sessions/asg-1/responses/r2',
+      r3: 'quiz_sessions/asg-1/responses/r3',
+    };
+    mockGetDocs.mockResolvedValueOnce({
+      empty: false,
+      docs: [{ ref: respRefs.r1 }, { ref: respRefs.r2 }, { ref: respRefs.r3 }],
+    });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+
+    await act(async () => {
+      await result.current.resumeAssignment(ASSIGNMENT_ID);
+    });
+
+    // Every live response got a lastWriteAt: serverTimestamp() update.
+    // Asserting on the sentinel identity proves the production code
+    // didn't substitute a client-side Date.now() or other value — the
+    // new firestore.rules predicate `lastWriteAt == request.time`
+    // would reject anything that's not the server stamp.
+    const responseUpdates = batchUpdate.mock.calls.filter(
+      ([ref]) =>
+        typeof ref === 'string' &&
+        ref.startsWith('quiz_sessions/') &&
+        ref.includes('/responses/')
+    );
+    expect(responseUpdates).toHaveLength(3);
+    for (const [, patch] of responseUpdates) {
+      expect(patch).toEqual({ lastWriteAt: SERVER_TIMESTAMP_SENTINEL });
+    }
   });
 });
 

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -7,6 +7,7 @@ import {
   getDoc,
   getDocs,
   onSnapshot,
+  serverTimestamp,
   writeBatch,
 } from 'firebase/firestore';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
@@ -35,6 +36,13 @@ vi.mock('firebase/firestore', () => ({
   where: vi.fn(),
   orderBy: vi.fn(),
   serverTimestamp: vi.fn(() => SERVER_TIMESTAMP_SENTINEL),
+  // Timestamp.fromMillis is used by resumeAssignment to compute the
+  // idle-refresh cutoff filter. Return a branded object so tests can
+  // verify the value flowed through to the query() args without pulling
+  // in the real SDK Timestamp class.
+  Timestamp: {
+    fromMillis: vi.fn((ms: number) => ({ __testTimestamp: ms })),
+  },
   updateDoc: vi.fn(),
   writeBatch: vi.fn(),
 }));
@@ -380,17 +388,21 @@ describe('useQuizAssignments - reopenAssignment', () => {
     expect(resumeSessionCall[1]).toMatchObject({ status: 'waiting' });
   });
 
-  it('resumeAssignment refreshes lastWriteAt on every joined/in-progress response so the idle-finalize cron does not force-finalize resumed students on the next tick', async () => {
+  it('resumeAssignment refreshes lastWriteAt on every joined/in-progress response BEFORE flipping session status, so a concurrent cron tick still sees paused and skips', async () => {
     // Regression shield for PR #1736 review finding: the cron
     // (functions/src/finalizeIdleQuizAttempts.ts) skips parent-status
     // 'paused' / 'waiting', but if a teacher pauses on Friday and
     // resumes Monday, `session.status` flips to 'active' while every
-    // response's `lastWriteAt` is still 48h+ stale. Without this
-    // refresh, the very next hourly cron tick after resume force-
-    // finalizes every paused student with `autoSubmitted: true`
-    // before they have a chance to type. The refresh stamps
+    // response's `lastWriteAt` is still 48h+ stale. The refresh stamps
     // `lastWriteAt: serverTimestamp()` on each joined/in-progress
     // response so the cron's idle threshold restarts from now.
+    //
+    // Critically, the refresh MUST commit before the status flip so a
+    // cron tick landing between the two operations still reads
+    // status='paused' and skips. This test pins both the field value
+    // (sentinel identity), the commit call (mock.commit invoked at
+    // least once for the response batch), and the ORDER (response
+    // batches before the session-flip batch).
     const session: Partial<QuizSession> = {
       id: ASSIGNMENT_ID,
       sessionMode: 'teacher',
@@ -402,11 +414,15 @@ describe('useQuizAssignments - reopenAssignment', () => {
     mockGetDoc.mockResolvedValueOnce({ data: () => session });
 
     // Three live responses (2 joined, 1 in-progress) and one already-
-    // completed response that should NOT be touched.
+    // completed response that should NOT be touched. Snapshot `ref` is
+    // a DocumentReference in production; we mock it as an object with
+    // a `path` getter so assertions can inspect the path while still
+    // exercising the same shape the production code passes through to
+    // `batch.update(respSnap.ref, ...)`.
     const respRefs = {
-      r1: 'quiz_sessions/asg-1/responses/r1',
-      r2: 'quiz_sessions/asg-1/responses/r2',
-      r3: 'quiz_sessions/asg-1/responses/r3',
+      r1: { path: 'quiz_sessions/asg-1/responses/r1' },
+      r2: { path: 'quiz_sessions/asg-1/responses/r2' },
+      r3: { path: 'quiz_sessions/asg-1/responses/r3' },
     };
     mockGetDocs.mockResolvedValueOnce({
       empty: false,
@@ -420,20 +436,62 @@ describe('useQuizAssignments - reopenAssignment', () => {
     });
 
     // Every live response got a lastWriteAt: serverTimestamp() update.
-    // Asserting on the sentinel identity proves the production code
-    // didn't substitute a client-side Date.now() or other value — the
-    // new firestore.rules predicate `lastWriteAt == request.time`
-    // would reject anything that's not the server stamp.
+    // Asserting on the sentinel identity AND that serverTimestamp() was
+    // actually called proves the production code didn't substitute a
+    // client-side Date.now() or hard-code the sentinel literal — the
+    // firestore.rules predicate `lastWriteAt == request.time` would
+    // reject anything that's not the server-resolved timestamp.
     const responseUpdates = batchUpdate.mock.calls.filter(
       ([ref]) =>
-        typeof ref === 'string' &&
-        ref.startsWith('quiz_sessions/') &&
-        ref.includes('/responses/')
+        ref &&
+        typeof ref === 'object' &&
+        typeof (ref as { path?: string }).path === 'string' &&
+        (ref as { path: string }).path.includes('/responses/')
     );
     expect(responseUpdates).toHaveLength(3);
     for (const [, patch] of responseUpdates) {
       expect(patch).toEqual({ lastWriteAt: SERVER_TIMESTAMP_SENTINEL });
     }
+    expect(serverTimestamp).toHaveBeenCalled();
+
+    // Order invariant: every response-doc batch.update must precede
+    // the session-doc batch.update. If a refactor reverses the order,
+    // a cron tick between the flip and the refresh would force-
+    // finalize the very students the refresh is meant to protect.
+    const callIndex = batchUpdate.mock.calls.findIndex(([ref]) => {
+      const refObj = ref as { path?: string } | string;
+      if (typeof refObj === 'object' && refObj?.path) return false; // response ref
+      return (
+        typeof refObj === 'string' &&
+        refObj.startsWith('quiz_sessions/') &&
+        !refObj.includes('/responses/')
+      );
+    });
+    const lastResponseIndex = batchUpdate.mock.calls.reduce<number>(
+      (max, [ref], i) => {
+        if (
+          ref &&
+          typeof ref === 'object' &&
+          typeof (ref as { path?: string }).path === 'string' &&
+          (ref as { path: string }).path.includes('/responses/')
+        ) {
+          return i;
+        }
+        return max;
+      },
+      -1
+    );
+    expect(callIndex).toBeGreaterThan(-1);
+    expect(lastResponseIndex).toBeGreaterThan(-1);
+    expect(lastResponseIndex).toBeLessThan(callIndex);
+
+    // The response batch must commit (not just stage) — a refactor
+    // that forgets the trailing `if (opsInBatch > 0) await
+    // batch.commit()` would leave staged writes uncommitted and the
+    // next cron tick would force-finalize the unrefreshed responses.
+    // With 3 responses < BATCH_LIMIT=450, the tail commit is the only
+    // commit path that fires for the response batch.
+    expect(batchCommit).toHaveBeenCalled();
   });
 });
 

--- a/tests/rules/quizResponseProtection.test.ts
+++ b/tests/rules/quizResponseProtection.test.ts
@@ -96,14 +96,21 @@ const asStudent = () =>
 // ---------------------------------------------------------------------------
 
 beforeAll(async () => {
+  // Resolve emulator host/port explicitly rather than via a chained
+  // optional + `[0]`/`[1]` access. The chained form is technically
+  // safe under ES2020 short-circuit semantics, but the explicit form
+  // reads better, avoids surprising future readers, and is robust to
+  // a malformed value (e.g. host with no `:port`) which would otherwise
+  // resolve to `Number(undefined) = NaN` and silently fail emulator
+  // connection.
+  const emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+  const [hostPart, portPart] = emulatorHost ? emulatorHost.split(':') : [];
   testEnv = await initializeTestEnvironment({
     projectId: PROJECT_ID,
     firestore: {
       rules: readFileSync(RULES_PATH, 'utf8'),
-      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
-      port: Number(
-        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
-      ),
+      host: hostPart || '127.0.0.1',
+      port: portPart ? Number(portPart) : 8080,
     },
   });
 });
@@ -263,6 +270,23 @@ describe('quiz response CREATE — lastWriteAt server-stamp enforcement', () => 
       )
     );
   });
+
+  it('CREATE with lastWriteAt: Date.now() (number) is REJECTED', async () => {
+    // Symmetric regression shield to the UPDATE-side numeric-rejection
+    // test below. The pre-PR-#1720 codepath wrote `Date.now()` on both
+    // CREATE and UPDATE; without a CREATE-side test, a partial
+    // regression that only re-introduces a numeric stamp on the join
+    // path would slip through.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { ...baseAnonCreate(), lastWriteAt: Date.now() }
+      )
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -278,12 +302,20 @@ describe('quiz response UPDATE — lastWriteAt server-stamp enforcement', () => 
   ) {
     const key = opts.key ?? PIN_KEY;
     const studentUid = opts.studentUid ?? ANON_UID;
+    // Seed with the full production schema (classId + classIds present)
+    // so the assertFails tests below anchor on the rule under test
+    // rather than on incidental gaps in the seed. If a future rules
+    // change adds a response-side classId requirement, this defense-in-
+    // depth keeps the existing tests from silently turning into
+    // assertFails-for-wrong-reason green-lights.
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       const db = ctx.firestore();
       await setDoc(doc(db, `quiz_sessions/${SESSION_ID}/responses/${key}`), {
         studentUid,
         pin: '01',
         classPeriod: 'period_1',
+        classId: CLASS_ID,
+        classIds: [CLASS_ID],
         joinedAt: 1000,
         score: null,
         answers: [],
@@ -375,25 +407,80 @@ describe('quiz response UPDATE — lastWriteAt server-stamp enforcement', () => 
 });
 
 // ---------------------------------------------------------------------------
+// UPDATE: teacher-context lastWriteAt refresh on student-owned response
+// ---------------------------------------------------------------------------
+
+describe('quiz response UPDATE — teacher refreshes lastWriteAt on student-owned response', () => {
+  // `resumeAssignment` in hooks/useQuizAssignments.ts batch-writes
+  // `lastWriteAt: serverTimestamp()` on every joined/in-progress
+  // response while authenticated as the teacher (auth.uid ==
+  // sessionTeacherUid()). The teacher branch in firestore.rules is
+  // currently unrestricted so this works — but no existing test pins
+  // the contract, leaving a future teacher-branch tightening able to
+  // silently break the resume flow in production. This is the missing
+  // positive shield.
+  const asTeacher = () =>
+    testEnv
+      .authenticatedContext(TEACHER_UID, {
+        email: 'teacher@school.edu',
+        firebase: { sign_in_provider: 'google.com' },
+      })
+      .firestore();
+
+  async function seedStudentResponse() {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(
+        doc(db, `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`),
+        {
+          studentUid: ANON_UID,
+          pin: '01',
+          classPeriod: 'period_1',
+          classId: CLASS_ID,
+          classIds: [CLASS_ID],
+          joinedAt: 1000,
+          score: null,
+          answers: [],
+          status: 'in-progress',
+          completedAttempts: 0,
+          preSyncVersion: 0,
+          tabSwitchWarnings: 0,
+          lastWriteAt: Timestamp.fromMillis(1000),
+        }
+      );
+    });
+  }
+
+  it('teacher UPDATE of lastWriteAt: serverTimestamp() on a student-owned response SUCCEEDS', async () => {
+    await seedStudentResponse();
+    await assertSucceeds(
+      updateDoc(
+        doc(asTeacher(), `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`),
+        { lastWriteAt: serverTimestamp() }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // UPDATE: unlocked self-elevation rejection (companion to CREATE guard)
 // ---------------------------------------------------------------------------
 
 describe('quiz response UPDATE — unlocked self-elevation', () => {
-  it('UPDATE setting unlocked: true is REJECTED', async () => {
-    // The CREATE-side guard above blocks forging `unlocked: true` at
-    // join. This is the companion UPDATE-side guard: a student who
-    // already joined cannot post-hoc flip themselves to unlocked via
-    // an update. The rule predicate is
-    //   `request.resource.data.get('unlocked', false) == false`
-    // — students may only ever CLEAR the flag (write false), never
-    // raise it. The teacher's unlock action runs from the unrestricted
-    // teacher branch and is not affected.
+  // Seed a fresh student-owned response with the full production
+  // schema (classId/classIds present) so the assertFails/assertSucceeds
+  // pair below anchors on the unlocked predicate, not on incidental
+  // gaps in the seed.
+  async function seedSsoResponse() {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       const db = ctx.firestore();
       await setDoc(
         doc(db, `quiz_sessions/${SESSION_ID}/responses/${STUDENT_UID}`),
         {
           studentUid: STUDENT_UID,
+          classPeriod: 'period_1',
+          classId: CLASS_ID,
+          classIds: [CLASS_ID],
           joinedAt: 1000,
           score: null,
           answers: [],
@@ -404,6 +491,18 @@ describe('quiz response UPDATE — unlocked self-elevation', () => {
         }
       );
     });
+  }
+
+  it('UPDATE setting unlocked: true is REJECTED', async () => {
+    // The CREATE-side guard above blocks forging `unlocked: true` at
+    // join. This is the companion UPDATE-side guard: a student who
+    // already joined cannot post-hoc flip themselves to unlocked via
+    // an update. The rule predicate is
+    //   `request.resource.data.get('unlocked', false) == false`
+    // — students may only ever CLEAR the flag (write false), never
+    // raise it. The teacher's unlock action runs from the unrestricted
+    // teacher branch and is not affected.
+    await seedSsoResponse();
     await assertFails(
       updateDoc(
         doc(
@@ -411,6 +510,26 @@ describe('quiz response UPDATE — unlocked self-elevation', () => {
           `quiz_sessions/${SESSION_ID}/responses/${STUDENT_UID}`
         ),
         { unlocked: true }
+      )
+    );
+  });
+
+  it('UPDATE setting unlocked: false SUCCEEDS (positive control)', async () => {
+    // Positive control for the rejection test above. With the same
+    // seed and the same auth context, writing `unlocked: false`
+    // must succeed — students are permitted to clear the flag, just
+    // not raise it. This anchors the negative test to the unlocked
+    // predicate specifically; if a future seed change causes the
+    // negative test to fail for an unrelated reason, this positive
+    // control will red and catch the drift.
+    await seedSsoResponse();
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${STUDENT_UID}`
+        ),
+        { unlocked: false }
       )
     );
   });

--- a/tests/rules/quizResponseProtection.test.ts
+++ b/tests/rules/quizResponseProtection.test.ts
@@ -1,0 +1,417 @@
+// Firestore security-rules tests for the quiz response CREATE forgery
+// guards and the UPDATE `lastWriteAt == request.time` enforcement
+// landed in PR #1733 (quiz data-loss fix).
+//
+// Contract under test:
+//   - CREATE: a malicious join payload cannot stamp the cron-only /
+//     teacher-only fields `autoSubmitted`, `unlocked`, `unlockedAt`,
+//     or `grading`. Without this guard a student could set
+//     `unlocked: true` at join and trip the rejoin resume-unlocked
+//     branch in useQuizSession (granting an extra attempt without
+//     consuming a slot).
+//   - CREATE + UPDATE: `lastWriteAt` (the idle-auto-submit cron's
+//     cutoff field) must be server-stamped via `serverTimestamp()`,
+//     never a client `Date.now()` number or a forged Timestamp. The
+//     rule predicate is `lastWriteAt == request.time` (server-resolved
+//     equality). Closes the clock-skew failure modes: past-clock
+//     devices can't be force-finalized on the next sweep, future-clock
+//     devices can't evade idle auto-submit indefinitely, and multi-tab
+//     students with drifting clocks can't lock themselves out.
+//   - UPDATE: writes that don't touch `lastWriteAt` (e.g. a
+//     results-protection `resultsTabWarnings` increment) must still
+//     succeed without supplying it — the rule predicate is an
+//     `affectedKeys().hasAny(['lastWriteAt'])` short-circuit.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  setDoc,
+  updateDoc,
+  doc,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-quiz-response-protection-test';
+const SESSION_ID = 'session-protection';
+const TEACHER_UID = 'teacher-uid-protection';
+const ANON_UID = 'anon-protection-uid';
+const STUDENT_UID = 'student-protection-uid';
+const CLASS_ID = 'class-protection';
+
+// Anonymous PIN-derived response keys follow `pin-{period}-{pin}` per
+// `encodeResponseKeySegment()`. The rule's regex enforces this shape on
+// create; for UPDATE the `studentUid` field is the ownership check.
+const PIN_KEY = 'pin-period_1-01';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+// ---------------------------------------------------------------------------
+// Auth contexts
+// ---------------------------------------------------------------------------
+// Bare anonymous PIN-joiner token. Real production anon Auth tokens carry
+// no custom claims; spelling out empty/false defaults here matches the
+// shape that the rules engine reads via `.get()`-safe helpers.
+const asAnonStudent = () =>
+  testEnv
+    .authenticatedContext(ANON_UID, {
+      email: '',
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'anonymous' },
+    })
+    .firestore();
+
+// SSO-joined student-role token.
+const asStudent = () =>
+  testEnv
+    .authenticatedContext(STUDENT_UID, {
+      email: 'student@school.edu',
+      studentRole: true,
+      classIds: [CLASS_ID],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  // Seed the parent quiz_session. `mode` is omitted so `sessionMode()`
+  // defaults to 'submissions' (legacy default — see firestore.rules
+  // L2092-2096).
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `quiz_sessions/${SESSION_ID}`), {
+      teacherUid: TEACHER_UID,
+      status: 'active',
+      code: 'PROTECT',
+      classId: CLASS_ID,
+      classIds: [CLASS_ID],
+    });
+  });
+});
+
+// Minimal valid CREATE payload for an anonymous PIN joiner. Tests below
+// spread this and override one field at a time so the failure mode under
+// test is the one being asserted.
+const baseAnonCreate = () => ({
+  studentUid: ANON_UID,
+  pin: '01',
+  classPeriod: 'period_1',
+  joinedAt: 1000,
+  score: null,
+  answers: [],
+  status: 'joined' as const,
+  completedAttempts: 0,
+  preSyncVersion: 0,
+  tabSwitchWarnings: 0,
+});
+
+// ---------------------------------------------------------------------------
+// CREATE: forgery rejection for cron-only / teacher-only fields
+// ---------------------------------------------------------------------------
+
+describe('quiz response CREATE — cron/teacher-only field forgery', () => {
+  it('control: minimal valid CREATE succeeds (without lastWriteAt)', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        baseAnonCreate()
+      )
+    );
+  });
+
+  it('CREATE with autoSubmitted: true is REJECTED', async () => {
+    // Cron-only signal. A student setting it at join would falsely
+    // mark the attempt as auto-finalized from the start, evading
+    // teacher attention.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { ...baseAnonCreate(), autoSubmitted: true }
+      )
+    );
+  });
+
+  it('CREATE with unlocked: true is REJECTED', async () => {
+    // Teacher-only signal. A student setting it at join would trip
+    // the rejoin resume-unlocked branch in useQuizSession and grant
+    // an extra attempt without consuming a slot — silently bypassing
+    // the assignment's attempt cap.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { ...baseAnonCreate(), unlocked: true }
+      )
+    );
+  });
+
+  it('CREATE with unlockedAt timestamp is REJECTED', async () => {
+    // Companion field to `unlocked`. Stamped by the teacher's unlock
+    // action; forging it client-side has no useful purpose for the
+    // student but is denied for surface-area minimization.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { ...baseAnonCreate(), unlockedAt: 1000 }
+      )
+    );
+  });
+
+  it('CREATE with forged grading payload is REJECTED', async () => {
+    // Grading data is teacher-only. A forged `grading.<qid>` write at
+    // CREATE would let a student pre-populate their own rubric scores
+    // and pass them through to the teacher's view.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        {
+          ...baseAnonCreate(),
+          grading: { q1: { pointsAwarded: 999, gradedBy: 'student' } },
+        }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CREATE: lastWriteAt server-stamp enforcement
+// ---------------------------------------------------------------------------
+
+describe('quiz response CREATE — lastWriteAt server-stamp enforcement', () => {
+  it('CREATE with lastWriteAt: serverTimestamp() SUCCEEDS', async () => {
+    // The SDK resolves `serverTimestamp()` to `request.time` at rule
+    // evaluation. Equality holds; create passes.
+    await assertSucceeds(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { ...baseAnonCreate(), lastWriteAt: serverTimestamp() }
+      )
+    );
+  });
+
+  it('CREATE with lastWriteAt as a client Timestamp is REJECTED', async () => {
+    // A forged Timestamp (e.g. crafted by a future-clocked client to
+    // evade the 90-min idle sweep) is rejected because it does not
+    // equal `request.time`.
+    await assertFails(
+      setDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        {
+          ...baseAnonCreate(),
+          lastWriteAt: Timestamp.fromMillis(Date.now() + 1000 * 60 * 60 * 24),
+        }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UPDATE: lastWriteAt server-stamp enforcement
+// ---------------------------------------------------------------------------
+
+describe('quiz response UPDATE — lastWriteAt server-stamp enforcement', () => {
+  // Each UPDATE test starts from a freshly-seeded response doc. Seeded
+  // with a `lastWriteAt` already in place so the update path's diff
+  // computation has a baseline.
+  async function seedResponse(
+    opts: { studentUid?: string; key?: string } = {}
+  ) {
+    const key = opts.key ?? PIN_KEY;
+    const studentUid = opts.studentUid ?? ANON_UID;
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `quiz_sessions/${SESSION_ID}/responses/${key}`), {
+        studentUid,
+        pin: '01',
+        classPeriod: 'period_1',
+        joinedAt: 1000,
+        score: null,
+        answers: [],
+        status: 'in-progress',
+        completedAttempts: 0,
+        preSyncVersion: 0,
+        tabSwitchWarnings: 0,
+        lastWriteAt: Timestamp.fromMillis(1000),
+      });
+    });
+  }
+
+  it('UPDATE touching lastWriteAt with serverTimestamp() SUCCEEDS', async () => {
+    await seedResponse();
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        {
+          status: 'in-progress',
+          answers: [{ questionId: 'q1', status: 'submitted' }],
+          lastWriteAt: serverTimestamp(),
+        }
+      )
+    );
+  });
+
+  it('UPDATE with lastWriteAt: Date.now() (number) is REJECTED', async () => {
+    // The original pre-PR-#1720 codepath wrote `Date.now()` (a JS
+    // number). Under the new rule, that number is not equal to the
+    // server-resolved `request.time` Timestamp → the predicate fails
+    // and the update is rejected. This is the regression-shield: if
+    // someone reintroduces a client-side numeric stamp on the
+    // autosave path, this test reds.
+    await seedResponse();
+    await assertFails(
+      updateDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        {
+          status: 'in-progress',
+          answers: [{ questionId: 'q1', status: 'submitted' }],
+          lastWriteAt: Date.now(),
+        }
+      )
+    );
+  });
+
+  it('UPDATE with lastWriteAt as a forged future Timestamp is REJECTED', async () => {
+    // Future-clock evasion attempt: a student writes a Timestamp far
+    // in the future hoping the idle sweep never catches them. The
+    // rule rejects because the value is not equal to `request.time`.
+    await seedResponse();
+    await assertFails(
+      updateDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        {
+          status: 'in-progress',
+          answers: [{ questionId: 'q1', status: 'submitted' }],
+          lastWriteAt: Timestamp.fromMillis(Date.now() + 1000 * 60 * 60 * 24),
+        }
+      )
+    );
+  });
+
+  it('UPDATE that does NOT touch lastWriteAt SUCCEEDS without supplying it', async () => {
+    // results-protection / tab-warning writes after publish don't
+    // refresh idle-cron freshness. The rule's
+    // `affectedKeys().hasAny(['lastWriteAt'])` short-circuit must
+    // allow these through with no `lastWriteAt` in the payload.
+    await seedResponse();
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asAnonStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${PIN_KEY}`
+        ),
+        { tabSwitchWarnings: 1 }
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UPDATE: unlocked self-elevation rejection (companion to CREATE guard)
+// ---------------------------------------------------------------------------
+
+describe('quiz response UPDATE — unlocked self-elevation', () => {
+  it('UPDATE setting unlocked: true is REJECTED', async () => {
+    // The CREATE-side guard above blocks forging `unlocked: true` at
+    // join. This is the companion UPDATE-side guard: a student who
+    // already joined cannot post-hoc flip themselves to unlocked via
+    // an update. The rule predicate is
+    //   `request.resource.data.get('unlocked', false) == false`
+    // — students may only ever CLEAR the flag (write false), never
+    // raise it. The teacher's unlock action runs from the unrestricted
+    // teacher branch and is not affected.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(
+        doc(db, `quiz_sessions/${SESSION_ID}/responses/${STUDENT_UID}`),
+        {
+          studentUid: STUDENT_UID,
+          joinedAt: 1000,
+          score: null,
+          answers: [],
+          status: 'completed',
+          completedAttempts: 1,
+          preSyncVersion: 0,
+          tabSwitchWarnings: 0,
+        }
+      );
+    });
+    await assertFails(
+      updateDoc(
+        doc(
+          asStudent(),
+          `quiz_sessions/${SESSION_ID}/responses/${STUDENT_UID}`
+        ),
+        { unlocked: true }
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR started as post-merge follow-ups for PR #1733 (the quiz data-loss fix), grew through code review, and picked up two widget polish changes from cleaned-up worktrees. Three teacher-facing improvements plus internal robustness, with a CI workflow fix to safely deploy the new Firestore index that the resume flow now needs.

## What ships

### Live quiz — auto-submit safeguards
- **Paused sessions are exempt from the 90-min idle auto-submit.** Pause a quiz at the end of a period and resume the next morning — student work is preserved instead of being force-submitted while the session is paused.
- **Lobby attendees aren't force-submitted.** Students who joined a quiz the teacher never advanced to Q1 stay in the lobby instead of being auto-finalized with 0 answers. Lobby sessions left untouched for >24h are treated as abandoned and finalized normally so old practice/demo sessions don't pile up.
- **Resume restarts the 90-min idle clock per student, BEFORE flipping status off paused.** xhigh-review follow-up: the original ordering left a race window where a concurrent cron tick could still force-finalize during the gap. Refresh-first is the safe order — the cron skips paused, so refreshing while still paused is harmless, and a mid-refresh failure leaves the session paused for a clean retry instead of an active-but-stale state.

### Cron robustness (xhigh-review follow-ups)
- **Retry getAll once, then abort instead of degrading.** The original "degrade to pre-PR sweep-everything on failure" path was itself the data-loss bug. Now the function aborts and Cloud Scheduler retries on the next tick — strictly safer.
- **Undefined parent status is treated as orphan (skip)**, not auto-finalized — safe default for legacy/malformed session docs.
- **Read cap is 4× the write cap** so abandoned waiting/paused/orphan responses (oldest by lastWriteAt, so they sort first) can't starve out genuinely-stale active responses.
- **24h abandoned-lobby threshold** so 'waiting' sessions don't get skipped indefinitely.
- **Low-N total failures escalate** with `logger.error` (Cloud Logging severity ERROR) instead of `console.warn` — a 9/9 failure at 3 AM now pages.
- **Shared `parseQuizResponsePath` helper** used by both the gather loop and the per-doc loop so the path-shape contract can't drift apart.

### Scoreboard widget — layout toggle moved
- The Cards / Rows layout toggle moved from the widget chrome into the Settings panel as a labelled `radiogroup`. Existing scoreboards keep whichever layout was set. Widget header is now reserved for the score display.

### Random widget — class context chip
- New `RandomClassContextButton` consolidates the active-class chip and the Mark Absent button into a single icon-only chip with a popover (class name, class switcher, Mark Absent Students footer action). Mark Absent only renders when `rosterMode === 'class'`. Stations / Seating Chart / Lunch Count keep their separate chips for now.
- Pluralized aria labels (`*_one` / `*_other`) for the new affordances added to `locales/en.json`.

### Test coverage backfill
- **`tests/rules/quizResponseProtection.test.ts`** — full coverage of the PR #1733 rules: CREATE forgery rejection (`autoSubmitted` / `unlocked` / `unlockedAt` / `grading`), CREATE `lastWriteAt` server-stamp enforcement (`serverTimestamp()` succeeds, `Date.now()` numeric + future Timestamp rejected), UPDATE `lastWriteAt == request.time` enforcement, UPDATE `affectedKeys().hasAny(['lastWriteAt'])` short-circuit, UPDATE unlocked self-elevation rejection. Includes:
  - **Positive control** `unlocked: false SUCCEEDS` against the same seed/auth — anchors the negative test to the unlocked predicate rather than incidental seed gaps.
  - **Teacher-context positive shield** for `updateDoc({ lastWriteAt: serverTimestamp() })` on a student-owned response — exactly the write `resumeAssignment` performs, so a future teacher-branch tightening can't break it silently.
  - `classId`/`classIds` added to seeded response docs as defense-in-depth.
- **`tests/hooks/useQuizAssignments.test.ts`** — refresh-before-flip ORDER assertion, `batch.commit()` call assertion, `serverTimestamp()` call assertion, mocked `respSnap.ref` shape that matches production `DocumentReference` (asserts on `ref.path` instead of a string-equality coincidence).
- Random widget + class-context-button tests for the new component (popover open/close, switcher, `rosterMode` gate on Mark Absent).

### Infrastructure
- **New `COLLECTION`-scope composite index** on `responses` (`status` + `lastWriteAt`) for the per-session subcollection query that `resumeAssignment` runs. The existing index was `COLLECTION_GROUP`-scope (used by the cron); the hook's single-collection query needs its own scope.
- **Production deploy workflow reordered**: backend (functions, rules, indexes, storage) deploys first, then a new wait step blocks until every composite index reports `state=READY`, then hosting goes live. Closes the window where a new client bundle could ship before the index it depends on is built (would return `FAILED_PRECONDITION` to the first teacher who pauses+resumes).
- **`.github/scripts/wait-for-firestore-indexes.sh`** — new shared script that authenticates `gcloud` with the existing service account and polls `gcloud firestore indexes composite list` until every index is `READY` (10-min timeout; `NEEDS_REPAIR` fails fast).
- Dev preview workflow uses the same wait step so preview channels match production safety.

### Review feedback addressed
- **Copilot on `hooks/useQuizAssignments.ts:962`** — race window between status flip and lastWriteAt refresh. Fixed by the refresh-before-flip reorder above. (Thread resolved.)
- **gemini-code-assist on `tests/rules/quizResponseProtection.test.ts:106`** — `FIRESTORE_EMULATOR_HOST` optional-chaining concern. Rewrote in the explicit `const [host, port] = ... .split(':')` form for readability and to catch a malformed value (host with no `:port` would have silently resolved to `Number(undefined) = NaN`). (Thread resolved.)

## Validation
- `pnpm run type-check:all` — clean
- `pnpm run lint` — clean (`--max-warnings 0`)
- `pnpm run format:check` — clean
- `pnpm run test` — 3720+ tests pass

## Deploy order (handled by CI)
1. Backend deploy: rules + new composite index + functions + storage
2. Wait until every composite index reports `state=READY`
3. Hosting deploy

The new index must be `READY` before the new client bundle can be reached by users — otherwise the first teacher to hit Pause+Resume in the gap would see `FAILED_PRECONDITION`. The CI ordering closes that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
