### PR TITLE
fix(quiz): keep untouched answer cache synced to server + guard structured re-emit

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1035,6 +1035,17 @@ const ActiveQuiz: React.FC<{
   // saved-equal short-circuit holding and prevents a stale seed from being
   // written back over a newer server answer.
   const touchedQuestionsRef = useRef<Set<string>>(new Set());
+  // Questions whose cache entry was populated by the seed-from-server
+  // block (i.e. a real Firestore value, not a local edit). Used by the
+  // `WrittenResponseEditor` questionKey to decide between `init` (no
+  // saved value to recover) and `seeded` (saved value recovered, force
+  // a one-time remount so the editor's mount-time `innerHTML` seed
+  // picks it up). Tracking this separately from `answerCache` keys
+  // avoids the bug where the student's first keystroke on an unanswered
+  // question would add the question to `answerCache`, flip the key from
+  // `init` to `seeded`, and remount the editor mid-type — stealing
+  // focus and resetting the caret.
+  const seededQuestionsRef = useRef<Set<string>>(new Set());
 
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
@@ -1135,6 +1146,9 @@ const ActiveQuiz: React.FC<{
     // ref so the seed still uses the freshest value if React applies it on
     // a later tick.
     const qid = currentQuestion.id;
+    // Mark as seeded BEFORE the setState so a render-phase reader (the
+    // editor questionKey) sees the right state on the same commit.
+    seededQuestionsRef.current.add(qid);
     setAnswerCache((prev) => {
       const fresh = savedAnswerForCurrentRef.current;
       if (fresh === null || prev[qid] === fresh) return prev;
@@ -1316,6 +1330,11 @@ const ActiveQuiz: React.FC<{
     // mirroring later snapshots over this local edit.
     touchedQuestionsRef.current.add(currentQid);
     setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+    // Clear any stale save-error banner once the student resumes editing.
+    // The deliberate-clear banner ("Click Submit to clear it") and other
+    // transient autosave errors otherwise persist on screen after the
+    // student starts typing/selecting again, which is misleading.
+    setSaveError(null);
   };
   useEffect(() => {
     const qid = currentQid;
@@ -2179,7 +2198,9 @@ const ActiveQuiz: React.FC<{
                 // student stares at a blank editor while React state
                 // already holds the recovered value.
                 questionKey={`${currentQuestion.id}:${
-                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                  seededQuestionsRef.current.has(currentQuestion.id)
+                    ? 'seeded'
+                    : 'init'
                 }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1027,6 +1027,14 @@ const ActiveQuiz: React.FC<{
   const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
   const answerCacheRef = useRef<Record<string, string>>(answerCache);
   answerCacheRef.current = answerCache;
+  // Questions the student has locally edited this session. Once a question
+  // is touched, the in-memory cache is authoritative for it: the
+  // seed-from-server block below stops mirroring later snapshots into it so
+  // a resync can't clobber an in-progress local edit. Untouched questions
+  // keep tracking the freshest saved value, which keeps the autosave's
+  // saved-equal short-circuit holding and prevents a stale seed from being
+  // written back over a newer server answer.
+  const touchedQuestionsRef = useRef<Set<string>>(new Set());
 
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
@@ -1084,7 +1092,7 @@ const ActiveQuiz: React.FC<{
 
   // Reset `selectedAnswer` on question change. The per-type live values
   // (what's currently typed/selected) now live in `answerCache` and are
-  // populated lazily — see the cache-miss-fill block below — so there's
+  // populated by the seed-from-server block below — so there's
   // nothing per-question to wipe here besides the post-submit display
   // indicator.
   const hydrateAnswerControls = (): void => {
@@ -1095,26 +1103,43 @@ const ActiveQuiz: React.FC<{
     );
   };
 
-  // Lazy cache-miss-fill for the current question. If the cache has no
-  // entry yet AND a saved value exists in the Firestore snapshot, seed
-  // the cache from it. Runs every render but the conditional functional
-  // updater no-ops once the key is present, so it costs nothing on the
-  // hot path. Handles three load orders without dedicated effects:
-  //   1) Initial mount before myResponse arrives — cache is empty, saved
-  //      is null, both miss; the next render after the snapshot fills
-  //      in fires this branch.
-  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
-  //      first render after load seeds the current question.
-  //   3) Teacher resume / late snapshot — saved transitions null→text
-  //      while the question hasn't changed; this re-fills the cache
-  //      without going through hydrateAnswerControls.
-  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+  // Seed-from-server for the current question. For any question the
+  // student hasn't locally edited this session, mirror the freshest saved
+  // value into the cache so navigation / refresh / teacher-resume all
+  // recover prior work without dedicated effects. Handles the same load
+  // orders the old lazy-fill did (initial mount before myResponse arrives;
+  // page refresh mid-quiz; teacher resume / late snapshot) plus the
+  // data-loss race below. Two correctness details:
+  //
+  //   - Read `savedAnswerForCurrentRef.current` *inside* the updater rather
+  //     than closing over the render-time `savedAnswerForCurrent`. If a
+  //     newer Firestore snapshot lands between this update being scheduled
+  //     and React applying it, the closure would otherwise lock the stale
+  //     pre-snapshot value into the cache while the autosave already diffs
+  //     against the newer saved value — and write the stale one back over
+  //     the newer server answer.
+  //   - Refresh, not fill-once: if the saved value changes while the
+  //     question is still untouched, update the cache to match so the
+  //     autosave's saved-equal short-circuit holds and never fires a write
+  //     of an outdated seed. Touched questions are skipped — the cache wins
+  //     after the first local edit.
+  if (
+    currentQuestion?.id &&
+    savedAnswerForCurrent !== null &&
+    !touchedQuestionsRef.current.has(currentQuestion.id) &&
+    answerCache[currentQuestion.id] !== savedAnswerForCurrent
+  ) {
+    // Guarded so this render-phase update only fires when the cache is
+    // actually out of step with the saved value — calling setState
+    // unconditionally during render would loop. The updater re-reads the
+    // ref so the seed still uses the freshest value if React applies it on
+    // a later tick.
     const qid = currentQuestion.id;
-    if (!(qid in answerCache)) {
-      setAnswerCache((prev) =>
-        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
-      );
-    }
+    setAnswerCache((prev) => {
+      const fresh = savedAnswerForCurrentRef.current;
+      if (fresh === null || prev[qid] === fresh) return prev;
+      return { ...prev, [qid]: fresh };
+    });
   }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
@@ -1275,7 +1300,7 @@ const ActiveQuiz: React.FC<{
     currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
   // Render-time live answer for editors and inputs. Falls back to the
   // Firestore saved value on the single render between question
-  // navigation and the cache-miss-fill block populating the cache, so
+  // navigation and the seed-from-server block populating the cache, so
   // controlled inputs (MC highlight, FIB value, structured initial
   // seed) never flicker through an empty state when a saved value is
   // available. `cachedDraft` (cache-only) is what drives autosave —
@@ -1287,6 +1312,9 @@ const ActiveQuiz: React.FC<{
   // answer slot, but keeps the type signature honest).
   const setCacheForCurrent = (value: string): void => {
     if (!currentQid) return;
+    // Mark the question touched so the seed-from-server block above stops
+    // mirroring later snapshots over this local edit.
+    touchedQuestionsRef.current.add(currentQid);
     setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
   };
   useEffect(() => {
@@ -2108,6 +2136,15 @@ const ActiveQuiz: React.FC<{
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
+              // The input remounts per question (keyed by id) and its
+              // mount effect re-emits the seeded answer. Skip the write
+              // when the emitted value already matches the cache: a
+              // back-nav remount would otherwise mark the question touched
+              // (freezing out the seed-from-server refresh) and churn the
+              // autosave / pollute the history log for a no-op overwrite.
+              // Genuine placements differ from the cache and fall through.
+              if (currentQid && answerCacheRef.current[currentQid] === answer)
+                return;
               // Push the live placement into the cache; the autosave
               // effect picks it up and debounces the Firestore write.
               setCacheForCurrent(answer);
@@ -2136,7 +2173,7 @@ const ActiveQuiz: React.FC<{
                 // seeded" boolean in the questionKey. A page refresh
                 // mid-essay first mounts with value='' (cache empty,
                 // saved null); when the Firestore snapshot arrives the
-                // cache-miss-fill block populates the cache, the key
+                // seed-from-server block populates the cache, the key
                 // flips from `…:init` → `…:seeded`, and the editor
                 // remounts with the recovered text. Without this, the
                 // student stares at a blank editor while React state

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1004,27 +1004,34 @@ const ActiveQuiz: React.FC<{
   const initialTimeLimit = currentQuestion?.timeLimit ?? 0;
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [fibAnswer, setFibAnswer] = useState('');
-  const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
-  // Written-response live draft (sanitized HTML). Hydrated on question
-  // change from any saved response so pause/resume next class period
-  // picks up exactly where the student left off.
-  const [writtenAnswer, setWrittenAnswer] = useState<string>('');
-  const writtenAnswerRef = useRef<string>('');
-  // Per-question draft autosave timer. Originally written-response-only;
-  // now coalesces autosaves for every answer type (MC, FIB, Matching,
-  // Ordering, short, essay) because dropping non-written answers on tab
-  // close was the primary source of the reported quiz data loss.
+
+  // Per-question live answer cache. Source of truth for editors and
+  // inputs during a session — replaces the per-type live state slots
+  // (writtenAnswer / fibAnswer / draftMcAnswer / structuredAnswerRef)
+  // that used to be reset and re-hydrated from Firestore on every
+  // question change. With the cache:
+  //   - Navigation (next/back) reads from the cache. No Firestore round
+  //     trip, no hydration race.
+  //   - The Firestore snapshot only seeds the cache on demand — once
+  //     per question, the first time it's visited with a saved value
+  //     available. After that, the local value is authoritative.
+  //   - The autosave path writes the cache value to Firestore in the
+  //     background; student typing never depends on Firestore being
+  //     current.
+  //
+  // Values are the canonical serialized form per type:
+  //   - short / essay: sanitized HTML
+  //   - MC: the chosen option string (absent if never clicked)
+  //   - FIB: the typed string
+  //   - Matching / Ordering: pipe-delimited serialization
+  const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
+  const answerCacheRef = useRef<Record<string, string>>(answerCache);
+  answerCacheRef.current = answerCache;
+
+  // Per-question draft autosave timer. Coalesces autosaves for every
+  // answer type — dropping non-written answers on tab close was the
+  // primary source of the originally reported quiz data loss.
   const draftAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Which question id the current `writtenAnswer` belongs to. Used by the
-  // autosave effect to refuse writes during the single render between
-  // `currentQuestion.id` advancing (student-paced submit-and-advance) and
-  // the hydration branch replacing `writtenAnswer` with the new
-  // question's saved value. Without this guard, the diff
-  // `writtenAnswer !== savedAnswerForCurrent` is briefly true on the new
-  // question and would persist the *previous* question's draft against
-  // the new question's id 500 ms later.
-  const writtenAnswerQuestionIdRef = useRef<string | undefined>(undefined);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -1075,40 +1082,40 @@ const ActiveQuiz: React.FC<{
   const savedAnswerForCurrentRef = useRef<string | null>(null);
   savedAnswerForCurrentRef.current = savedAnswerForCurrent;
 
-  // Hydrate the answer controls from any saved answer so a previously-
-  // answered question shows the student's prior choice. For MC we set
-  // `draftMcAnswer` (not `selectedAnswer`) so the existing draft styling
-  // highlights it and the NEXT button is enabled immediately. Inline so we
-  // can call it from both the question-change branch (back-nav) and the
-  // alreadyAnswered branch (page reload while answers are mid-load).
+  // Reset `selectedAnswer` on question change. The per-type live values
+  // (what's currently typed/selected) now live in `answerCache` and are
+  // populated lazily — see the cache-miss-fill block below — so there's
+  // nothing per-question to wipe here besides the post-submit display
+  // indicator.
   const hydrateAnswerControls = (): void => {
-    if (alreadyAnswered && savedAnswerForCurrent !== null) {
-      setSelectedAnswer(savedAnswerForCurrent);
-      setDraftMcAnswer(
-        currentQuestion?.type === 'MC' ? savedAnswerForCurrent : null
-      );
-      setFibAnswer(
-        currentQuestion?.type === 'FIB' ? savedAnswerForCurrent : ''
-      );
-    } else {
-      setSelectedAnswer(null);
-      setDraftMcAnswer(null);
-      setFibAnswer('');
-    }
-    // Always seed the written-answer slot from any saved response so
-    // pause/resume across class periods rehydrates the editor at the
-    // exact text the student left behind. Other types get an empty
-    // string here, which the editor branches never read. The
-    // question-id ref is updated in lockstep so the autosave effect
-    // refuses to write the new question with a draft that's still about
-    // to be replaced (see the autosave effect comment).
-    const isWritten =
-      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
-    const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
-    setWrittenAnswer(next);
-    writtenAnswerRef.current = next;
-    writtenAnswerQuestionIdRef.current = currentQuestion?.id;
+    setSelectedAnswer(
+      alreadyAnswered && savedAnswerForCurrent !== null
+        ? savedAnswerForCurrent
+        : null
+    );
   };
+
+  // Lazy cache-miss-fill for the current question. If the cache has no
+  // entry yet AND a saved value exists in the Firestore snapshot, seed
+  // the cache from it. Runs every render but the conditional functional
+  // updater no-ops once the key is present, so it costs nothing on the
+  // hot path. Handles three load orders without dedicated effects:
+  //   1) Initial mount before myResponse arrives — cache is empty, saved
+  //      is null, both miss; the next render after the snapshot fills
+  //      in fires this branch.
+  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
+  //      first render after load seeds the current question.
+  //   3) Teacher resume / late snapshot — saved transitions null→text
+  //      while the question hasn't changed; this re-fills the cache
+  //      without going through hydrateAnswerControls.
+  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+    const qid = currentQuestion.id;
+    if (!(qid in answerCache)) {
+      setAnswerCache((prev) =>
+        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
+      );
+    }
+  }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
   //
@@ -1164,11 +1171,11 @@ const ActiveQuiz: React.FC<{
   }
 
   // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change.
+  // doesn't restart on every keystroke or selection change. Per-type live
+  // values were folded into `answerCacheRef` (synced in render body) so
+  // this set only carries the values the cache doesn't represent.
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
-  const fibAnswerRef = useRef(fibAnswer);
-  const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
@@ -1178,57 +1185,26 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
-  // Mirror of the per-question `submitted` state so the imperative
-  // autosave path (Matching/Ordering's onAnswerChange) can refuse to
-  // schedule a draft write for an already-submitted question. Without
-  // this, back-navigating to a submitted structured question and
-  // triggering onAnswerChange (e.g., StructuredQuestionInput's mount
-  // effect re-emits the saved answer) downgrades the answer from
-  // `status: 'submitted'` to `status: 'draft'`, vanishing it from the
-  // teacher's results view.
+  // Mirror of the per-question `submitted` state for the imperative
+  // paths (flush handler, structured-input change callbacks) that can't
+  // read state directly.
   const submittedRef = useRef(false);
   submittedRef.current = submitted;
-  // Pending draft tracker for question-change flushes. Both the state-
-  // driven autosave effect AND scheduleDraftAutosave populate this when
-  // they schedule a write; a watcher on `currentQuestion?.id` calls
-  // `write()` synchronously when the question advances, flushing the
-  // outgoing question's last edit before the new question's autosave
-  // path clobbers the shared timer slot.
+  // Pending draft tracker for question-change flushes. The state-driven
+  // autosave effect populates this when it schedules a write; a watcher
+  // on `currentQuestion?.id` calls `write()` synchronously when the
+  // question advances, flushing the outgoing question's last edit before
+  // the new question's autosave path clobbers the shared timer slot.
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-  // Live serialized answer for Matching/Ordering, written by the child
-  // StructuredQuestionInput on every drag/tap so timer auto-submit can
-  // capture partial placements instead of submitting the empty string.
-  const structuredAnswerRef = useRef<string>('');
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
     selectedAnswerRef.current = selectedAnswer;
-    fibAnswerRef.current = fibAnswer;
-    draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
-    writtenAnswerRef.current = writtenAnswer;
     myResponseStatusRef.current = myResponse?.status;
-  }, [
-    currentQuestion,
-    selectedAnswer,
-    fibAnswer,
-    draftMcAnswer,
-    onAnswer,
-    writtenAnswer,
-    myResponse?.status,
-  ]);
-
-  // Reset the structured answer ref when the question changes so a stale
-  // answer from a previous question can't leak into auto-submit.
-  const [prevStructuredQuestionId, setPrevStructuredQuestionId] = useState(
-    currentQuestion?.id ?? null
-  );
-  if ((currentQuestion?.id ?? null) !== prevStructuredQuestionId) {
-    setPrevStructuredQuestionId(currentQuestion?.id ?? null);
-    structuredAnswerRef.current = '';
-  }
+  }, [currentQuestion, selectedAnswer, onAnswer, myResponse?.status]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -1267,18 +1243,15 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the type-appropriate live ref so a half-completed
-    // matching/ordering answer is preserved on timeout instead of
-    // submitting the empty string.
+    // Pull from the cache so a half-finished value (typed essay,
+    // partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. selectedAnswerRef is a fallback
+    // for the rare case where the student submitted, didn't touch
+    // the cache afterward, and the timer expired.
     const answer =
-      question.type === 'Matching' || question.type === 'Ordering'
-        ? structuredAnswerRef.current
-        : question.type === 'short' || question.type === 'essay'
-          ? writtenAnswerRef.current
-          : (selectedAnswerRef.current ??
-            draftMcAnswerRef.current ??
-            fibAnswerRef.current ??
-            '');
+      answerCacheRef.current[autoSubmitTriggeredFor] ??
+      selectedAnswerRef.current ??
+      '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1290,58 +1263,50 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
-  // Per-question draft autosave for every answer type. Originally
-  // written-response-only — MC/FIB/Matching/Ordering used to only write
-  // on explicit Submit, so a tab close mid-attempt silently dropped the
-  // student's answers (the bug the user reported as "sporadic data
-  // loss"). The 500 ms debounce mirrors the PLC notes editor pattern;
-  // Submit/advance still writes the final state, so the debounce is
-  // purely a write-rate optimization.
-  //
-  // Matching/Ordering live in `structuredAnswerRef` (a ref so drag-and-
-  // drop doesn't re-render this whole component on every move), so they
-  // schedule their own autosave from the StructuredQuestionInput's
-  // `onAnswerChange` callback via `scheduleDraftAutosave` below. This
-  // effect covers the state-driven types (MC, FIB, short, essay).
+  // Per-question draft autosave driven by the live answer cache. The
+  // cache is the only source of truth for in-progress values, so this
+  // single effect now covers every answer type — MC, FIB, short,
+  // essay, matching, ordering. 500 ms debounce coalesces rapid edits.
+  // Explicit Submit / submit-and-advance write the final state through
+  // their own paths; the debounce is purely a write-rate optimization
+  // and a tab-close safety net.
+  const currentQid = currentQuestion?.id;
+  const cachedDraft =
+    currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
+  // Render-time live answer for editors and inputs. Falls back to the
+  // Firestore saved value on the single render between question
+  // navigation and the cache-miss-fill block populating the cache, so
+  // controlled inputs (MC highlight, FIB value, structured initial
+  // seed) never flicker through an empty state when a saved value is
+  // available. `cachedDraft` (cache-only) is what drives autosave —
+  // they intentionally differ here.
+  const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Convenience cache writer for the editor / input onChange handlers.
+  // Updates the cache for the current question; no-ops if there's no
+  // current question (impossible in practice during render of an
+  // answer slot, but keeps the type signature honest).
+  const setCacheForCurrent = (value: string): void => {
+    if (!currentQid) return;
+    setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+  };
   useEffect(() => {
-    const qid = currentQuestion?.id;
+    const qid = currentQid;
     const type = currentQuestion?.type;
     if (!qid || !type) return;
     if (submitted) return;
+    // Cache miss — student hasn't touched this question this session
+    // and there's no saved value either. Nothing to write.
+    if (cachedDraft === null) return;
+    // Saved-equal short-circuit: don't write what's already on the
+    // server. Handles the "lazy-fill seeded cache from saved value"
+    // case (cache and saved are identical → no-op), the "deliberate
+    // re-type to identical text" case (also no-op), and crucially
+    // does NOT short-circuit a deliberate clear (saved=text, draft=''
+    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
+    // case from there).
+    if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
 
-    let draft: string | null = null;
-    if (type === 'short' || type === 'essay') {
-      // Race guard: if `currentQuestion.id` has advanced (student-paced
-      // submit-and-advance) but `hydrateAnswerControls` hasn't yet
-      // replaced `writtenAnswer` with the new question's saved value,
-      // the draft we see here is still from the previous question.
-      // Refuse to write — the next render after hydration will
-      // re-evaluate with the correct draft.
-      if (writtenAnswerQuestionIdRef.current !== qid) return;
-      draft = writtenAnswer;
-    } else if (type === 'MC') {
-      draft = draftMcAnswer;
-    } else if (type === 'FIB') {
-      draft = fibAnswer;
-    } else {
-      // Matching/Ordering autosave via scheduleDraftAutosave from the
-      // structured input's onAnswerChange; not driven by this effect.
-      return;
-    }
-
-    if (draft === null) return;
-    // Skip the initial-hydration call: if the seeded value matches what
-    // was already saved, there's nothing to write. This also handles
-    // the "FIB: empty draft + no prior save" case (both sides reduce
-    // to '') without short-circuiting on empty draft alone — which
-    // would have silently dropped a deliberate clear of a previously-
-    // saved FIB answer.
-    if (draft === (savedAnswerForCurrent ?? '')) return;
-
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const snapshot = draft;
+    const snapshot = cachedDraft;
     const capturedQid = qid;
     const writeNow = () => {
       void onAnswerRef
@@ -1351,31 +1316,29 @@ const ActiveQuiz: React.FC<{
             questionId: capturedQid,
             questionType: type,
           });
-          // Surface autosave failures to the student. The new
-          // `lastWriteAt == request.time` Firestore rule (response
-          // UPDATE predicate) rejects writes from clients with stale
-          // auth tokens or session state, AND any other transient
-          // failure (offline, quota) lands here too. Without this
-          // setter the student silently loses every keystroke for up
-          // to 90 min until the idle-finalize cron sweeps them with
-          // whatever last successfully persisted. The existing
-          // SaveErrorBanner + "Retry Submit" button repurposing
-          // already handles the recovery affordance.
+          // Surface autosave failures to the student. The
+          // `lastWriteAt == request.time` Firestore rule rejects
+          // writes from clients with stale auth tokens / session
+          // state, and other transient failures (offline, quota)
+          // land here too. Without this setter the student silently
+          // loses keystrokes until the idle-finalize cron sweeps
+          // their last successfully persisted value.
           setSaveError("Couldn't save your answer. Tap to try again.");
         });
     };
+
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
     draftAutosaveTimer.current = setTimeout(writeNow, 500);
     pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
-      // Only clear the timer here. We CAN'T flush from this cleanup
-      // even when the question has advanced: React commits cleanups
-      // BEFORE the ref-sync effect at L1205 updates
-      // `currentQuestionRef.current` to the new id, so any condition
-      // like `currentQuestionRef.current?.id !== capturedQid` would
-      // always read stale (equal) refs and never fire. The actual
-      // flush-on-advance happens in the question-change watcher at
-      // L1418, which runs AFTER the ref-sync. handleSubmit /
+      // Only clear the timer here. We can't flush from this cleanup
+      // when the question has advanced — React runs cleanups BEFORE
+      // the ref-sync effect updates `currentQuestionRef.current`. The
+      // flush-on-advance happens in the question-change watcher
+      // below, which runs after the ref-sync. handleSubmit /
       // handleSubmitAndAdvance / the timer-expiry auto-submit effect
       // all explicitly null `pendingDraftRef.current` so the watcher
       // skips already-submitted answers.
@@ -1385,59 +1348,12 @@ const ActiveQuiz: React.FC<{
       }
     };
   }, [
-    writtenAnswer,
-    draftMcAnswer,
-    fibAnswer,
-    currentQuestion?.id,
+    cachedDraft,
+    currentQid,
     currentQuestion?.type,
     submitted,
     savedAnswerForCurrent,
   ]);
-
-  // Imperative draft autosave for ref-driven types (Matching/Ordering)
-  // whose value updates don't flow through React state. Called from the
-  // child StructuredQuestionInput's `onAnswerChange` on every drag/drop
-  // so the same 500 ms debounce window coalesces rapid placements.
-  const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
-    if (myResponseStatusRef.current === 'completed') return;
-    // Per-question guard: don't downgrade an already-submitted answer
-    // back to draft. Back-navigation in student-paced mode can land on
-    // a previously-submitted Matching/Ordering question; if
-    // StructuredQuestionInput's mount effect (or a stray drag) calls
-    // onAnswerChange, the resulting draft write would silently
-    // un-submit the question and drop it from the teacher's results.
-    if (submittedRef.current) return;
-    // Saved-equal guard: StructuredQuestionInput's mount effect re-emits
-    // the saved answer on every remount. Without this short-circuit
-    // each question advance triggers a redundant 500ms-debounced write
-    // (cost) AND overwrites pendingDraftRef.qid to the new question
-    // before the question-change watcher can flush the outgoing
-    // question's still-pending draft — silently dropping it. Mirrors
-    // the state-driven effect's `draft === savedAnswerForCurrent`
-    // short-circuit.
-    if (answer === (savedAnswerForCurrentRef.current ?? '')) return;
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const writeNow = () => {
-      void onAnswerRef
-        .current(qid, answer, undefined, { isDraft: true })
-        .catch((err: unknown) => {
-          logError('QuizStudentApp.draftAutosave', err, {
-            questionId: qid,
-            questionType: 'structured',
-          });
-          // Same rationale as the state-driven autosave path above:
-          // surface autosave failures so the student isn't silently
-          // losing Matching/Ordering placements when Firestore rejects
-          // (rule denial, expired auth, offline) until the idle-finalize
-          // cron picks them up 90 min later.
-          setSaveError("Couldn't save your answer. Tap to try again.");
-        });
-    };
-    draftAutosaveTimer.current = setTimeout(writeNow, 500);
-    pendingDraftRef.current = { qid, write: writeNow };
-  }, []);
 
   // Question-change watcher: if a draft is pending for the OUTGOING
   // question when the user advances, flush it synchronously before
@@ -1482,32 +1398,18 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      let draft: string | null = null;
-      switch (type) {
-        case 'short':
-        case 'essay':
-          draft = writtenAnswerRef.current;
-          break;
-        case 'MC':
-          draft = draftMcAnswerRef.current;
-          break;
-        case 'FIB':
-          draft = fibAnswerRef.current;
-          break;
-        case 'Matching':
-        case 'Ordering':
-          draft = structuredAnswerRef.current;
-          break;
-        default:
-          return;
-      }
-      if (draft === null) return;
-      // Use the ref-synced live value rather than the closure-captured
-      // `savedAnswerForCurrent`, which was frozen at mount because this
-      // effect has [] deps. The saved-equal check handles the "never
-      // typed" empty case (saved null, draft '') without short-
-      // circuiting on empty draft alone — which would have silently
-      // dropped a deliberate clear of a previously-saved FIB answer.
+      // Read the live value from the cache. A `null` here means the
+      // student never touched this question in the current session,
+      // so there's nothing to flush.
+      const cacheValue = answerCacheRef.current[qid];
+      if (cacheValue === undefined) return;
+      const draft = cacheValue;
+      // Saved-equal short-circuit. Uses the ref-synced saved value so
+      // the [] deps don't freeze the closure. Handles the "never typed"
+      // empty case (saved null, draft '') without short-circuiting on
+      // empty draft alone — a deliberate clear of a previously-saved
+      // answer is allowed through; the #1 guard in submitAnswer
+      // refuses the unsafe blank-over-non-blank case from there.
       if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
@@ -1959,12 +1861,15 @@ const ActiveQuiz: React.FC<{
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
-              // Self-paced revisits stay editable, so we use the draft styling
-              // (and `draftMcAnswer` highlight) even when `submitted=true`.
+              // Self-paced revisits stay editable, so the highlight tracks
+              // the live cache value (which is what the student last
+              // clicked). When locked, fall back to the post-submit
+              // `selectedAnswer` indicator — equal to the cache value in
+              // practice but kept explicit for clarity.
               const isLocked = submitted && !isStudentPaced;
               const isSelected = isLocked
                 ? selectedAnswer === opt
-                : draftMcAnswer === opt;
+                : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
               if (!isLocked) {
@@ -1979,7 +1884,7 @@ const ActiveQuiz: React.FC<{
               return (
                 <button
                   key={opt}
-                  onClick={() => !isLocked && setDraftMcAnswer(opt)}
+                  onClick={() => !isLocked && setCacheForCurrent(opt)}
                   disabled={isLocked || submitting}
                   className={cls}
                 >
@@ -2014,10 +1919,9 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        draftMcAnswer &&
-                        void handleSubmitAndAdvance(draftMcAnswer)
+                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
                       }
-                      disabled={!draftMcAnswer || submitting}
+                      disabled={!liveAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2038,10 +1942,8 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    draftMcAnswer && void handleSubmit(draftMcAnswer)
-                  }
-                  disabled={!draftMcAnswer || submitting}
+                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
+                  disabled={!liveAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2077,14 +1979,14 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-4 flex-1">
             <input
               type="text"
-              value={fibAnswer}
-              onChange={(e) => setFibAnswer(e.target.value)}
+              value={liveAnswer ?? ''}
+              onChange={(e) => setCacheForCurrent(e.target.value)}
               disabled={submitted && !isStudentPaced}
               placeholder="Type your answer…"
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = fibAnswer.trim();
+                const trimmed = (liveAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2115,10 +2017,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        fibAnswer.trim() &&
-                        void handleSubmitAndAdvance(fibAnswer.trim())
+                        (liveAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
                       }
-                      disabled={!fibAnswer.trim() || submitting}
+                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2140,9 +2042,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    fibAnswer.trim() && void handleSubmit(fibAnswer.trim())
+                    (liveAnswer ?? '').trim() &&
+                    void handleSubmit((liveAnswer ?? '').trim())
                   }
-                  disabled={!fibAnswer.trim() || submitting}
+                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2181,14 +2084,13 @@ const ActiveQuiz: React.FC<{
             question={currentQuestion}
             submitted={submitted}
             isAutoSubmitted={autoSubmitTriggeredFor === currentQuestion.id}
-            savedAnswer={savedAnswerForCurrent}
+            savedAnswer={liveAnswer}
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
-              structuredAnswerRef.current = answer;
-              // Persist the placement as a draft so a tab close before
-              // Submit doesn't lose the student's in-progress pairings.
-              scheduleDraftAutosave(currentQuestion.id, answer);
+              // Push the live placement into the cache; the autosave
+              // effect picks it up and debounces the Firestore write.
+              setCacheForCurrent(answer);
             }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
@@ -2210,14 +2112,8 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 questionKey={currentQuestion.id}
-                value={writtenAnswer}
-                onChange={(html) => {
-                  setWrittenAnswer(html);
-                  writtenAnswerRef.current = html;
-                  // Mark the draft as belonging to this question so the
-                  // autosave race guard lets it through.
-                  writtenAnswerQuestionIdRef.current = currentQuestion.id;
-                }}
+                value={liveAnswer ?? ''}
+                onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}
                 maxWords={currentQuestion.maxWords}
                 disabled={submitted && !isStudentPaced}
@@ -2238,7 +2134,9 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() => void handleSubmitAndAdvance(writtenAnswer)}
+                      onClick={() =>
+                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                      }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
@@ -2260,7 +2158,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(writtenAnswer)}
+                  onClick={() => void handleSubmit(liveAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1299,12 +1299,21 @@ const ActiveQuiz: React.FC<{
     if (cachedDraft === null) return;
     // Saved-equal short-circuit: don't write what's already on the
     // server. Handles the "lazy-fill seeded cache from saved value"
-    // case (cache and saved are identical → no-op), the "deliberate
-    // re-type to identical text" case (also no-op), and crucially
-    // does NOT short-circuit a deliberate clear (saved=text, draft=''
-    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
-    // case from there).
+    // case (cache and saved are identical → no-op) and the
+    // "deliberate re-type to identical text" case.
     if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
+    // Deliberate-clear short-circuit: the student cleared a previously-
+    // saved answer. The hook's `isUnsafeBlankDraft` guard would refuse
+    // the write silently, so detect the condition here and surface a
+    // hint to the student instead of queuing a doomed timer. Submit
+    // with the explicit Submit/Next button still bypasses the guard
+    // and lets them persist an empty answer if that's really intended.
+    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
+      setSaveError(
+        'Your previously-saved answer is still on file. Click Submit to clear it.'
+      );
+      return;
+    }
 
     const snapshot = cachedDraft;
     const capturedQid = qid;
@@ -1476,8 +1485,17 @@ const ActiveQuiz: React.FC<{
       session.showResultToStudent &&
       answerFeedback === null
     ) {
+      // Read order: selectedAnswer (post-explicit-submit) → cache (timer
+      // auto-submit landed but the response listener hasn't echoed yet)
+      // → Firestore answers as the final fallback. Without the cache
+      // hop, an auto-submitted answer compared against a stale
+      // myResponse can produce a false-incorrect on a correct
+      // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
+        (currentQuestion?.id
+          ? answerCacheRef.current[currentQuestion.id]
+          : undefined) ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1862,13 +1880,15 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
               // Self-paced revisits stay editable, so the highlight tracks
-              // the live cache value (which is what the student last
-              // clicked). When locked, fall back to the post-submit
-              // `selectedAnswer` indicator — equal to the cache value in
-              // practice but kept explicit for clarity.
+              // the live cache value. When locked, fall back to the
+              // post-submit `selectedAnswer` indicator; timer auto-submit
+              // never sets selectedAnswer, so degrade to liveAnswer so the
+              // student can still see which option was submitted from
+              // their cached pick.
               const isLocked = submitted && !isStudentPaced;
+              const lockedRef = selectedAnswer ?? liveAnswer;
               const isSelected = isLocked
-                ? selectedAnswer === opt
+                ? lockedRef === opt
                 : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
@@ -2111,7 +2131,19 @@ const ActiveQuiz: React.FC<{
               }
             >
               <WrittenResponseEditor
-                questionKey={currentQuestion.id}
+                // The editor seeds its `innerHTML` once on mount (caret
+                // preservation), so we encode the "cache has been
+                // seeded" boolean in the questionKey. A page refresh
+                // mid-essay first mounts with value='' (cache empty,
+                // saved null); when the Firestore snapshot arrives the
+                // cache-miss-fill block populates the cache, the key
+                // flips from `…:init` → `…:seeded`, and the editor
+                // remounts with the recovered text. Without this, the
+                // student stares at a blank editor while React state
+                // already holds the recovered value.
+                questionKey={`${currentQuestion.id}:${
+                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2304,6 +2304,44 @@ service cloud.firestore {
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
+
+        // Append-only snapshot log of overwritten answers. Each entry
+        // captures a prior `answers[i]` value the moment before it gets
+        // replaced in the parent response doc — see `submitAnswer` in
+        // `useQuizSession.ts`. Used to recover student text lost to a
+        // race (stray blank draft after a hydration miss) or to a
+        // student retyping over their own work after a lockout. Writes
+        // are throttled per-question on the client; the rule still
+        // pins the doc shape so a hostile authenticated user can't
+        // dump arbitrary data into the subcollection.
+        match /history/{historyId} {
+          function parentStudentUid() {
+            return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)/responses/$(responseKey)).data.studentUid;
+          }
+          // Read: teacher, admin, or the owning student.
+          allow read: if request.auth != null && (
+            isAdmin() ||
+            request.auth.uid == sessionTeacherUid() ||
+            request.auth.uid == parentStudentUid()
+          );
+          // Create: only the owning student of the parent response.
+          // Field shape is strict so a malicious caller can't smuggle
+          // fields; `snapshotAt == request.time` forces server stamping.
+          allow create: if request.auth != null &&
+            request.auth.uid == parentStudentUid() &&
+            request.resource.data.keys().hasOnly(
+              ['questionId', 'answer', 'answeredAt', 'status', 'snapshotAt']
+            ) &&
+            request.resource.data.questionId is string &&
+            request.resource.data.answer is string &&
+            request.resource.data.answeredAt is number &&
+            request.resource.data.status in ['draft', 'submitted'] &&
+            request.resource.data.snapshotAt == request.time;
+          // Immutable from clients. Teachers/admins may clean up.
+          allow update: if false;
+          allow delete: if request.auth != null &&
+            (request.auth.uid == sessionTeacherUid() || isAdmin());
+        }
       }
 
       // Archived responses — copies of student responses that the teacher

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -126,22 +126,45 @@ export function isUnsafeBlankDraft(
 }
 
 /**
+ * Defensive predicate: refuse a draft autosave that would downgrade an
+ * already-submitted answer's status to 'draft'. The cache-driven
+ * autosave path can re-fire for the same question during the SSO
+ * listener-fast race window (back-nav before the response listener
+ * echoes the just-submitted answer back, so the local `submitted` state
+ * briefly flips false), and without this guard the autosave silently
+ * flips status 'submitted' → 'draft' and drops the question from the
+ * teacher's "Finished" view. Explicit submits (`isDraft=false`) still
+ * pass through.
+ */
+export function isUnsafeStatusDowngrade(
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && priorEntry?.status === 'submitted';
+}
+
+/**
  * Decide whether to snapshot the prior answer entry to the history
- * subcollection before overwriting. Only meaningful prior values
- * (non-empty and different from the incoming value) are worth
- * snapshotting, and the per-question throttle keeps a long essay from
- * fanning out to hundreds of near-identical docs.
+ * subcollection before overwriting. Captures any prior non-empty value
+ * the incoming write is about to lose — either because the text
+ * changed, or because the status is being destructively downgraded
+ * from 'submitted' to 'draft' (which can erase grading state even
+ * with identical text). The per-question throttle keeps a long essay
+ * from fanning out to hundreds of near-identical docs.
  */
 export function shouldSnapshotHistory(
   priorEntry: QuizResponseAnswer | undefined,
   newAnswer: string,
+  newIsDraft: boolean,
   lastSnapshotAt: number,
   now: number,
   throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
 ): boolean {
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
-  if (priorEntry.answer === newAnswer) return false;
+  const textChanged = priorEntry.answer !== newAnswer;
+  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }
 
@@ -1342,6 +1365,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     ): Promise<string> => {
       setLoading(true);
       setError(null);
+      // Clear per-question history throttle on every join. The same hook
+      // instance survives a teacher unlock / attempt-cap rejoin, so a
+      // stale `lastSnapshotAt` from the prior attempt would suppress
+      // legitimate snapshots in the new one.
+      lastHistorySnapshotAtRef.current.clear();
       try {
         const normCode = code
           .trim()
@@ -1982,6 +2010,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
         return;
       }
+      // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
+      // Stops the back-nav listener-lag race from silently flipping a
+      // 'submitted' answer back to 'draft' status.
+      if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
+        return;
+      }
 
       const newAnswer: QuizResponseAnswer = {
         questionId,
@@ -2040,10 +2074,15 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       const now = Date.now();
       const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
       if (
-        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        ) &&
         priorEntry
       ) {
-        lastHistorySnapshotAtRef.current.set(questionId, now);
         void addDoc(
           collection(
             db,
@@ -2060,9 +2099,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             status: priorEntry.status ?? 'submitted',
             snapshotAt: serverTimestamp(),
           }
-        ).catch(() => {
-          // Safety-net write; nothing actionable on failure.
-        });
+        )
+          .then(() => {
+            // Only consume the throttle slot for snapshots that actually
+            // landed. A failed write (offline, rule denial, quota) used
+            // to bump `now` regardless, suppressing the next legitimate
+            // snapshot for the throttle window even though no recovery
+            // doc had been written.
+            lastHistorySnapshotAtRef.current.set(questionId, now);
+          })
+          .catch(() => {
+            // Safety-net write; nothing actionable on failure.
+          });
       }
     },
     []

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -19,6 +19,7 @@ import {
   collection,
   onSnapshot,
   setDoc,
+  addDoc,
   updateDoc,
   getDocs,
   getDoc,
@@ -65,6 +66,25 @@ export const RESPONSES_COLLECTION = 'responses';
  */
 export const ARCHIVED_RESPONSES_COLLECTION = 'archived_responses';
 /**
+ * Append-only per-response snapshot log. Each entry captures the prior
+ * value of a question's answer just before it gets overwritten in the
+ * `responses/{rid}.answers` array, so a teacher (or admin) can recover
+ * text that was lost to a race, a stray empty draft, or a student who
+ * retyped over their own work. Writes are fire-and-forget and throttled
+ * per-question (see `HISTORY_SNAPSHOT_THROTTLE_MS`) to keep storage and
+ * write costs bounded — typical essay quiz has a low double-digit
+ * count per student.
+ */
+export const RESPONSE_HISTORY_COLLECTION = 'history';
+/**
+ * Minimum interval between history snapshots for the same questionId on
+ * the same response. The autosave debounce is 500 ms; without throttling
+ * a long essay would fan out to hundreds of near-identical history docs.
+ * 5 s gives "enough resolution to recover meaningful state" without
+ * making history a per-keystroke audit log.
+ */
+const HISTORY_SNAPSHOT_THROTTLE_MS = 5000;
+/**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
  * and accumulates a student's completed-attempt count across every session
  * the teacher creates for the same quiz. Without this collection, the
@@ -88,6 +108,42 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Defensive predicate: refuse a draft autosave that would overwrite a
+ * non-empty saved answer with the empty string. Almost always indicates
+ * a race (editor briefly emitted '' after a remount or a hydration miss)
+ * rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * bypass this — a student who really wants to clear an answer can still
+ * submit empty.
+ */
+export function isUnsafeBlankDraft(
+  answer: string,
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
+}
+
+/**
+ * Decide whether to snapshot the prior answer entry to the history
+ * subcollection before overwriting. Only meaningful prior values
+ * (non-empty and different from the incoming value) are worth
+ * snapshotting, and the per-question throttle keeps a long essay from
+ * fanning out to hundreds of near-identical docs.
+ */
+export function shouldSnapshotHistory(
+  priorEntry: QuizResponseAnswer | undefined,
+  newAnswer: string,
+  lastSnapshotAt: number,
+  now: number,
+  throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
+): boolean {
+  if (!priorEntry) return false;
+  if (priorEntry.answer === '') return false;
+  if (priorEntry.answer === newAnswer) return false;
+  return now - lastSnapshotAt >= throttleMs;
+}
 
 /** Unbiased Fisher-Yates in-place shuffle (returns new array) */
 function fisherYatesShuffle<T>(arr: T[]): T[] {
@@ -1132,6 +1188,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
 
+  // Per-questionId timestamp of the most recent history snapshot write.
+  // Used to throttle snapshots — see HISTORY_SNAPSHOT_THROTTLE_MS.
+  const lastHistorySnapshotAtRef = useRef<Map<string, number>>(new Map());
+
   // Optimistic local counter state to ensure UI updates immediately.
   // warningCountRef mirrors the state so reportTabSwitch can return the
   // updated value synchronously (React functional updaters run on the next
@@ -1912,6 +1972,17 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // only) from an explicit submit. The student's `alreadyAnswered` gate
       // checks for `'submitted'` so a draft autosave doesn't masquerade as
       // a final answer and prematurely fire the completion card.
+      const existingAnswers = myResponseRef.current?.answers ?? [];
+      const priorEntry = existingAnswers.find(
+        (a) => a.questionId === questionId
+      );
+
+      // #1 guard — see `isUnsafeBlankDraft` doc. Refuses a draft autosave
+      // that would silently clobber a non-empty saved answer with ''.
+      if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
+        return;
+      }
+
       const newAnswer: QuizResponseAnswer = {
         questionId,
         answer,
@@ -1922,7 +1993,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           : {}),
       };
 
-      const existingAnswers = myResponseRef.current?.answers ?? [];
       const updated = [
         ...existingAnswers.filter((a) => a.questionId !== questionId),
         newAnswer,
@@ -1962,6 +2032,38 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
+
+      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
+      // safety net so a value that turns out to be a regression (stray
+      // blank draft that the #1 guard didn't catch, or a student
+      // retyping after a lockout) can still be recovered.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      if (
+        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        priorEntry
+      ) {
+        lastHistorySnapshotAtRef.current.set(questionId, now);
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            answeredAt: priorEntry.answeredAt,
+            status: priorEntry.status ?? 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        ).catch(() => {
+          // Safety-net write; nothing actionable on failure.
+        });
+      }
     },
     []
   );

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -766,4 +766,158 @@ describe('QuizStudentApp — in-memory answer cache', () => {
       'border-violet-500'
     );
   });
+
+  it('does not write a stale lazy-fill seed over a newer snapshot value (untouched question)', async () => {
+    // Issue #1 regression. The student never touches q1 this session — its
+    // value comes purely from the server. The saved answer is a DRAFT so
+    // `submitted` stays false and the autosave path stays armed (a plain
+    // submit short-circuits it). The cache seeds from the first snapshot,
+    // then a later snapshot (teacher resync of a shared assignment, listener
+    // catch-up) moves the saved value to a NEWER one — still with no local
+    // edit. Pre-fix the cache kept the first seed ('4') while saved moved to
+    // '5', and the autosave diffed the two and wrote the stale '4' back over
+    // the server's '5'. The seed must track the freshest saved value.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      mockSubmitAnswer.mockImplementation(async () => {});
+      hookState.myResponse = buildResponse({
+        answers: [
+          {
+            questionId: 'q1',
+            answer: '4',
+            answeredAt: Date.now(),
+            status: 'draft',
+          },
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // A newer snapshot for the SAME untouched question.
+      act(() => {
+        hookState.myResponse = buildResponse({
+          answers: [
+            {
+              questionId: 'q1',
+              answer: '5',
+              answeredAt: Date.now() + 1,
+              status: 'draft',
+            },
+          ],
+        });
+        triggerRefresh();
+      });
+
+      // Drain the 500 ms autosave debounce.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+
+      // The newer value won the cache — '5' carries the editable draft
+      // highlight, not the stale '4'.
+      expect(screen.getByRole('button', { name: '5' }).className).toContain(
+        'border-violet-500'
+      );
+      // And the stale '4' was never autosaved back over the server's '5'.
+      expect(mockSubmitAnswer).not.toHaveBeenCalledWith('q1', '4', undefined, {
+        isDraft: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('back-nav to a saved Matching question keeps it seed-tracked (no stale draft write after a resync)', async () => {
+    // Issue #2 regression. StructuredQuestionInput remounts per question and
+    // its mount effect re-emits the seeded answer through onAnswerChange. If
+    // that no-op re-emit reached setCacheForCurrent it would mark the
+    // never-edited question touched, freezing out the seed-from-server
+    // refresh — so a later resync to a newer saved value would be ignored
+    // and the autosave would write the stale draft back over it. The guard
+    // skips the re-emit, keeping the question untouched and seed-tracked.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const matching: QuizPublicQuestion = {
+        id: 'qm',
+        type: 'Matching',
+        text: 'Match the capitals',
+        timeLimit: 0,
+        matchingLeft: ['France', 'Germany'],
+        matchingRight: ['Paris', 'Berlin'],
+      };
+      hookState.session = buildSession({
+        publicQuestions: [QUESTIONS[0], matching],
+        totalQuestions: 2,
+      });
+      // Matching answer saved as a DRAFT so `submitted` stays false (autosave
+      // armed) and the question renders its editable form, not the
+      // post-submit placeholder.
+      hookState.myResponse = buildResponse({
+        answers: [
+          {
+            questionId: 'qm',
+            answer: 'France:Paris|Germany:Berlin',
+            answeredAt: Date.now(),
+            status: 'draft',
+          },
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // Forward to the Matching question (submitting q1 on the way).
+      await user.click(screen.getByRole('button', { name: '4' }));
+      await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+      expect(
+        await screen.findByText(/Match the capitals/i)
+      ).toBeInTheDocument();
+
+      // Back to q1, then forward again — the second arrival is the remount
+      // that re-fires StructuredQuestionInput's mount-only re-emit.
+      await user.click(
+        screen.getByRole('button', { name: /Previous question/i })
+      );
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+      expect(
+        await screen.findByText(/Match the capitals/i)
+      ).toBeInTheDocument();
+
+      // Teacher resync moves the saved draft to a NEWER arrangement while the
+      // student still hasn't touched the question.
+      act(() => {
+        hookState.myResponse = buildResponse({
+          answers: [
+            { questionId: 'q1', answer: '4', answeredAt: Date.now() },
+            {
+              questionId: 'qm',
+              answer: 'France:Paris|Germany:Madrid',
+              answeredAt: Date.now() + 1,
+              status: 'draft',
+            },
+          ],
+        });
+        triggerRefresh();
+      });
+
+      // Drain the autosave debounce.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+
+      // The stale 'Berlin' arrangement must never be autosaved back over the
+      // server's newer 'Madrid'.
+      expect(mockSubmitAnswer).not.toHaveBeenCalledWith(
+        'qm',
+        'France:Paris|Germany:Berlin',
+        undefined,
+        { isDraft: true }
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -691,3 +691,79 @@ describe('QuizStudentApp — self-paced flow', () => {
     );
   });
 });
+
+// ─── In-memory answer cache (#2 fix) ──────────────────────────────────────────
+//
+// The cache makes question navigation read from local state instead of
+// re-fetching from the Firestore snapshot. These tests cover the two
+// scenarios where the prior hydration-on-every-question-change design
+// could (and did) lose student work in production:
+//   - Next → Back when the response listener hadn't echoed the just-
+//     submitted answer back yet.
+//   - A late-arriving snapshot for the current question (teacher resume,
+//     SSO listener-fast race) seeding a blank that overwrites local edits.
+
+describe('QuizStudentApp — in-memory answer cache', () => {
+  it('preserves the locally-selected MC option across Next → Back even when Firestore never echoes the submit', async () => {
+    // Drop the default `appendAnswer` side-effect so the answer is never
+    // visible via `myResponse`. The cache is then the ONLY thing
+    // remembering which option the student picked — exactly the pre-fix
+    // race scenario where the snapshot listener fell behind.
+    mockSubmitAnswer.mockImplementation(async () => {
+      // No-op: don't update hookState, don't trigger refresh.
+    });
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Pick "4", advance to Q2.
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
+
+    // Back to Q1.
+    await user.click(
+      screen.getByRole('button', { name: /Previous question/i })
+    );
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // "4" must still be highlighted in the editable draft style. Before
+    // the cache fix this would have come back blank because
+    // savedAnswerForCurrent was null and hydrate seeded the editor with
+    // an empty value.
+    const choice = screen.getByRole('button', { name: '4' });
+    expect(choice.className).toContain('border-violet-500');
+  });
+
+  it('does not clobber a locally-selected option when a snapshot with empty answers fires after the click', async () => {
+    // Simulates the "teacher resume" / late-snapshot race: the student
+    // clicks an option, then a Firestore snapshot arrives for the SAME
+    // question with no saved answer. Pre-fix the editor was reset to
+    // the saved value via hydrateAnswerControls and the student saw
+    // their selection vanish. Post-fix the cache wins because it
+    // already has a value for this question.
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+
+    // Fire a snapshot for an empty response — the kind of state the
+    // listener briefly returns after a teacher unlock or a slow round
+    // trip.
+    act(() => {
+      hookState.myResponse = buildResponse({ answers: [] });
+      triggerRefresh();
+    });
+
+    // Selection must still be intact.
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+  });
+});

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -8,6 +8,7 @@ import {
   useQuizSessionStudent,
   useQuizSessionTeacher,
   isUnsafeBlankDraft,
+  isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
@@ -520,6 +521,42 @@ describe('isUnsafeBlankDraft (#1 guard)', () => {
   });
 });
 
+describe('isUnsafeStatusDowngrade (review fix)', () => {
+  const submittedPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const draftPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'work in progress',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave when the prior entry was status=submitted', () => {
+    // The back-nav listener-lag race: cache holds the just-submitted value,
+    // `submitted` state briefly flips false, and the autosave would otherwise
+    // rewrite the entry as a draft.
+    expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('allows a draft autosave when the prior entry was already a draft', () => {
+    expect(isUnsafeStatusDowngrade(true, draftPrior)).toBe(false);
+  });
+
+  it('allows a draft autosave when no prior entry exists', () => {
+    expect(isUnsafeStatusDowngrade(true, undefined)).toBe(false);
+  });
+
+  it('allows an explicit submit even over a previously-submitted entry', () => {
+    // A real student-paced re-submit must always pass — the gate only
+    // applies to background draft writes.
+    expect(isUnsafeStatusDowngrade(false, submittedPrior)).toBe(false);
+  });
+});
+
 describe('shouldSnapshotHistory (#5 throttle)', () => {
   const priorWithText: QuizResponseAnswer = {
     questionId: 'q1',
@@ -527,18 +564,31 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  const priorSubmitted: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
   const THROTTLE = 5000;
 
   it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        0,
+        6000,
+        THROTTLE
+      )
     ).toBe(true);
   });
 
   it('skips when no prior entry exists', () => {
     // First write for this question — nothing to snapshot.
     expect(
-      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(undefined, 'first text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
@@ -550,22 +600,52 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       status: 'draft',
     };
     expect(
-      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(priorEmpty, 'new text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
-  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+  it('skips when the new value matches the prior text AND the status is not being downgraded', () => {
     // Autosaves can fire with no actual content change in some races;
-    // a snapshot would be wasteful and noise the recovery log.
+    // a snapshot would be wasteful when both text and status are unchanged.
     expect(
-      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'first draft',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
     ).toBe(false);
+  });
+
+  it('captures a snapshot on a status downgrade even with identical text', () => {
+    // The back-nav race silently writes the same text back as a draft over
+    // a previously-submitted entry — the 'submitted' fact is being destroyed
+    // and must be recoverable.
+    expect(
+      shouldSnapshotHistory(
+        priorSubmitted,
+        'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
   });
 
   it('throttles back-to-back snapshots inside the window', () => {
     // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        4000,
+        5000,
+        THROTTLE
+      )
     ).toBe(false);
   });
 });

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,11 +7,14 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  isUnsafeBlankDraft,
+  shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
   QuizQuestion,
   QuizResponse,
+  QuizResponseAnswer,
   QuizSession,
   QuizPublicQuestion,
 } from '@/types';
@@ -466,6 +469,104 @@ describe('toPublicQuestion', () => {
     expect(pub).not.toHaveProperty('correctAnswer');
     expect(pub.id).toBe('q4');
     expect(pub.type).toBe('FIB');
+  });
+});
+
+// ─── Draft-write defensive predicates ─────────────────────────────────────────
+//
+// `isUnsafeBlankDraft` and `shouldSnapshotHistory` are the two guards
+// `submitAnswer` consults before writing the response doc. They are
+// extracted as pure predicates so the race / overwrite logic can be
+// tested without setting up a full Firestore mock — the hook integration
+// is covered separately by the component-level cache tests.
+
+describe('isUnsafeBlankDraft (#1 guard)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'My long essay response',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const priorEmpty: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: '',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
+    expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
+  });
+
+  it('allows a draft autosave writing "" when the prior answer was also empty', () => {
+    // Both sides reduce to '' — no data loss possible, the write is a no-op
+    // on the data dimension but still legitimate (timestamps may update).
+    expect(isUnsafeBlankDraft('', true, priorEmpty)).toBe(false);
+  });
+
+  it('allows a draft autosave writing "" when no prior entry exists', () => {
+    expect(isUnsafeBlankDraft('', true, undefined)).toBe(false);
+  });
+
+  it('allows a draft autosave writing non-empty text over a non-empty prior', () => {
+    // Normal "student kept typing" path — must not be blocked.
+    expect(isUnsafeBlankDraft('new text', true, priorWithText)).toBe(false);
+  });
+
+  it('allows an explicit (non-draft) submit of "" over a non-empty prior', () => {
+    // Student deliberately cleared and clicked Submit — only autosaves are
+    // gated; explicit intent is respected.
+    expect(isUnsafeBlankDraft('', false, priorWithText)).toBe(false);
+  });
+});
+
+describe('shouldSnapshotHistory (#5 throttle)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'first draft',
+    answeredAt: 100,
+    status: 'draft',
+  };
+  const THROTTLE = 5000;
+
+  it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+    ).toBe(true);
+  });
+
+  it('skips when no prior entry exists', () => {
+    // First write for this question — nothing to snapshot.
+    expect(
+      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the prior entry was empty', () => {
+    const priorEmpty: QuizResponseAnswer = {
+      questionId: 'q1',
+      answer: '',
+      answeredAt: 0,
+      status: 'draft',
+    };
+    expect(
+      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+    // Autosaves can fire with no actual content change in some races;
+    // a snapshot would be wasteful and noise the recovery log.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('throttles back-to-back snapshots inside the window', () => {
+    // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to #1741, which made an in-memory `answerCache` the source of truth for in-progress student quiz answers. Two bugs in that cache's lifecycle in `components/quiz/QuizStudentApp.tsx` (`ActiveQuiz`) could silently lose typed answers or pay for redundant writes.

> **Stacked on #1741.** This branch is based on `claude/wonderful-williamson-0bf1b0`, which has not yet merged into `dev-paul`. Until #1741 merges, this PR's diff against `dev-paul` will also show #1741's commits; afterward it narrows to just the two commits here.

## What

### Issue 1 — stale lazy-fill seed clobbers a newer snapshot

The cache-miss-fill seeded the cache **once** (on key-absence) and the functional updater closed over the render-time `savedAnswerForCurrent`. When a newer Firestore snapshot moved the saved value while a question was still **untouched** (a teacher syncing a shared assignment, or any listener catch-up), the cache kept the stale seed. The autosave effect then diffed the stale cache value against the newer saved value, saw them differ, and fired a draft write of the **stale** value back over the newer server answer — losing a value the student may never have seen.

**Fix:** the block now mirrors the *freshest* saved value into the cache for any question the student hasn't locally edited:

- Reads `savedAnswerForCurrentRef.current` **inside the updater** (the ref the file already keeps), so a snapshot landing between the update being scheduled and React applying it can't lock in a stale value.
- **Refreshes** (not fill-once): while a question is untouched, the cache tracks the latest saved value, so the autosave's saved-equal short-circuit always holds and never writes an outdated seed.
- A per-question `touchedQuestionsRef` set preserves the **"cache wins after the first local edit"** invariant — once edited, the seed never overwrites it.
- The outer guard (`answerCache[id] !== savedAnswerForCurrent`) keeps it a render-phase update that only fires when the cache is actually out of step (calling `setState` unconditionally during render loops).

### Issue 2 — structured-question mount re-emit churn

`StructuredQuestionInput` (Matching/Ordering) is keyed by `currentQuestion.id`, so it remounts per question, and its mount effect re-emits `savedAnswer` (now `liveAnswer`) through `onAnswerChange`. With the touched-set above, an unchanged re-emit on a back-nav remount would mark a never-edited question **touched** — freezing out the Issue 1 refresh and re-introducing the clobber for structured questions — and churn the autosave / pollute the append-only history log (write + rule-get cost) for a no-op overwrite.

**Fix:** guard `onAnswerChange` to skip when the emitted value already equals the cache for that question. Genuine placements differ from the cache and fall through unchanged.

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm run lint` (max-warnings 0)
- [x] `pnpm run format:check`
- [x] Full unit suite — **3756 passed** (372 files)
- [x] New: 2 component tests in `tests/components/quiz/QuizStudentApp.selfPaced.test.tsx`:
  - a newer snapshot for an untouched question is not clobbered by a stale seed (the seed tracks the freshest saved value)
  - a back-nav remount of a saved Matching question stays seed-tracked, so a later resync isn't overwritten by a stale draft write
- [x] Both new tests verified to **fail without** their respective fix (reverting the seed-refresh fails (a); removing the `onAnswerChange` guard fails (b)).

https://claude.ai/code/session_01MdiaFatsgE2euf5SwBfExq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdiaFatsgE2euf5SwBfExq)_