### PR TITLE
test(rules): widen flaky shared_collections expiresAt margin from 10s to 5min

### DIFF
--- a/tests/rules/sharedCollections.test.ts
+++ b/tests/rules/sharedCollections.test.ts
@@ -324,10 +324,16 @@ describe('shared_collections — create, substitute field constraints', () => {
   });
 
   it('substitute create rejected when expiresAt is more than 14 days out', async () => {
+    // 5-minute margin (not 10s) so the assertion still trips on a slow CI
+    // run. NOW_MS is captured at module load; by the time this test fires,
+    // request.time inside the emulator has drifted forward. A 10s margin
+    // can vanish during emulator boot + earlier-test execution, making the
+    // request fall inside the 14-day cap and silently *succeed* — that
+    // already caused a false-positive CI failure on dev-paul.
     await assertFails(
       setDoc(
         doc(asHost(), sharePath),
-        subShareDoc({ expiresAt: NOW_MS + FOURTEEN_DAYS_MS + 10_000 })
+        subShareDoc({ expiresAt: NOW_MS + FOURTEEN_DAYS_MS + 5 * 60 * 1000 })
       )
     );
   });


### PR DESCRIPTION
## Summary

The `substitute create rejected when expiresAt is more than 14 days out` test at [tests/rules/sharedCollections.test.ts:326](tests/rules/sharedCollections.test.ts#L326) was flaking on CI. Caught when it false-positive-failed [PR #1739](https://github.com/OPS-PIvers/SpartBoard/pull/1739), which had nothing to do with rules ([failed run](https://github.com/OPS-PIvers/SpartBoard/actions/runs/26595237809/job/78364266935)).

## Root cause

- `NOW_MS = Date.now()` is captured at **module load** (line 81).
- The test set `expiresAt: NOW_MS + FOURTEEN_DAYS_MS + 10_000` and asserted the rule rejects.
- By the time *this specific test* fires, the Firestore emulator's `request.time` has drifted forward — emulator boot, 19 earlier test files in the suite, fixture setup, etc.
- On a slow CI runner that drift exceeds 10 seconds, so `expiresAt - request.time` slips back inside the 14-day cap. The rule then *allows* the write and `assertFails` fails.

The neighboring boundary test at [:339](tests/rules/sharedCollections.test.ts#L339) even has an inline comment about needing "comfortably under" margins "to avoid emulator clock skew" — same risk, opposite side of the boundary, already acknowledged.

## Fix

Widened the over-the-cap margin from 10 seconds to 5 minutes (`5 * 60 * 1000`). All other `expiresAt` usages in the file drift in the safe direction (60s-under-cap stays under as drift accumulates; past-time tests stay further in the past), so no other call sites needed adjustment.

Skipped the deeper refactor of making `NOW_MS` a lazy `() => Date.now()` invoked per-test — the margin widening alone solves the immediate flake without changing the test-helper shape.

## Test plan

- [ ] **CI must pass `Firestore Rules Tests`** on this PR. The change is a single-line constant widening with identical semantics in the same direction as before, so the only thing that could fail is the flake itself — which is now mitigated.
- [ ] (Optional) Re-run the `Firestore Rules Tests` check a few times to gain confidence the flake is gone end-to-end.

**Local verification skipped:** the Firebase emulator requires JDK 21+ which isn't installed on the dev box. The change is a single-line constant widening with provably-equivalent semantics — happy to run locally if needed once JDK is installed, but CI is the authoritative environment for this test family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)