### PR TITLE
Implement data-loss prevention measures for quiz responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,24 +41,34 @@ SpartBoard is an interactive classroom management dashboard built with React 19,
 │   ├── miniApp/         # Mini-app runner
 │   ├── activityWall/    # Activity wall
 │   ├── announcements/   # Announcement system
-│   └── classes/         # Roster / class management UI
-├── context/             # React Context providers (Auth, Dashboard, CustomWidgets, Dialog)
+│   ├── classes/         # Roster / class management UI
+│   ├── plc/             # PLC (professional learning community) sharing UI
+│   ├── subs/            # Substitute teacher portal (/subs)
+│   ├── converter/       # SMART Notebook → .spartnb converter (/convert)
+│   ├── spotify/         # Spotify OAuth + library integration
+│   ├── share/           # Share/collaboration UI
+│   ├── settingsModal/   # User settings modal
+│   ├── backgroundsModal/, boardsModal/, quickAccessModal/  # Sidebar/dock modals
+│   └── dev/             # DEV-only harnesses (e.g. NotebookEditorDevHarness)
+├── context/             # React Context providers (Auth, Dashboard, CustomWidgets, SavedWidgets, Dialog, StudentAuth)
 │   ├── AuthContext.tsx           # Authentication and permissions
 │   ├── DashboardContext.tsx      # Dashboard state management
 │   ├── CustomWidgetsContext.tsx  # Custom widget system
+│   ├── SavedWidgetsContext.tsx   # User's saved/pinned widget configs
 │   ├── DialogContext.tsx         # Dialog/modal management
-│   └── *.ts files               # Context value types + hook exports (useAuth, useDashboard, useCustomWidgets, useDialog)
+│   ├── StudentAuthContext.tsx    # SSO student session lifecycle (/my-assignments)
+│   └── *.ts files               # Context value types + hook exports (useAuth, useDashboard, useCustomWidgets, useSavedWidgets, useDialog, useStudentAuth)
 ├── hooks/               # Custom React hooks (see directory for full list)
 ├── config/              # Configuration files (see directory for full list)
 ├── utils/               # Utility functions (see directory for full list)
 ├── scripts/             # Setup and maintenance scripts (admin setup, version generation, env setup)
 ├── i18n/                # Internationalization setup (i18next)
 ├── locales/             # Translation files (en, de, es, fr)
-├── tests/               # Test suites (components, e2e, hooks, i18n, utils)
+├── tests/               # Test suites (components, context, e2e, hooks, i18n, rules, utils) — also many *.test.ts colocated with source
 ├── docs/                # Project documentation (ADMIN_SETUP, DEV_WORKFLOW, LINTING_SETUP, etc.)
 ├── functions/           # Firebase Cloud Functions (Node.js)
 ├── .github/workflows/   # CI/CD GitHub Actions (pr-validation, firebase-deploy, firebase-dev-deploy, docker-build)
-├── App.tsx              # Root component with BrowserRouter
+├── App.tsx              # Root component + manual pathname-based router (no react-router)
 ├── index.tsx            # Application entry point
 ├── types.ts             # Global TypeScript types
 ├── vite.config.ts       # Vite configuration
@@ -97,6 +107,8 @@ SpartBoard is an interactive classroom management dashboard built with React 19,
 
 - **Run unit tests**: `pnpm run test`
 - **Run E2E tests**: `pnpm run test:e2e`
+- **Run Firestore rules tests**: `pnpm run test:rules` (boots the Firestore emulator and runs `vitest.rules.config.ts` against `tests/rules/`)
+- **Run all unit tests (root + functions)**: `pnpm run test:all`
 - **Watch mode**: `pnpm run test:watch`
 - **Coverage report**: `pnpm run test:coverage`
 
@@ -161,8 +173,14 @@ For development and automated testing, you can enable an authentication bypass m
 - **CustomWidgetsContext** (`context/CustomWidgetsContext.tsx`): Custom widget creation and management
   - Provides `useCustomWidgets()` hook
 
+- **SavedWidgetsContext** (`context/SavedWidgetsContext.tsx`): User's saved/pinned widget configurations
+  - Provides `useSavedWidgets()` hook
+
 - **DialogContext** (`context/DialogContext.tsx`): Dialog/modal state management
   - Provides `useDialog()` hook
+
+- **StudentAuthContext** (`context/StudentAuthContext.tsx`): SSO student session lifecycle (idle timeout, custom claims)
+  - Provides `useStudentAuth()` hook; gates the `/my-assignments` route via `RequireStudentAuth`
 
 **Widget System**: Plugin-based architecture
 
@@ -183,42 +201,55 @@ For development and automated testing, you can enable an authentication bypass m
 
 **Component Hierarchy**:
 
+**Routing**: There is **no react-router**. `App.tsx` inspects `window.location.pathname` directly and renders the matching subtree (each route mounts only the providers it needs, so anonymous/student routes don't boot teacher Firestore listeners).
+
 ```
-App.tsx (root, BrowserRouter)
-├── Student routes (lazy-loaded, no auth required):
-│   ├── /join → StudentApp (student lobby & live session)
-│   ├── /quiz → QuizStudentApp
-│   ├── /activity → VideoActivityStudentApp
-│   ├── /activity-wall → ActivityWallStudentApp
-│   ├── /guided-learning → GuidedLearningStudentApp
-│   ├── /miniapp → MiniAppStudentApp
-│   └── /nextup → NextUpStudentApp
-├── /remote → MobileRemoteView (mobile remote control)
+App.tsx (root — manual pathname switch)
+├── Anonymous / no-provider routes:
+│   ├── /r, /r/:code        → ShortLinkRedirect (single Firestore lookup + redirect)
+│   ├── /spotify-callback   → SpotifyCallback (popup; posts code to window.opener)
+│   ├── /convert            → ConverterPage (SMART Notebook → .spartnb, client-only)
+│   └── /notebook-editor-dev → NotebookEditorDevHarness (DEV builds only)
+├── Student routes (lazy-loaded, wrapped in DialogProvider only):
+│   ├── /join               → StudentApp (lobby & live session)
+│   ├── /quiz               → QuizStudentApp (self-handles anonymous/custom-token auth)
+│   ├── /activity           → VideoActivityStudentApp
+│   ├── /activity-wall      → ActivityWallStudentApp (+ /activity-wall/gallery → gallery view)
+│   ├── /guided-learning    → GuidedLearningStudentApp
+│   ├── /miniapp/...        → MiniAppStudentApp
+│   ├── /nextup             → NextUpStudentApp
+│   ├── /student/login      → StudentLoginPage (PII-free GIS sign-in)
+│   └── /my-assignments     → StudentAuthProvider → RequireStudentAuth → MyAssignmentsPage
+├── Auth-only routes (AuthProvider, no DashboardProvider):
+│   ├── /invite/...         → InviteAcceptance (org invite)
+│   ├── /plc-invite/...     → PlcInviteAcceptance
+│   └── /subs               → SubsApp (substitute teacher portal)
+├── /remote                 → AuthProvider → AuthenticatedApp (isRemote) → MobileRemoteView
 └── / → Teacher app:
-    └── AuthProvider
-        └── DashboardProvider
-            └── CustomWidgetsProvider
-                └── DialogProvider
-                    └── Conditional: isAuthenticated?
-                        ├── DashboardView (main app)
-                        │   ├── Background layer
-                        │   ├── WidgetRenderer (one per widget)
-                        │   │   └── DraggableWindow (wraps all widgets)
-                        │   │       ├── Front face (widget content)
-                        │   │       └── Back face (settings panel)
-                        │   ├── Sidebar (dashboard + background management)
-                        │   ├── Dock (widget toolbar)
-                        │   └── AdminSettings (admin-only)
-                        └── ToastContainer (notifications)
-                        OR
-                        └── LoginScreen (if not authenticated)
+    └── DialogProvider
+        └── AuthProvider
+            └── (if signed in) CustomWidgetsProvider
+                └── SavedWidgetsProvider
+                    └── DashboardProvider
+                        └── AppContent
+                            ├── NewUserSetup (first run, if !setupCompleted)
+                            └── DashboardView (main app)
+                                ├── Background layer
+                                ├── WidgetRenderer (one per widget)
+                                │   └── DraggableWindow (drag/resize/flip/z-index)
+                                │       ├── Front face (widget content)
+                                │       └── Back face (settings panel)
+                                ├── Sidebar (dashboard + background management)
+                                ├── Dock (widget toolbar)
+                                └── AdminSettings (admin-only)
+            └── (if not signed in) LoginScreen
 ```
 
 ### Key Files
 
 **Root Level:**
 
-- `App.tsx`: Root component with BrowserRouter, lazy-loaded student routes, and teacher app providers
+- `App.tsx`: Root component with manual `window.location.pathname` routing (no react-router), lazy-loaded student routes, and teacher app providers
 - `index.tsx`: Application entry point, mounts App to DOM
 - `types.ts`: All TypeScript type definitions (WidgetType union, WidgetData, Dashboard, etc.)
 
@@ -276,7 +307,7 @@ Domain-specific config (catalyst colors, sound library, snap layouts, instructio
 
 The project uses `@/` as an alias for the **root directory** (not `src/`):
 
-- Configured in `vite.config.ts` (line 12-14) and `tsconfig.json` (line 15-17)
+- Configured in `vite.config.ts` (`resolve.alias`) and `tsconfig.json` (`compilerOptions.paths`)
 - Example: `import { useDashboard } from '@/context/DashboardContext'`
 - Maps to: `/context/DashboardContext.tsx` (no src folder)
 
@@ -297,18 +328,38 @@ The project uses `@/` as an alias for the **root directory** (not `src/`):
 /users/{userId}/userProfile/{profileId}     # User profile / building selection
 /users/{userId}/quiz_assignments/{id}       # Teacher's quiz assignment archive
 
+# Organization / building system (multi-tenant; org admins write, members read)
+/organizations/{orgId}                      # Organization root
+/organizations/{orgId}/buildings/{id}       # Buildings within an org
+/organizations/{orgId}/domains/{id}         # Email domains mapped to the org
+/organizations/{orgId}/roles/{id}           # Custom roles
+/organizations/{orgId}/members/{uid}        # Org membership + roleId per user
+/organizations/{orgId}/invitations/{id}     # Pending org invites (claimed at /invite)
+/organizations/{orgId}/studentPageConfig/{id} # Student landing-page config
+/organizations/{orgId}/testClasses/{id}     # Test/demo classes
+
 # Admin collections (admin read/write, authenticated read)
 /admins/{email}                             # Admin users (existence = admin)
-/feature_permissions/{widgetType}           # Widget access levels
+/feature_permissions/{widgetType}           # Widget access levels (keyed per building)
 /global_permissions/{featureId}             # Global feature permissions
 /admin_settings/{document}                  # Admin-only configuration
+/admin_audit_log/{entryId}                  # Admin action audit trail
 /admin_backgrounds/{backgroundId}           # Admin background images
 /dashboard_templates/{templateId}           # Shared dashboard templates
 /instructional_routines/{routineId}         # Instructional routines library
+/short_links/{code}                         # /r/:code short-link redirects
+/mail/{id}                                  # Outbound email queue (invite emails)
 
 # Shared/global collections
 /shared_boards/{shareId}                    # Shared dashboards
+/shared_collections/{shareId}               # Shared folder/collection bundles
 /shared_assignments/{shareId}               # Shared quiz assignments (PLC sharing)
+/shared_quizzes/{shareId}                   # Shared standalone quizzes
+/shared_video_activity_assignments/{id}     # Shared video-activity assignments
+/shared_notebooks/{shareId}                 # Shared SMART notebooks
+/shared_activity_walls/{shareId}            # Shared activity walls
+/synced_quizzes/{id}                        # PLC-synced quiz library
+/synced_video_activities/{id}               # PLC-synced video-activity library
 /global_weather/{document}                  # Cached weather data
 /global_music_stations/{document}           # Shared music stations
 /global_pdfs/{pdfId}                        # Shared PDF library
@@ -316,6 +367,13 @@ The project uses `@/` as an alias for the **root directory** (not `src/`):
 /global_video_activities/{activityId}       # Shared video activities
 /custom_widgets/{widgetId}                  # Custom widgets (user-built)
 /announcements/{announcementId}             # School announcements
+/preset_sub_emails/{id}                     # Preset substitute-teacher emails
+
+# PLC (Professional Learning Community) collections
+/plcs/{plcId}                               # PLC root (members, shared library)
+/plcs/{plcId}/{quizzes|video_activities|assignments|notes|docs|todos|contributions}/{id}
+/plc_invitations/{id}                       # PLC invites (claimed at /plc-invite)
+/plc_resources/{id}                         # PLC shared resources
 
 # Live session collections
 /sessions/{userId}/students/{studentId}     # Live session students
@@ -617,20 +675,17 @@ Widgets use a two-mode scaling system configured in `components/widgets/WidgetRe
 
 ### Audio Context Management
 
-Widgets using sound (Timer, Stopwatch, SoundWidget) use a global AudioContext singleton pattern to avoid browser's context limits:
+Widgets using sound share a single lazily-created `AudioContext` singleton (SSR-safe, `webkitAudioContext` fallback) to avoid the browser's per-page context limit. The canonical helper lives in `utils/timeToolAudio.ts`:
 
 ```typescript
-let globalAudioContext: AudioContext | null = null;
+import { getAudioCtx, resumeAudio } from '@/utils/timeToolAudio';
 
-const getAudioContext = (): AudioContext => {
-  if (!globalAudioContext) {
-    globalAudioContext = new AudioContext();
-  }
-  return globalAudioContext;
-};
+// getAudioCtx() returns the shared context (or null outside the browser).
+// resumeAudio() must be called from a user gesture before playback —
+// browsers start the context 'suspended'.
 ```
 
-See `components/widgets/TimeToolWidget.tsx` lines 20-35 for reference.
+See `utils/timeToolAudio.ts` for the singleton + sound-synthesis helpers, and `utils/quizAudio.ts` for the quiz variant. Widget components import these rather than instantiating their own `AudioContext`.
 
 ### Persistence
 
@@ -839,7 +894,7 @@ See [docs/DEV_WORKFLOW.md](docs/DEV_WORKFLOW.md) for development branch workflow
 - **TypeScript**: Strict mode enabled, no `any` without explicit annotation
 - **ESLint**: Zero errors allowed, warnings acceptable
 - **Prettier**: All files must be formatted
-- **Tests**: (Not yet implemented)
+- **Tests**: Vitest (unit/integration) + Playwright (E2E) + a Firestore-rules suite (`test:rules`). `pnpm run validate` runs type-check, lint, format-check, and the root + functions test suites.
 
 See [docs/LINTING_SETUP.md](docs/LINTING_SETUP.md) for complete linting documentation.
 
@@ -901,15 +956,18 @@ See [docs/LINTING_SETUP.md](docs/LINTING_SETUP.md) for complete linting document
 
 - **Run unit tests**: `pnpm run test`
 - **Run E2E tests**: `pnpm run test:e2e`
+- **Run Firestore rules tests**: `pnpm run test:rules` (Firestore emulator + `vitest.rules.config.ts`)
 - **Watch mode**: `pnpm run test:watch`
 - **Coverage report**: `pnpm run test:coverage`
 
-Test directories:
+Test directories (note: many `*.test.ts(x)` files also live colocated next to their source):
 
 - `tests/components/` - Component tests
+- `tests/context/` - Context provider tests
 - `tests/hooks/` - Hook tests (useClickOutside, useFeaturePermissions, useWindowSize, useMusicStations)
 - `tests/utils/` - Utility function tests (migration, security, smartPaste, widgetHelpers)
 - `tests/i18n/` - Internationalization tests
+- `tests/rules/` - Firestore security-rules tests (run via `test:rules`)
 - `tests/e2e/` - Playwright E2E tests
 
 ## Performance Considerations
@@ -978,7 +1036,7 @@ Test directories:
 
 ---
 
-**Last Updated**: 2026-04-17
+**Last Updated**: 2026-05-28
 **Version**: 2.1.0
 
 ## Widget Appearance Standard (Visual System)

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1185,14 +1185,27 @@ const ActiveQuiz: React.FC<{
     setSubmitted(true);
   }
 
-  // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change. The current
-  // question's live answer is mirrored separately into `currentAnswerRef`
-  // (synced in the render body, above) so this set only carries the values
-  // the cache doesn't represent.
+  // Keep refs for volatile state used by the countdown / autosave / flush
+  // paths so the timer doesn't restart on every keystroke or selection
+  // change. The current question's live answer is mirrored separately
+  // into `currentAnswerRef` (synced in the render body, above) so this
+  // set only carries the values the cache doesn't represent.
+  //
+  // These are synced by direct assignment in the render body (not a
+  // useEffect): every consumer reads them from an effect or an event
+  // handler that runs AFTER commit, so assigning during render gives
+  // them the freshest value with no staleness window — matching
+  // `submittedRef` / `currentAnswerRef` and the project's ref-sync rule
+  // (CLAUDE.md "useEffect is an escape hatch, not a default"). Using an
+  // effect here would have meant any imperative reader firing in the
+  // same commit (visibility flush, structured input change) would see
+  // the previous render's value.
   const currentQuestionRef = useRef(currentQuestion);
+  currentQuestionRef.current = currentQuestion;
   const selectedAnswerRef = useRef(selectedAnswer);
+  selectedAnswerRef.current = selectedAnswer;
   const onAnswerRef = useRef(onAnswer);
+  onAnswerRef.current = onAnswer;
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
   // directly). Used to short-circuit the flush after the student has
@@ -1201,6 +1214,7 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
+  myResponseStatusRef.current = myResponse?.status;
   // Mirror of the per-question `submitted` state for the imperative
   // paths (flush handler, structured-input change callbacks) that can't
   // read state directly.
@@ -1214,13 +1228,6 @@ const ActiveQuiz: React.FC<{
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-
-  useEffect(() => {
-    currentQuestionRef.current = currentQuestion;
-    selectedAnswerRef.current = selectedAnswer;
-    onAnswerRef.current = onAnswer;
-    myResponseStatusRef.current = myResponse?.status;
-  }, [currentQuestion, selectedAnswer, onAnswer, myResponse?.status]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -49,7 +49,6 @@ import { logError } from '@/utils/logError';
 import {
   useQuizSessionStudent,
   normalizeAnswer,
-  isBlankAnswerText,
   SessionEndedError,
 } from '@/hooks/useQuizSession';
 import {
@@ -1029,17 +1028,6 @@ const ActiveQuiz: React.FC<{
   const answerCacheRef = useRef<Record<string, string>>(answerCache);
   answerCacheRef.current = answerCache;
 
-  // Tracks question ids whose cache entry was seeded from a Firestore saved
-  // value (the recovery path in the cache-miss-fill block), NOT from the
-  // student's own typing. The WrittenResponseEditor seeds its innerHTML once
-  // on mount, so it must remount when recovered text arrives after an empty
-  // mount — but it must NOT remount when the student types the first char.
-  // Keying the editor on general cache presence conflated the two and dropped
-  // focus on the first keystroke; keying on this set flips :init→:seeded only
-  // for the recovery case. Monotonic per question, so it never flip-flops on
-  // autosave echoes.
-  const recoverySeededRef = useRef<Set<string>>(new Set());
-
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
   // primary source of the originally reported quiz data loss.
@@ -1123,11 +1111,6 @@ const ActiveQuiz: React.FC<{
   if (currentQuestion?.id && savedAnswerForCurrent !== null) {
     const qid = currentQuestion.id;
     if (!(qid in answerCache)) {
-      // Recovery seed: this value came from Firestore, not the student's
-      // keystrokes. Mark it so the editor remounts to display it (see
-      // `recoverySeededRef`). Recorded before the questionKey is read later
-      // in this same render pass.
-      recoverySeededRef.current.add(qid);
       setAnswerCache((prev) =>
         qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
       );
@@ -1327,23 +1310,12 @@ const ActiveQuiz: React.FC<{
     // hint to the student instead of queuing a doomed timer. Submit
     // with the explicit Submit/Next button still bypasses the guard
     // and lets them persist an empty answer if that's really intended.
-    // Uses `isBlankAnswerText` (not `=== ''`) so a cleared essay — which
-    // serializes to `<p></p>`/`<br>`, not '' — is recognized as a clear.
-    if (
-      isBlankAnswerText(cachedDraft) &&
-      (savedAnswerForCurrent ?? '') !== ''
-    ) {
+    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
       setSaveError(
         'Your previously-saved answer is still on file. Click Submit to clear it.'
       );
       return;
     }
-
-    // We have a legitimate non-empty draft that differs from the server.
-    // Clear any stale banner from a prior deliberate-clear hint or failed
-    // write — this fresh autosave attempt supersedes it; `writeNow` re-sets
-    // the banner if this attempt itself fails.
-    setSaveError(null);
 
     const snapshot = cachedDraft;
     const capturedQid = qid;
@@ -2162,24 +2134,17 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 // The editor seeds its `innerHTML` once on mount (caret
-                // preservation), so we encode a "recovered text needs
-                // injecting" boolean in the questionKey. A page refresh
+                // preservation), so we encode the "cache has been
+                // seeded" boolean in the questionKey. A page refresh
                 // mid-essay first mounts with value='' (cache empty,
                 // saved null); when the Firestore snapshot arrives the
-                // cache-miss-fill block recovery-seeds the cache, the key
+                // cache-miss-fill block populates the cache, the key
                 // flips from `…:init` → `…:seeded`, and the editor
                 // remounts with the recovered text. Without this, the
                 // student stares at a blank editor while React state
                 // already holds the recovered value.
-                //
-                // Keyed on `recoverySeededRef` (Firestore-sourced seeds)
-                // rather than general cache presence: a student's own first
-                // keystroke also populates `answerCache`, and keying on that
-                // remounted the editor mid-type, dropping focus and the caret.
                 questionKey={`${currentQuestion.id}:${
-                  recoverySeededRef.current.has(currentQuestion.id)
-                    ? 'seeded'
-                    : 'init'
+                  currentQuestion.id in answerCache ? 'seeded' : 'init'
                 }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2009,7 +2009,11 @@ const ActiveQuiz: React.FC<{
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
                 const trimmed = (liveAnswer ?? '').trim();
-                if (!trimmed) return;
+                // Allow an empty Enter when there's a saved answer to
+                // clear — the autosave's deliberate-clear branch refuses
+                // the write and instructs the student to use Submit/Enter,
+                // so blocking here would deadlock the clear path.
+                if (!trimmed && !savedAnswerForCurrent) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
                 } else if (!submitted) {
@@ -2038,11 +2042,18 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() =>
-                        (liveAnswer ?? '').trim() &&
-                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
+                      onClick={() => {
+                        const trimmed = (liveAnswer ?? '').trim();
+                        // Allow empty submit when there's a saved answer
+                        // to clear — autosave routes the student here for
+                        // the deliberate-clear path.
+                        if (!trimmed && !savedAnswerForCurrent) return;
+                        void handleSubmitAndAdvance(trimmed);
+                      }}
+                      disabled={
+                        submitting ||
+                        (!(liveAnswer ?? '').trim() && !savedAnswerForCurrent)
                       }
-                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2063,11 +2074,18 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    (liveAnswer ?? '').trim() &&
-                    void handleSubmit((liveAnswer ?? '').trim())
+                  onClick={() => {
+                    const trimmed = (liveAnswer ?? '').trim();
+                    // Allow empty submit when there's a saved answer to
+                    // clear — autosave routes the student here for the
+                    // deliberate-clear path.
+                    if (!trimmed && !savedAnswerForCurrent) return;
+                    void handleSubmit(trimmed);
+                  }}
+                  disabled={
+                    submitting ||
+                    (!(liveAnswer ?? '').trim() && !savedAnswerForCurrent)
                   }
-                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1004,27 +1004,34 @@ const ActiveQuiz: React.FC<{
   const initialTimeLimit = currentQuestion?.timeLimit ?? 0;
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [fibAnswer, setFibAnswer] = useState('');
-  const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
-  // Written-response live draft (sanitized HTML). Hydrated on question
-  // change from any saved response so pause/resume next class period
-  // picks up exactly where the student left off.
-  const [writtenAnswer, setWrittenAnswer] = useState<string>('');
-  const writtenAnswerRef = useRef<string>('');
-  // Per-question draft autosave timer. Originally written-response-only;
-  // now coalesces autosaves for every answer type (MC, FIB, Matching,
-  // Ordering, short, essay) because dropping non-written answers on tab
-  // close was the primary source of the reported quiz data loss.
+
+  // Per-question live answer cache. Source of truth for editors and
+  // inputs during a session — replaces the per-type live state slots
+  // (writtenAnswer / fibAnswer / draftMcAnswer / structuredAnswerRef)
+  // that used to be reset and re-hydrated from Firestore on every
+  // question change. With the cache:
+  //   - Navigation (next/back) reads from the cache. No Firestore round
+  //     trip, no hydration race.
+  //   - The Firestore snapshot only seeds the cache on demand — once
+  //     per question, the first time it's visited with a saved value
+  //     available. After that, the local value is authoritative.
+  //   - The autosave path writes the cache value to Firestore in the
+  //     background; student typing never depends on Firestore being
+  //     current.
+  //
+  // Values are the canonical serialized form per type:
+  //   - short / essay: sanitized HTML
+  //   - MC: the chosen option string (absent if never clicked)
+  //   - FIB: the typed string
+  //   - Matching / Ordering: pipe-delimited serialization
+  const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
+  const answerCacheRef = useRef<Record<string, string>>(answerCache);
+  answerCacheRef.current = answerCache;
+
+  // Per-question draft autosave timer. Coalesces autosaves for every
+  // answer type — dropping non-written answers on tab close was the
+  // primary source of the originally reported quiz data loss.
   const draftAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Which question id the current `writtenAnswer` belongs to. Used by the
-  // autosave effect to refuse writes during the single render between
-  // `currentQuestion.id` advancing (student-paced submit-and-advance) and
-  // the hydration branch replacing `writtenAnswer` with the new
-  // question's saved value. Without this guard, the diff
-  // `writtenAnswer !== savedAnswerForCurrent` is briefly true on the new
-  // question and would persist the *previous* question's draft against
-  // the new question's id 500 ms later.
-  const writtenAnswerQuestionIdRef = useRef<string | undefined>(undefined);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -1075,40 +1082,40 @@ const ActiveQuiz: React.FC<{
   const savedAnswerForCurrentRef = useRef<string | null>(null);
   savedAnswerForCurrentRef.current = savedAnswerForCurrent;
 
-  // Hydrate the answer controls from any saved answer so a previously-
-  // answered question shows the student's prior choice. For MC we set
-  // `draftMcAnswer` (not `selectedAnswer`) so the existing draft styling
-  // highlights it and the NEXT button is enabled immediately. Inline so we
-  // can call it from both the question-change branch (back-nav) and the
-  // alreadyAnswered branch (page reload while answers are mid-load).
+  // Reset `selectedAnswer` on question change. The per-type live values
+  // (what's currently typed/selected) now live in `answerCache` and are
+  // populated lazily — see the cache-miss-fill block below — so there's
+  // nothing per-question to wipe here besides the post-submit display
+  // indicator.
   const hydrateAnswerControls = (): void => {
-    if (alreadyAnswered && savedAnswerForCurrent !== null) {
-      setSelectedAnswer(savedAnswerForCurrent);
-      setDraftMcAnswer(
-        currentQuestion?.type === 'MC' ? savedAnswerForCurrent : null
-      );
-      setFibAnswer(
-        currentQuestion?.type === 'FIB' ? savedAnswerForCurrent : ''
-      );
-    } else {
-      setSelectedAnswer(null);
-      setDraftMcAnswer(null);
-      setFibAnswer('');
-    }
-    // Always seed the written-answer slot from any saved response so
-    // pause/resume across class periods rehydrates the editor at the
-    // exact text the student left behind. Other types get an empty
-    // string here, which the editor branches never read. The
-    // question-id ref is updated in lockstep so the autosave effect
-    // refuses to write the new question with a draft that's still about
-    // to be replaced (see the autosave effect comment).
-    const isWritten =
-      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
-    const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
-    setWrittenAnswer(next);
-    writtenAnswerRef.current = next;
-    writtenAnswerQuestionIdRef.current = currentQuestion?.id;
+    setSelectedAnswer(
+      alreadyAnswered && savedAnswerForCurrent !== null
+        ? savedAnswerForCurrent
+        : null
+    );
   };
+
+  // Lazy cache-miss-fill for the current question. If the cache has no
+  // entry yet AND a saved value exists in the Firestore snapshot, seed
+  // the cache from it. Runs every render but the conditional functional
+  // updater no-ops once the key is present, so it costs nothing on the
+  // hot path. Handles three load orders without dedicated effects:
+  //   1) Initial mount before myResponse arrives — cache is empty, saved
+  //      is null, both miss; the next render after the snapshot fills
+  //      in fires this branch.
+  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
+  //      first render after load seeds the current question.
+  //   3) Teacher resume / late snapshot — saved transitions null→text
+  //      while the question hasn't changed; this re-fills the cache
+  //      without going through hydrateAnswerControls.
+  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+    const qid = currentQuestion.id;
+    if (!(qid in answerCache)) {
+      setAnswerCache((prev) =>
+        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
+      );
+    }
+  }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
   //
@@ -1163,13 +1170,21 @@ const ActiveQuiz: React.FC<{
     setSubmitted(true);
   }
 
-  // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change.
+  // Keep refs for volatile state used by the countdown / autosave / flush
+  // paths so the timer doesn't restart on every keystroke or selection
+  // change. Per-type live values were folded into `answerCacheRef`.
+  //
+  // These are synced by direct assignment in the render body (not a
+  // useEffect): every consumer reads them from an effect or an event
+  // handler that runs AFTER commit, so assigning during render gives
+  // them the freshest value with no staleness window — matching
+  // `answerCacheRef` / `submittedRef` and the project's ref-sync rule.
   const currentQuestionRef = useRef(currentQuestion);
+  currentQuestionRef.current = currentQuestion;
   const selectedAnswerRef = useRef(selectedAnswer);
-  const fibAnswerRef = useRef(fibAnswer);
-  const draftMcAnswerRef = useRef(draftMcAnswer);
+  selectedAnswerRef.current = selectedAnswer;
   const onAnswerRef = useRef(onAnswer);
+  onAnswerRef.current = onAnswer;
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
   // directly). Used to short-circuit the flush after the student has
@@ -1178,57 +1193,20 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
-  // Mirror of the per-question `submitted` state so the imperative
-  // autosave path (Matching/Ordering's onAnswerChange) can refuse to
-  // schedule a draft write for an already-submitted question. Without
-  // this, back-navigating to a submitted structured question and
-  // triggering onAnswerChange (e.g., StructuredQuestionInput's mount
-  // effect re-emits the saved answer) downgrades the answer from
-  // `status: 'submitted'` to `status: 'draft'`, vanishing it from the
-  // teacher's results view.
+  myResponseStatusRef.current = myResponse?.status;
+  // Mirror of the per-question `submitted` state for the imperative
+  // paths (flush handler, structured-input change callbacks) that can't
+  // read state directly.
   const submittedRef = useRef(false);
   submittedRef.current = submitted;
-  // Pending draft tracker for question-change flushes. Both the state-
-  // driven autosave effect AND scheduleDraftAutosave populate this when
-  // they schedule a write; a watcher on `currentQuestion?.id` calls
-  // `write()` synchronously when the question advances, flushing the
-  // outgoing question's last edit before the new question's autosave
-  // path clobbers the shared timer slot.
+  // Pending draft tracker for question-change flushes. The state-driven
+  // autosave effect populates this when it schedules a write; a watcher
+  // on `currentQuestion?.id` calls `write()` synchronously when the
+  // question advances, flushing the outgoing question's last edit before
+  // the new question's autosave path clobbers the shared timer slot.
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-  // Live serialized answer for Matching/Ordering, written by the child
-  // StructuredQuestionInput on every drag/tap so timer auto-submit can
-  // capture partial placements instead of submitting the empty string.
-  const structuredAnswerRef = useRef<string>('');
-
-  useEffect(() => {
-    currentQuestionRef.current = currentQuestion;
-    selectedAnswerRef.current = selectedAnswer;
-    fibAnswerRef.current = fibAnswer;
-    draftMcAnswerRef.current = draftMcAnswer;
-    onAnswerRef.current = onAnswer;
-    writtenAnswerRef.current = writtenAnswer;
-    myResponseStatusRef.current = myResponse?.status;
-  }, [
-    currentQuestion,
-    selectedAnswer,
-    fibAnswer,
-    draftMcAnswer,
-    onAnswer,
-    writtenAnswer,
-    myResponse?.status,
-  ]);
-
-  // Reset the structured answer ref when the question changes so a stale
-  // answer from a previous question can't leak into auto-submit.
-  const [prevStructuredQuestionId, setPrevStructuredQuestionId] = useState(
-    currentQuestion?.id ?? null
-  );
-  if ((currentQuestion?.id ?? null) !== prevStructuredQuestionId) {
-    setPrevStructuredQuestionId(currentQuestion?.id ?? null);
-    structuredAnswerRef.current = '';
-  }
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -1267,18 +1245,15 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the type-appropriate live ref so a half-completed
-    // matching/ordering answer is preserved on timeout instead of
-    // submitting the empty string.
+    // Pull from the cache so a half-finished value (typed essay,
+    // partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. selectedAnswerRef is a fallback
+    // for the rare case where the student submitted, didn't touch
+    // the cache afterward, and the timer expired.
     const answer =
-      question.type === 'Matching' || question.type === 'Ordering'
-        ? structuredAnswerRef.current
-        : question.type === 'short' || question.type === 'essay'
-          ? writtenAnswerRef.current
-          : (selectedAnswerRef.current ??
-            draftMcAnswerRef.current ??
-            fibAnswerRef.current ??
-            '');
+      answerCacheRef.current[autoSubmitTriggeredFor] ??
+      selectedAnswerRef.current ??
+      '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1290,58 +1265,59 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
-  // Per-question draft autosave for every answer type. Originally
-  // written-response-only — MC/FIB/Matching/Ordering used to only write
-  // on explicit Submit, so a tab close mid-attempt silently dropped the
-  // student's answers (the bug the user reported as "sporadic data
-  // loss"). The 500 ms debounce mirrors the PLC notes editor pattern;
-  // Submit/advance still writes the final state, so the debounce is
-  // purely a write-rate optimization.
-  //
-  // Matching/Ordering live in `structuredAnswerRef` (a ref so drag-and-
-  // drop doesn't re-render this whole component on every move), so they
-  // schedule their own autosave from the StructuredQuestionInput's
-  // `onAnswerChange` callback via `scheduleDraftAutosave` below. This
-  // effect covers the state-driven types (MC, FIB, short, essay).
+  // Per-question draft autosave driven by the live answer cache. The
+  // cache is the only source of truth for in-progress values, so this
+  // single effect now covers every answer type — MC, FIB, short,
+  // essay, matching, ordering. 500 ms debounce coalesces rapid edits.
+  // Explicit Submit / submit-and-advance write the final state through
+  // their own paths; the debounce is purely a write-rate optimization
+  // and a tab-close safety net.
+  const currentQid = currentQuestion?.id;
+  const cachedDraft =
+    currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
+  // Render-time live answer for editors and inputs. Falls back to the
+  // Firestore saved value on the single render between question
+  // navigation and the cache-miss-fill block populating the cache, so
+  // controlled inputs (MC highlight, FIB value, structured initial
+  // seed) never flicker through an empty state when a saved value is
+  // available. `cachedDraft` (cache-only) is what drives autosave —
+  // they intentionally differ here.
+  const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Convenience cache writer for the editor / input onChange handlers.
+  // Updates the cache for the current question; no-ops if there's no
+  // current question (impossible in practice during render of an
+  // answer slot, but keeps the type signature honest).
+  const setCacheForCurrent = (value: string): void => {
+    if (!currentQid) return;
+    setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+  };
   useEffect(() => {
-    const qid = currentQuestion?.id;
+    const qid = currentQid;
     const type = currentQuestion?.type;
     if (!qid || !type) return;
     if (submitted) return;
-
-    let draft: string | null = null;
-    if (type === 'short' || type === 'essay') {
-      // Race guard: if `currentQuestion.id` has advanced (student-paced
-      // submit-and-advance) but `hydrateAnswerControls` hasn't yet
-      // replaced `writtenAnswer` with the new question's saved value,
-      // the draft we see here is still from the previous question.
-      // Refuse to write — the next render after hydration will
-      // re-evaluate with the correct draft.
-      if (writtenAnswerQuestionIdRef.current !== qid) return;
-      draft = writtenAnswer;
-    } else if (type === 'MC') {
-      draft = draftMcAnswer;
-    } else if (type === 'FIB') {
-      draft = fibAnswer;
-    } else {
-      // Matching/Ordering autosave via scheduleDraftAutosave from the
-      // structured input's onAnswerChange; not driven by this effect.
+    // Cache miss — student hasn't touched this question this session
+    // and there's no saved value either. Nothing to write.
+    if (cachedDraft === null) return;
+    // Saved-equal short-circuit: don't write what's already on the
+    // server. Handles the "lazy-fill seeded cache from saved value"
+    // case (cache and saved are identical → no-op) and the
+    // "deliberate re-type to identical text" case.
+    if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
+    // Deliberate-clear short-circuit: the student cleared a previously-
+    // saved answer. The hook's `isUnsafeBlankDraft` guard would refuse
+    // the write silently, so detect the condition here and surface a
+    // hint to the student instead of queuing a doomed timer. Submit
+    // with the explicit Submit/Next button still bypasses the guard
+    // and lets them persist an empty answer if that's really intended.
+    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
+      setSaveError(
+        'Your previously-saved answer is still on file. Click Submit to clear it.'
+      );
       return;
     }
 
-    if (draft === null) return;
-    // Skip the initial-hydration call: if the seeded value matches what
-    // was already saved, there's nothing to write. This also handles
-    // the "FIB: empty draft + no prior save" case (both sides reduce
-    // to '') without short-circuiting on empty draft alone — which
-    // would have silently dropped a deliberate clear of a previously-
-    // saved FIB answer.
-    if (draft === (savedAnswerForCurrent ?? '')) return;
-
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const snapshot = draft;
+    const snapshot = cachedDraft;
     const capturedQid = qid;
     const writeNow = () => {
       void onAnswerRef
@@ -1351,31 +1327,29 @@ const ActiveQuiz: React.FC<{
             questionId: capturedQid,
             questionType: type,
           });
-          // Surface autosave failures to the student. The new
-          // `lastWriteAt == request.time` Firestore rule (response
-          // UPDATE predicate) rejects writes from clients with stale
-          // auth tokens or session state, AND any other transient
-          // failure (offline, quota) lands here too. Without this
-          // setter the student silently loses every keystroke for up
-          // to 90 min until the idle-finalize cron sweeps them with
-          // whatever last successfully persisted. The existing
-          // SaveErrorBanner + "Retry Submit" button repurposing
-          // already handles the recovery affordance.
+          // Surface autosave failures to the student. The
+          // `lastWriteAt == request.time` Firestore rule rejects
+          // writes from clients with stale auth tokens / session
+          // state, and other transient failures (offline, quota)
+          // land here too. Without this setter the student silently
+          // loses keystrokes until the idle-finalize cron sweeps
+          // their last successfully persisted value.
           setSaveError("Couldn't save your answer. Tap to try again.");
         });
     };
+
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
     draftAutosaveTimer.current = setTimeout(writeNow, 500);
     pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
-      // Only clear the timer here. We CAN'T flush from this cleanup
-      // even when the question has advanced: React commits cleanups
-      // BEFORE the ref-sync effect at L1205 updates
-      // `currentQuestionRef.current` to the new id, so any condition
-      // like `currentQuestionRef.current?.id !== capturedQid` would
-      // always read stale (equal) refs and never fire. The actual
-      // flush-on-advance happens in the question-change watcher at
-      // L1418, which runs AFTER the ref-sync. handleSubmit /
+      // Only clear the timer here. We can't flush from this cleanup
+      // when the question has advanced — React runs cleanups BEFORE
+      // the ref-sync effect updates `currentQuestionRef.current`. The
+      // flush-on-advance happens in the question-change watcher
+      // below, which runs after the ref-sync. handleSubmit /
       // handleSubmitAndAdvance / the timer-expiry auto-submit effect
       // all explicitly null `pendingDraftRef.current` so the watcher
       // skips already-submitted answers.
@@ -1385,59 +1359,12 @@ const ActiveQuiz: React.FC<{
       }
     };
   }, [
-    writtenAnswer,
-    draftMcAnswer,
-    fibAnswer,
-    currentQuestion?.id,
+    cachedDraft,
+    currentQid,
     currentQuestion?.type,
     submitted,
     savedAnswerForCurrent,
   ]);
-
-  // Imperative draft autosave for ref-driven types (Matching/Ordering)
-  // whose value updates don't flow through React state. Called from the
-  // child StructuredQuestionInput's `onAnswerChange` on every drag/drop
-  // so the same 500 ms debounce window coalesces rapid placements.
-  const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
-    if (myResponseStatusRef.current === 'completed') return;
-    // Per-question guard: don't downgrade an already-submitted answer
-    // back to draft. Back-navigation in student-paced mode can land on
-    // a previously-submitted Matching/Ordering question; if
-    // StructuredQuestionInput's mount effect (or a stray drag) calls
-    // onAnswerChange, the resulting draft write would silently
-    // un-submit the question and drop it from the teacher's results.
-    if (submittedRef.current) return;
-    // Saved-equal guard: StructuredQuestionInput's mount effect re-emits
-    // the saved answer on every remount. Without this short-circuit
-    // each question advance triggers a redundant 500ms-debounced write
-    // (cost) AND overwrites pendingDraftRef.qid to the new question
-    // before the question-change watcher can flush the outgoing
-    // question's still-pending draft — silently dropping it. Mirrors
-    // the state-driven effect's `draft === savedAnswerForCurrent`
-    // short-circuit.
-    if (answer === (savedAnswerForCurrentRef.current ?? '')) return;
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const writeNow = () => {
-      void onAnswerRef
-        .current(qid, answer, undefined, { isDraft: true })
-        .catch((err: unknown) => {
-          logError('QuizStudentApp.draftAutosave', err, {
-            questionId: qid,
-            questionType: 'structured',
-          });
-          // Same rationale as the state-driven autosave path above:
-          // surface autosave failures so the student isn't silently
-          // losing Matching/Ordering placements when Firestore rejects
-          // (rule denial, expired auth, offline) until the idle-finalize
-          // cron picks them up 90 min later.
-          setSaveError("Couldn't save your answer. Tap to try again.");
-        });
-    };
-    draftAutosaveTimer.current = setTimeout(writeNow, 500);
-    pendingDraftRef.current = { qid, write: writeNow };
-  }, []);
 
   // Question-change watcher: if a draft is pending for the OUTGOING
   // question when the user advances, flush it synchronously before
@@ -1482,32 +1409,18 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      let draft: string | null = null;
-      switch (type) {
-        case 'short':
-        case 'essay':
-          draft = writtenAnswerRef.current;
-          break;
-        case 'MC':
-          draft = draftMcAnswerRef.current;
-          break;
-        case 'FIB':
-          draft = fibAnswerRef.current;
-          break;
-        case 'Matching':
-        case 'Ordering':
-          draft = structuredAnswerRef.current;
-          break;
-        default:
-          return;
-      }
-      if (draft === null) return;
-      // Use the ref-synced live value rather than the closure-captured
-      // `savedAnswerForCurrent`, which was frozen at mount because this
-      // effect has [] deps. The saved-equal check handles the "never
-      // typed" empty case (saved null, draft '') without short-
-      // circuiting on empty draft alone — which would have silently
-      // dropped a deliberate clear of a previously-saved FIB answer.
+      // Read the live value from the cache. A `null` here means the
+      // student never touched this question in the current session,
+      // so there's nothing to flush.
+      const cacheValue = answerCacheRef.current[qid];
+      if (cacheValue === undefined) return;
+      const draft = cacheValue;
+      // Saved-equal short-circuit. Uses the ref-synced saved value so
+      // the [] deps don't freeze the closure. Handles the "never typed"
+      // empty case (saved null, draft '') without short-circuiting on
+      // empty draft alone — a deliberate clear of a previously-saved
+      // answer is allowed through; the #1 guard in submitAnswer
+      // refuses the unsafe blank-over-non-blank case from there.
       if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
@@ -1574,8 +1487,17 @@ const ActiveQuiz: React.FC<{
       session.showResultToStudent &&
       answerFeedback === null
     ) {
+      // Read order: selectedAnswer (post-explicit-submit) → cache (timer
+      // auto-submit landed but the response listener hasn't echoed yet)
+      // → Firestore answers as the final fallback. Without the cache
+      // hop, an auto-submitted answer compared against a stale
+      // myResponse can produce a false-incorrect on a correct
+      // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
+        (currentQuestion?.id
+          ? answerCacheRef.current[currentQuestion.id]
+          : undefined) ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1959,12 +1881,17 @@ const ActiveQuiz: React.FC<{
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
-              // Self-paced revisits stay editable, so we use the draft styling
-              // (and `draftMcAnswer` highlight) even when `submitted=true`.
+              // Self-paced revisits stay editable, so the highlight tracks
+              // the live cache value. When locked, fall back to the
+              // post-submit `selectedAnswer` indicator; timer auto-submit
+              // never sets selectedAnswer, so degrade to liveAnswer so the
+              // student can still see which option was submitted from
+              // their cached pick.
               const isLocked = submitted && !isStudentPaced;
+              const lockedRef = selectedAnswer ?? liveAnswer;
               const isSelected = isLocked
-                ? selectedAnswer === opt
-                : draftMcAnswer === opt;
+                ? lockedRef === opt
+                : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
               if (!isLocked) {
@@ -1979,7 +1906,7 @@ const ActiveQuiz: React.FC<{
               return (
                 <button
                   key={opt}
-                  onClick={() => !isLocked && setDraftMcAnswer(opt)}
+                  onClick={() => !isLocked && setCacheForCurrent(opt)}
                   disabled={isLocked || submitting}
                   className={cls}
                 >
@@ -2014,10 +1941,9 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        draftMcAnswer &&
-                        void handleSubmitAndAdvance(draftMcAnswer)
+                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
                       }
-                      disabled={!draftMcAnswer || submitting}
+                      disabled={!liveAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2038,10 +1964,8 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    draftMcAnswer && void handleSubmit(draftMcAnswer)
-                  }
-                  disabled={!draftMcAnswer || submitting}
+                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
+                  disabled={!liveAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2077,14 +2001,14 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-4 flex-1">
             <input
               type="text"
-              value={fibAnswer}
-              onChange={(e) => setFibAnswer(e.target.value)}
+              value={liveAnswer ?? ''}
+              onChange={(e) => setCacheForCurrent(e.target.value)}
               disabled={submitted && !isStudentPaced}
               placeholder="Type your answer…"
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = fibAnswer.trim();
+                const trimmed = (liveAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2115,10 +2039,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        fibAnswer.trim() &&
-                        void handleSubmitAndAdvance(fibAnswer.trim())
+                        (liveAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
                       }
-                      disabled={!fibAnswer.trim() || submitting}
+                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2140,9 +2064,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    fibAnswer.trim() && void handleSubmit(fibAnswer.trim())
+                    (liveAnswer ?? '').trim() &&
+                    void handleSubmit((liveAnswer ?? '').trim())
                   }
-                  disabled={!fibAnswer.trim() || submitting}
+                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2181,14 +2106,13 @@ const ActiveQuiz: React.FC<{
             question={currentQuestion}
             submitted={submitted}
             isAutoSubmitted={autoSubmitTriggeredFor === currentQuestion.id}
-            savedAnswer={savedAnswerForCurrent}
+            savedAnswer={liveAnswer}
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
-              structuredAnswerRef.current = answer;
-              // Persist the placement as a draft so a tab close before
-              // Submit doesn't lose the student's in-progress pairings.
-              scheduleDraftAutosave(currentQuestion.id, answer);
+              // Push the live placement into the cache; the autosave
+              // effect picks it up and debounces the Firestore write.
+              setCacheForCurrent(answer);
             }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
@@ -2209,15 +2133,21 @@ const ActiveQuiz: React.FC<{
               }
             >
               <WrittenResponseEditor
-                questionKey={currentQuestion.id}
-                value={writtenAnswer}
-                onChange={(html) => {
-                  setWrittenAnswer(html);
-                  writtenAnswerRef.current = html;
-                  // Mark the draft as belonging to this question so the
-                  // autosave race guard lets it through.
-                  writtenAnswerQuestionIdRef.current = currentQuestion.id;
-                }}
+                // The editor seeds its `innerHTML` once on mount (caret
+                // preservation), so we encode the "cache has been
+                // seeded" boolean in the questionKey. A page refresh
+                // mid-essay first mounts with value='' (cache empty,
+                // saved null); when the Firestore snapshot arrives the
+                // cache-miss-fill block populates the cache, the key
+                // flips from `…:init` → `…:seeded`, and the editor
+                // remounts with the recovered text. Without this, the
+                // student stares at a blank editor while React state
+                // already holds the recovered value.
+                questionKey={`${currentQuestion.id}:${
+                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                }`}
+                value={liveAnswer ?? ''}
+                onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}
                 maxWords={currentQuestion.maxWords}
                 disabled={submitted && !isStudentPaced}
@@ -2238,7 +2168,9 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() => void handleSubmitAndAdvance(writtenAnswer)}
+                      onClick={() =>
+                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                      }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
@@ -2260,7 +2192,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(writtenAnswer)}
+                  onClick={() => void handleSubmit(liveAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1116,7 +1116,7 @@ const ActiveQuiz: React.FC<{
 
   // Reset `selectedAnswer` on question change. The per-type live values
   // (what's currently typed/selected) now live in `answerCache` and are
-  // populated lazily — see the cache-miss-fill block below — so there's
+  // populated by the seed-from-server block below — so there's
   // nothing per-question to wipe here besides the post-submit display
   // indicator.
   const hydrateAnswerControls = (): void => {
@@ -1329,7 +1329,7 @@ const ActiveQuiz: React.FC<{
     currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
   // Render-time live answer for editors and inputs. Falls back to the
   // Firestore saved value on the single render between question
-  // navigation and the cache-miss-fill block populating the cache, so
+  // navigation and the seed-from-server block populating the cache, so
   // controlled inputs (MC highlight, FIB value, structured initial
   // seed) never flicker through an empty state when a saved value is
   // available. `cachedDraft` (cache-only) is what drives autosave —
@@ -1347,10 +1347,10 @@ const ActiveQuiz: React.FC<{
   // fallback). The Submit / NEXT affordances gate on this — not on
   // `liveAnswer` — so a tap can never fire on a value the student hasn't
   // committed to the cache: something they typed/selected this session, or
-  // that the cache-miss-fill seeded from a saved value (resume / revisit).
+  // that the seed-from-server seeded from a saved value (resume / revisit).
   // `liveAnswer` still feeds the inputs/highlights so a saved answer shows
   // immediately while the submit affordance waits for the cache to back it.
-  // (React coalesces the cache-miss-fill render-phase update into the same
+  // (React coalesces the seed-from-server render-phase update into the same
   // commit, so today this matches `liveAnswer` in committed renders — but
   // gating on the cache is the correct statement of intent and stays safe
   // if that seed ever moves into an effect, where the fallback WOULD reach

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -49,6 +49,7 @@ import { logError } from '@/utils/logError';
 import {
   useQuizSessionStudent,
   normalizeAnswer,
+  isBlankAnswerText,
   SessionEndedError,
 } from '@/hooks/useQuizSession';
 import {
@@ -1028,6 +1029,17 @@ const ActiveQuiz: React.FC<{
   const answerCacheRef = useRef<Record<string, string>>(answerCache);
   answerCacheRef.current = answerCache;
 
+  // Tracks question ids whose cache entry was seeded from a Firestore saved
+  // value (the recovery path in the cache-miss-fill block), NOT from the
+  // student's own typing. The WrittenResponseEditor seeds its innerHTML once
+  // on mount, so it must remount when recovered text arrives after an empty
+  // mount — but it must NOT remount when the student types the first char.
+  // Keying the editor on general cache presence conflated the two and dropped
+  // focus on the first keystroke; keying on this set flips :init→:seeded only
+  // for the recovery case. Monotonic per question, so it never flip-flops on
+  // autosave echoes.
+  const recoverySeededRef = useRef<Set<string>>(new Set());
+
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
   // primary source of the originally reported quiz data loss.
@@ -1111,6 +1123,11 @@ const ActiveQuiz: React.FC<{
   if (currentQuestion?.id && savedAnswerForCurrent !== null) {
     const qid = currentQuestion.id;
     if (!(qid in answerCache)) {
+      // Recovery seed: this value came from Firestore, not the student's
+      // keystrokes. Mark it so the editor remounts to display it (see
+      // `recoverySeededRef`). Recorded before the questionKey is read later
+      // in this same render pass.
+      recoverySeededRef.current.add(qid);
       setAnswerCache((prev) =>
         qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
       );
@@ -1310,12 +1327,23 @@ const ActiveQuiz: React.FC<{
     // hint to the student instead of queuing a doomed timer. Submit
     // with the explicit Submit/Next button still bypasses the guard
     // and lets them persist an empty answer if that's really intended.
-    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
+    // Uses `isBlankAnswerText` (not `=== ''`) so a cleared essay — which
+    // serializes to `<p></p>`/`<br>`, not '' — is recognized as a clear.
+    if (
+      isBlankAnswerText(cachedDraft) &&
+      (savedAnswerForCurrent ?? '') !== ''
+    ) {
       setSaveError(
         'Your previously-saved answer is still on file. Click Submit to clear it.'
       );
       return;
     }
+
+    // We have a legitimate non-empty draft that differs from the server.
+    // Clear any stale banner from a prior deliberate-clear hint or failed
+    // write — this fresh autosave attempt supersedes it; `writeNow` re-sets
+    // the banner if this attempt itself fails.
+    setSaveError(null);
 
     const snapshot = cachedDraft;
     const capturedQid = qid;
@@ -2134,17 +2162,24 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 // The editor seeds its `innerHTML` once on mount (caret
-                // preservation), so we encode the "cache has been
-                // seeded" boolean in the questionKey. A page refresh
+                // preservation), so we encode a "recovered text needs
+                // injecting" boolean in the questionKey. A page refresh
                 // mid-essay first mounts with value='' (cache empty,
                 // saved null); when the Firestore snapshot arrives the
-                // cache-miss-fill block populates the cache, the key
+                // cache-miss-fill block recovery-seeds the cache, the key
                 // flips from `…:init` → `…:seeded`, and the editor
                 // remounts with the recovered text. Without this, the
                 // student stares at a blank editor while React state
                 // already holds the recovered value.
+                //
+                // Keyed on `recoverySeededRef` (Firestore-sourced seeds)
+                // rather than general cache presence: a student's own first
+                // keystroke also populates `answerCache`, and keying on that
+                // remounted the editor mid-type, dropping focus and the caret.
                 questionKey={`${currentQuestion.id}:${
-                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                  recoverySeededRef.current.has(currentQuestion.id)
+                    ? 'seeded'
+                    : 'init'
                 }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1042,6 +1042,23 @@ const ActiveQuiz: React.FC<{
     qid: string | undefined;
     value: string | undefined;
   }>({ qid: undefined, value: undefined });
+  // Questions the student has locally edited this session. Once a question
+  // is touched, the in-memory cache is authoritative for it: the
+  // seed-from-server block below stops mirroring later snapshots into it so
+  // a resync can't clobber an in-progress local edit. Untouched questions
+  // keep tracking the freshest saved value, which keeps the autosave's
+  // saved-equal short-circuit holding and prevents a stale seed from being
+  // written back over a newer server answer.
+  const touchedQuestionsRef = useRef<Set<string>>(new Set());
+  // Questions whose cache entry was seeded from a Firestore saved value
+  // (the seed-from-server block), NOT the student's own typing. The
+  // `WrittenResponseEditor` seeds its `innerHTML` once on mount, so it must
+  // remount when recovered text arrives after an empty mount — but it must
+  // NOT remount when the student types the first character. Keying the
+  // editor on general cache presence conflated the two and stole focus /
+  // reset the caret on the first keystroke; keying on this set flips
+  // `init`→`seeded` only for the recovery case.
+  const seededQuestionsRef = useRef<Set<string>>(new Set());
 
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
@@ -1110,26 +1127,37 @@ const ActiveQuiz: React.FC<{
     );
   };
 
-  // Lazy cache-miss-fill for the current question. If the cache has no
-  // entry yet AND a saved value exists in the Firestore snapshot, seed
-  // the cache from it. Runs every render but the conditional functional
-  // updater no-ops once the key is present, so it costs nothing on the
-  // hot path. Handles three load orders without dedicated effects:
-  //   1) Initial mount before myResponse arrives — cache is empty, saved
-  //      is null, both miss; the next render after the snapshot fills
-  //      in fires this branch.
-  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
-  //      first render after load seeds the current question.
-  //   3) Teacher resume / late snapshot — saved transitions null→text
-  //      while the question hasn't changed; this re-fills the cache
-  //      without going through hydrateAnswerControls.
-  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+  // Seed-from-server for the current question. For any question the
+  // student hasn't locally edited this session, mirror the freshest saved
+  // value into the cache so navigation / refresh / teacher-resume all
+  // recover prior work without dedicated effects. Handles the same load
+  // orders the old lazy-fill did (initial mount before myResponse arrives;
+  // page refresh mid-quiz; teacher resume / late snapshot) plus the
+  // stale-seed-clobber race. Two correctness details:
+  //
+  //   - Refresh, not fill-once: if the saved value changes while the
+  //     question is still untouched, update the cache to match so the
+  //     autosave's saved-equal short-circuit holds and never writes an
+  //     outdated seed back over a newer server answer. Touched questions
+  //     are skipped — the cache wins after the first local edit.
+  //   - Re-read `savedAnswerForCurrentRef.current` inside the updater: if a
+  //     newer snapshot lands between scheduling and React applying it, the
+  //     closure would otherwise lock the stale value into the cache.
+  if (
+    currentQuestion?.id &&
+    savedAnswerForCurrent !== null &&
+    !touchedQuestionsRef.current.has(currentQuestion.id) &&
+    answerCache[currentQuestion.id] !== savedAnswerForCurrent
+  ) {
     const qid = currentQuestion.id;
-    if (!(qid in answerCache)) {
-      setAnswerCache((prev) =>
-        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
-      );
-    }
+    // Mark as seeded BEFORE the setState so the editor questionKey (read
+    // later in this same render pass) sees the right state on this commit.
+    seededQuestionsRef.current.add(qid);
+    setAnswerCache((prev) => {
+      const fresh = savedAnswerForCurrentRef.current;
+      if (fresh === null || prev[qid] === fresh) return prev;
+      return { ...prev, [qid]: fresh };
+    });
   }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
@@ -1335,7 +1363,15 @@ const ActiveQuiz: React.FC<{
   // answer slot, but keeps the type signature honest).
   const setCacheForCurrent = (value: string): void => {
     if (!currentQid) return;
+    // Mark the question touched so the seed-from-server block above stops
+    // mirroring later snapshots over this local edit.
+    touchedQuestionsRef.current.add(currentQid);
     setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+    // Clear any stale save-error banner once the student resumes editing.
+    // The deliberate-clear banner ("Click Submit to clear it") and other
+    // transient autosave errors otherwise linger on screen after the
+    // student starts typing/selecting again, which is misleading.
+    setSaveError(null);
   };
   useEffect(() => {
     const qid = currentQid;
@@ -2177,6 +2213,18 @@ const ActiveQuiz: React.FC<{
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
+              // The input remounts per question (keyed by id) and its mount
+              // effect re-emits the seeded answer. Skip the write when the
+              // emitted value already matches the cached value: a back-nav
+              // remount would otherwise mark the question touched (freezing
+              // out the seed-from-server refresh) and churn the autosave /
+              // pollute the history log for a no-op overwrite. Genuine
+              // placements differ from the cache and fall through.
+              if (
+                currentAnswerRef.current.qid === currentQid &&
+                currentAnswerRef.current.value === answer
+              )
+                return;
               // Push the live placement into the cache; the autosave
               // effect picks it up and debounces the Firestore write.
               setCacheForCurrent(answer);
@@ -2201,17 +2249,24 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 // The editor seeds its `innerHTML` once on mount (caret
-                // preservation), so we encode the "cache has been
-                // seeded" boolean in the questionKey. A page refresh
+                // preservation), so we encode a "recovered text needs
+                // injecting" boolean in the questionKey. A page refresh
                 // mid-essay first mounts with value='' (cache empty,
                 // saved null); when the Firestore snapshot arrives the
-                // cache-miss-fill block populates the cache, the key
+                // seed-from-server block recovery-seeds the cache, the key
                 // flips from `…:init` → `…:seeded`, and the editor
                 // remounts with the recovered text. Without this, the
                 // student stares at a blank editor while React state
                 // already holds the recovered value.
+                //
+                // Keyed on `seededQuestionsRef` (Firestore-sourced seeds)
+                // rather than general cache presence: a student's own first
+                // keystroke also populates `answerCache`, and keying on that
+                // remounted the editor mid-type, stealing focus and the caret.
                 questionKey={`${currentQuestion.id}:${
-                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                  seededQuestionsRef.current.has(currentQuestion.id)
+                    ? 'seeded'
+                    : 'init'
                 }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1004,27 +1004,34 @@ const ActiveQuiz: React.FC<{
   const initialTimeLimit = currentQuestion?.timeLimit ?? 0;
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [fibAnswer, setFibAnswer] = useState('');
-  const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
-  // Written-response live draft (sanitized HTML). Hydrated on question
-  // change from any saved response so pause/resume next class period
-  // picks up exactly where the student left off.
-  const [writtenAnswer, setWrittenAnswer] = useState<string>('');
-  const writtenAnswerRef = useRef<string>('');
-  // Per-question draft autosave timer. Originally written-response-only;
-  // now coalesces autosaves for every answer type (MC, FIB, Matching,
-  // Ordering, short, essay) because dropping non-written answers on tab
-  // close was the primary source of the reported quiz data loss.
+
+  // Per-question live answer cache. Source of truth for editors and
+  // inputs during a session — replaces the per-type live state slots
+  // (writtenAnswer / fibAnswer / draftMcAnswer / structuredAnswerRef)
+  // that used to be reset and re-hydrated from Firestore on every
+  // question change. With the cache:
+  //   - Navigation (next/back) reads from the cache. No Firestore round
+  //     trip, no hydration race.
+  //   - The Firestore snapshot only seeds the cache on demand — once
+  //     per question, the first time it's visited with a saved value
+  //     available. After that, the local value is authoritative.
+  //   - The autosave path writes the cache value to Firestore in the
+  //     background; student typing never depends on Firestore being
+  //     current.
+  //
+  // Values are the canonical serialized form per type:
+  //   - short / essay: sanitized HTML
+  //   - MC: the chosen option string (absent if never clicked)
+  //   - FIB: the typed string
+  //   - Matching / Ordering: pipe-delimited serialization
+  const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
+  const answerCacheRef = useRef<Record<string, string>>(answerCache);
+  answerCacheRef.current = answerCache;
+
+  // Per-question draft autosave timer. Coalesces autosaves for every
+  // answer type — dropping non-written answers on tab close was the
+  // primary source of the originally reported quiz data loss.
   const draftAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Which question id the current `writtenAnswer` belongs to. Used by the
-  // autosave effect to refuse writes during the single render between
-  // `currentQuestion.id` advancing (student-paced submit-and-advance) and
-  // the hydration branch replacing `writtenAnswer` with the new
-  // question's saved value. Without this guard, the diff
-  // `writtenAnswer !== savedAnswerForCurrent` is briefly true on the new
-  // question and would persist the *previous* question's draft against
-  // the new question's id 500 ms later.
-  const writtenAnswerQuestionIdRef = useRef<string | undefined>(undefined);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -1075,40 +1082,40 @@ const ActiveQuiz: React.FC<{
   const savedAnswerForCurrentRef = useRef<string | null>(null);
   savedAnswerForCurrentRef.current = savedAnswerForCurrent;
 
-  // Hydrate the answer controls from any saved answer so a previously-
-  // answered question shows the student's prior choice. For MC we set
-  // `draftMcAnswer` (not `selectedAnswer`) so the existing draft styling
-  // highlights it and the NEXT button is enabled immediately. Inline so we
-  // can call it from both the question-change branch (back-nav) and the
-  // alreadyAnswered branch (page reload while answers are mid-load).
+  // Reset `selectedAnswer` on question change. The per-type live values
+  // (what's currently typed/selected) now live in `answerCache` and are
+  // populated lazily — see the cache-miss-fill block below — so there's
+  // nothing per-question to wipe here besides the post-submit display
+  // indicator.
   const hydrateAnswerControls = (): void => {
-    if (alreadyAnswered && savedAnswerForCurrent !== null) {
-      setSelectedAnswer(savedAnswerForCurrent);
-      setDraftMcAnswer(
-        currentQuestion?.type === 'MC' ? savedAnswerForCurrent : null
-      );
-      setFibAnswer(
-        currentQuestion?.type === 'FIB' ? savedAnswerForCurrent : ''
-      );
-    } else {
-      setSelectedAnswer(null);
-      setDraftMcAnswer(null);
-      setFibAnswer('');
-    }
-    // Always seed the written-answer slot from any saved response so
-    // pause/resume across class periods rehydrates the editor at the
-    // exact text the student left behind. Other types get an empty
-    // string here, which the editor branches never read. The
-    // question-id ref is updated in lockstep so the autosave effect
-    // refuses to write the new question with a draft that's still about
-    // to be replaced (see the autosave effect comment).
-    const isWritten =
-      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
-    const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
-    setWrittenAnswer(next);
-    writtenAnswerRef.current = next;
-    writtenAnswerQuestionIdRef.current = currentQuestion?.id;
+    setSelectedAnswer(
+      alreadyAnswered && savedAnswerForCurrent !== null
+        ? savedAnswerForCurrent
+        : null
+    );
   };
+
+  // Lazy cache-miss-fill for the current question. If the cache has no
+  // entry yet AND a saved value exists in the Firestore snapshot, seed
+  // the cache from it. Runs every render but the conditional functional
+  // updater no-ops once the key is present, so it costs nothing on the
+  // hot path. Handles three load orders without dedicated effects:
+  //   1) Initial mount before myResponse arrives — cache is empty, saved
+  //      is null, both miss; the next render after the snapshot fills
+  //      in fires this branch.
+  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
+  //      first render after load seeds the current question.
+  //   3) Teacher resume / late snapshot — saved transitions null→text
+  //      while the question hasn't changed; this re-fills the cache
+  //      without going through hydrateAnswerControls.
+  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+    const qid = currentQuestion.id;
+    if (!(qid in answerCache)) {
+      setAnswerCache((prev) =>
+        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
+      );
+    }
+  }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
   //
@@ -1164,11 +1171,11 @@ const ActiveQuiz: React.FC<{
   }
 
   // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change.
+  // doesn't restart on every keystroke or selection change. Per-type live
+  // values were folded into `answerCacheRef` (synced in render body) so
+  // this set only carries the values the cache doesn't represent.
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
-  const fibAnswerRef = useRef(fibAnswer);
-  const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
@@ -1178,57 +1185,26 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
-  // Mirror of the per-question `submitted` state so the imperative
-  // autosave path (Matching/Ordering's onAnswerChange) can refuse to
-  // schedule a draft write for an already-submitted question. Without
-  // this, back-navigating to a submitted structured question and
-  // triggering onAnswerChange (e.g., StructuredQuestionInput's mount
-  // effect re-emits the saved answer) downgrades the answer from
-  // `status: 'submitted'` to `status: 'draft'`, vanishing it from the
-  // teacher's results view.
+  // Mirror of the per-question `submitted` state for the imperative
+  // paths (flush handler, structured-input change callbacks) that can't
+  // read state directly.
   const submittedRef = useRef(false);
   submittedRef.current = submitted;
-  // Pending draft tracker for question-change flushes. Both the state-
-  // driven autosave effect AND scheduleDraftAutosave populate this when
-  // they schedule a write; a watcher on `currentQuestion?.id` calls
-  // `write()` synchronously when the question advances, flushing the
-  // outgoing question's last edit before the new question's autosave
-  // path clobbers the shared timer slot.
+  // Pending draft tracker for question-change flushes. The state-driven
+  // autosave effect populates this when it schedules a write; a watcher
+  // on `currentQuestion?.id` calls `write()` synchronously when the
+  // question advances, flushing the outgoing question's last edit before
+  // the new question's autosave path clobbers the shared timer slot.
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-  // Live serialized answer for Matching/Ordering, written by the child
-  // StructuredQuestionInput on every drag/tap so timer auto-submit can
-  // capture partial placements instead of submitting the empty string.
-  const structuredAnswerRef = useRef<string>('');
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
     selectedAnswerRef.current = selectedAnswer;
-    fibAnswerRef.current = fibAnswer;
-    draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
-    writtenAnswerRef.current = writtenAnswer;
     myResponseStatusRef.current = myResponse?.status;
-  }, [
-    currentQuestion,
-    selectedAnswer,
-    fibAnswer,
-    draftMcAnswer,
-    onAnswer,
-    writtenAnswer,
-    myResponse?.status,
-  ]);
-
-  // Reset the structured answer ref when the question changes so a stale
-  // answer from a previous question can't leak into auto-submit.
-  const [prevStructuredQuestionId, setPrevStructuredQuestionId] = useState(
-    currentQuestion?.id ?? null
-  );
-  if ((currentQuestion?.id ?? null) !== prevStructuredQuestionId) {
-    setPrevStructuredQuestionId(currentQuestion?.id ?? null);
-    structuredAnswerRef.current = '';
-  }
+  }, [currentQuestion, selectedAnswer, onAnswer, myResponse?.status]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -1267,18 +1243,15 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the type-appropriate live ref so a half-completed
-    // matching/ordering answer is preserved on timeout instead of
-    // submitting the empty string.
+    // Pull from the cache so a half-finished value (typed essay,
+    // partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. selectedAnswerRef is a fallback
+    // for the rare case where the student submitted, didn't touch
+    // the cache afterward, and the timer expired.
     const answer =
-      question.type === 'Matching' || question.type === 'Ordering'
-        ? structuredAnswerRef.current
-        : question.type === 'short' || question.type === 'essay'
-          ? writtenAnswerRef.current
-          : (selectedAnswerRef.current ??
-            draftMcAnswerRef.current ??
-            fibAnswerRef.current ??
-            '');
+      answerCacheRef.current[autoSubmitTriggeredFor] ??
+      selectedAnswerRef.current ??
+      '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1290,58 +1263,50 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
-  // Per-question draft autosave for every answer type. Originally
-  // written-response-only — MC/FIB/Matching/Ordering used to only write
-  // on explicit Submit, so a tab close mid-attempt silently dropped the
-  // student's answers (the bug the user reported as "sporadic data
-  // loss"). The 500 ms debounce mirrors the PLC notes editor pattern;
-  // Submit/advance still writes the final state, so the debounce is
-  // purely a write-rate optimization.
-  //
-  // Matching/Ordering live in `structuredAnswerRef` (a ref so drag-and-
-  // drop doesn't re-render this whole component on every move), so they
-  // schedule their own autosave from the StructuredQuestionInput's
-  // `onAnswerChange` callback via `scheduleDraftAutosave` below. This
-  // effect covers the state-driven types (MC, FIB, short, essay).
+  // Per-question draft autosave driven by the live answer cache. The
+  // cache is the only source of truth for in-progress values, so this
+  // single effect now covers every answer type — MC, FIB, short,
+  // essay, matching, ordering. 500 ms debounce coalesces rapid edits.
+  // Explicit Submit / submit-and-advance write the final state through
+  // their own paths; the debounce is purely a write-rate optimization
+  // and a tab-close safety net.
+  const currentQid = currentQuestion?.id;
+  const cachedDraft =
+    currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
+  // Render-time live answer for editors and inputs. Falls back to the
+  // Firestore saved value on the single render between question
+  // navigation and the cache-miss-fill block populating the cache, so
+  // controlled inputs (MC highlight, FIB value, structured initial
+  // seed) never flicker through an empty state when a saved value is
+  // available. `cachedDraft` (cache-only) is what drives autosave —
+  // they intentionally differ here.
+  const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Convenience cache writer for the editor / input onChange handlers.
+  // Updates the cache for the current question; no-ops if there's no
+  // current question (impossible in practice during render of an
+  // answer slot, but keeps the type signature honest).
+  const setCacheForCurrent = (value: string): void => {
+    if (!currentQid) return;
+    setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+  };
   useEffect(() => {
-    const qid = currentQuestion?.id;
+    const qid = currentQid;
     const type = currentQuestion?.type;
     if (!qid || !type) return;
     if (submitted) return;
+    // Cache miss — student hasn't touched this question this session
+    // and there's no saved value either. Nothing to write.
+    if (cachedDraft === null) return;
+    // Saved-equal short-circuit: don't write what's already on the
+    // server. Handles the "lazy-fill seeded cache from saved value"
+    // case (cache and saved are identical → no-op), the "deliberate
+    // re-type to identical text" case (also no-op), and crucially
+    // does NOT short-circuit a deliberate clear (saved=text, draft=''
+    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
+    // case from there).
+    if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
 
-    let draft: string | null = null;
-    if (type === 'short' || type === 'essay') {
-      // Race guard: if `currentQuestion.id` has advanced (student-paced
-      // submit-and-advance) but `hydrateAnswerControls` hasn't yet
-      // replaced `writtenAnswer` with the new question's saved value,
-      // the draft we see here is still from the previous question.
-      // Refuse to write — the next render after hydration will
-      // re-evaluate with the correct draft.
-      if (writtenAnswerQuestionIdRef.current !== qid) return;
-      draft = writtenAnswer;
-    } else if (type === 'MC') {
-      draft = draftMcAnswer;
-    } else if (type === 'FIB') {
-      draft = fibAnswer;
-    } else {
-      // Matching/Ordering autosave via scheduleDraftAutosave from the
-      // structured input's onAnswerChange; not driven by this effect.
-      return;
-    }
-
-    if (draft === null) return;
-    // Skip the initial-hydration call: if the seeded value matches what
-    // was already saved, there's nothing to write. This also handles
-    // the "FIB: empty draft + no prior save" case (both sides reduce
-    // to '') without short-circuiting on empty draft alone — which
-    // would have silently dropped a deliberate clear of a previously-
-    // saved FIB answer.
-    if (draft === (savedAnswerForCurrent ?? '')) return;
-
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const snapshot = draft;
+    const snapshot = cachedDraft;
     const capturedQid = qid;
     const writeNow = () => {
       void onAnswerRef
@@ -1351,31 +1316,29 @@ const ActiveQuiz: React.FC<{
             questionId: capturedQid,
             questionType: type,
           });
-          // Surface autosave failures to the student. The new
-          // `lastWriteAt == request.time` Firestore rule (response
-          // UPDATE predicate) rejects writes from clients with stale
-          // auth tokens or session state, AND any other transient
-          // failure (offline, quota) lands here too. Without this
-          // setter the student silently loses every keystroke for up
-          // to 90 min until the idle-finalize cron sweeps them with
-          // whatever last successfully persisted. The existing
-          // SaveErrorBanner + "Retry Submit" button repurposing
-          // already handles the recovery affordance.
+          // Surface autosave failures to the student. The
+          // `lastWriteAt == request.time` Firestore rule rejects
+          // writes from clients with stale auth tokens / session
+          // state, and other transient failures (offline, quota)
+          // land here too. Without this setter the student silently
+          // loses keystrokes until the idle-finalize cron sweeps
+          // their last successfully persisted value.
           setSaveError("Couldn't save your answer. Tap to try again.");
         });
     };
+
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
     draftAutosaveTimer.current = setTimeout(writeNow, 500);
     pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
-      // Only clear the timer here. We CAN'T flush from this cleanup
-      // even when the question has advanced: React commits cleanups
-      // BEFORE the ref-sync effect at L1205 updates
-      // `currentQuestionRef.current` to the new id, so any condition
-      // like `currentQuestionRef.current?.id !== capturedQid` would
-      // always read stale (equal) refs and never fire. The actual
-      // flush-on-advance happens in the question-change watcher at
-      // L1418, which runs AFTER the ref-sync. handleSubmit /
+      // Only clear the timer here. We can't flush from this cleanup
+      // when the question has advanced — React runs cleanups BEFORE
+      // the ref-sync effect updates `currentQuestionRef.current`. The
+      // flush-on-advance happens in the question-change watcher
+      // below, which runs after the ref-sync. handleSubmit /
       // handleSubmitAndAdvance / the timer-expiry auto-submit effect
       // all explicitly null `pendingDraftRef.current` so the watcher
       // skips already-submitted answers.
@@ -1385,59 +1348,12 @@ const ActiveQuiz: React.FC<{
       }
     };
   }, [
-    writtenAnswer,
-    draftMcAnswer,
-    fibAnswer,
-    currentQuestion?.id,
+    cachedDraft,
+    currentQid,
     currentQuestion?.type,
     submitted,
     savedAnswerForCurrent,
   ]);
-
-  // Imperative draft autosave for ref-driven types (Matching/Ordering)
-  // whose value updates don't flow through React state. Called from the
-  // child StructuredQuestionInput's `onAnswerChange` on every drag/drop
-  // so the same 500 ms debounce window coalesces rapid placements.
-  const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
-    if (myResponseStatusRef.current === 'completed') return;
-    // Per-question guard: don't downgrade an already-submitted answer
-    // back to draft. Back-navigation in student-paced mode can land on
-    // a previously-submitted Matching/Ordering question; if
-    // StructuredQuestionInput's mount effect (or a stray drag) calls
-    // onAnswerChange, the resulting draft write would silently
-    // un-submit the question and drop it from the teacher's results.
-    if (submittedRef.current) return;
-    // Saved-equal guard: StructuredQuestionInput's mount effect re-emits
-    // the saved answer on every remount. Without this short-circuit
-    // each question advance triggers a redundant 500ms-debounced write
-    // (cost) AND overwrites pendingDraftRef.qid to the new question
-    // before the question-change watcher can flush the outgoing
-    // question's still-pending draft — silently dropping it. Mirrors
-    // the state-driven effect's `draft === savedAnswerForCurrent`
-    // short-circuit.
-    if (answer === (savedAnswerForCurrentRef.current ?? '')) return;
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const writeNow = () => {
-      void onAnswerRef
-        .current(qid, answer, undefined, { isDraft: true })
-        .catch((err: unknown) => {
-          logError('QuizStudentApp.draftAutosave', err, {
-            questionId: qid,
-            questionType: 'structured',
-          });
-          // Same rationale as the state-driven autosave path above:
-          // surface autosave failures so the student isn't silently
-          // losing Matching/Ordering placements when Firestore rejects
-          // (rule denial, expired auth, offline) until the idle-finalize
-          // cron picks them up 90 min later.
-          setSaveError("Couldn't save your answer. Tap to try again.");
-        });
-    };
-    draftAutosaveTimer.current = setTimeout(writeNow, 500);
-    pendingDraftRef.current = { qid, write: writeNow };
-  }, []);
 
   // Question-change watcher: if a draft is pending for the OUTGOING
   // question when the user advances, flush it synchronously before
@@ -1482,32 +1398,18 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      let draft: string | null = null;
-      switch (type) {
-        case 'short':
-        case 'essay':
-          draft = writtenAnswerRef.current;
-          break;
-        case 'MC':
-          draft = draftMcAnswerRef.current;
-          break;
-        case 'FIB':
-          draft = fibAnswerRef.current;
-          break;
-        case 'Matching':
-        case 'Ordering':
-          draft = structuredAnswerRef.current;
-          break;
-        default:
-          return;
-      }
-      if (draft === null) return;
-      // Use the ref-synced live value rather than the closure-captured
-      // `savedAnswerForCurrent`, which was frozen at mount because this
-      // effect has [] deps. The saved-equal check handles the "never
-      // typed" empty case (saved null, draft '') without short-
-      // circuiting on empty draft alone — which would have silently
-      // dropped a deliberate clear of a previously-saved FIB answer.
+      // Read the live value from the cache. A `null` here means the
+      // student never touched this question in the current session,
+      // so there's nothing to flush.
+      const cacheValue = answerCacheRef.current[qid];
+      if (cacheValue === undefined) return;
+      const draft = cacheValue;
+      // Saved-equal short-circuit. Uses the ref-synced saved value so
+      // the [] deps don't freeze the closure. Handles the "never typed"
+      // empty case (saved null, draft '') without short-circuiting on
+      // empty draft alone — a deliberate clear of a previously-saved
+      // answer is allowed through; the #1 guard in submitAnswer
+      // refuses the unsafe blank-over-non-blank case from there.
       if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
@@ -1959,12 +1861,15 @@ const ActiveQuiz: React.FC<{
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
-              // Self-paced revisits stay editable, so we use the draft styling
-              // (and `draftMcAnswer` highlight) even when `submitted=true`.
+              // Self-paced revisits stay editable, so the highlight tracks
+              // the live cache value (which is what the student last
+              // clicked). When locked, fall back to the post-submit
+              // `selectedAnswer` indicator — equal to the cache value in
+              // practice but kept explicit for clarity.
               const isLocked = submitted && !isStudentPaced;
               const isSelected = isLocked
                 ? selectedAnswer === opt
-                : draftMcAnswer === opt;
+                : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
               if (!isLocked) {
@@ -1979,7 +1884,7 @@ const ActiveQuiz: React.FC<{
               return (
                 <button
                   key={opt}
-                  onClick={() => !isLocked && setDraftMcAnswer(opt)}
+                  onClick={() => !isLocked && setCacheForCurrent(opt)}
                   disabled={isLocked || submitting}
                   className={cls}
                 >
@@ -2014,10 +1919,9 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        draftMcAnswer &&
-                        void handleSubmitAndAdvance(draftMcAnswer)
+                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
                       }
-                      disabled={!draftMcAnswer || submitting}
+                      disabled={!liveAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2038,10 +1942,8 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    draftMcAnswer && void handleSubmit(draftMcAnswer)
-                  }
-                  disabled={!draftMcAnswer || submitting}
+                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
+                  disabled={!liveAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2077,14 +1979,14 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-4 flex-1">
             <input
               type="text"
-              value={fibAnswer}
-              onChange={(e) => setFibAnswer(e.target.value)}
+              value={liveAnswer ?? ''}
+              onChange={(e) => setCacheForCurrent(e.target.value)}
               disabled={submitted && !isStudentPaced}
               placeholder="Type your answer…"
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = fibAnswer.trim();
+                const trimmed = (liveAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2115,10 +2017,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        fibAnswer.trim() &&
-                        void handleSubmitAndAdvance(fibAnswer.trim())
+                        (liveAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
                       }
-                      disabled={!fibAnswer.trim() || submitting}
+                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2140,9 +2042,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    fibAnswer.trim() && void handleSubmit(fibAnswer.trim())
+                    (liveAnswer ?? '').trim() &&
+                    void handleSubmit((liveAnswer ?? '').trim())
                   }
-                  disabled={!fibAnswer.trim() || submitting}
+                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2181,14 +2084,13 @@ const ActiveQuiz: React.FC<{
             question={currentQuestion}
             submitted={submitted}
             isAutoSubmitted={autoSubmitTriggeredFor === currentQuestion.id}
-            savedAnswer={savedAnswerForCurrent}
+            savedAnswer={liveAnswer}
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
-              structuredAnswerRef.current = answer;
-              // Persist the placement as a draft so a tab close before
-              // Submit doesn't lose the student's in-progress pairings.
-              scheduleDraftAutosave(currentQuestion.id, answer);
+              // Push the live placement into the cache; the autosave
+              // effect picks it up and debounces the Firestore write.
+              setCacheForCurrent(answer);
             }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
@@ -2210,14 +2112,8 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 questionKey={currentQuestion.id}
-                value={writtenAnswer}
-                onChange={(html) => {
-                  setWrittenAnswer(html);
-                  writtenAnswerRef.current = html;
-                  // Mark the draft as belonging to this question so the
-                  // autosave race guard lets it through.
-                  writtenAnswerQuestionIdRef.current = currentQuestion.id;
-                }}
+                value={liveAnswer ?? ''}
+                onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}
                 maxWords={currentQuestion.maxWords}
                 disabled={submitted && !isStudentPaced}
@@ -2238,7 +2134,9 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() => void handleSubmitAndAdvance(writtenAnswer)}
+                      onClick={() =>
+                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                      }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
@@ -2260,7 +2158,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(writtenAnswer)}
+                  onClick={() => void handleSubmit(liveAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1299,12 +1299,21 @@ const ActiveQuiz: React.FC<{
     if (cachedDraft === null) return;
     // Saved-equal short-circuit: don't write what's already on the
     // server. Handles the "lazy-fill seeded cache from saved value"
-    // case (cache and saved are identical → no-op), the "deliberate
-    // re-type to identical text" case (also no-op), and crucially
-    // does NOT short-circuit a deliberate clear (saved=text, draft=''
-    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
-    // case from there).
+    // case (cache and saved are identical → no-op) and the
+    // "deliberate re-type to identical text" case.
     if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
+    // Deliberate-clear short-circuit: the student cleared a previously-
+    // saved answer. The hook's `isUnsafeBlankDraft` guard would refuse
+    // the write silently, so detect the condition here and surface a
+    // hint to the student instead of queuing a doomed timer. Submit
+    // with the explicit Submit/Next button still bypasses the guard
+    // and lets them persist an empty answer if that's really intended.
+    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
+      setSaveError(
+        'Your previously-saved answer is still on file. Click Submit to clear it.'
+      );
+      return;
+    }
 
     const snapshot = cachedDraft;
     const capturedQid = qid;
@@ -1476,8 +1485,17 @@ const ActiveQuiz: React.FC<{
       session.showResultToStudent &&
       answerFeedback === null
     ) {
+      // Read order: selectedAnswer (post-explicit-submit) → cache (timer
+      // auto-submit landed but the response listener hasn't echoed yet)
+      // → Firestore answers as the final fallback. Without the cache
+      // hop, an auto-submitted answer compared against a stale
+      // myResponse can produce a false-incorrect on a correct
+      // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
+        (currentQuestion?.id
+          ? answerCacheRef.current[currentQuestion.id]
+          : undefined) ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1862,13 +1880,15 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
               // Self-paced revisits stay editable, so the highlight tracks
-              // the live cache value (which is what the student last
-              // clicked). When locked, fall back to the post-submit
-              // `selectedAnswer` indicator — equal to the cache value in
-              // practice but kept explicit for clarity.
+              // the live cache value. When locked, fall back to the
+              // post-submit `selectedAnswer` indicator; timer auto-submit
+              // never sets selectedAnswer, so degrade to liveAnswer so the
+              // student can still see which option was submitted from
+              // their cached pick.
               const isLocked = submitted && !isStudentPaced;
+              const lockedRef = selectedAnswer ?? liveAnswer;
               const isSelected = isLocked
-                ? selectedAnswer === opt
+                ? lockedRef === opt
                 : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
@@ -2111,7 +2131,19 @@ const ActiveQuiz: React.FC<{
               }
             >
               <WrittenResponseEditor
-                questionKey={currentQuestion.id}
+                // The editor seeds its `innerHTML` once on mount (caret
+                // preservation), so we encode the "cache has been
+                // seeded" boolean in the questionKey. A page refresh
+                // mid-essay first mounts with value='' (cache empty,
+                // saved null); when the Firestore snapshot arrives the
+                // cache-miss-fill block populates the cache, the key
+                // flips from `…:init` → `…:seeded`, and the editor
+                // remounts with the recovered text. Without this, the
+                // student stares at a blank editor while React state
+                // already holds the recovered value.
+                questionKey={`${currentQuestion.id}:${
+                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1025,8 +1025,23 @@ const ActiveQuiz: React.FC<{
   //   - FIB: the typed string
   //   - Matching / Ordering: pipe-delimited serialization
   const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
-  const answerCacheRef = useRef<Record<string, string>>(answerCache);
-  answerCacheRef.current = answerCache;
+  // Narrow ref mirror of ONLY the current question's cached value — not the
+  // whole cache. The two imperative readers below (the timer auto-submit
+  // effect and the visibility/unmount flush handler) are scoped to `[]`/
+  // single-dep effects and can't read render state, but each only ever needs
+  // the ACTIVE question's draft. Mirroring the entire cache (potentially 60
+  // multi-paragraph essay answers on a long assignment) through the ref gave
+  // those readers a handle on far more than they use; the previous
+  // `answerCacheRef.current = answerCache` was a reference alias, so it never
+  // duplicated the answer text, but a single-entry ref keeps the imperative
+  // paths honest about what they touch and the ref's retained graph O(1).
+  // The `qid` tag lets those readers confirm the mirror still matches the
+  // question they're acting on. Synced in the render body once `cachedDraft`
+  // is computed (see below).
+  const currentAnswerRef = useRef<{
+    qid: string | undefined;
+    value: string | undefined;
+  }>({ qid: undefined, value: undefined });
 
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
@@ -1171,9 +1186,10 @@ const ActiveQuiz: React.FC<{
   }
 
   // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change. Per-type live
-  // values were folded into `answerCacheRef` (synced in render body) so
-  // this set only carries the values the cache doesn't represent.
+  // doesn't restart on every keystroke or selection change. The current
+  // question's live answer is mirrored separately into `currentAnswerRef`
+  // (synced in the render body, above) so this set only carries the values
+  // the cache doesn't represent.
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
   const onAnswerRef = useRef(onAnswer);
@@ -1243,15 +1259,18 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the cache so a half-finished value (typed essay,
-    // partial matching placement, etc.) is preserved on timeout
-    // instead of submitting empty. selectedAnswerRef is a fallback
-    // for the rare case where the student submitted, didn't touch
-    // the cache afterward, and the timer expired.
-    const answer =
-      answerCacheRef.current[autoSubmitTriggeredFor] ??
-      selectedAnswerRef.current ??
-      '';
+    // Pull from the current-answer ref so a half-finished value (typed
+    // essay, partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. The guard above already confirmed this
+    // is the active question, so the ref's `qid` matches; check it anyway
+    // and fall back to selectedAnswerRef (the post-explicit-submit value)
+    // for the rare case where the student submitted, didn't touch the
+    // cache afterward, and the timer expired.
+    const cached =
+      currentAnswerRef.current.qid === autoSubmitTriggeredFor
+        ? currentAnswerRef.current.value
+        : undefined;
+    const answer = cached ?? selectedAnswerRef.current ?? '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1281,6 +1300,28 @@ const ActiveQuiz: React.FC<{
   // available. `cachedDraft` (cache-only) is what drives autosave —
   // they intentionally differ here.
   const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Mirror only the current question's cached value into the ref for the
+  // imperative readers (auto-submit, flush). `cachedDraft` is null when the
+  // question has no cache entry; store `undefined` to preserve the old
+  // per-key lookup semantics (`record[qid]` was `undefined` when absent).
+  currentAnswerRef.current = {
+    qid: currentQid,
+    value: cachedDraft ?? undefined,
+  };
+  // Submit-gating value: the cache-backed answer ONLY (no Firestore
+  // fallback). The Submit / NEXT affordances gate on this — not on
+  // `liveAnswer` — so a tap can never fire on a value the student hasn't
+  // committed to the cache: something they typed/selected this session, or
+  // that the cache-miss-fill seeded from a saved value (resume / revisit).
+  // `liveAnswer` still feeds the inputs/highlights so a saved answer shows
+  // immediately while the submit affordance waits for the cache to back it.
+  // (React coalesces the cache-miss-fill render-phase update into the same
+  // commit, so today this matches `liveAnswer` in committed renders — but
+  // gating on the cache is the correct statement of intent and stays safe
+  // if that seed ever moves into an effect, where the fallback WOULD reach
+  // a committed render and a fast tap could re-submit-and-advance an answer
+  // the student never re-affirmed.)
+  const submittableAnswer = cachedDraft;
   // Convenience cache writer for the editor / input onChange handlers.
   // Updates the cache for the current question; no-ops if there's no
   // current question (impossible in practice during render of an
@@ -1407,10 +1448,15 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      // Read the live value from the cache. A `null` here means the
-      // student never touched this question in the current session,
-      // so there's nothing to flush.
-      const cacheValue = answerCacheRef.current[qid];
+      // Read the live value from the narrow current-answer ref. An
+      // `undefined` here means either the student never touched this
+      // question in the current session, or the ref has already advanced to
+      // a different question — either way there's nothing for THIS question
+      // to flush.
+      const cacheValue =
+        currentAnswerRef.current.qid === qid
+          ? currentAnswerRef.current.value
+          : undefined;
       if (cacheValue === undefined) return;
       const draft = cacheValue;
       // Saved-equal short-circuit. Uses the ref-synced saved value so
@@ -1493,9 +1539,7 @@ const ActiveQuiz: React.FC<{
       // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
-        (currentQuestion?.id
-          ? answerCacheRef.current[currentQuestion.id]
-          : undefined) ??
+        cachedDraft ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1939,9 +1983,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
+                        submittableAnswer &&
+                        void handleSubmitAndAdvance(submittableAnswer)
                       }
-                      disabled={!liveAnswer || submitting}
+                      disabled={!submittableAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -1962,8 +2007,10 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
-                  disabled={!liveAnswer || submitting}
+                  onClick={() =>
+                    submittableAnswer && void handleSubmit(submittableAnswer)
+                  }
+                  disabled={!submittableAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2006,7 +2053,7 @@ const ActiveQuiz: React.FC<{
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = (liveAnswer ?? '').trim();
+                const trimmed = (submittableAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2037,10 +2084,12 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        (liveAnswer ?? '').trim() &&
-                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
+                        (submittableAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance(
+                          (submittableAnswer ?? '').trim()
+                        )
                       }
-                      disabled={!(liveAnswer ?? '').trim() || submitting}
+                      disabled={!(submittableAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2062,10 +2111,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    (liveAnswer ?? '').trim() &&
-                    void handleSubmit((liveAnswer ?? '').trim())
+                    (submittableAnswer ?? '').trim() &&
+                    void handleSubmit((submittableAnswer ?? '').trim())
                   }
-                  disabled={!(liveAnswer ?? '').trim() || submitting}
+                  disabled={!(submittableAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2165,9 +2214,14 @@ const ActiveQuiz: React.FC<{
                 ) : (
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
+                    {/* Written NEXT stays enabled (only `submitting` gates it)
+                        so a student can advance past — or deliberately submit —
+                        a blank essay; gating it on the cache like MC/FIB would
+                        trap anyone who wants to skip. Submits the cache-backed
+                        value for consistency with the other types. */}
                     <button
                       onClick={() =>
-                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                        void handleSubmitAndAdvance(submittableAnswer ?? '')
                       }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
@@ -2190,7 +2244,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(liveAnswer ?? '')}
+                  onClick={() => void handleSubmit(submittableAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1692,7 +1692,18 @@ const ActiveQuiz: React.FC<{
   // On rejection we surface a retry banner via `saveError` instead of letting
   // the failure vanish into the console; the student's selection is still
   // intact (we never reset it on error) so the same tap retries.
-  const handleSubmitAndAdvance = async (answer: string) => {
+  //
+  // `skipWrite` advances WITHOUT calling `onAnswer`. It's used by the written
+  // editor when the cache has no entry for the question (`submittableAnswer`
+  // is null): the student either never typed (a deliberate skip) or their
+  // saved answer hasn't echoed back into `myResponse` yet. In both cases
+  // writing the editor's empty value would be wrong — at best a meaningless
+  // blank, at worst an explicit-submit blank that CLOBBERS the not-yet-loaded
+  // saved essay (explicit submits bypass the `isUnsafeBlankDraft` autosave
+  // guard). Skipping the write lets the student move on while any saved answer
+  // on the server is preserved untouched. A deliberate clear (cache holds '')
+  // still writes through — `submittableAnswer` is '' there, not null.
+  const handleSubmitAndAdvance = async (answer: string, skipWrite = false) => {
     if (advancingRef.current || submitting) return;
     // Self-paced revisits are intentional re-submissions — let them through
     // even when `submitted=true`. Teacher-paced still locks after first submit.
@@ -1708,25 +1719,27 @@ const ActiveQuiz: React.FC<{
     setSubmitting(true);
     setSaveError(null);
     try {
-      let computedSpeedBonus: number | undefined;
-      if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
-        const remaining = Math.max(0, timeLeft ?? 0);
-        const bonusPct = Math.round(
-          (remaining / currentQuestion.timeLimit) * 50
-        );
-        if (bonusPct > 0) computedSpeedBonus = bonusPct;
-      }
+      if (!skipWrite) {
+        let computedSpeedBonus: number | undefined;
+        if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
+          const remaining = Math.max(0, timeLeft ?? 0);
+          const bonusPct = Math.round(
+            (remaining / currentQuestion.timeLimit) * 50
+          );
+          if (bonusPct > 0) computedSpeedBonus = bonusPct;
+        }
 
-      try {
-        await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
-      } catch (err) {
-        console.error(
-          '[QuizStudentApp] onAnswer failed for question',
-          currentQuestion.id,
-          err
-        );
-        setSaveError("Couldn't save your answer. Tap to try again.");
-        return;
+        try {
+          await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+        } catch (err) {
+          console.error(
+            '[QuizStudentApp] onAnswer failed for question',
+            currentQuestion.id,
+            err
+          );
+          setSaveError("Couldn't save your answer. Tap to try again.");
+          return;
+        }
       }
 
       const isLast = currentIndex >= session.totalQuestions - 1;
@@ -2215,13 +2228,19 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     {/* Written NEXT stays enabled (only `submitting` gates it)
-                        so a student can advance past — or deliberately submit —
-                        a blank essay; gating it on the cache like MC/FIB would
-                        trap anyone who wants to skip. Submits the cache-backed
-                        value for consistency with the other types. */}
+                        so a student can advance past a blank essay; gating it
+                        on the cache like MC/FIB would trap anyone who wants to
+                        skip. When the cache HAS a value (typed, seeded, or a
+                        deliberate clear) we submit it; when it's unseeded
+                        (`submittableAnswer === null`) we advance WITHOUT writing
+                        so a fast tap can't clobber a not-yet-loaded saved essay
+                        with a blank (see handleSubmitAndAdvance `skipWrite`). */}
                     <button
                       onClick={() =>
-                        void handleSubmitAndAdvance(submittableAnswer ?? '')
+                        void handleSubmitAndAdvance(
+                          submittableAnswer ?? '',
+                          submittableAnswer === null
+                        )
                       }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
@@ -2243,9 +2262,17 @@ const ActiveQuiz: React.FC<{
                   </>
                 )
               ) : !submitted ? (
+                // Teacher-paced has no self-advance, so (unlike self-paced) we
+                // can safely gate Submit on the cache: disabled while the
+                // editor is unseeded (`submittableAnswer === null`) — never
+                // typed, or the saved answer hasn't echoed yet — so a fast tap
+                // can't write a blank over a not-yet-loaded saved essay. A
+                // deliberate clear (cache holds '') is non-null, so it stays
+                // enabled. The button re-enables once the student types or the
+                // saved answer loads and seeds the cache.
                 <button
                   onClick={() => void handleSubmit(submittableAnswer ?? '')}
-                  disabled={submitting}
+                  disabled={submitting || submittableAnswer === null}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (

--- a/firestore.rules
+++ b/firestore.rules
@@ -2304,6 +2304,44 @@ service cloud.firestore {
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
+
+        // Append-only snapshot log of overwritten answers. Each entry
+        // captures a prior `answers[i]` value the moment before it gets
+        // replaced in the parent response doc — see `submitAnswer` in
+        // `useQuizSession.ts`. Used to recover student text lost to a
+        // race (stray blank draft after a hydration miss) or to a
+        // student retyping over their own work after a lockout. Writes
+        // are throttled per-question on the client; the rule still
+        // pins the doc shape so a hostile authenticated user can't
+        // dump arbitrary data into the subcollection.
+        match /history/{historyId} {
+          function parentStudentUid() {
+            return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)/responses/$(responseKey)).data.studentUid;
+          }
+          // Read: teacher, admin, or the owning student.
+          allow read: if request.auth != null && (
+            isAdmin() ||
+            request.auth.uid == sessionTeacherUid() ||
+            request.auth.uid == parentStudentUid()
+          );
+          // Create: only the owning student of the parent response.
+          // Field shape is strict so a malicious caller can't smuggle
+          // fields; `snapshotAt == request.time` forces server stamping.
+          allow create: if request.auth != null &&
+            request.auth.uid == parentStudentUid() &&
+            request.resource.data.keys().hasOnly(
+              ['questionId', 'answer', 'answeredAt', 'status', 'snapshotAt']
+            ) &&
+            request.resource.data.questionId is string &&
+            request.resource.data.answer is string &&
+            request.resource.data.answeredAt is number &&
+            request.resource.data.status in ['draft', 'submitted'] &&
+            request.resource.data.snapshotAt == request.time;
+          // Immutable from clients. Teachers/admins may clean up.
+          allow update: if false;
+          allow delete: if request.auth != null &&
+            (request.auth.uid == sessionTeacherUid() || isAdmin());
+        }
       }
 
       // Archived responses — copies of student responses that the teacher

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -110,31 +110,10 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Is this serialized answer effectively blank? Catches the empty string,
- * whitespace-only text, and the tags-only markup the written-response
- * editor emits when a student clears an essay — `sanitizeQuizResponse`
- * keeps `<p>`/`<br>`, so a cleared essay serializes to `<p></p>` /
- * `<p><br></p>`, NOT ''. A plain `=== ''` check misses that and would let
- * the blank-draft guard be bypassed, silently clobbering a saved essay.
- *
- * For non-HTML answer types (MC option strings, FIB text, pipe-delimited
- * matching/ordering) the tag strip is a no-op, so this only reclassifies
- * genuinely text-empty values as blank.
- */
-export function isBlankAnswerText(answer: string): boolean {
-  return (
-    answer
-      .replace(/<[^>]*>/g, '')
-      .replace(/&nbsp;/gi, ' ')
-      .trim() === ''
-  );
-}
-
-/**
  * Defensive predicate: refuse a draft autosave that would overwrite a
- * non-empty saved answer with a blank one. Almost always indicates a race
- * (editor briefly emitted blank markup after a remount or a hydration
- * miss) rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * non-empty saved answer with the empty string. Almost always indicates
+ * a race (editor briefly emitted '' after a remount or a hydration miss)
+ * rather than a deliberate clear. Explicit submits (`isDraft=false`)
  * bypass this — a student who really wants to clear an answer can still
  * submit empty.
  */
@@ -143,12 +122,7 @@ export function isUnsafeBlankDraft(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return (
-    isDraft &&
-    isBlankAnswerText(answer) &&
-    !!priorEntry &&
-    priorEntry.answer !== ''
-  );
+  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
 }
 
 /**

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -140,7 +140,11 @@ export function isUnsafeStatusDowngrade(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return isDraft && priorEntry?.status === 'submitted';
+  // Use `!== 'draft'` rather than `=== 'submitted'` so legacy entries
+  // with `status === undefined` (predate the draft flag — treated as
+  // submitted everywhere else via `isAnswerSubmitted`) are also
+  // protected from being silently downgraded to draft.
+  return isDraft && priorEntry !== undefined && priorEntry.status !== 'draft';
 }
 
 /**
@@ -163,7 +167,10 @@ export function shouldSnapshotHistory(
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
   const textChanged = priorEntry.answer !== newAnswer;
-  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  // Mirror `isUnsafeStatusDowngrade`: treat legacy entries with
+  // `status === undefined` as submitted so a downgrade attempt on a
+  // legacy answer still gets a forensic snapshot.
+  const statusDowngrade = priorEntry.status !== 'draft' && newIsDraft;
   if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -126,22 +126,45 @@ export function isUnsafeBlankDraft(
 }
 
 /**
+ * Defensive predicate: refuse a draft autosave that would downgrade an
+ * already-submitted answer's status to 'draft'. The cache-driven
+ * autosave path can re-fire for the same question during the SSO
+ * listener-fast race window (back-nav before the response listener
+ * echoes the just-submitted answer back, so the local `submitted` state
+ * briefly flips false), and without this guard the autosave silently
+ * flips status 'submitted' → 'draft' and drops the question from the
+ * teacher's "Finished" view. Explicit submits (`isDraft=false`) still
+ * pass through.
+ */
+export function isUnsafeStatusDowngrade(
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && priorEntry?.status === 'submitted';
+}
+
+/**
  * Decide whether to snapshot the prior answer entry to the history
- * subcollection before overwriting. Only meaningful prior values
- * (non-empty and different from the incoming value) are worth
- * snapshotting, and the per-question throttle keeps a long essay from
- * fanning out to hundreds of near-identical docs.
+ * subcollection before overwriting. Captures any prior non-empty value
+ * the incoming write is about to lose — either because the text
+ * changed, or because the status is being destructively downgraded
+ * from 'submitted' to 'draft' (which can erase grading state even
+ * with identical text). The per-question throttle keeps a long essay
+ * from fanning out to hundreds of near-identical docs.
  */
 export function shouldSnapshotHistory(
   priorEntry: QuizResponseAnswer | undefined,
   newAnswer: string,
+  newIsDraft: boolean,
   lastSnapshotAt: number,
   now: number,
   throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
 ): boolean {
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
-  if (priorEntry.answer === newAnswer) return false;
+  const textChanged = priorEntry.answer !== newAnswer;
+  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }
 
@@ -1342,6 +1365,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     ): Promise<string> => {
       setLoading(true);
       setError(null);
+      // Clear per-question history throttle on every join. The same hook
+      // instance survives a teacher unlock / attempt-cap rejoin, so a
+      // stale `lastSnapshotAt` from the prior attempt would suppress
+      // legitimate snapshots in the new one.
+      lastHistorySnapshotAtRef.current.clear();
       try {
         const normCode = code
           .trim()
@@ -1982,6 +2010,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
         return;
       }
+      // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
+      // Stops the back-nav listener-lag race from silently flipping a
+      // 'submitted' answer back to 'draft' status.
+      if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
+        return;
+      }
 
       const newAnswer: QuizResponseAnswer = {
         questionId,
@@ -2040,10 +2074,15 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       const now = Date.now();
       const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
       if (
-        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        ) &&
         priorEntry
       ) {
-        lastHistorySnapshotAtRef.current.set(questionId, now);
         void addDoc(
           collection(
             db,
@@ -2060,9 +2099,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             status: priorEntry.status ?? 'submitted',
             snapshotAt: serverTimestamp(),
           }
-        ).catch(() => {
-          // Safety-net write; nothing actionable on failure.
-        });
+        )
+          .then(() => {
+            // Only consume the throttle slot for snapshots that actually
+            // landed. A failed write (offline, rule denial, quota) used
+            // to bump `now` regardless, suppressing the next legitimate
+            // snapshot for the throttle window even though no recovery
+            // doc had been written.
+            lastHistorySnapshotAtRef.current.set(questionId, now);
+          })
+          .catch(() => {
+            // Safety-net write; nothing actionable on failure.
+          });
       }
     },
     []

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -19,6 +19,7 @@ import {
   collection,
   onSnapshot,
   setDoc,
+  addDoc,
   updateDoc,
   getDocs,
   getDoc,
@@ -65,6 +66,25 @@ export const RESPONSES_COLLECTION = 'responses';
  */
 export const ARCHIVED_RESPONSES_COLLECTION = 'archived_responses';
 /**
+ * Append-only per-response snapshot log. Each entry captures the prior
+ * value of a question's answer just before it gets overwritten in the
+ * `responses/{rid}.answers` array, so a teacher (or admin) can recover
+ * text that was lost to a race, a stray empty draft, or a student who
+ * retyped over their own work. Writes are fire-and-forget and throttled
+ * per-question (see `HISTORY_SNAPSHOT_THROTTLE_MS`) to keep storage and
+ * write costs bounded — typical essay quiz has a low double-digit
+ * count per student.
+ */
+export const RESPONSE_HISTORY_COLLECTION = 'history';
+/**
+ * Minimum interval between history snapshots for the same questionId on
+ * the same response. The autosave debounce is 500 ms; without throttling
+ * a long essay would fan out to hundreds of near-identical history docs.
+ * 5 s gives "enough resolution to recover meaningful state" without
+ * making history a per-keystroke audit log.
+ */
+const HISTORY_SNAPSHOT_THROTTLE_MS = 5000;
+/**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
  * and accumulates a student's completed-attempt count across every session
  * the teacher creates for the same quiz. Without this collection, the
@@ -88,6 +108,42 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Defensive predicate: refuse a draft autosave that would overwrite a
+ * non-empty saved answer with the empty string. Almost always indicates
+ * a race (editor briefly emitted '' after a remount or a hydration miss)
+ * rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * bypass this — a student who really wants to clear an answer can still
+ * submit empty.
+ */
+export function isUnsafeBlankDraft(
+  answer: string,
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
+}
+
+/**
+ * Decide whether to snapshot the prior answer entry to the history
+ * subcollection before overwriting. Only meaningful prior values
+ * (non-empty and different from the incoming value) are worth
+ * snapshotting, and the per-question throttle keeps a long essay from
+ * fanning out to hundreds of near-identical docs.
+ */
+export function shouldSnapshotHistory(
+  priorEntry: QuizResponseAnswer | undefined,
+  newAnswer: string,
+  lastSnapshotAt: number,
+  now: number,
+  throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
+): boolean {
+  if (!priorEntry) return false;
+  if (priorEntry.answer === '') return false;
+  if (priorEntry.answer === newAnswer) return false;
+  return now - lastSnapshotAt >= throttleMs;
+}
 
 /** Unbiased Fisher-Yates in-place shuffle (returns new array) */
 function fisherYatesShuffle<T>(arr: T[]): T[] {
@@ -1132,6 +1188,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
 
+  // Per-questionId timestamp of the most recent history snapshot write.
+  // Used to throttle snapshots — see HISTORY_SNAPSHOT_THROTTLE_MS.
+  const lastHistorySnapshotAtRef = useRef<Map<string, number>>(new Map());
+
   // Optimistic local counter state to ensure UI updates immediately.
   // warningCountRef mirrors the state so reportTabSwitch can return the
   // updated value synchronously (React functional updaters run on the next
@@ -1912,6 +1972,17 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // only) from an explicit submit. The student's `alreadyAnswered` gate
       // checks for `'submitted'` so a draft autosave doesn't masquerade as
       // a final answer and prematurely fire the completion card.
+      const existingAnswers = myResponseRef.current?.answers ?? [];
+      const priorEntry = existingAnswers.find(
+        (a) => a.questionId === questionId
+      );
+
+      // #1 guard — see `isUnsafeBlankDraft` doc. Refuses a draft autosave
+      // that would silently clobber a non-empty saved answer with ''.
+      if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
+        return;
+      }
+
       const newAnswer: QuizResponseAnswer = {
         questionId,
         answer,
@@ -1922,7 +1993,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           : {}),
       };
 
-      const existingAnswers = myResponseRef.current?.answers ?? [];
       const updated = [
         ...existingAnswers.filter((a) => a.questionId !== questionId),
         newAnswer,
@@ -1962,6 +2032,38 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
+
+      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
+      // safety net so a value that turns out to be a regression (stray
+      // blank draft that the #1 guard didn't catch, or a student
+      // retyping after a lockout) can still be recovered.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      if (
+        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        priorEntry
+      ) {
+        lastHistorySnapshotAtRef.current.set(questionId, now);
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            answeredAt: priorEntry.answeredAt,
+            status: priorEntry.status ?? 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        ).catch(() => {
+          // Safety-net write; nothing actionable on failure.
+        });
+      }
     },
     []
   );

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -19,6 +19,7 @@ import {
   collection,
   onSnapshot,
   setDoc,
+  addDoc,
   updateDoc,
   getDocs,
   getDoc,
@@ -65,6 +66,25 @@ export const RESPONSES_COLLECTION = 'responses';
  */
 export const ARCHIVED_RESPONSES_COLLECTION = 'archived_responses';
 /**
+ * Append-only per-response snapshot log. Each entry captures the prior
+ * value of a question's answer just before it gets overwritten in the
+ * `responses/{rid}.answers` array, so a teacher (or admin) can recover
+ * text that was lost to a race, a stray empty draft, or a student who
+ * retyped over their own work. Writes are fire-and-forget and throttled
+ * per-question (see `HISTORY_SNAPSHOT_THROTTLE_MS`) to keep storage and
+ * write costs bounded — typical essay quiz has a low double-digit
+ * count per student.
+ */
+export const RESPONSE_HISTORY_COLLECTION = 'history';
+/**
+ * Minimum interval between history snapshots for the same questionId on
+ * the same response. The autosave debounce is 500 ms; without throttling
+ * a long essay would fan out to hundreds of near-identical history docs.
+ * 5 s gives "enough resolution to recover meaningful state" without
+ * making history a per-keystroke audit log.
+ */
+const HISTORY_SNAPSHOT_THROTTLE_MS = 5000;
+/**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
  * and accumulates a student's completed-attempt count across every session
  * the teacher creates for the same quiz. Without this collection, the
@@ -88,6 +108,65 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Defensive predicate: refuse a draft autosave that would overwrite a
+ * non-empty saved answer with the empty string. Almost always indicates
+ * a race (editor briefly emitted '' after a remount or a hydration miss)
+ * rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * bypass this — a student who really wants to clear an answer can still
+ * submit empty.
+ */
+export function isUnsafeBlankDraft(
+  answer: string,
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
+}
+
+/**
+ * Defensive predicate: refuse a draft autosave that would downgrade an
+ * already-submitted answer's status to 'draft'. The cache-driven
+ * autosave path can re-fire for the same question during the SSO
+ * listener-fast race window (back-nav before the response listener
+ * echoes the just-submitted answer back, so the local `submitted` state
+ * briefly flips false), and without this guard the autosave silently
+ * flips status 'submitted' → 'draft' and drops the question from the
+ * teacher's "Finished" view. Explicit submits (`isDraft=false`) still
+ * pass through.
+ */
+export function isUnsafeStatusDowngrade(
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && priorEntry?.status === 'submitted';
+}
+
+/**
+ * Decide whether to snapshot the prior answer entry to the history
+ * subcollection before overwriting. Captures any prior non-empty value
+ * the incoming write is about to lose — either because the text
+ * changed, or because the status is being destructively downgraded
+ * from 'submitted' to 'draft' (which can erase grading state even
+ * with identical text). The per-question throttle keeps a long essay
+ * from fanning out to hundreds of near-identical docs.
+ */
+export function shouldSnapshotHistory(
+  priorEntry: QuizResponseAnswer | undefined,
+  newAnswer: string,
+  newIsDraft: boolean,
+  lastSnapshotAt: number,
+  now: number,
+  throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
+): boolean {
+  if (!priorEntry) return false;
+  if (priorEntry.answer === '') return false;
+  const textChanged = priorEntry.answer !== newAnswer;
+  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  if (!textChanged && !statusDowngrade) return false;
+  return now - lastSnapshotAt >= throttleMs;
+}
 
 /** Unbiased Fisher-Yates in-place shuffle (returns new array) */
 function fisherYatesShuffle<T>(arr: T[]): T[] {
@@ -733,6 +812,39 @@ export const useQuizSessionTeacher = (
             )
           : null;
 
+      // Clean up the answer-history subcollection BEFORE deleting the
+      // parent response. Firestore does not cascade subcollection
+      // deletes, so without this the snapshots orphan — and because the
+      // response key is deterministic (`auth.uid` for SSO, `pin-…` for
+      // anonymous), a removed student who rejoins lands on the same key
+      // and the history read rule (`request.auth.uid == parentStudentUid`)
+      // would let them read their own prior-attempt drafts. The teacher's
+      // archive preserves the final answers; the intermediate-draft
+      // history is intentionally discarded on removal. Chunked at 450 to
+      // stay under the 500-op Firestore batch limit; these are independent
+      // of the atomic archive+delete batch below, so a partial failure
+      // just leaves a smaller orphan tail that a retry sweeps.
+      const historyDocs = (
+        await getDocs(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          )
+        )
+      ).docs;
+      const HISTORY_DELETE_CHUNK = 450;
+      for (let i = 0; i < historyDocs.length; i += HISTORY_DELETE_CHUNK) {
+        const historyBatch = writeBatch(db);
+        for (const d of historyDocs.slice(i, i + HISTORY_DELETE_CHUNK)) {
+          historyBatch.delete(d.ref);
+        }
+        await historyBatch.commit();
+      }
+
       // Archive the response before delete so partial answers survive
       // the teacher's "remove" action. The deterministic key model
       // means we can't soft-delete in place (the slot must be free for
@@ -1132,6 +1244,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
 
+  // Per-questionId timestamp of the most recent history snapshot write.
+  // Used to throttle snapshots — see HISTORY_SNAPSHOT_THROTTLE_MS.
+  const lastHistorySnapshotAtRef = useRef<Map<string, number>>(new Map());
+
   // Optimistic local counter state to ensure UI updates immediately.
   // warningCountRef mirrors the state so reportTabSwitch can return the
   // updated value synchronously (React functional updaters run on the next
@@ -1282,6 +1398,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     ): Promise<string> => {
       setLoading(true);
       setError(null);
+      // Clear per-question history throttle on every join. The same hook
+      // instance survives a teacher unlock / attempt-cap rejoin, so a
+      // stale `lastSnapshotAt` from the prior attempt would suppress
+      // legitimate snapshots in the new one.
+      lastHistorySnapshotAtRef.current.clear();
       try {
         const normCode = code
           .trim()
@@ -1912,6 +2033,23 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // only) from an explicit submit. The student's `alreadyAnswered` gate
       // checks for `'submitted'` so a draft autosave doesn't masquerade as
       // a final answer and prematurely fire the completion card.
+      const existingAnswers = myResponseRef.current?.answers ?? [];
+      const priorEntry = existingAnswers.find(
+        (a) => a.questionId === questionId
+      );
+
+      // #1 guard — see `isUnsafeBlankDraft` doc. Refuses a draft autosave
+      // that would silently clobber a non-empty saved answer with ''.
+      if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
+        return;
+      }
+      // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
+      // Stops the back-nav listener-lag race from silently flipping a
+      // 'submitted' answer back to 'draft' status.
+      if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
+        return;
+      }
+
       const newAnswer: QuizResponseAnswer = {
         questionId,
         answer,
@@ -1922,7 +2060,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           : {}),
       };
 
-      const existingAnswers = myResponseRef.current?.answers ?? [];
       const updated = [
         ...existingAnswers.filter((a) => a.questionId !== questionId),
         newAnswer,
@@ -1962,6 +2099,62 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
+
+      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
+      // safety net so a value that turns out to be a regression (stray
+      // blank draft that the #1 guard didn't catch, or a student
+      // retyping after a lockout) can still be recovered.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      if (
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        ) &&
+        priorEntry
+      ) {
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            answeredAt: priorEntry.answeredAt,
+            // Narrow explicitly rather than `?? 'submitted'`: the rule
+            // pins `status in ['draft','submitted']`, so any future
+            // schema value would silently fail every history write.
+            status: priorEntry.status === 'draft' ? 'draft' : 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        )
+          .then(() => {
+            // Only consume the throttle slot for snapshots that actually
+            // landed. A failed write (offline, rule denial, quota) used
+            // to bump `now` regardless, suppressing the next legitimate
+            // snapshot for the throttle window even though no recovery
+            // doc had been written.
+            lastHistorySnapshotAtRef.current.set(questionId, now);
+          })
+          .catch((err: unknown) => {
+            // Safety-net write — recovery still works without it, so we
+            // don't surface to the student. But log it: a silently
+            // failing recovery net (e.g. a future rules/schema drift)
+            // should be visible rather than vanish.
+            console.error(
+              '[useQuizSession] history snapshot write failed:',
+              err
+            );
+          });
+      }
     },
     []
   );

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -110,10 +110,31 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
+ * Is this serialized answer effectively blank? Catches the empty string,
+ * whitespace-only text, and the tags-only markup the written-response
+ * editor emits when a student clears an essay — `sanitizeQuizResponse`
+ * keeps `<p>`/`<br>`, so a cleared essay serializes to `<p></p>` /
+ * `<p><br></p>`, NOT ''. A plain `=== ''` check misses that and would let
+ * the blank-draft guard be bypassed, silently clobbering a saved essay.
+ *
+ * For non-HTML answer types (MC option strings, FIB text, pipe-delimited
+ * matching/ordering) the tag strip is a no-op, so this only reclassifies
+ * genuinely text-empty values as blank.
+ */
+export function isBlankAnswerText(answer: string): boolean {
+  return (
+    answer
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/gi, ' ')
+      .trim() === ''
+  );
+}
+
+/**
  * Defensive predicate: refuse a draft autosave that would overwrite a
- * non-empty saved answer with the empty string. Almost always indicates
- * a race (editor briefly emitted '' after a remount or a hydration miss)
- * rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * non-empty saved answer with a blank one. Almost always indicates a race
+ * (editor briefly emitted blank markup after a remount or a hydration
+ * miss) rather than a deliberate clear. Explicit submits (`isDraft=false`)
  * bypass this — a student who really wants to clear an answer can still
  * submit empty.
  */
@@ -122,7 +143,12 @@ export function isUnsafeBlankDraft(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
+  return (
+    isDraft &&
+    isBlankAnswerText(answer) &&
+    !!priorEntry &&
+    priorEntry.answer !== ''
+  );
 }
 
 /**

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -140,7 +140,11 @@ export function isUnsafeStatusDowngrade(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return isDraft && priorEntry?.status === 'submitted';
+  // Use `!== 'draft'` rather than `=== 'submitted'` so legacy entries
+  // with `status === undefined` (predate the draft flag — treated as
+  // submitted everywhere else via `isAnswerSubmitted`) are also
+  // protected from being silently downgraded to draft.
+  return isDraft && priorEntry !== undefined && priorEntry.status !== 'draft';
 }
 
 /**
@@ -163,7 +167,10 @@ export function shouldSnapshotHistory(
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
   const textChanged = priorEntry.answer !== newAnswer;
-  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  // Mirror `isUnsafeStatusDowngrade`: treat legacy entries with
+  // `status === undefined` as submitted so a downgrade attempt on a
+  // legacy answer still gets a forensic snapshot.
+  const statusDowngrade = priorEntry.status !== 'draft' && newIsDraft;
   if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }
@@ -2043,9 +2050,71 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
         return;
       }
+
+      // #5 history snapshot decision — runs BEFORE the status-downgrade
+      // guard so a rejected downgrade attempt is still recorded as a
+      // forensic snapshot. Without this ordering, the downgrade branch
+      // of `shouldSnapshotHistory` was unreachable in production
+      // (`isUnsafeStatusDowngrade` returns early on the very condition
+      // the snapshot path wants to capture). Keeping it here means the
+      // recovery log records both completed and rejected overwrites.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      const wantSnapshot =
+        !!priorEntry &&
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        );
+      if (wantSnapshot && priorEntry) {
+        // Consume the throttle slot eagerly — BEFORE issuing the addDoc
+        // — so a tap-storm with multiple in-flight writes can't all see
+        // the same stale `lastAt` and slip past the throttle, and an
+        // out-of-order resolution can't move the timestamp backwards.
+        // A one-time failure burns the throttle slot for the window
+        // (logged below); the alternative is unbounded write-
+        // amplification on a flaky network, which is the worse failure
+        // mode for a fire-and-forget safety net.
+        lastHistorySnapshotAtRef.current.set(questionId, now);
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            // `answeredAt` is typed `number` (required) but Firestore
+            // can return any shape on legacy docs — fall back to `now`
+            // so the rule's required-fields check still passes instead
+            // of crashing on `undefined`.
+            answeredAt: priorEntry.answeredAt ?? now,
+            // Narrow explicitly rather than `?? 'submitted'`: the rule
+            // pins `status in ['draft','submitted']`, so any future
+            // schema value would silently fail every history write.
+            status: priorEntry.status === 'draft' ? 'draft' : 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        ).catch((err: unknown) => {
+          // Safety-net write — recovery still works without it, so we
+          // don't surface to the student. But log it: a silently
+          // failing recovery net (e.g. a future rules/schema drift)
+          // should be visible rather than vanish.
+          console.error('[useQuizSession] history snapshot write failed:', err);
+        });
+      }
+
       // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
       // Stops the back-nav listener-lag race from silently flipping a
-      // 'submitted' answer back to 'draft' status.
+      // 'submitted' answer back to 'draft' status. Runs AFTER the
+      // history snapshot so the rejected attempt is still recorded.
       if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
         return;
       }
@@ -2099,62 +2168,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
-
-      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
-      // safety net so a value that turns out to be a regression (stray
-      // blank draft that the #1 guard didn't catch, or a student
-      // retyping after a lockout) can still be recovered.
-      const now = Date.now();
-      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
-      if (
-        shouldSnapshotHistory(
-          priorEntry,
-          answer,
-          opts?.isDraft === true,
-          lastAt,
-          now
-        ) &&
-        priorEntry
-      ) {
-        void addDoc(
-          collection(
-            db,
-            QUIZ_SESSIONS_COLLECTION,
-            sessionId,
-            RESPONSES_COLLECTION,
-            responseKey,
-            RESPONSE_HISTORY_COLLECTION
-          ),
-          {
-            questionId: priorEntry.questionId,
-            answer: priorEntry.answer,
-            answeredAt: priorEntry.answeredAt,
-            // Narrow explicitly rather than `?? 'submitted'`: the rule
-            // pins `status in ['draft','submitted']`, so any future
-            // schema value would silently fail every history write.
-            status: priorEntry.status === 'draft' ? 'draft' : 'submitted',
-            snapshotAt: serverTimestamp(),
-          }
-        )
-          .then(() => {
-            // Only consume the throttle slot for snapshots that actually
-            // landed. A failed write (offline, rule denial, quota) used
-            // to bump `now` regardless, suppressing the next legitimate
-            // snapshot for the throttle window even though no recovery
-            // doc had been written.
-            lastHistorySnapshotAtRef.current.set(questionId, now);
-          })
-          .catch((err: unknown) => {
-            // Safety-net write — recovery still works without it, so we
-            // don't surface to the student. But log it: a silently
-            // failing recovery net (e.g. a future rules/schema drift)
-            // should be visible rather than vanish.
-            console.error(
-              '[useQuizSession] history snapshot write failed:',
-              err
-            );
-          });
-      }
     },
     []
   );

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,54 @@
 {
   "entries": [
     {
+      "version": "2026.05.28.4",
+      "date": "2026-05-28",
+      "title": "Live quiz answer integrity safeguards",
+      "overview": [
+        {
+          "type": "fix",
+          "subtitle": "Answers no longer disappear",
+          "items": [
+            {
+              "text": "Student-typed essay and written answers no longer come back blank when you unlock a question for editing or when students back-navigate to a previously-submitted question."
+            },
+            {
+              "text": "When a question's timer auto-submits a multiple choice answer, the committed option now stays highlighted on the locked screen instead of appearing blank."
+            },
+            {
+              "text": "Revealing answers immediately after a timer auto-submit no longer shows students a brief flash of \"incorrect\" feedback before the correct response catches up."
+            }
+          ]
+        },
+        {
+          "type": "improvement",
+          "items": [
+            {
+              "text": "If a student tries to clear a previously-saved answer by deleting all their text, a banner now tells them to use Submit to confirm the clear — previously the deletion was silently blocked and the student had no idea why it didn't stick."
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "type": "fix",
+          "text": "Live quiz — student-typed essay and written answers no longer disappear when you unlock a question for editing, or when students back-navigate to a previously-submitted question. The student app now keeps every answer in local memory and prefers that over slower cloud syncs, so a late-arriving sync can't wipe out text the student already typed. Reported on a live \"Independent Reading Test\" essay quiz where students saw their work come back blank after a teacher unlock."
+        },
+        {
+          "type": "fix",
+          "text": "Live quiz — when a question's timer expires and auto-submits a multiple choice answer, the chosen option is now highlighted on the locked screen. Previously the answer was committed correctly but the highlight was missing, making the locked screen look as if nothing had been chosen."
+        },
+        {
+          "type": "fix",
+          "text": "Live quiz — when you reveal answers right after a timer auto-submit, students no longer see a brief flash of \"incorrect\" feedback before the correct response catches up. The reveal now reads from the same local cache the student just committed against, so the feedback matches what they actually answered."
+        },
+        {
+          "type": "improvement",
+          "text": "Live quiz — if a student tries to clear a previously-saved answer by deleting all the text in the field, the app now surfaces a banner asking them to use Submit to confirm the clear. Previously, the deletion was silently refused as a safeguard against accidental loss, and the student had no UI signal explaining why their clear didn't stick."
+        }
+      ]
+    },
+    {
       "version": "2026.05.28.3",
       "date": "2026-05-28",
       "title": "Shared notebook hotspots and Boards modal copy",

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -767,3 +767,98 @@ describe('QuizStudentApp — in-memory answer cache', () => {
     );
   });
 });
+
+// ─── Narrowed current-answer ref + submit gating (#1741 follow-up) ────────────
+//
+// Issue #2: `currentAnswerRef` mirrors ONLY the active question's cached value
+// (not the whole cache). The two imperative readers — the timer auto-submit
+// effect and the visibility/unmount flush handler — must still see the current
+// question's live draft through it. These pin both read paths for a
+// non-structured type (the Matching/Ordering timer tests above cover the
+// structured auto-submit path).
+//
+// Issue #1: the Submit/NEXT affordances gate on the cache-backed value
+// (`submittableAnswer`), not on `liveAnswer` (which folds in the Firestore
+// fallback). The transient pre-seed render the fix guards against is coalesced
+// away by React (the cache-miss-fill is a render-phase update), so it isn't
+// observable here; the test below pins the end-state contract — the gate tracks
+// the cache, going from disabled → enabled as the option lands in it.
+
+describe('QuizStudentApp — current-answer ref + submit gating', () => {
+  it('auto-submits the cached MC selection on timeout (reads currentAnswerRef)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      hookState.session = buildSession({
+        publicQuestions: [
+          { ...QUESTIONS[0], timeLimit: 5 },
+          QUESTIONS[1],
+          QUESTIONS[2],
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // Pick "4" but never submit — the value lives only in the cache,
+      // mirrored into the narrowed currentAnswerRef.
+      await user.click(screen.getByRole('button', { name: '4' }));
+
+      // Run the clock out. The auto-submit effect must read the cached "4"
+      // back out of the ref, not submit an empty answer.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      expect(mockSubmitAnswer).toHaveBeenCalledWith('q1', '4', 0, undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes the current question's cached draft on visibilitychange→hidden (reads currentAnswerRef)", async () => {
+    const user = userEvent.setup();
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Cache "4". The 500 ms autosave debounce hasn't fired yet.
+    await user.click(screen.getByRole('button', { name: '4' }));
+
+    // Tab-switch away. The flush handler reads the active question's value out
+    // of the narrowed ref and writes it as a draft immediately (best-effort,
+    // before the debounce would have).
+    try {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await waitFor(() => {
+        expect(mockSubmitAnswer).toHaveBeenCalledWith('q1', '4', undefined, {
+          isDraft: true,
+        });
+      });
+    } finally {
+      // Drop the instance override so the jsdom prototype getter (default
+      // 'visible') is restored for other tests.
+      Reflect.deleteProperty(document, 'visibilityState');
+    }
+  });
+
+  it('keeps NEXT disabled until an option is cached, then enables it (gates on the cache, not the saved fallback)', async () => {
+    const user = userEvent.setup();
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Fresh question, nothing selected → no cache entry → the submit
+    // affordance is disabled. It gates on `submittableAnswer` (cache-backed),
+    // never on a Firestore fallback showing through `liveAnswer`.
+    expect(screen.getByRole('button', { name: /^NEXT/i })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    expect(screen.getByRole('button', { name: /^NEXT/i })).not.toBeDisabled();
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -862,3 +862,68 @@ describe('QuizStudentApp — current-answer ref + submit gating', () => {
     expect(screen.getByRole('button', { name: /^NEXT/i })).not.toBeDisabled();
   });
 });
+
+// ─── Written blank-overwrite guard (#1741 follow-up) ──────────────────────────
+//
+// The written editor's submit affordance is the one explicit-submit path that
+// can fire with an empty value (MC/FIB/structured all gate on content). An
+// explicit submit bypasses the autosave `isUnsafeBlankDraft` guard, so a fast
+// tap on a blank-but-unseeded essay — never typed, OR the saved answer hasn't
+// echoed into myResponse yet — would clobber the saved essay with ''. The fix:
+// when the cache has no entry (`submittableAnswer === null`), self-paced
+// advances WITHOUT writing and teacher-paced disables Submit; a deliberate
+// clear (cache holds '') still writes through.
+
+describe('QuizStudentApp — written blank-overwrite guard', () => {
+  const ESSAY: QuizPublicQuestion = {
+    id: 'qe',
+    type: 'essay',
+    text: 'Describe your summer',
+    timeLimit: 0,
+  };
+
+  it('advances a blank, unseeded essay WITHOUT writing a blank (self-paced)', async () => {
+    const user = userEvent.setup();
+    hookState.session = buildSession({
+      publicQuestions: [ESSAY, QUESTIONS[1]],
+      totalQuestions: 2,
+    });
+
+    render(<QuizStudentApp />);
+    expect(
+      await screen.findByText(/Describe your summer/i)
+    ).toBeInTheDocument();
+    // Let the lazy editor settle so NEXT isn't tapped mid-Suspense.
+    await screen.findByRole('textbox', { name: /Your response/i });
+
+    // Tap NEXT without typing. The cache has no entry for this question, so we
+    // must advance without writing — a blank explicit submit here would
+    // clobber a saved essay that simply hasn't echoed back yet.
+    await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+
+    // Advanced to Q2…
+    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
+    // …and nothing was written for the blank essay.
+    expect(mockSubmitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('disables teacher-paced essay Submit while the editor is unseeded', async () => {
+    hookState.session = buildSession({
+      sessionMode: 'teacher',
+      publicQuestions: [ESSAY, QUESTIONS[1]],
+      totalQuestions: 2,
+    });
+
+    render(<QuizStudentApp />);
+    expect(
+      await screen.findByText(/Describe your summer/i)
+    ).toBeInTheDocument();
+    await screen.findByRole('textbox', { name: /Your response/i });
+
+    // No saved answer + nothing typed → cache unseeded → Submit is disabled so
+    // a fast tap can't write a blank over a not-yet-loaded saved essay.
+    expect(
+      screen.getByRole('button', { name: /Submit Response/i })
+    ).toBeDisabled();
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -691,3 +691,79 @@ describe('QuizStudentApp — self-paced flow', () => {
     );
   });
 });
+
+// ─── In-memory answer cache (#2 fix) ──────────────────────────────────────────
+//
+// The cache makes question navigation read from local state instead of
+// re-fetching from the Firestore snapshot. These tests cover the two
+// scenarios where the prior hydration-on-every-question-change design
+// could (and did) lose student work in production:
+//   - Next → Back when the response listener hadn't echoed the just-
+//     submitted answer back yet.
+//   - A late-arriving snapshot for the current question (teacher resume,
+//     SSO listener-fast race) seeding a blank that overwrites local edits.
+
+describe('QuizStudentApp — in-memory answer cache', () => {
+  it('preserves the locally-selected MC option across Next → Back even when Firestore never echoes the submit', async () => {
+    // Drop the default `appendAnswer` side-effect so the answer is never
+    // visible via `myResponse`. The cache is then the ONLY thing
+    // remembering which option the student picked — exactly the pre-fix
+    // race scenario where the snapshot listener fell behind.
+    mockSubmitAnswer.mockImplementation(async () => {
+      // No-op: don't update hookState, don't trigger refresh.
+    });
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Pick "4", advance to Q2.
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
+
+    // Back to Q1.
+    await user.click(
+      screen.getByRole('button', { name: /Previous question/i })
+    );
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // "4" must still be highlighted in the editable draft style. Before
+    // the cache fix this would have come back blank because
+    // savedAnswerForCurrent was null and hydrate seeded the editor with
+    // an empty value.
+    const choice = screen.getByRole('button', { name: '4' });
+    expect(choice.className).toContain('border-violet-500');
+  });
+
+  it('does not clobber a locally-selected option when a snapshot with empty answers fires after the click', async () => {
+    // Simulates the "teacher resume" / late-snapshot race: the student
+    // clicks an option, then a Firestore snapshot arrives for the SAME
+    // question with no saved answer. Pre-fix the editor was reset to
+    // the saved value via hydrateAnswerControls and the student saw
+    // their selection vanish. Post-fix the cache wins because it
+    // already has a value for this question.
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+
+    // Fire a snapshot for an empty response — the kind of state the
+    // listener briefly returns after a teacher unlock or a slow round
+    // trip.
+    act(() => {
+      hookState.myResponse = buildResponse({ answers: [] });
+      triggerRefresh();
+    });
+
+    // Selection must still be intact.
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -115,11 +115,6 @@ vi.mock('@/hooks/useQuizSession', () => ({
     };
   },
   normalizeAnswer: (s: string) => s,
-  isBlankAnswerText: (answer: string) =>
-    answer
-      .replace(/<[^>]*>/g, '')
-      .replace(/&nbsp;/gi, ' ')
-      .trim() === '',
 }));
 
 import { QuizStudentApp } from '@/components/quiz/QuizStudentApp';

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -766,6 +766,162 @@ describe('QuizStudentApp — in-memory answer cache', () => {
       'border-violet-500'
     );
   });
+
+  it('does not write a stale seed over a newer snapshot value (untouched question)', async () => {
+    // The student never touches q1 this session — its value comes purely
+    // from the server. The saved answer is a DRAFT so `submitted` stays
+    // false and the autosave path stays armed. The cache seeds from the
+    // first snapshot, then a later snapshot (teacher resync, listener
+    // catch-up) moves the saved value to a NEWER one — still with no local
+    // edit. Pre-fix the cache kept the first seed ('4') while saved moved to
+    // '5', and the autosave diffed the two and wrote the stale '4' back over
+    // the server's '5'. The seed-from-server block must track the freshest
+    // saved value for untouched questions.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockSubmitAnswer.mockImplementation(async () => {
+        // No-op: keep writes out of `myResponse` so we can assert exactly
+        // what the autosave did (and didn't) attempt to persist.
+      });
+      hookState.myResponse = buildResponse({
+        answers: [
+          {
+            questionId: 'q1',
+            answer: '4',
+            answeredAt: Date.now(),
+            status: 'draft',
+          },
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // A newer snapshot for the SAME untouched question.
+      act(() => {
+        hookState.myResponse = buildResponse({
+          answers: [
+            {
+              questionId: 'q1',
+              answer: '5',
+              answeredAt: Date.now() + 1,
+              status: 'draft',
+            },
+          ],
+        });
+        triggerRefresh();
+      });
+
+      // Drain the 500 ms autosave debounce.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+
+      // The newer value won the cache — '5' carries the editable draft
+      // highlight, not the stale '4'.
+      expect(screen.getByRole('button', { name: '5' }).className).toContain(
+        'border-violet-500'
+      );
+      // And the stale '4' was never autosaved back over the server's '5'.
+      expect(mockSubmitAnswer).not.toHaveBeenCalledWith('q1', '4', undefined, {
+        isDraft: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('back-nav to a saved Matching question keeps it seed-tracked (no stale draft write after a resync)', async () => {
+    // StructuredQuestionInput remounts per question and its mount effect
+    // re-emits the seeded answer through onAnswerChange. If that no-op
+    // re-emit reached setCacheForCurrent it would mark the never-edited
+    // question touched, freezing out the seed-from-server refresh — so a
+    // later resync to a newer saved value would be ignored and the autosave
+    // would write the stale draft back over it. The re-emit guard skips it,
+    // keeping the question untouched and seed-tracked.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const matching: QuizPublicQuestion = {
+        id: 'qm',
+        type: 'Matching',
+        text: 'Match the capitals',
+        timeLimit: 0,
+        matchingLeft: ['France', 'Germany'],
+        matchingRight: ['Paris', 'Berlin'],
+      };
+      hookState.session = buildSession({
+        publicQuestions: [QUESTIONS[0], matching],
+        totalQuestions: 2,
+      });
+      // Matching answer saved as a DRAFT so `submitted` stays false (autosave
+      // armed) and the question renders its editable form.
+      hookState.myResponse = buildResponse({
+        answers: [
+          {
+            questionId: 'qm',
+            answer: 'France:Paris|Germany:Berlin',
+            answeredAt: Date.now(),
+            status: 'draft',
+          },
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // Forward to the Matching question (submitting q1 on the way).
+      await user.click(screen.getByRole('button', { name: '4' }));
+      await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+      expect(
+        await screen.findByText(/Match the capitals/i)
+      ).toBeInTheDocument();
+
+      // Back to q1, then forward again — the second arrival is the remount
+      // that re-fires StructuredQuestionInput's mount-only re-emit.
+      await user.click(
+        screen.getByRole('button', { name: /Previous question/i })
+      );
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+      expect(
+        await screen.findByText(/Match the capitals/i)
+      ).toBeInTheDocument();
+
+      // Teacher resync moves the saved draft to a NEWER arrangement while the
+      // student still hasn't touched the question.
+      act(() => {
+        hookState.myResponse = buildResponse({
+          answers: [
+            { questionId: 'q1', answer: '4', answeredAt: Date.now() },
+            {
+              questionId: 'qm',
+              answer: 'France:Paris|Germany:Madrid',
+              answeredAt: Date.now() + 1,
+              status: 'draft',
+            },
+          ],
+        });
+        triggerRefresh();
+      });
+
+      // Drain the autosave debounce.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+
+      // The stale 'Berlin' arrangement must never be autosaved back over the
+      // server's newer 'Madrid'.
+      expect(mockSubmitAnswer).not.toHaveBeenCalledWith(
+        'qm',
+        'France:Paris|Germany:Berlin',
+        undefined,
+        { isDraft: true }
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ─── Narrowed current-answer ref + submit gating (#1741 follow-up) ────────────

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -115,6 +115,11 @@ vi.mock('@/hooks/useQuizSession', () => ({
     };
   },
   normalizeAnswer: (s: string) => s,
+  isBlankAnswerText: (answer: string) =>
+    answer
+      .replace(/<[^>]*>/g, '')
+      .replace(/&nbsp;/gi, ' ')
+      .trim() === '',
 }));
 
 import { QuizStudentApp } from '@/components/quiz/QuizStudentApp';

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -8,6 +8,7 @@ import {
   useQuizSessionStudent,
   useQuizSessionTeacher,
   isUnsafeBlankDraft,
+  isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
@@ -520,6 +521,42 @@ describe('isUnsafeBlankDraft (#1 guard)', () => {
   });
 });
 
+describe('isUnsafeStatusDowngrade (review fix)', () => {
+  const submittedPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const draftPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'work in progress',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave when the prior entry was status=submitted', () => {
+    // The back-nav listener-lag race: cache holds the just-submitted value,
+    // `submitted` state briefly flips false, and the autosave would otherwise
+    // rewrite the entry as a draft.
+    expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('allows a draft autosave when the prior entry was already a draft', () => {
+    expect(isUnsafeStatusDowngrade(true, draftPrior)).toBe(false);
+  });
+
+  it('allows a draft autosave when no prior entry exists', () => {
+    expect(isUnsafeStatusDowngrade(true, undefined)).toBe(false);
+  });
+
+  it('allows an explicit submit even over a previously-submitted entry', () => {
+    // A real student-paced re-submit must always pass — the gate only
+    // applies to background draft writes.
+    expect(isUnsafeStatusDowngrade(false, submittedPrior)).toBe(false);
+  });
+});
+
 describe('shouldSnapshotHistory (#5 throttle)', () => {
   const priorWithText: QuizResponseAnswer = {
     questionId: 'q1',
@@ -527,18 +564,31 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  const priorSubmitted: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
   const THROTTLE = 5000;
 
   it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        0,
+        6000,
+        THROTTLE
+      )
     ).toBe(true);
   });
 
   it('skips when no prior entry exists', () => {
     // First write for this question — nothing to snapshot.
     expect(
-      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(undefined, 'first text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
@@ -550,22 +600,52 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       status: 'draft',
     };
     expect(
-      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(priorEmpty, 'new text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
-  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+  it('skips when the new value matches the prior text AND the status is not being downgraded', () => {
     // Autosaves can fire with no actual content change in some races;
-    // a snapshot would be wasteful and noise the recovery log.
+    // a snapshot would be wasteful when both text and status are unchanged.
     expect(
-      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'first draft',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
     ).toBe(false);
+  });
+
+  it('captures a snapshot on a status downgrade even with identical text', () => {
+    // The back-nav race silently writes the same text back as a draft over
+    // a previously-submitted entry — the 'submitted' fact is being destroyed
+    // and must be recoverable.
+    expect(
+      shouldSnapshotHistory(
+        priorSubmitted,
+        'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
   });
 
   it('throttles back-to-back snapshots inside the window', () => {
     // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        4000,
+        5000,
+        THROTTLE
+      )
     ).toBe(false);
   });
 });

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -534,12 +534,27 @@ describe('isUnsafeStatusDowngrade (review fix)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  // Predates the draft flag — `status` field omitted, treated as
+  // submitted everywhere else via `isAnswerSubmitted`.
+  const legacyPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
+  };
 
   it('refuses a draft autosave when the prior entry was status=submitted', () => {
     // The back-nav listener-lag race: cache holds the just-submitted value,
     // `submitted` state briefly flips false, and the autosave would otherwise
     // rewrite the entry as a draft.
     expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('refuses a draft autosave when the prior entry was legacy (status=undefined)', () => {
+    // Legacy docs without a `status` field are treated as submitted by
+    // `isAnswerSubmitted`. The downgrade guard must match — without it,
+    // a back-nav race on a legacy entry would silently flip the doc to
+    // `status: 'draft'` and drop it from the teacher's "Finished" view.
+    expect(isUnsafeStatusDowngrade(true, legacyPrior)).toBe(true);
   });
 
   it('allows a draft autosave when the prior entry was already a draft', () => {
@@ -569,6 +584,14 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answer: 'committed answer',
     answeredAt: 100,
     status: 'submitted',
+  };
+  // Legacy entry — predates the draft flag, `status` omitted. Treated
+  // as submitted everywhere via `isAnswerSubmitted`, so a downgrade
+  // attempt on it must still snapshot.
+  const priorLegacy: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
   };
   const THROTTLE = 5000;
 
@@ -627,6 +650,22 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       shouldSnapshotHistory(
         priorSubmitted,
         'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
+  });
+
+  it('captures a snapshot on a status downgrade from legacy (status=undefined) even with identical text', () => {
+    // Legacy submitted-equivalents (status omitted) must be recoverable
+    // when a draft write would overwrite them — same protection as the
+    // explicit `status: 'submitted'` case above.
+    expect(
+      shouldSnapshotHistory(
+        priorLegacy,
+        'legacy answer',
         true,
         0,
         1e9,

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,6 +7,7 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  isBlankAnswerText,
   isUnsafeBlankDraft,
   isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
@@ -481,6 +482,36 @@ describe('toPublicQuestion', () => {
 // tested without setting up a full Firestore mock — the hook integration
 // is covered separately by the component-level cache tests.
 
+describe('isBlankAnswerText', () => {
+  it('treats the empty string and whitespace-only text as blank', () => {
+    expect(isBlankAnswerText('')).toBe(true);
+    expect(isBlankAnswerText('   ')).toBe(true);
+    expect(isBlankAnswerText('\n\t ')).toBe(true);
+  });
+
+  it('treats the cleared-essay markup the editor emits as blank', () => {
+    // `sanitizeQuizResponse` keeps <p>/<br>, so a cleared essay serializes
+    // to tags-only markup rather than ''.
+    expect(isBlankAnswerText('<p></p>')).toBe(true);
+    expect(isBlankAnswerText('<p><br></p>')).toBe(true);
+    expect(isBlankAnswerText('<br>')).toBe(true);
+    expect(isBlankAnswerText('<p>&nbsp;</p>')).toBe(true);
+  });
+
+  it('treats real prose (even formatted) as non-blank', () => {
+    expect(isBlankAnswerText('<p>Real answer</p>')).toBe(false);
+    expect(isBlankAnswerText('Paris')).toBe(false);
+  });
+
+  it('does not misclassify non-HTML answer serializations as blank', () => {
+    // MC option strings, FIB text, and pipe-delimited matching/ordering
+    // have no tags to strip, so only genuinely text-empty values are blank.
+    expect(isBlankAnswerText('4')).toBe(false);
+    expect(isBlankAnswerText('France:Paris|Germany:Berlin')).toBe(false);
+    expect(isBlankAnswerText('First|Second|Third')).toBe(false);
+  });
+});
+
 describe('isUnsafeBlankDraft (#1 guard)', () => {
   const priorWithText: QuizResponseAnswer = {
     questionId: 'q1',
@@ -497,6 +528,13 @@ describe('isUnsafeBlankDraft (#1 guard)', () => {
 
   it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
     expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
+  });
+
+  it('refuses a draft autosave of cleared-essay markup over a non-empty prior', () => {
+    // Regression: a cleared essay serializes to `<p></p>`, which the old
+    // `=== ''` check let through, silently clobbering the saved essay.
+    expect(isUnsafeBlankDraft('<p></p>', true, priorWithText)).toBe(true);
+    expect(isUnsafeBlankDraft('<p><br></p>', true, priorWithText)).toBe(true);
   });
 
   it('allows a draft autosave writing "" when the prior answer was also empty', () => {

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,7 +7,6 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
-  isBlankAnswerText,
   isUnsafeBlankDraft,
   isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
@@ -482,36 +481,6 @@ describe('toPublicQuestion', () => {
 // tested without setting up a full Firestore mock — the hook integration
 // is covered separately by the component-level cache tests.
 
-describe('isBlankAnswerText', () => {
-  it('treats the empty string and whitespace-only text as blank', () => {
-    expect(isBlankAnswerText('')).toBe(true);
-    expect(isBlankAnswerText('   ')).toBe(true);
-    expect(isBlankAnswerText('\n\t ')).toBe(true);
-  });
-
-  it('treats the cleared-essay markup the editor emits as blank', () => {
-    // `sanitizeQuizResponse` keeps <p>/<br>, so a cleared essay serializes
-    // to tags-only markup rather than ''.
-    expect(isBlankAnswerText('<p></p>')).toBe(true);
-    expect(isBlankAnswerText('<p><br></p>')).toBe(true);
-    expect(isBlankAnswerText('<br>')).toBe(true);
-    expect(isBlankAnswerText('<p>&nbsp;</p>')).toBe(true);
-  });
-
-  it('treats real prose (even formatted) as non-blank', () => {
-    expect(isBlankAnswerText('<p>Real answer</p>')).toBe(false);
-    expect(isBlankAnswerText('Paris')).toBe(false);
-  });
-
-  it('does not misclassify non-HTML answer serializations as blank', () => {
-    // MC option strings, FIB text, and pipe-delimited matching/ordering
-    // have no tags to strip, so only genuinely text-empty values are blank.
-    expect(isBlankAnswerText('4')).toBe(false);
-    expect(isBlankAnswerText('France:Paris|Germany:Berlin')).toBe(false);
-    expect(isBlankAnswerText('First|Second|Third')).toBe(false);
-  });
-});
-
 describe('isUnsafeBlankDraft (#1 guard)', () => {
   const priorWithText: QuizResponseAnswer = {
     questionId: 'q1',
@@ -528,13 +497,6 @@ describe('isUnsafeBlankDraft (#1 guard)', () => {
 
   it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
     expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
-  });
-
-  it('refuses a draft autosave of cleared-essay markup over a non-empty prior', () => {
-    // Regression: a cleared essay serializes to `<p></p>`, which the old
-    // `=== ''` check let through, silently clobbering the saved essay.
-    expect(isUnsafeBlankDraft('<p></p>', true, priorWithText)).toBe(true);
-    expect(isUnsafeBlankDraft('<p><br></p>', true, priorWithText)).toBe(true);
   });
 
   it('allows a draft autosave writing "" when the prior answer was also empty', () => {

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,11 +7,15 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  isUnsafeBlankDraft,
+  isUnsafeStatusDowngrade,
+  shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
   QuizQuestion,
   QuizResponse,
+  QuizResponseAnswer,
   QuizSession,
   QuizPublicQuestion,
 } from '@/types';
@@ -466,6 +470,183 @@ describe('toPublicQuestion', () => {
     expect(pub).not.toHaveProperty('correctAnswer');
     expect(pub.id).toBe('q4');
     expect(pub.type).toBe('FIB');
+  });
+});
+
+// ─── Draft-write defensive predicates ─────────────────────────────────────────
+//
+// `isUnsafeBlankDraft` and `shouldSnapshotHistory` are the two guards
+// `submitAnswer` consults before writing the response doc. They are
+// extracted as pure predicates so the race / overwrite logic can be
+// tested without setting up a full Firestore mock — the hook integration
+// is covered separately by the component-level cache tests.
+
+describe('isUnsafeBlankDraft (#1 guard)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'My long essay response',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const priorEmpty: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: '',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
+    expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
+  });
+
+  it('allows a draft autosave writing "" when the prior answer was also empty', () => {
+    // Both sides reduce to '' — no data loss possible, the write is a no-op
+    // on the data dimension but still legitimate (timestamps may update).
+    expect(isUnsafeBlankDraft('', true, priorEmpty)).toBe(false);
+  });
+
+  it('allows a draft autosave writing "" when no prior entry exists', () => {
+    expect(isUnsafeBlankDraft('', true, undefined)).toBe(false);
+  });
+
+  it('allows a draft autosave writing non-empty text over a non-empty prior', () => {
+    // Normal "student kept typing" path — must not be blocked.
+    expect(isUnsafeBlankDraft('new text', true, priorWithText)).toBe(false);
+  });
+
+  it('allows an explicit (non-draft) submit of "" over a non-empty prior', () => {
+    // Student deliberately cleared and clicked Submit — only autosaves are
+    // gated; explicit intent is respected.
+    expect(isUnsafeBlankDraft('', false, priorWithText)).toBe(false);
+  });
+});
+
+describe('isUnsafeStatusDowngrade (review fix)', () => {
+  const submittedPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const draftPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'work in progress',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave when the prior entry was status=submitted', () => {
+    // The back-nav listener-lag race: cache holds the just-submitted value,
+    // `submitted` state briefly flips false, and the autosave would otherwise
+    // rewrite the entry as a draft.
+    expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('allows a draft autosave when the prior entry was already a draft', () => {
+    expect(isUnsafeStatusDowngrade(true, draftPrior)).toBe(false);
+  });
+
+  it('allows a draft autosave when no prior entry exists', () => {
+    expect(isUnsafeStatusDowngrade(true, undefined)).toBe(false);
+  });
+
+  it('allows an explicit submit even over a previously-submitted entry', () => {
+    // A real student-paced re-submit must always pass — the gate only
+    // applies to background draft writes.
+    expect(isUnsafeStatusDowngrade(false, submittedPrior)).toBe(false);
+  });
+});
+
+describe('shouldSnapshotHistory (#5 throttle)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'first draft',
+    answeredAt: 100,
+    status: 'draft',
+  };
+  const priorSubmitted: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const THROTTLE = 5000;
+
+  it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
+    expect(
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        0,
+        6000,
+        THROTTLE
+      )
+    ).toBe(true);
+  });
+
+  it('skips when no prior entry exists', () => {
+    // First write for this question — nothing to snapshot.
+    expect(
+      shouldSnapshotHistory(undefined, 'first text', true, 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the prior entry was empty', () => {
+    const priorEmpty: QuizResponseAnswer = {
+      questionId: 'q1',
+      answer: '',
+      answeredAt: 0,
+      status: 'draft',
+    };
+    expect(
+      shouldSnapshotHistory(priorEmpty, 'new text', true, 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the new value matches the prior text AND the status is not being downgraded', () => {
+    // Autosaves can fire with no actual content change in some races;
+    // a snapshot would be wasteful when both text and status are unchanged.
+    expect(
+      shouldSnapshotHistory(
+        priorWithText,
+        'first draft',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(false);
+  });
+
+  it('captures a snapshot on a status downgrade even with identical text', () => {
+    // The back-nav race silently writes the same text back as a draft over
+    // a previously-submitted entry — the 'submitted' fact is being destroyed
+    // and must be recoverable.
+    expect(
+      shouldSnapshotHistory(
+        priorSubmitted,
+        'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
+  });
+
+  it('throttles back-to-back snapshots inside the window', () => {
+    // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
+    expect(
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        4000,
+        5000,
+        THROTTLE
+      )
+    ).toBe(false);
   });
 });
 
@@ -1563,6 +1744,14 @@ function setupTeacherMocks(): TeacherMockEnv {
   (firestore.writeBatch as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
     env.batch
   );
+  // removeStudent fetches the answer-history subcollection to cascade-
+  // delete it before removing the parent response. Default to an empty
+  // result so the common path issues no history batch; tests that need
+  // orphan cleanup override this with `mockResolvedValueOnce`.
+  (firestore.getDocs as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+    docs: [],
+    empty: true,
+  });
 
   return env;
 }
@@ -1652,6 +1841,73 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
     // No batch should be created when sessionId is null.
     expect(env.batch.delete).not.toHaveBeenCalled();
     expect(env.batch.commit).not.toHaveBeenCalled();
+  });
+
+  it('cascade-deletes the answer-history subcollection before removing the parent response', async () => {
+    // Firestore does not cascade subcollection deletes, so removeStudent
+    // must sweep `responses/{key}/history/*` itself — otherwise the
+    // snapshots orphan and a rejoined student under the same
+    // deterministic key could read their prior-attempt drafts.
+    const historyDocs = [
+      {
+        ref: {
+          __type: 'doc',
+          path: [
+            'quiz_sessions',
+            'sess-1',
+            'responses',
+            'pin-period_1-9999',
+            'history',
+            'h1',
+          ],
+        },
+      },
+      {
+        ref: {
+          __type: 'doc',
+          path: [
+            'quiz_sessions',
+            'sess-1',
+            'responses',
+            'pin-period_1-9999',
+            'history',
+            'h2',
+          ],
+        },
+      },
+    ];
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ docs: historyDocs, empty: false });
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+    await act(async () => {
+      await result.current.removeStudent('pin-period_1-9999');
+    });
+
+    // Both history docs + the parent response doc are deleted.
+    expect(env.batch.delete).toHaveBeenCalledTimes(3);
+    // One commit for the history chunk, one for the archive/delete batch.
+    expect(env.batch.commit).toHaveBeenCalledTimes(2);
+    const deletedPaths = env.batch.delete.mock.calls.map(
+      (c) => (c[0] as { path: string[] }).path
+    );
+    expect(deletedPaths).toContainEqual([
+      'quiz_sessions',
+      'sess-1',
+      'responses',
+      'pin-period_1-9999',
+      'history',
+      'h1',
+    ]);
+    expect(deletedPaths).toContainEqual([
+      'quiz_sessions',
+      'sess-1',
+      'responses',
+      'pin-period_1-9999',
+      'history',
+      'h2',
+    ]);
   });
 
   it('revealAnswer writes a dotted-path map entry on the session doc', async () => {

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,11 +7,14 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  isUnsafeBlankDraft,
+  shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
   QuizQuestion,
   QuizResponse,
+  QuizResponseAnswer,
   QuizSession,
   QuizPublicQuestion,
 } from '@/types';
@@ -466,6 +469,104 @@ describe('toPublicQuestion', () => {
     expect(pub).not.toHaveProperty('correctAnswer');
     expect(pub.id).toBe('q4');
     expect(pub.type).toBe('FIB');
+  });
+});
+
+// ─── Draft-write defensive predicates ─────────────────────────────────────────
+//
+// `isUnsafeBlankDraft` and `shouldSnapshotHistory` are the two guards
+// `submitAnswer` consults before writing the response doc. They are
+// extracted as pure predicates so the race / overwrite logic can be
+// tested without setting up a full Firestore mock — the hook integration
+// is covered separately by the component-level cache tests.
+
+describe('isUnsafeBlankDraft (#1 guard)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'My long essay response',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const priorEmpty: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: '',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
+    expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
+  });
+
+  it('allows a draft autosave writing "" when the prior answer was also empty', () => {
+    // Both sides reduce to '' — no data loss possible, the write is a no-op
+    // on the data dimension but still legitimate (timestamps may update).
+    expect(isUnsafeBlankDraft('', true, priorEmpty)).toBe(false);
+  });
+
+  it('allows a draft autosave writing "" when no prior entry exists', () => {
+    expect(isUnsafeBlankDraft('', true, undefined)).toBe(false);
+  });
+
+  it('allows a draft autosave writing non-empty text over a non-empty prior', () => {
+    // Normal "student kept typing" path — must not be blocked.
+    expect(isUnsafeBlankDraft('new text', true, priorWithText)).toBe(false);
+  });
+
+  it('allows an explicit (non-draft) submit of "" over a non-empty prior', () => {
+    // Student deliberately cleared and clicked Submit — only autosaves are
+    // gated; explicit intent is respected.
+    expect(isUnsafeBlankDraft('', false, priorWithText)).toBe(false);
+  });
+});
+
+describe('shouldSnapshotHistory (#5 throttle)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'first draft',
+    answeredAt: 100,
+    status: 'draft',
+  };
+  const THROTTLE = 5000;
+
+  it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+    ).toBe(true);
+  });
+
+  it('skips when no prior entry exists', () => {
+    // First write for this question — nothing to snapshot.
+    expect(
+      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the prior entry was empty', () => {
+    const priorEmpty: QuizResponseAnswer = {
+      questionId: 'q1',
+      answer: '',
+      answeredAt: 0,
+      status: 'draft',
+    };
+    expect(
+      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+    // Autosaves can fire with no actual content change in some races;
+    // a snapshot would be wasteful and noise the recovery log.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('throttles back-to-back snapshots inside the window', () => {
+    // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
This pull request introduces robust protections against data loss and regression in student quiz responses, focusing on both client-side and server-side safeguards. The main changes add a per-question append-only answer history for recovery, implement defensive checks to prevent overwriting or downgrading answers due to race conditions, and ensure proper cleanup of historical data. Additional tests validate the new in-memory caching logic that prevents lost answers during navigation and snapshot races.

**Recovery and Data Integrity Improvements**

* Added a Firestore subcollection (`history`) for each student response to store an append-only log of previous answers before they are overwritten, enabling recovery from lost or overwritten student work. Strict security rules restrict creation and reading to the owning student, teachers, or admins, and enforce a fixed schema and server timestamps.
* Implemented logic in `useQuizSession.ts` to throttle history snapshots per question (default: 5 seconds), preventing excessive writes while ensuring meaningful recovery points. [[1]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR68-R86) [[2]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR1247-R1250)

**Client-side Data Loss Prevention**

* Introduced two defensive predicates: `isUnsafeBlankDraft` to block draft autosaves that would overwrite a non-empty answer with a blank (avoiding accidental erasure from race conditions), and `isUnsafeStatusDowngrade` to prevent autosaves from downgrading a submitted answer to draft status (avoiding loss of grading state). [[1]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR112-R170) [[2]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR2036-R2052)
* Updated the student answer submission flow to snapshot the prior answer to history (if eligible) before overwriting, and to apply the above guards on every save. [[1]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR2036-R2052) [[2]](diffhunk://#diff-c3df9b2601aa95b7241a4e7891e3e652338904d1cf5594edded74f51a30ee13dR2102-R2157)

**Cleanup and Maintenance**

* Ensured that when a teacher deletes a student response, all associated answer history documents are deleted first to prevent orphaned recovery data and potential privacy leaks if a student rejoins.

**Testing and Validation**

* Added new tests to verify that the in-memory answer cache preserves student work across navigation and snapshot races, addressing scenarios where answers could be lost due to delayed Firestore updates or hydration issues.

These changes collectively make student answer handling more robust against both user error and technical edge cases, while providing tools for recovery in the event of unexpected data loss.…history log (#1741)

* fix(quiz): prevent student-text loss via cache + blank-write guard + history log

Three layered fixes for the data-loss patterns reported on the live "Independent Reading Test" essay quiz (students seeing previously-typed answers come back blank after a teacher unlock, and back-navigation losing text on previously-submitted questions).

1. Defensive autosave guard (`isUnsafeBlankDraft`). Refuses a draft autosave that would replace a non-empty saved answer with the empty string — almost always a race symptom rather than a deliberate clear. Explicit submits still pass through; only the debounced background path is gated.

2. In-memory per-question answer cache. Replaces the per-type live state slots (`writtenAnswer`, `fibAnswer`, `draftMcAnswer`, the structured ref) with a single `Map<questionId, string>` that's the source of truth for editors and inputs. Navigation reads from the cache instead of rehydrating from the Firestore snapshot on every question change, so the snapshot-listener race that produced blank-after-resume and blank-after-back-nav can no longer drop the student's local edits. `scheduleDraftAutosave` collapses into the existing state-driven autosave effect since matching/ordering now flow through the cache.

3. Append-only `responses/{rid}/history` subcollection. Each prior non-empty answer is snapshotted before being overwritten, throttled per-question to ≥5s so a long essay can't fan out to hundreds of docs. Pure safety net for anything the other two guards miss; teacher / admin reads the subcollection on demand to recover text that a future bug clobbers. Firestore rules pin field shape and immutability.

Tests cover the two pure predicates directly (10 cases across the guard + history-throttle decision) and add two component-level cache behavior tests (navigation preserves text without a Firestore round trip; a late-arriving empty snapshot doesn't clobber a local selection).



* fix(quiz): address code-review findings on PR 1741

Follow-up to the data-loss prevention PR after a high-effort code review surfaced several correctness gaps. All fixes are surgical layered on the cache + history + guard architecture from the parent commit.

- New `isUnsafeStatusDowngrade` predicate refuses a draft autosave that would silently flip an already-submitted answer back to 'draft'. The back-nav listener-lag race in self-paced mode could otherwise rewrite a 'submitted' entry with status='draft' when the response listener hadn't yet echoed the just-submitted answer, dropping the question from the teacher's "Finished" view.

- `shouldSnapshotHistory` now captures snapshots on status downgrades even when the answer text is unchanged. Without this, the same race above destroyed the 'submitted' fact with no recovery record.

- History throttle slot is consumed only AFTER `addDoc` resolves. A failed snapshot (offline, transient permission-denied) used to suppress the next legitimate snapshot for the throttle window even though no recovery doc had been written.

- `lastHistorySnapshotAtRef` cleared on every `joinQuizSession` so a teacher-unlock / attempt-cap rejoin doesn't inherit stale throttle entries from the prior attempt.

- MC locked-branch highlight falls back to the cache value when `selectedAnswer` is null (timer auto-submit never sets it), so an auto-submitted MC question shows which option was committed instead of rendering no highlight at all.

- Reveal-feedback effect consults the cache before falling back to `myResponse.answers` — fixes false-incorrect feedback after timer auto-submit when the Firestore echo lags the teacher's reveal tick.

- WrittenResponseEditor's `questionKey` now encodes whether the cache has been seeded for the current question. A page refresh that mounts the editor before the Firestore snapshot arrives now triggers a one-time remount with the recovered text when the cache populates, instead of leaving the editor blank with the recovered value trapped in React state.

- The autosave effect locally detects the cleared-saved-answer case (cache='', saved=text) and surfaces a `SaveErrorBanner` instructing the student to use Submit to persist the clear — closes the silent trap where the hook's `isUnsafeBlankDraft` refused the write with no UI signal.

Tests: added 4 cases for `isUnsafeStatusDowngrade` and 1 for the status-downgrade snapshot path. Existing 102 quiz tests still pass.



* fix(quiz): cascade-delete answer history + render-body ref sync

Addresses Gemini code-review feedback on PR #1741.

- removeStudent now sweeps the responses/{key}/history subcollection (chunked at 450/batch) before deleting the parent response. Firestore doesn't cascade subcollection deletes, so these snapshots orphaned — and because the response key is deterministic, a removed-then-rejoined student could read their own prior-attempt drafts. The teacher archive still preserves final answers; intermediate-draft history is discarded on removal.

- History snapshot write narrows status to ('draft' ? 'draft' : 'submitted') so a future schema value can't silently fail the rule, and the fire-and-forget catch now logs instead of swallowing — a silently-broken recovery net should be visible.

- Moved the currentQuestion/selectedAnswer/onAnswer/myResponseStatus ref sync from a useEffect into direct render-body assignment, matching answerCacheRef/submittedRef and the project's ref-sync convention. Every consumer reads from an effect or event handler that runs after commit, so this is strictly fresher with no staleness window.



---------