### PR TITLE
fix(notebook): shared notebook import preserves objectLinks + minor BoardsModal title

### DIFF
--- a/components/boardsModal/BoardsModal.tsx
+++ b/components/boardsModal/BoardsModal.tsx
@@ -505,7 +505,7 @@ export const BoardsModal: React.FC<BoardsModalProps> = ({ onClose }) => {
       <div className="bg-white w-full h-full overflow-hidden flex flex-col">
         <div className="bg-gradient-to-r from-brand-blue-primary to-brand-blue-dark text-white h-14 md:h-16 px-4 flex items-center justify-between shadow-sm shrink-0">
           <h2 id="boards-modal-title" className="text-lg font-bold">
-            {t('boardsModal.title', { defaultValue: 'Boards' })}
+            {t('boardsModal.title', { defaultValue: 'Boards & Collections' })}
           </h2>
           <button
             onClick={onClose}

--- a/hooks/useNotebookSharing.ts
+++ b/hooks/useNotebookSharing.ts
@@ -36,9 +36,12 @@ export const useNotebookSharing = () => {
         assetUrls: notebook.assetUrls ?? [],
         originalAuthor: user.uid,
         sharedAt: Date.now(),
-        // Firestore rejects `undefined`; only include sections when present.
+        // Firestore rejects `undefined`; only include optional arrays when present.
         ...(notebook.sections && notebook.sections.length > 0
           ? { sections: notebook.sections }
+          : {}),
+        ...(notebook.objectLinks && notebook.objectLinks.length > 0
+          ? { objectLinks: notebook.objectLinks }
           : {}),
       };
       const ref = await addDoc(collection(db, 'shared_notebooks'), payload);
@@ -100,6 +103,9 @@ export const useNotebookSharing = () => {
           createdAt: Date.now(),
           ...(shared.sections && shared.sections.length > 0
             ? { sections: shared.sections }
+            : {}),
+          ...(shared.objectLinks && shared.objectLinks.length > 0
+            ? { objectLinks: shared.objectLinks }
             : {}),
         };
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -411,7 +411,7 @@
     "root": "All Boards (root)"
   },
   "boardsModal": {
-    "title": "Boards",
+    "title": "Boards & Collections",
     "close": "Close",
     "searchPlaceholder": "Search Boards & Collections",
     "newBoard": "New Board",

--- a/locales/en.json
+++ b/locales/en.json
@@ -907,7 +907,7 @@
     "root": "No Collection"
   },
   "boardsModal": {
-    "title": "Boards",
+    "title": "Boards & Collections",
     "close": "Close",
     "searchPlaceholder": "Search Boards & Collections",
     "newBoard": "New Board",

--- a/locales/es.json
+++ b/locales/es.json
@@ -533,7 +533,7 @@
     "root": "All Boards (root)"
   },
   "boardsModal": {
-    "title": "Boards",
+    "title": "Boards & Collections",
     "close": "Close",
     "searchPlaceholder": "Search Boards & Collections",
     "newBoard": "New Board",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -411,7 +411,7 @@
     "root": "All Boards (root)"
   },
   "boardsModal": {
-    "title": "Boards",
+    "title": "Boards & Collections",
     "close": "Close",
     "searchPlaceholder": "Search Boards & Collections",
     "newBoard": "New Board",

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,21 @@
 {
   "entries": [
     {
+      "version": "2026.05.28.3",
+      "date": "2026-05-28",
+      "title": "Shared notebook hotspots and Boards modal copy",
+      "details": [
+        {
+          "type": "fix",
+          "text": "Shared notebooks — page-link hotspots no longer disappear when a colleague imports a shared notebook. If you authored a notebook with objects that jump to another page on Ctrl/Cmd+click, those hotspots now travel with the share, and the teacher who imports the copy gets the same jumps wired up to the same objects."
+        },
+        {
+          "type": "improvement",
+          "text": "Boards modal — the header now reads \"Boards & Collections\" instead of just \"Boards\", matching the search placeholder copy already in place and making it clearer that collections live alongside individual boards in the same modal."
+        }
+      ]
+    },
+    {
       "version": "2026.05.28.2",
       "date": "2026-05-28",
       "title": "Quiz safeguards, Scoreboard layout, and Random widget chip",

--- a/tests/hooks/useNotebookSharing.test.ts
+++ b/tests/hooks/useNotebookSharing.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression tests for useNotebookSharing.
+ *
+ * Verifies that `objectLinks` (object-to-page hyperlinks authored by the
+ * original teacher) survive the share → import roundtrip. Earlier versions
+ * dropped the field from both the `SharedNotebook` payload and the imported
+ * `NotebookItem`, so a teacher who imported a shared notebook lost every
+ * page-link hotspot the author had set up.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { NotebookItem, NotebookObjectLink } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('firebase/firestore', () => {
+  const docs = new Map<string, unknown>();
+  let nextShareId = 0;
+  return {
+    addDoc: vi.fn((ref: { path: string }, data: unknown) => {
+      nextShareId += 1;
+      const id = `share-${nextShareId}`;
+      docs.set(`${ref.path}/${id}`, data);
+      return Promise.resolve({ id });
+    }),
+    setDoc: vi.fn((ref: { path: string }, data: unknown) => {
+      docs.set(ref.path, data);
+      return Promise.resolve(undefined);
+    }),
+    getDoc: vi.fn((ref: { path: string }) =>
+      Promise.resolve({
+        exists: () => docs.has(ref.path),
+        data: () => docs.get(ref.path),
+      })
+    ),
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+      path: segments.join('/'),
+    })),
+    __testHelpers: {
+      docs,
+      reset: () => {
+        docs.clear();
+        nextShareId = 0;
+      },
+    },
+  };
+});
+
+vi.mock('@/config/firebase', () => ({
+  db: { __mock: 'db' },
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: { uid: 'importer-uid' } })),
+}));
+
+// `uploadFile` round-trips the same bytes (matching real Storage behavior).
+// We return a fake download URL derived from the path so the test can assert
+// the import wrote new URLs without caring about the bytes themselves.
+vi.mock('@/hooks/useStorage', () => ({
+  useStorage: () => ({
+    uploadFile: vi.fn((path: string) =>
+      Promise.resolve(`https://storage.test/${path}?token=copy`)
+    ),
+    deleteFile: vi.fn(() => Promise.resolve(undefined)),
+  }),
+}));
+
+// Stub `window.location.origin` so `shareNotebook`'s returned URL is
+// deterministic on jsdom.
+Object.defineProperty(window, 'location', {
+  value: { origin: 'https://spartboard.test' },
+  writable: true,
+});
+
+// `fetch` is hit once per page/asset URL during import. Return a tiny
+// well-typed blob — bytes don't matter for this test.
+const fetchMock = vi.fn(() =>
+  Promise.resolve({
+    ok: true,
+    blob: () =>
+      Promise.resolve(
+        new Blob([new Uint8Array([0])], { type: 'image/svg+xml' })
+      ),
+  } as unknown as Response)
+);
+vi.stubGlobal('fetch', fetchMock);
+
+// ---------------------------------------------------------------------------
+// Imports after mocks are hoisted
+// ---------------------------------------------------------------------------
+
+import * as firestore from 'firebase/firestore';
+import { useNotebookSharing } from '@/hooks/useNotebookSharing';
+
+const firestoreHelpers = (
+  firestore as unknown as {
+    __testHelpers: { docs: Map<string, unknown>; reset: () => void };
+  }
+).__testHelpers;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OBJECT_LINKS: NotebookObjectLink[] = [
+  {
+    id: 'link-1',
+    objectId: 'svg-obj-abc',
+    sourcePage: 0,
+    targetPage: 2,
+    xFrac: 0.1,
+    yFrac: 0.2,
+    wFrac: 0.3,
+    hFrac: 0.4,
+  },
+  {
+    id: 'link-2',
+    objectId: 'svg-obj-def',
+    sourcePage: 1,
+    targetPage: 0,
+    xFrac: 0.5,
+    yFrac: 0.5,
+    wFrac: 0.2,
+    hFrac: 0.2,
+  },
+];
+
+const NOTEBOOK_WITH_LINKS: NotebookItem = {
+  id: 'src-notebook',
+  title: 'Lesson with hotspots',
+  pageUrls: [
+    'https://storage.test/users/author/notebooks/src/page0.svg?token=a',
+    'https://storage.test/users/author/notebooks/src/page1.svg?token=a',
+    'https://storage.test/users/author/notebooks/src/page2.svg?token=a',
+  ],
+  pagePaths: [
+    'users/author/notebooks/src/page0.svg',
+    'users/author/notebooks/src/page1.svg',
+    'users/author/notebooks/src/page2.svg',
+  ],
+  assetUrls: [],
+  createdAt: 1700000000000,
+  objectLinks: OBJECT_LINKS,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  firestoreHelpers.reset();
+  fetchMock.mockClear();
+});
+
+describe('useNotebookSharing — objectLinks roundtrip', () => {
+  it('shareNotebook persists objectLinks on the shared_notebooks doc', async () => {
+    const { result } = renderHook(() => useNotebookSharing());
+
+    let shareUrl = '';
+    await act(async () => {
+      shareUrl = await result.current.shareNotebook(NOTEBOOK_WITH_LINKS);
+    });
+
+    expect(shareUrl).toMatch(
+      /^https:\/\/spartboard\.test\/share\/notebook\/share-1$/
+    );
+    const sharedDoc = firestoreHelpers.docs.get('shared_notebooks/share-1') as
+      | { objectLinks?: NotebookObjectLink[] }
+      | undefined;
+    expect(sharedDoc?.objectLinks).toEqual(OBJECT_LINKS);
+  });
+
+  it('importSharedNotebookCopy carries objectLinks onto the imported NotebookItem', async () => {
+    const { result } = renderHook(() => useNotebookSharing());
+
+    await act(async () => {
+      await result.current.shareNotebook(NOTEBOOK_WITH_LINKS);
+    });
+
+    let importedId = '';
+    await act(async () => {
+      importedId = await result.current.importSharedNotebookCopy('share-1');
+    });
+
+    const imported = firestoreHelpers.docs.get(
+      `users/importer-uid/notebooks/${importedId}`
+    ) as NotebookItem | undefined;
+
+    expect(imported).toBeDefined();
+    expect(imported?.objectLinks).toEqual(OBJECT_LINKS);
+    // Page count is preserved → sourcePage/targetPage indices stay in range.
+    expect(imported?.pageUrls).toHaveLength(
+      NOTEBOOK_WITH_LINKS.pageUrls.length
+    );
+  });
+
+  it('omits objectLinks from the payload when the source notebook has none (Firestore rejects undefined)', async () => {
+    const { result } = renderHook(() => useNotebookSharing());
+    const { objectLinks: _drop, ...noLinks } = NOTEBOOK_WITH_LINKS;
+    void _drop;
+
+    await act(async () => {
+      await result.current.shareNotebook(noLinks);
+    });
+
+    const sharedDoc = firestoreHelpers.docs.get('shared_notebooks/share-1') as
+      | Record<string, unknown>
+      | undefined;
+    expect(sharedDoc).toBeDefined();
+    expect('objectLinks' in (sharedDoc as Record<string, unknown>)).toBe(false);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2392,6 +2392,13 @@ export interface SharedNotebook {
   pageUrls: string[];
   assetUrls?: string[];
   sections?: NotebookSection[];
+  /**
+   * Object-to-page hyperlinks authored by the original teacher. Page indices
+   * (sourcePage/targetPage) and normalized hotspot fractions stay valid across
+   * a copy import because the importer preserves page order, and the linked
+   * SVG objects' `data-edit-id`s round-trip unchanged through the re-upload.
+   */
+  objectLinks?: NotebookObjectLink[];
   originalAuthor: string;
   sharedAt: number;
 }


### PR DESCRIPTION
## Summary

- **fix(notebook):** Shared SMART Notebook imports were dropping every object-to-page hotspot the original author had set up. `SharedNotebook` and `useNotebookSharing` now carry `objectLinks` across both ends of the share → import roundtrip. Page indices and normalized hotspot fractions stay valid across a copy import, and the linked SVG objects' `data-edit-id`s round-trip unchanged through `fetch` → re-upload, so this is purely a "stop dropping the field" fix.
- **chore(boards-modal):** Header title broadened from "Boards" to "Boards & Collections" so the modal header matches the search-placeholder copy already in place.

## Test plan

- [x] `pnpm run validate` — type-check, lint, format-check, 3737 unit tests, 299 functions tests all pass
- [x] New hook-level regression test (`tests/hooks/useNotebookSharing.test.ts`) asserts the share/import roundtrip preserves `objectLinks` and omits the field when source has none
- [x] Existing `tests/i18n/boardsModalLocales.test.ts` still passes after the title rename
- [ ] Manual: share a notebook with hotspots between two teacher accounts on the dev preview and confirm the hotspots come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)