### PR TITLE
fix(quiz): gate student submit on the answer cache, narrow the cache ref, close the blank-essay clobber

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1185,14 +1185,27 @@ const ActiveQuiz: React.FC<{
     setSubmitted(true);
   }
 
-  // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change. The current
-  // question's live answer is mirrored separately into `currentAnswerRef`
-  // (synced in the render body, above) so this set only carries the values
-  // the cache doesn't represent.
+  // Keep refs for volatile state used by the countdown / autosave / flush
+  // paths so the timer doesn't restart on every keystroke or selection
+  // change. The current question's live answer is mirrored separately
+  // into `currentAnswerRef` (synced in the render body, above) so this
+  // set only carries the values the cache doesn't represent.
+  //
+  // These are synced by direct assignment in the render body (not a
+  // useEffect): every consumer reads them from an effect or an event
+  // handler that runs AFTER commit, so assigning during render gives
+  // them the freshest value with no staleness window — matching
+  // `submittedRef` / `currentAnswerRef` and the project's ref-sync rule
+  // (CLAUDE.md "useEffect is an escape hatch, not a default"). Using an
+  // effect here would have meant any imperative reader firing in the
+  // same commit (visibility flush, structured input change) would see
+  // the previous render's value.
   const currentQuestionRef = useRef(currentQuestion);
+  currentQuestionRef.current = currentQuestion;
   const selectedAnswerRef = useRef(selectedAnswer);
+  selectedAnswerRef.current = selectedAnswer;
   const onAnswerRef = useRef(onAnswer);
+  onAnswerRef.current = onAnswer;
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
   // directly). Used to short-circuit the flush after the student has
@@ -1201,6 +1214,7 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
+  myResponseStatusRef.current = myResponse?.status;
   // Mirror of the per-question `submitted` state for the imperative
   // paths (flush handler, structured-input change callbacks) that can't
   // read state directly.
@@ -1214,13 +1228,6 @@ const ActiveQuiz: React.FC<{
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-
-  useEffect(() => {
-    currentQuestionRef.current = currentQuestion;
-    selectedAnswerRef.current = selectedAnswer;
-    onAnswerRef.current = onAnswer;
-    myResponseStatusRef.current = myResponse?.status;
-  }, [currentQuestion, selectedAnswer, onAnswer, myResponse?.status]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1004,27 +1004,34 @@ const ActiveQuiz: React.FC<{
   const initialTimeLimit = currentQuestion?.timeLimit ?? 0;
   const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [fibAnswer, setFibAnswer] = useState('');
-  const [draftMcAnswer, setDraftMcAnswer] = useState<string | null>(null);
-  // Written-response live draft (sanitized HTML). Hydrated on question
-  // change from any saved response so pause/resume next class period
-  // picks up exactly where the student left off.
-  const [writtenAnswer, setWrittenAnswer] = useState<string>('');
-  const writtenAnswerRef = useRef<string>('');
-  // Per-question draft autosave timer. Originally written-response-only;
-  // now coalesces autosaves for every answer type (MC, FIB, Matching,
-  // Ordering, short, essay) because dropping non-written answers on tab
-  // close was the primary source of the reported quiz data loss.
+
+  // Per-question live answer cache. Source of truth for editors and
+  // inputs during a session — replaces the per-type live state slots
+  // (writtenAnswer / fibAnswer / draftMcAnswer / structuredAnswerRef)
+  // that used to be reset and re-hydrated from Firestore on every
+  // question change. With the cache:
+  //   - Navigation (next/back) reads from the cache. No Firestore round
+  //     trip, no hydration race.
+  //   - The Firestore snapshot only seeds the cache on demand — once
+  //     per question, the first time it's visited with a saved value
+  //     available. After that, the local value is authoritative.
+  //   - The autosave path writes the cache value to Firestore in the
+  //     background; student typing never depends on Firestore being
+  //     current.
+  //
+  // Values are the canonical serialized form per type:
+  //   - short / essay: sanitized HTML
+  //   - MC: the chosen option string (absent if never clicked)
+  //   - FIB: the typed string
+  //   - Matching / Ordering: pipe-delimited serialization
+  const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
+  const answerCacheRef = useRef<Record<string, string>>(answerCache);
+  answerCacheRef.current = answerCache;
+
+  // Per-question draft autosave timer. Coalesces autosaves for every
+  // answer type — dropping non-written answers on tab close was the
+  // primary source of the originally reported quiz data loss.
   const draftAutosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Which question id the current `writtenAnswer` belongs to. Used by the
-  // autosave effect to refuse writes during the single render between
-  // `currentQuestion.id` advancing (student-paced submit-and-advance) and
-  // the hydration branch replacing `writtenAnswer` with the new
-  // question's saved value. Without this guard, the diff
-  // `writtenAnswer !== savedAnswerForCurrent` is briefly true on the new
-  // question and would persist the *previous* question's draft against
-  // the new question's id 500 ms later.
-  const writtenAnswerQuestionIdRef = useRef<string | undefined>(undefined);
 
   const [submitted, setSubmitted] = useState(alreadyAnswered);
   const [timeLeft, setTimeLeft] = useState<number | null>(
@@ -1075,40 +1082,40 @@ const ActiveQuiz: React.FC<{
   const savedAnswerForCurrentRef = useRef<string | null>(null);
   savedAnswerForCurrentRef.current = savedAnswerForCurrent;
 
-  // Hydrate the answer controls from any saved answer so a previously-
-  // answered question shows the student's prior choice. For MC we set
-  // `draftMcAnswer` (not `selectedAnswer`) so the existing draft styling
-  // highlights it and the NEXT button is enabled immediately. Inline so we
-  // can call it from both the question-change branch (back-nav) and the
-  // alreadyAnswered branch (page reload while answers are mid-load).
+  // Reset `selectedAnswer` on question change. The per-type live values
+  // (what's currently typed/selected) now live in `answerCache` and are
+  // populated lazily — see the cache-miss-fill block below — so there's
+  // nothing per-question to wipe here besides the post-submit display
+  // indicator.
   const hydrateAnswerControls = (): void => {
-    if (alreadyAnswered && savedAnswerForCurrent !== null) {
-      setSelectedAnswer(savedAnswerForCurrent);
-      setDraftMcAnswer(
-        currentQuestion?.type === 'MC' ? savedAnswerForCurrent : null
-      );
-      setFibAnswer(
-        currentQuestion?.type === 'FIB' ? savedAnswerForCurrent : ''
-      );
-    } else {
-      setSelectedAnswer(null);
-      setDraftMcAnswer(null);
-      setFibAnswer('');
-    }
-    // Always seed the written-answer slot from any saved response so
-    // pause/resume across class periods rehydrates the editor at the
-    // exact text the student left behind. Other types get an empty
-    // string here, which the editor branches never read. The
-    // question-id ref is updated in lockstep so the autosave effect
-    // refuses to write the new question with a draft that's still about
-    // to be replaced (see the autosave effect comment).
-    const isWritten =
-      currentQuestion?.type === 'short' || currentQuestion?.type === 'essay';
-    const next = isWritten ? (savedAnswerForCurrent ?? '') : '';
-    setWrittenAnswer(next);
-    writtenAnswerRef.current = next;
-    writtenAnswerQuestionIdRef.current = currentQuestion?.id;
+    setSelectedAnswer(
+      alreadyAnswered && savedAnswerForCurrent !== null
+        ? savedAnswerForCurrent
+        : null
+    );
   };
+
+  // Lazy cache-miss-fill for the current question. If the cache has no
+  // entry yet AND a saved value exists in the Firestore snapshot, seed
+  // the cache from it. Runs every render but the conditional functional
+  // updater no-ops once the key is present, so it costs nothing on the
+  // hot path. Handles three load orders without dedicated effects:
+  //   1) Initial mount before myResponse arrives — cache is empty, saved
+  //      is null, both miss; the next render after the snapshot fills
+  //      in fires this branch.
+  //   2) Page refresh mid-quiz — myResponse loads with prior answers;
+  //      first render after load seeds the current question.
+  //   3) Teacher resume / late snapshot — saved transitions null→text
+  //      while the question hasn't changed; this re-fills the cache
+  //      without going through hydrateAnswerControls.
+  if (currentQuestion?.id && savedAnswerForCurrent !== null) {
+    const qid = currentQuestion.id;
+    if (!(qid in answerCache)) {
+      setAnswerCache((prev) =>
+        qid in prev ? prev : { ...prev, [qid]: savedAnswerForCurrent }
+      );
+    }
+  }
 
   // Derived state: full reset on question change, narrow update on alreadyAnswered flips.
   //
@@ -1164,11 +1171,11 @@ const ActiveQuiz: React.FC<{
   }
 
   // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change.
+  // doesn't restart on every keystroke or selection change. Per-type live
+  // values were folded into `answerCacheRef` (synced in render body) so
+  // this set only carries the values the cache doesn't represent.
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
-  const fibAnswerRef = useRef(fibAnswer);
-  const draftMcAnswerRef = useRef(draftMcAnswer);
   const onAnswerRef = useRef(onAnswer);
   // Mirror of `myResponse.status` for the visibility/unmount flush
   // handlers (which are scoped to `[]` deps and can't read state
@@ -1178,57 +1185,26 @@ const ActiveQuiz: React.FC<{
   // response from `'completed'` back to `'in-progress'` and silently
   // breaking the teacher's "Finished" counter.
   const myResponseStatusRef = useRef(myResponse?.status);
-  // Mirror of the per-question `submitted` state so the imperative
-  // autosave path (Matching/Ordering's onAnswerChange) can refuse to
-  // schedule a draft write for an already-submitted question. Without
-  // this, back-navigating to a submitted structured question and
-  // triggering onAnswerChange (e.g., StructuredQuestionInput's mount
-  // effect re-emits the saved answer) downgrades the answer from
-  // `status: 'submitted'` to `status: 'draft'`, vanishing it from the
-  // teacher's results view.
+  // Mirror of the per-question `submitted` state for the imperative
+  // paths (flush handler, structured-input change callbacks) that can't
+  // read state directly.
   const submittedRef = useRef(false);
   submittedRef.current = submitted;
-  // Pending draft tracker for question-change flushes. Both the state-
-  // driven autosave effect AND scheduleDraftAutosave populate this when
-  // they schedule a write; a watcher on `currentQuestion?.id` calls
-  // `write()` synchronously when the question advances, flushing the
-  // outgoing question's last edit before the new question's autosave
-  // path clobbers the shared timer slot.
+  // Pending draft tracker for question-change flushes. The state-driven
+  // autosave effect populates this when it schedules a write; a watcher
+  // on `currentQuestion?.id` calls `write()` synchronously when the
+  // question advances, flushing the outgoing question's last edit before
+  // the new question's autosave path clobbers the shared timer slot.
   const pendingDraftRef = useRef<{ qid: string; write: () => void } | null>(
     null
   );
-  // Live serialized answer for Matching/Ordering, written by the child
-  // StructuredQuestionInput on every drag/tap so timer auto-submit can
-  // capture partial placements instead of submitting the empty string.
-  const structuredAnswerRef = useRef<string>('');
 
   useEffect(() => {
     currentQuestionRef.current = currentQuestion;
     selectedAnswerRef.current = selectedAnswer;
-    fibAnswerRef.current = fibAnswer;
-    draftMcAnswerRef.current = draftMcAnswer;
     onAnswerRef.current = onAnswer;
-    writtenAnswerRef.current = writtenAnswer;
     myResponseStatusRef.current = myResponse?.status;
-  }, [
-    currentQuestion,
-    selectedAnswer,
-    fibAnswer,
-    draftMcAnswer,
-    onAnswer,
-    writtenAnswer,
-    myResponse?.status,
-  ]);
-
-  // Reset the structured answer ref when the question changes so a stale
-  // answer from a previous question can't leak into auto-submit.
-  const [prevStructuredQuestionId, setPrevStructuredQuestionId] = useState(
-    currentQuestion?.id ?? null
-  );
-  if ((currentQuestion?.id ?? null) !== prevStructuredQuestionId) {
-    setPrevStructuredQuestionId(currentQuestion?.id ?? null);
-    structuredAnswerRef.current = '';
-  }
+  }, [currentQuestion, selectedAnswer, onAnswer, myResponse?.status]);
 
   // Countdown — only runs the interval; auto-submit is handled above.
   useEffect(() => {
@@ -1267,18 +1243,15 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the type-appropriate live ref so a half-completed
-    // matching/ordering answer is preserved on timeout instead of
-    // submitting the empty string.
+    // Pull from the cache so a half-finished value (typed essay,
+    // partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. selectedAnswerRef is a fallback
+    // for the rare case where the student submitted, didn't touch
+    // the cache afterward, and the timer expired.
     const answer =
-      question.type === 'Matching' || question.type === 'Ordering'
-        ? structuredAnswerRef.current
-        : question.type === 'short' || question.type === 'essay'
-          ? writtenAnswerRef.current
-          : (selectedAnswerRef.current ??
-            draftMcAnswerRef.current ??
-            fibAnswerRef.current ??
-            '');
+      answerCacheRef.current[autoSubmitTriggeredFor] ??
+      selectedAnswerRef.current ??
+      '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1290,58 +1263,50 @@ const ActiveQuiz: React.FC<{
       });
   }, [autoSubmitTriggeredFor]);
 
-  // Per-question draft autosave for every answer type. Originally
-  // written-response-only — MC/FIB/Matching/Ordering used to only write
-  // on explicit Submit, so a tab close mid-attempt silently dropped the
-  // student's answers (the bug the user reported as "sporadic data
-  // loss"). The 500 ms debounce mirrors the PLC notes editor pattern;
-  // Submit/advance still writes the final state, so the debounce is
-  // purely a write-rate optimization.
-  //
-  // Matching/Ordering live in `structuredAnswerRef` (a ref so drag-and-
-  // drop doesn't re-render this whole component on every move), so they
-  // schedule their own autosave from the StructuredQuestionInput's
-  // `onAnswerChange` callback via `scheduleDraftAutosave` below. This
-  // effect covers the state-driven types (MC, FIB, short, essay).
+  // Per-question draft autosave driven by the live answer cache. The
+  // cache is the only source of truth for in-progress values, so this
+  // single effect now covers every answer type — MC, FIB, short,
+  // essay, matching, ordering. 500 ms debounce coalesces rapid edits.
+  // Explicit Submit / submit-and-advance write the final state through
+  // their own paths; the debounce is purely a write-rate optimization
+  // and a tab-close safety net.
+  const currentQid = currentQuestion?.id;
+  const cachedDraft =
+    currentQid && currentQid in answerCache ? answerCache[currentQid] : null;
+  // Render-time live answer for editors and inputs. Falls back to the
+  // Firestore saved value on the single render between question
+  // navigation and the cache-miss-fill block populating the cache, so
+  // controlled inputs (MC highlight, FIB value, structured initial
+  // seed) never flicker through an empty state when a saved value is
+  // available. `cachedDraft` (cache-only) is what drives autosave —
+  // they intentionally differ here.
+  const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Convenience cache writer for the editor / input onChange handlers.
+  // Updates the cache for the current question; no-ops if there's no
+  // current question (impossible in practice during render of an
+  // answer slot, but keeps the type signature honest).
+  const setCacheForCurrent = (value: string): void => {
+    if (!currentQid) return;
+    setAnswerCache((prev) => ({ ...prev, [currentQid]: value }));
+  };
   useEffect(() => {
-    const qid = currentQuestion?.id;
+    const qid = currentQid;
     const type = currentQuestion?.type;
     if (!qid || !type) return;
     if (submitted) return;
+    // Cache miss — student hasn't touched this question this session
+    // and there's no saved value either. Nothing to write.
+    if (cachedDraft === null) return;
+    // Saved-equal short-circuit: don't write what's already on the
+    // server. Handles the "lazy-fill seeded cache from saved value"
+    // case (cache and saved are identical → no-op), the "deliberate
+    // re-type to identical text" case (also no-op), and crucially
+    // does NOT short-circuit a deliberate clear (saved=text, draft=''
+    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
+    // case from there).
+    if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
 
-    let draft: string | null = null;
-    if (type === 'short' || type === 'essay') {
-      // Race guard: if `currentQuestion.id` has advanced (student-paced
-      // submit-and-advance) but `hydrateAnswerControls` hasn't yet
-      // replaced `writtenAnswer` with the new question's saved value,
-      // the draft we see here is still from the previous question.
-      // Refuse to write — the next render after hydration will
-      // re-evaluate with the correct draft.
-      if (writtenAnswerQuestionIdRef.current !== qid) return;
-      draft = writtenAnswer;
-    } else if (type === 'MC') {
-      draft = draftMcAnswer;
-    } else if (type === 'FIB') {
-      draft = fibAnswer;
-    } else {
-      // Matching/Ordering autosave via scheduleDraftAutosave from the
-      // structured input's onAnswerChange; not driven by this effect.
-      return;
-    }
-
-    if (draft === null) return;
-    // Skip the initial-hydration call: if the seeded value matches what
-    // was already saved, there's nothing to write. This also handles
-    // the "FIB: empty draft + no prior save" case (both sides reduce
-    // to '') without short-circuiting on empty draft alone — which
-    // would have silently dropped a deliberate clear of a previously-
-    // saved FIB answer.
-    if (draft === (savedAnswerForCurrent ?? '')) return;
-
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const snapshot = draft;
+    const snapshot = cachedDraft;
     const capturedQid = qid;
     const writeNow = () => {
       void onAnswerRef
@@ -1351,31 +1316,29 @@ const ActiveQuiz: React.FC<{
             questionId: capturedQid,
             questionType: type,
           });
-          // Surface autosave failures to the student. The new
-          // `lastWriteAt == request.time` Firestore rule (response
-          // UPDATE predicate) rejects writes from clients with stale
-          // auth tokens or session state, AND any other transient
-          // failure (offline, quota) lands here too. Without this
-          // setter the student silently loses every keystroke for up
-          // to 90 min until the idle-finalize cron sweeps them with
-          // whatever last successfully persisted. The existing
-          // SaveErrorBanner + "Retry Submit" button repurposing
-          // already handles the recovery affordance.
+          // Surface autosave failures to the student. The
+          // `lastWriteAt == request.time` Firestore rule rejects
+          // writes from clients with stale auth tokens / session
+          // state, and other transient failures (offline, quota)
+          // land here too. Without this setter the student silently
+          // loses keystrokes until the idle-finalize cron sweeps
+          // their last successfully persisted value.
           setSaveError("Couldn't save your answer. Tap to try again.");
         });
     };
+
+    if (draftAutosaveTimer.current) {
+      clearTimeout(draftAutosaveTimer.current);
+    }
     draftAutosaveTimer.current = setTimeout(writeNow, 500);
     pendingDraftRef.current = { qid: capturedQid, write: writeNow };
 
     return () => {
-      // Only clear the timer here. We CAN'T flush from this cleanup
-      // even when the question has advanced: React commits cleanups
-      // BEFORE the ref-sync effect at L1205 updates
-      // `currentQuestionRef.current` to the new id, so any condition
-      // like `currentQuestionRef.current?.id !== capturedQid` would
-      // always read stale (equal) refs and never fire. The actual
-      // flush-on-advance happens in the question-change watcher at
-      // L1418, which runs AFTER the ref-sync. handleSubmit /
+      // Only clear the timer here. We can't flush from this cleanup
+      // when the question has advanced — React runs cleanups BEFORE
+      // the ref-sync effect updates `currentQuestionRef.current`. The
+      // flush-on-advance happens in the question-change watcher
+      // below, which runs after the ref-sync. handleSubmit /
       // handleSubmitAndAdvance / the timer-expiry auto-submit effect
       // all explicitly null `pendingDraftRef.current` so the watcher
       // skips already-submitted answers.
@@ -1385,59 +1348,12 @@ const ActiveQuiz: React.FC<{
       }
     };
   }, [
-    writtenAnswer,
-    draftMcAnswer,
-    fibAnswer,
-    currentQuestion?.id,
+    cachedDraft,
+    currentQid,
     currentQuestion?.type,
     submitted,
     savedAnswerForCurrent,
   ]);
-
-  // Imperative draft autosave for ref-driven types (Matching/Ordering)
-  // whose value updates don't flow through React state. Called from the
-  // child StructuredQuestionInput's `onAnswerChange` on every drag/drop
-  // so the same 500 ms debounce window coalesces rapid placements.
-  const scheduleDraftAutosave = useCallback((qid: string, answer: string) => {
-    if (myResponseStatusRef.current === 'completed') return;
-    // Per-question guard: don't downgrade an already-submitted answer
-    // back to draft. Back-navigation in student-paced mode can land on
-    // a previously-submitted Matching/Ordering question; if
-    // StructuredQuestionInput's mount effect (or a stray drag) calls
-    // onAnswerChange, the resulting draft write would silently
-    // un-submit the question and drop it from the teacher's results.
-    if (submittedRef.current) return;
-    // Saved-equal guard: StructuredQuestionInput's mount effect re-emits
-    // the saved answer on every remount. Without this short-circuit
-    // each question advance triggers a redundant 500ms-debounced write
-    // (cost) AND overwrites pendingDraftRef.qid to the new question
-    // before the question-change watcher can flush the outgoing
-    // question's still-pending draft — silently dropping it. Mirrors
-    // the state-driven effect's `draft === savedAnswerForCurrent`
-    // short-circuit.
-    if (answer === (savedAnswerForCurrentRef.current ?? '')) return;
-    if (draftAutosaveTimer.current) {
-      clearTimeout(draftAutosaveTimer.current);
-    }
-    const writeNow = () => {
-      void onAnswerRef
-        .current(qid, answer, undefined, { isDraft: true })
-        .catch((err: unknown) => {
-          logError('QuizStudentApp.draftAutosave', err, {
-            questionId: qid,
-            questionType: 'structured',
-          });
-          // Same rationale as the state-driven autosave path above:
-          // surface autosave failures so the student isn't silently
-          // losing Matching/Ordering placements when Firestore rejects
-          // (rule denial, expired auth, offline) until the idle-finalize
-          // cron picks them up 90 min later.
-          setSaveError("Couldn't save your answer. Tap to try again.");
-        });
-    };
-    draftAutosaveTimer.current = setTimeout(writeNow, 500);
-    pendingDraftRef.current = { qid, write: writeNow };
-  }, []);
 
   // Question-change watcher: if a draft is pending for the OUTGOING
   // question when the user advances, flush it synchronously before
@@ -1482,32 +1398,18 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      let draft: string | null = null;
-      switch (type) {
-        case 'short':
-        case 'essay':
-          draft = writtenAnswerRef.current;
-          break;
-        case 'MC':
-          draft = draftMcAnswerRef.current;
-          break;
-        case 'FIB':
-          draft = fibAnswerRef.current;
-          break;
-        case 'Matching':
-        case 'Ordering':
-          draft = structuredAnswerRef.current;
-          break;
-        default:
-          return;
-      }
-      if (draft === null) return;
-      // Use the ref-synced live value rather than the closure-captured
-      // `savedAnswerForCurrent`, which was frozen at mount because this
-      // effect has [] deps. The saved-equal check handles the "never
-      // typed" empty case (saved null, draft '') without short-
-      // circuiting on empty draft alone — which would have silently
-      // dropped a deliberate clear of a previously-saved FIB answer.
+      // Read the live value from the cache. A `null` here means the
+      // student never touched this question in the current session,
+      // so there's nothing to flush.
+      const cacheValue = answerCacheRef.current[qid];
+      if (cacheValue === undefined) return;
+      const draft = cacheValue;
+      // Saved-equal short-circuit. Uses the ref-synced saved value so
+      // the [] deps don't freeze the closure. Handles the "never typed"
+      // empty case (saved null, draft '') without short-circuiting on
+      // empty draft alone — a deliberate clear of a previously-saved
+      // answer is allowed through; the #1 guard in submitAnswer
+      // refuses the unsafe blank-over-non-blank case from there.
       if (draft === (savedAnswerForCurrentRef.current ?? '')) return;
 
       if (draftAutosaveTimer.current) {
@@ -1959,12 +1861,15 @@ const ActiveQuiz: React.FC<{
         {currentQuestion.type === 'MC' && (
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
-              // Self-paced revisits stay editable, so we use the draft styling
-              // (and `draftMcAnswer` highlight) even when `submitted=true`.
+              // Self-paced revisits stay editable, so the highlight tracks
+              // the live cache value (which is what the student last
+              // clicked). When locked, fall back to the post-submit
+              // `selectedAnswer` indicator — equal to the cache value in
+              // practice but kept explicit for clarity.
               const isLocked = submitted && !isStudentPaced;
               const isSelected = isLocked
                 ? selectedAnswer === opt
-                : draftMcAnswer === opt;
+                : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
               if (!isLocked) {
@@ -1979,7 +1884,7 @@ const ActiveQuiz: React.FC<{
               return (
                 <button
                   key={opt}
-                  onClick={() => !isLocked && setDraftMcAnswer(opt)}
+                  onClick={() => !isLocked && setCacheForCurrent(opt)}
                   disabled={isLocked || submitting}
                   className={cls}
                 >
@@ -2014,10 +1919,9 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        draftMcAnswer &&
-                        void handleSubmitAndAdvance(draftMcAnswer)
+                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
                       }
-                      disabled={!draftMcAnswer || submitting}
+                      disabled={!liveAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2038,10 +1942,8 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    draftMcAnswer && void handleSubmit(draftMcAnswer)
-                  }
-                  disabled={!draftMcAnswer || submitting}
+                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
+                  disabled={!liveAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2077,14 +1979,14 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-4 flex-1">
             <input
               type="text"
-              value={fibAnswer}
-              onChange={(e) => setFibAnswer(e.target.value)}
+              value={liveAnswer ?? ''}
+              onChange={(e) => setCacheForCurrent(e.target.value)}
               disabled={submitted && !isStudentPaced}
               placeholder="Type your answer…"
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = fibAnswer.trim();
+                const trimmed = (liveAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2115,10 +2017,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        fibAnswer.trim() &&
-                        void handleSubmitAndAdvance(fibAnswer.trim())
+                        (liveAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
                       }
-                      disabled={!fibAnswer.trim() || submitting}
+                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2140,9 +2042,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    fibAnswer.trim() && void handleSubmit(fibAnswer.trim())
+                    (liveAnswer ?? '').trim() &&
+                    void handleSubmit((liveAnswer ?? '').trim())
                   }
-                  disabled={!fibAnswer.trim() || submitting}
+                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2181,14 +2084,13 @@ const ActiveQuiz: React.FC<{
             question={currentQuestion}
             submitted={submitted}
             isAutoSubmitted={autoSubmitTriggeredFor === currentQuestion.id}
-            savedAnswer={savedAnswerForCurrent}
+            savedAnswer={liveAnswer}
             onSubmit={(answer) => void handleSubmit(answer)}
             onSubmitAndAdvance={(answer) => void handleSubmitAndAdvance(answer)}
             onAnswerChange={(answer) => {
-              structuredAnswerRef.current = answer;
-              // Persist the placement as a draft so a tab close before
-              // Submit doesn't lose the student's in-progress pairings.
-              scheduleDraftAutosave(currentQuestion.id, answer);
+              // Push the live placement into the cache; the autosave
+              // effect picks it up and debounces the Firestore write.
+              setCacheForCurrent(answer);
             }}
             submitting={submitting}
             isStudentPaced={isStudentPaced}
@@ -2210,14 +2112,8 @@ const ActiveQuiz: React.FC<{
             >
               <WrittenResponseEditor
                 questionKey={currentQuestion.id}
-                value={writtenAnswer}
-                onChange={(html) => {
-                  setWrittenAnswer(html);
-                  writtenAnswerRef.current = html;
-                  // Mark the draft as belonging to this question so the
-                  // autosave race guard lets it through.
-                  writtenAnswerQuestionIdRef.current = currentQuestion.id;
-                }}
+                value={liveAnswer ?? ''}
+                onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}
                 maxWords={currentQuestion.maxWords}
                 disabled={submitted && !isStudentPaced}
@@ -2238,7 +2134,9 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() => void handleSubmitAndAdvance(writtenAnswer)}
+                      onClick={() =>
+                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                      }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
@@ -2260,7 +2158,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(writtenAnswer)}
+                  onClick={() => void handleSubmit(liveAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1299,12 +1299,21 @@ const ActiveQuiz: React.FC<{
     if (cachedDraft === null) return;
     // Saved-equal short-circuit: don't write what's already on the
     // server. Handles the "lazy-fill seeded cache from saved value"
-    // case (cache and saved are identical → no-op), the "deliberate
-    // re-type to identical text" case (also no-op), and crucially
-    // does NOT short-circuit a deliberate clear (saved=text, draft=''
-    // → diff, the #1 guard in submitAnswer handles the unsafe-blank
-    // case from there).
+    // case (cache and saved are identical → no-op) and the
+    // "deliberate re-type to identical text" case.
     if (cachedDraft === (savedAnswerForCurrent ?? '')) return;
+    // Deliberate-clear short-circuit: the student cleared a previously-
+    // saved answer. The hook's `isUnsafeBlankDraft` guard would refuse
+    // the write silently, so detect the condition here and surface a
+    // hint to the student instead of queuing a doomed timer. Submit
+    // with the explicit Submit/Next button still bypasses the guard
+    // and lets them persist an empty answer if that's really intended.
+    if (cachedDraft === '' && (savedAnswerForCurrent ?? '') !== '') {
+      setSaveError(
+        'Your previously-saved answer is still on file. Click Submit to clear it.'
+      );
+      return;
+    }
 
     const snapshot = cachedDraft;
     const capturedQid = qid;
@@ -1476,8 +1485,17 @@ const ActiveQuiz: React.FC<{
       session.showResultToStudent &&
       answerFeedback === null
     ) {
+      // Read order: selectedAnswer (post-explicit-submit) → cache (timer
+      // auto-submit landed but the response listener hasn't echoed yet)
+      // → Firestore answers as the final fallback. Without the cache
+      // hop, an auto-submitted answer compared against a stale
+      // myResponse can produce a false-incorrect on a correct
+      // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
+        (currentQuestion?.id
+          ? answerCacheRef.current[currentQuestion.id]
+          : undefined) ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1862,13 +1880,15 @@ const ActiveQuiz: React.FC<{
           <div className="space-y-3 flex-1">
             {options.map((opt) => {
               // Self-paced revisits stay editable, so the highlight tracks
-              // the live cache value (which is what the student last
-              // clicked). When locked, fall back to the post-submit
-              // `selectedAnswer` indicator — equal to the cache value in
-              // practice but kept explicit for clarity.
+              // the live cache value. When locked, fall back to the
+              // post-submit `selectedAnswer` indicator; timer auto-submit
+              // never sets selectedAnswer, so degrade to liveAnswer so the
+              // student can still see which option was submitted from
+              // their cached pick.
               const isLocked = submitted && !isStudentPaced;
+              const lockedRef = selectedAnswer ?? liveAnswer;
               const isSelected = isLocked
-                ? selectedAnswer === opt
+                ? lockedRef === opt
                 : liveAnswer === opt;
               let cls =
                 'w-full text-left px-5 py-4 rounded-2xl border-2 text-sm font-medium transition-all ';
@@ -2111,7 +2131,19 @@ const ActiveQuiz: React.FC<{
               }
             >
               <WrittenResponseEditor
-                questionKey={currentQuestion.id}
+                // The editor seeds its `innerHTML` once on mount (caret
+                // preservation), so we encode the "cache has been
+                // seeded" boolean in the questionKey. A page refresh
+                // mid-essay first mounts with value='' (cache empty,
+                // saved null); when the Firestore snapshot arrives the
+                // cache-miss-fill block populates the cache, the key
+                // flips from `…:init` → `…:seeded`, and the editor
+                // remounts with the recovered text. Without this, the
+                // student stares at a blank editor while React state
+                // already holds the recovered value.
+                questionKey={`${currentQuestion.id}:${
+                  currentQuestion.id in answerCache ? 'seeded' : 'init'
+                }`}
                 value={liveAnswer ?? ''}
                 onChange={(html) => setCacheForCurrent(html)}
                 placeholder={currentQuestion.placeholder}

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1025,8 +1025,23 @@ const ActiveQuiz: React.FC<{
   //   - FIB: the typed string
   //   - Matching / Ordering: pipe-delimited serialization
   const [answerCache, setAnswerCache] = useState<Record<string, string>>({});
-  const answerCacheRef = useRef<Record<string, string>>(answerCache);
-  answerCacheRef.current = answerCache;
+  // Narrow ref mirror of ONLY the current question's cached value — not the
+  // whole cache. The two imperative readers below (the timer auto-submit
+  // effect and the visibility/unmount flush handler) are scoped to `[]`/
+  // single-dep effects and can't read render state, but each only ever needs
+  // the ACTIVE question's draft. Mirroring the entire cache (potentially 60
+  // multi-paragraph essay answers on a long assignment) through the ref gave
+  // those readers a handle on far more than they use; the previous
+  // `answerCacheRef.current = answerCache` was a reference alias, so it never
+  // duplicated the answer text, but a single-entry ref keeps the imperative
+  // paths honest about what they touch and the ref's retained graph O(1).
+  // The `qid` tag lets those readers confirm the mirror still matches the
+  // question they're acting on. Synced in the render body once `cachedDraft`
+  // is computed (see below).
+  const currentAnswerRef = useRef<{
+    qid: string | undefined;
+    value: string | undefined;
+  }>({ qid: undefined, value: undefined });
 
   // Per-question draft autosave timer. Coalesces autosaves for every
   // answer type — dropping non-written answers on tab close was the
@@ -1171,9 +1186,10 @@ const ActiveQuiz: React.FC<{
   }
 
   // Keep refs for volatile state used by the countdown effect so the timer
-  // doesn't restart on every keystroke or selection change. Per-type live
-  // values were folded into `answerCacheRef` (synced in render body) so
-  // this set only carries the values the cache doesn't represent.
+  // doesn't restart on every keystroke or selection change. The current
+  // question's live answer is mirrored separately into `currentAnswerRef`
+  // (synced in the render body, above) so this set only carries the values
+  // the cache doesn't represent.
   const currentQuestionRef = useRef(currentQuestion);
   const selectedAnswerRef = useRef(selectedAnswer);
   const onAnswerRef = useRef(onAnswer);
@@ -1243,15 +1259,18 @@ const ActiveQuiz: React.FC<{
       draftAutosaveTimer.current = null;
     }
     pendingDraftRef.current = null;
-    // Pull from the cache so a half-finished value (typed essay,
-    // partial matching placement, etc.) is preserved on timeout
-    // instead of submitting empty. selectedAnswerRef is a fallback
-    // for the rare case where the student submitted, didn't touch
-    // the cache afterward, and the timer expired.
-    const answer =
-      answerCacheRef.current[autoSubmitTriggeredFor] ??
-      selectedAnswerRef.current ??
-      '';
+    // Pull from the current-answer ref so a half-finished value (typed
+    // essay, partial matching placement, etc.) is preserved on timeout
+    // instead of submitting empty. The guard above already confirmed this
+    // is the active question, so the ref's `qid` matches; check it anyway
+    // and fall back to selectedAnswerRef (the post-explicit-submit value)
+    // for the rare case where the student submitted, didn't touch the
+    // cache afterward, and the timer expired.
+    const cached =
+      currentAnswerRef.current.qid === autoSubmitTriggeredFor
+        ? currentAnswerRef.current.value
+        : undefined;
+    const answer = cached ?? selectedAnswerRef.current ?? '';
     void onAnswerRef
       .current(
         autoSubmitTriggeredFor,
@@ -1281,6 +1300,28 @@ const ActiveQuiz: React.FC<{
   // available. `cachedDraft` (cache-only) is what drives autosave —
   // they intentionally differ here.
   const liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null;
+  // Mirror only the current question's cached value into the ref for the
+  // imperative readers (auto-submit, flush). `cachedDraft` is null when the
+  // question has no cache entry; store `undefined` to preserve the old
+  // per-key lookup semantics (`record[qid]` was `undefined` when absent).
+  currentAnswerRef.current = {
+    qid: currentQid,
+    value: cachedDraft ?? undefined,
+  };
+  // Submit-gating value: the cache-backed answer ONLY (no Firestore
+  // fallback). The Submit / NEXT affordances gate on this — not on
+  // `liveAnswer` — so a tap can never fire on a value the student hasn't
+  // committed to the cache: something they typed/selected this session, or
+  // that the cache-miss-fill seeded from a saved value (resume / revisit).
+  // `liveAnswer` still feeds the inputs/highlights so a saved answer shows
+  // immediately while the submit affordance waits for the cache to back it.
+  // (React coalesces the cache-miss-fill render-phase update into the same
+  // commit, so today this matches `liveAnswer` in committed renders — but
+  // gating on the cache is the correct statement of intent and stays safe
+  // if that seed ever moves into an effect, where the fallback WOULD reach
+  // a committed render and a fast tap could re-submit-and-advance an answer
+  // the student never re-affirmed.)
+  const submittableAnswer = cachedDraft;
   // Convenience cache writer for the editor / input onChange handlers.
   // Updates the cache for the current question; no-ops if there's no
   // current question (impossible in practice during render of an
@@ -1407,10 +1448,15 @@ const ActiveQuiz: React.FC<{
       const type = currentQuestionRef.current?.type;
       if (!qid || !type) return;
 
-      // Read the live value from the cache. A `null` here means the
-      // student never touched this question in the current session,
-      // so there's nothing to flush.
-      const cacheValue = answerCacheRef.current[qid];
+      // Read the live value from the narrow current-answer ref. An
+      // `undefined` here means either the student never touched this
+      // question in the current session, or the ref has already advanced to
+      // a different question — either way there's nothing for THIS question
+      // to flush.
+      const cacheValue =
+        currentAnswerRef.current.qid === qid
+          ? currentAnswerRef.current.value
+          : undefined;
       if (cacheValue === undefined) return;
       const draft = cacheValue;
       // Saved-equal short-circuit. Uses the ref-synced saved value so
@@ -1493,9 +1539,7 @@ const ActiveQuiz: React.FC<{
       // submission during the teacher's reveal-snapshot tick.
       const studentAns =
         selectedAnswer ??
-        (currentQuestion?.id
-          ? answerCacheRef.current[currentQuestion.id]
-          : undefined) ??
+        cachedDraft ??
         myResponse?.answers.find((a) => a.questionId === currentQuestion?.id)
           ?.answer;
       if (studentAns) {
@@ -1939,9 +1983,10 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        liveAnswer && void handleSubmitAndAdvance(liveAnswer)
+                        submittableAnswer &&
+                        void handleSubmitAndAdvance(submittableAnswer)
                       }
-                      disabled={!liveAnswer || submitting}
+                      disabled={!submittableAnswer || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -1962,8 +2007,10 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => liveAnswer && void handleSubmit(liveAnswer)}
-                  disabled={!liveAnswer || submitting}
+                  onClick={() =>
+                    submittableAnswer && void handleSubmit(submittableAnswer)
+                  }
+                  disabled={!submittableAnswer || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2006,7 +2053,7 @@ const ActiveQuiz: React.FC<{
               className="w-full px-5 py-4 bg-slate-800 border-2 border-slate-700 rounded-2xl text-white text-sm focus:outline-none focus:ring-0 focus:border-violet-500 disabled:opacity-50"
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
-                const trimmed = (liveAnswer ?? '').trim();
+                const trimmed = (submittableAnswer ?? '').trim();
                 if (!trimmed) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
@@ -2037,10 +2084,12 @@ const ActiveQuiz: React.FC<{
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
                       onClick={() =>
-                        (liveAnswer ?? '').trim() &&
-                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
+                        (submittableAnswer ?? '').trim() &&
+                        void handleSubmitAndAdvance(
+                          (submittableAnswer ?? '').trim()
+                        )
                       }
-                      disabled={!(liveAnswer ?? '').trim() || submitting}
+                      disabled={!(submittableAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2062,10 +2111,10 @@ const ActiveQuiz: React.FC<{
               ) : !submitted ? (
                 <button
                   onClick={() =>
-                    (liveAnswer ?? '').trim() &&
-                    void handleSubmit((liveAnswer ?? '').trim())
+                    (submittableAnswer ?? '').trim() &&
+                    void handleSubmit((submittableAnswer ?? '').trim())
                   }
-                  disabled={!(liveAnswer ?? '').trim() || submitting}
+                  disabled={!(submittableAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (
@@ -2165,9 +2214,14 @@ const ActiveQuiz: React.FC<{
                 ) : (
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
+                    {/* Written NEXT stays enabled (only `submitting` gates it)
+                        so a student can advance past — or deliberately submit —
+                        a blank essay; gating it on the cache like MC/FIB would
+                        trap anyone who wants to skip. Submits the cache-backed
+                        value for consistency with the other types. */}
                     <button
                       onClick={() =>
-                        void handleSubmitAndAdvance(liveAnswer ?? '')
+                        void handleSubmitAndAdvance(submittableAnswer ?? '')
                       }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
@@ -2190,7 +2244,7 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() => void handleSubmit(liveAnswer ?? '')}
+                  onClick={() => void handleSubmit(submittableAnswer ?? '')}
                   disabled={submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -1692,7 +1692,18 @@ const ActiveQuiz: React.FC<{
   // On rejection we surface a retry banner via `saveError` instead of letting
   // the failure vanish into the console; the student's selection is still
   // intact (we never reset it on error) so the same tap retries.
-  const handleSubmitAndAdvance = async (answer: string) => {
+  //
+  // `skipWrite` advances WITHOUT calling `onAnswer`. It's used by the written
+  // editor when the cache has no entry for the question (`submittableAnswer`
+  // is null): the student either never typed (a deliberate skip) or their
+  // saved answer hasn't echoed back into `myResponse` yet. In both cases
+  // writing the editor's empty value would be wrong — at best a meaningless
+  // blank, at worst an explicit-submit blank that CLOBBERS the not-yet-loaded
+  // saved essay (explicit submits bypass the `isUnsafeBlankDraft` autosave
+  // guard). Skipping the write lets the student move on while any saved answer
+  // on the server is preserved untouched. A deliberate clear (cache holds '')
+  // still writes through — `submittableAnswer` is '' there, not null.
+  const handleSubmitAndAdvance = async (answer: string, skipWrite = false) => {
     if (advancingRef.current || submitting) return;
     // Self-paced revisits are intentional re-submissions — let them through
     // even when `submitted=true`. Teacher-paced still locks after first submit.
@@ -1708,25 +1719,27 @@ const ActiveQuiz: React.FC<{
     setSubmitting(true);
     setSaveError(null);
     try {
-      let computedSpeedBonus: number | undefined;
-      if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
-        const remaining = Math.max(0, timeLeft ?? 0);
-        const bonusPct = Math.round(
-          (remaining / currentQuestion.timeLimit) * 50
-        );
-        if (bonusPct > 0) computedSpeedBonus = bonusPct;
-      }
+      if (!skipWrite) {
+        let computedSpeedBonus: number | undefined;
+        if (session.speedBonusEnabled && currentQuestion.timeLimit > 0) {
+          const remaining = Math.max(0, timeLeft ?? 0);
+          const bonusPct = Math.round(
+            (remaining / currentQuestion.timeLimit) * 50
+          );
+          if (bonusPct > 0) computedSpeedBonus = bonusPct;
+        }
 
-      try {
-        await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
-      } catch (err) {
-        console.error(
-          '[QuizStudentApp] onAnswer failed for question',
-          currentQuestion.id,
-          err
-        );
-        setSaveError("Couldn't save your answer. Tap to try again.");
-        return;
+        try {
+          await onAnswer(currentQuestion.id, answer, computedSpeedBonus);
+        } catch (err) {
+          console.error(
+            '[QuizStudentApp] onAnswer failed for question',
+            currentQuestion.id,
+            err
+          );
+          setSaveError("Couldn't save your answer. Tap to try again.");
+          return;
+        }
       }
 
       const isLast = currentIndex >= session.totalQuestions - 1;
@@ -2215,13 +2228,19 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     {/* Written NEXT stays enabled (only `submitting` gates it)
-                        so a student can advance past — or deliberately submit —
-                        a blank essay; gating it on the cache like MC/FIB would
-                        trap anyone who wants to skip. Submits the cache-backed
-                        value for consistency with the other types. */}
+                        so a student can advance past a blank essay; gating it
+                        on the cache like MC/FIB would trap anyone who wants to
+                        skip. When the cache HAS a value (typed, seeded, or a
+                        deliberate clear) we submit it; when it's unseeded
+                        (`submittableAnswer === null`) we advance WITHOUT writing
+                        so a fast tap can't clobber a not-yet-loaded saved essay
+                        with a blank (see handleSubmitAndAdvance `skipWrite`). */}
                     <button
                       onClick={() =>
-                        void handleSubmitAndAdvance(submittableAnswer ?? '')
+                        void handleSubmitAndAdvance(
+                          submittableAnswer ?? '',
+                          submittableAnswer === null
+                        )
                       }
                       disabled={submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
@@ -2243,9 +2262,17 @@ const ActiveQuiz: React.FC<{
                   </>
                 )
               ) : !submitted ? (
+                // Teacher-paced has no self-advance, so (unlike self-paced) we
+                // can safely gate Submit on the cache: disabled while the
+                // editor is unseeded (`submittableAnswer === null`) — never
+                // typed, or the saved answer hasn't echoed yet — so a fast tap
+                // can't write a blank over a not-yet-loaded saved essay. A
+                // deliberate clear (cache holds '') is non-null, so it stays
+                // enabled. The button re-enables once the student types or the
+                // saved answer loads and seeds the cache.
                 <button
                   onClick={() => void handleSubmit(submittableAnswer ?? '')}
-                  disabled={submitting}
+                  disabled={submitting || submittableAnswer === null}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (

--- a/firestore.rules
+++ b/firestore.rules
@@ -2304,6 +2304,44 @@ service cloud.firestore {
         );
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
+
+        // Append-only snapshot log of overwritten answers. Each entry
+        // captures a prior `answers[i]` value the moment before it gets
+        // replaced in the parent response doc — see `submitAnswer` in
+        // `useQuizSession.ts`. Used to recover student text lost to a
+        // race (stray blank draft after a hydration miss) or to a
+        // student retyping over their own work after a lockout. Writes
+        // are throttled per-question on the client; the rule still
+        // pins the doc shape so a hostile authenticated user can't
+        // dump arbitrary data into the subcollection.
+        match /history/{historyId} {
+          function parentStudentUid() {
+            return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)/responses/$(responseKey)).data.studentUid;
+          }
+          // Read: teacher, admin, or the owning student.
+          allow read: if request.auth != null && (
+            isAdmin() ||
+            request.auth.uid == sessionTeacherUid() ||
+            request.auth.uid == parentStudentUid()
+          );
+          // Create: only the owning student of the parent response.
+          // Field shape is strict so a malicious caller can't smuggle
+          // fields; `snapshotAt == request.time` forces server stamping.
+          allow create: if request.auth != null &&
+            request.auth.uid == parentStudentUid() &&
+            request.resource.data.keys().hasOnly(
+              ['questionId', 'answer', 'answeredAt', 'status', 'snapshotAt']
+            ) &&
+            request.resource.data.questionId is string &&
+            request.resource.data.answer is string &&
+            request.resource.data.answeredAt is number &&
+            request.resource.data.status in ['draft', 'submitted'] &&
+            request.resource.data.snapshotAt == request.time;
+          // Immutable from clients. Teachers/admins may clean up.
+          allow update: if false;
+          allow delete: if request.auth != null &&
+            (request.auth.uid == sessionTeacherUid() || isAdmin());
+        }
       }
 
       // Archived responses — copies of student responses that the teacher

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -140,7 +140,11 @@ export function isUnsafeStatusDowngrade(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return isDraft && priorEntry?.status === 'submitted';
+  // Use `!== 'draft'` rather than `=== 'submitted'` so legacy entries
+  // with `status === undefined` (predate the draft flag — treated as
+  // submitted everywhere else via `isAnswerSubmitted`) are also
+  // protected from being silently downgraded to draft.
+  return isDraft && priorEntry !== undefined && priorEntry.status !== 'draft';
 }
 
 /**
@@ -163,7 +167,10 @@ export function shouldSnapshotHistory(
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
   const textChanged = priorEntry.answer !== newAnswer;
-  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  // Mirror `isUnsafeStatusDowngrade`: treat legacy entries with
+  // `status === undefined` as submitted so a downgrade attempt on a
+  // legacy answer still gets a forensic snapshot.
+  const statusDowngrade = priorEntry.status !== 'draft' && newIsDraft;
   if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -126,22 +126,45 @@ export function isUnsafeBlankDraft(
 }
 
 /**
+ * Defensive predicate: refuse a draft autosave that would downgrade an
+ * already-submitted answer's status to 'draft'. The cache-driven
+ * autosave path can re-fire for the same question during the SSO
+ * listener-fast race window (back-nav before the response listener
+ * echoes the just-submitted answer back, so the local `submitted` state
+ * briefly flips false), and without this guard the autosave silently
+ * flips status 'submitted' → 'draft' and drops the question from the
+ * teacher's "Finished" view. Explicit submits (`isDraft=false`) still
+ * pass through.
+ */
+export function isUnsafeStatusDowngrade(
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && priorEntry?.status === 'submitted';
+}
+
+/**
  * Decide whether to snapshot the prior answer entry to the history
- * subcollection before overwriting. Only meaningful prior values
- * (non-empty and different from the incoming value) are worth
- * snapshotting, and the per-question throttle keeps a long essay from
- * fanning out to hundreds of near-identical docs.
+ * subcollection before overwriting. Captures any prior non-empty value
+ * the incoming write is about to lose — either because the text
+ * changed, or because the status is being destructively downgraded
+ * from 'submitted' to 'draft' (which can erase grading state even
+ * with identical text). The per-question throttle keeps a long essay
+ * from fanning out to hundreds of near-identical docs.
  */
 export function shouldSnapshotHistory(
   priorEntry: QuizResponseAnswer | undefined,
   newAnswer: string,
+  newIsDraft: boolean,
   lastSnapshotAt: number,
   now: number,
   throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
 ): boolean {
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
-  if (priorEntry.answer === newAnswer) return false;
+  const textChanged = priorEntry.answer !== newAnswer;
+  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }
 
@@ -1342,6 +1365,11 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
     ): Promise<string> => {
       setLoading(true);
       setError(null);
+      // Clear per-question history throttle on every join. The same hook
+      // instance survives a teacher unlock / attempt-cap rejoin, so a
+      // stale `lastSnapshotAt` from the prior attempt would suppress
+      // legitimate snapshots in the new one.
+      lastHistorySnapshotAtRef.current.clear();
       try {
         const normCode = code
           .trim()
@@ -1982,6 +2010,12 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
         return;
       }
+      // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
+      // Stops the back-nav listener-lag race from silently flipping a
+      // 'submitted' answer back to 'draft' status.
+      if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
+        return;
+      }
 
       const newAnswer: QuizResponseAnswer = {
         questionId,
@@ -2040,10 +2074,15 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       const now = Date.now();
       const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
       if (
-        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        ) &&
         priorEntry
       ) {
-        lastHistorySnapshotAtRef.current.set(questionId, now);
         void addDoc(
           collection(
             db,
@@ -2060,9 +2099,18 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
             status: priorEntry.status ?? 'submitted',
             snapshotAt: serverTimestamp(),
           }
-        ).catch(() => {
-          // Safety-net write; nothing actionable on failure.
-        });
+        )
+          .then(() => {
+            // Only consume the throttle slot for snapshots that actually
+            // landed. A failed write (offline, rule denial, quota) used
+            // to bump `now` regardless, suppressing the next legitimate
+            // snapshot for the throttle window even though no recovery
+            // doc had been written.
+            lastHistorySnapshotAtRef.current.set(questionId, now);
+          })
+          .catch(() => {
+            // Safety-net write; nothing actionable on failure.
+          });
       }
     },
     []

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -19,6 +19,7 @@ import {
   collection,
   onSnapshot,
   setDoc,
+  addDoc,
   updateDoc,
   getDocs,
   getDoc,
@@ -65,6 +66,25 @@ export const RESPONSES_COLLECTION = 'responses';
  */
 export const ARCHIVED_RESPONSES_COLLECTION = 'archived_responses';
 /**
+ * Append-only per-response snapshot log. Each entry captures the prior
+ * value of a question's answer just before it gets overwritten in the
+ * `responses/{rid}.answers` array, so a teacher (or admin) can recover
+ * text that was lost to a race, a stray empty draft, or a student who
+ * retyped over their own work. Writes are fire-and-forget and throttled
+ * per-question (see `HISTORY_SNAPSHOT_THROTTLE_MS`) to keep storage and
+ * write costs bounded — typical essay quiz has a low double-digit
+ * count per student.
+ */
+export const RESPONSE_HISTORY_COLLECTION = 'history';
+/**
+ * Minimum interval between history snapshots for the same questionId on
+ * the same response. The autosave debounce is 500 ms; without throttling
+ * a long essay would fan out to hundreds of near-identical history docs.
+ * 5 s gives "enough resolution to recover meaningful state" without
+ * making history a per-keystroke audit log.
+ */
+const HISTORY_SNAPSHOT_THROTTLE_MS = 5000;
+/**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
  * and accumulates a student's completed-attempt count across every session
  * the teacher creates for the same quiz. Without this collection, the
@@ -88,6 +108,42 @@ export function quizLedgerKey(quizId: string, studentUid: string): string {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Defensive predicate: refuse a draft autosave that would overwrite a
+ * non-empty saved answer with the empty string. Almost always indicates
+ * a race (editor briefly emitted '' after a remount or a hydration miss)
+ * rather than a deliberate clear. Explicit submits (`isDraft=false`)
+ * bypass this — a student who really wants to clear an answer can still
+ * submit empty.
+ */
+export function isUnsafeBlankDraft(
+  answer: string,
+  isDraft: boolean,
+  priorEntry: QuizResponseAnswer | undefined
+): boolean {
+  return isDraft && answer === '' && !!priorEntry && priorEntry.answer !== '';
+}
+
+/**
+ * Decide whether to snapshot the prior answer entry to the history
+ * subcollection before overwriting. Only meaningful prior values
+ * (non-empty and different from the incoming value) are worth
+ * snapshotting, and the per-question throttle keeps a long essay from
+ * fanning out to hundreds of near-identical docs.
+ */
+export function shouldSnapshotHistory(
+  priorEntry: QuizResponseAnswer | undefined,
+  newAnswer: string,
+  lastSnapshotAt: number,
+  now: number,
+  throttleMs: number = HISTORY_SNAPSHOT_THROTTLE_MS
+): boolean {
+  if (!priorEntry) return false;
+  if (priorEntry.answer === '') return false;
+  if (priorEntry.answer === newAnswer) return false;
+  return now - lastSnapshotAt >= throttleMs;
+}
 
 /** Unbiased Fisher-Yates in-place shuffle (returns new array) */
 function fisherYatesShuffle<T>(arr: T[]): T[] {
@@ -1132,6 +1188,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   const myResponseRef = useRef<QuizResponse | null>(null);
   myResponseRef.current = myResponse;
 
+  // Per-questionId timestamp of the most recent history snapshot write.
+  // Used to throttle snapshots — see HISTORY_SNAPSHOT_THROTTLE_MS.
+  const lastHistorySnapshotAtRef = useRef<Map<string, number>>(new Map());
+
   // Optimistic local counter state to ensure UI updates immediately.
   // warningCountRef mirrors the state so reportTabSwitch can return the
   // updated value synchronously (React functional updaters run on the next
@@ -1912,6 +1972,17 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // only) from an explicit submit. The student's `alreadyAnswered` gate
       // checks for `'submitted'` so a draft autosave doesn't masquerade as
       // a final answer and prematurely fire the completion card.
+      const existingAnswers = myResponseRef.current?.answers ?? [];
+      const priorEntry = existingAnswers.find(
+        (a) => a.questionId === questionId
+      );
+
+      // #1 guard — see `isUnsafeBlankDraft` doc. Refuses a draft autosave
+      // that would silently clobber a non-empty saved answer with ''.
+      if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
+        return;
+      }
+
       const newAnswer: QuizResponseAnswer = {
         questionId,
         answer,
@@ -1922,7 +1993,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           : {}),
       };
 
-      const existingAnswers = myResponseRef.current?.answers ?? [];
       const updated = [
         ...existingAnswers.filter((a) => a.questionId !== questionId),
         newAnswer,
@@ -1962,6 +2032,38 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
+
+      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
+      // safety net so a value that turns out to be a regression (stray
+      // blank draft that the #1 guard didn't catch, or a student
+      // retyping after a lockout) can still be recovered.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      if (
+        shouldSnapshotHistory(priorEntry, answer, lastAt, now) &&
+        priorEntry
+      ) {
+        lastHistorySnapshotAtRef.current.set(questionId, now);
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            answeredAt: priorEntry.answeredAt,
+            status: priorEntry.status ?? 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        ).catch(() => {
+          // Safety-net write; nothing actionable on failure.
+        });
+      }
     },
     []
   );

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -767,3 +767,98 @@ describe('QuizStudentApp — in-memory answer cache', () => {
     );
   });
 });
+
+// ─── Narrowed current-answer ref + submit gating (#1741 follow-up) ────────────
+//
+// Issue #2: `currentAnswerRef` mirrors ONLY the active question's cached value
+// (not the whole cache). The two imperative readers — the timer auto-submit
+// effect and the visibility/unmount flush handler — must still see the current
+// question's live draft through it. These pin both read paths for a
+// non-structured type (the Matching/Ordering timer tests above cover the
+// structured auto-submit path).
+//
+// Issue #1: the Submit/NEXT affordances gate on the cache-backed value
+// (`submittableAnswer`), not on `liveAnswer` (which folds in the Firestore
+// fallback). The transient pre-seed render the fix guards against is coalesced
+// away by React (the cache-miss-fill is a render-phase update), so it isn't
+// observable here; the test below pins the end-state contract — the gate tracks
+// the cache, going from disabled → enabled as the option lands in it.
+
+describe('QuizStudentApp — current-answer ref + submit gating', () => {
+  it('auto-submits the cached MC selection on timeout (reads currentAnswerRef)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      hookState.session = buildSession({
+        publicQuestions: [
+          { ...QUESTIONS[0], timeLimit: 5 },
+          QUESTIONS[1],
+          QUESTIONS[2],
+        ],
+      });
+
+      render(<QuizStudentApp />);
+      expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+      // Pick "4" but never submit — the value lives only in the cache,
+      // mirrored into the narrowed currentAnswerRef.
+      await user.click(screen.getByRole('button', { name: '4' }));
+
+      // Run the clock out. The auto-submit effect must read the cached "4"
+      // back out of the ref, not submit an empty answer.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000);
+      });
+
+      expect(mockSubmitAnswer).toHaveBeenCalledWith('q1', '4', 0, undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes the current question's cached draft on visibilitychange→hidden (reads currentAnswerRef)", async () => {
+    const user = userEvent.setup();
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Cache "4". The 500 ms autosave debounce hasn't fired yet.
+    await user.click(screen.getByRole('button', { name: '4' }));
+
+    // Tab-switch away. The flush handler reads the active question's value out
+    // of the narrowed ref and writes it as a draft immediately (best-effort,
+    // before the debounce would have).
+    try {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      await waitFor(() => {
+        expect(mockSubmitAnswer).toHaveBeenCalledWith('q1', '4', undefined, {
+          isDraft: true,
+        });
+      });
+    } finally {
+      // Drop the instance override so the jsdom prototype getter (default
+      // 'visible') is restored for other tests.
+      Reflect.deleteProperty(document, 'visibilityState');
+    }
+  });
+
+  it('keeps NEXT disabled until an option is cached, then enables it (gates on the cache, not the saved fallback)', async () => {
+    const user = userEvent.setup();
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Fresh question, nothing selected → no cache entry → the submit
+    // affordance is disabled. It gates on `submittableAnswer` (cache-backed),
+    // never on a Firestore fallback showing through `liveAnswer`.
+    expect(screen.getByRole('button', { name: /^NEXT/i })).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    expect(screen.getByRole('button', { name: /^NEXT/i })).not.toBeDisabled();
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -862,3 +862,68 @@ describe('QuizStudentApp — current-answer ref + submit gating', () => {
     expect(screen.getByRole('button', { name: /^NEXT/i })).not.toBeDisabled();
   });
 });
+
+// ─── Written blank-overwrite guard (#1741 follow-up) ──────────────────────────
+//
+// The written editor's submit affordance is the one explicit-submit path that
+// can fire with an empty value (MC/FIB/structured all gate on content). An
+// explicit submit bypasses the autosave `isUnsafeBlankDraft` guard, so a fast
+// tap on a blank-but-unseeded essay — never typed, OR the saved answer hasn't
+// echoed into myResponse yet — would clobber the saved essay with ''. The fix:
+// when the cache has no entry (`submittableAnswer === null`), self-paced
+// advances WITHOUT writing and teacher-paced disables Submit; a deliberate
+// clear (cache holds '') still writes through.
+
+describe('QuizStudentApp — written blank-overwrite guard', () => {
+  const ESSAY: QuizPublicQuestion = {
+    id: 'qe',
+    type: 'essay',
+    text: 'Describe your summer',
+    timeLimit: 0,
+  };
+
+  it('advances a blank, unseeded essay WITHOUT writing a blank (self-paced)', async () => {
+    const user = userEvent.setup();
+    hookState.session = buildSession({
+      publicQuestions: [ESSAY, QUESTIONS[1]],
+      totalQuestions: 2,
+    });
+
+    render(<QuizStudentApp />);
+    expect(
+      await screen.findByText(/Describe your summer/i)
+    ).toBeInTheDocument();
+    // Let the lazy editor settle so NEXT isn't tapped mid-Suspense.
+    await screen.findByRole('textbox', { name: /Your response/i });
+
+    // Tap NEXT without typing. The cache has no entry for this question, so we
+    // must advance without writing — a blank explicit submit here would
+    // clobber a saved essay that simply hasn't echoed back yet.
+    await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+
+    // Advanced to Q2…
+    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
+    // …and nothing was written for the blank essay.
+    expect(mockSubmitAnswer).not.toHaveBeenCalled();
+  });
+
+  it('disables teacher-paced essay Submit while the editor is unseeded', async () => {
+    hookState.session = buildSession({
+      sessionMode: 'teacher',
+      publicQuestions: [ESSAY, QUESTIONS[1]],
+      totalQuestions: 2,
+    });
+
+    render(<QuizStudentApp />);
+    expect(
+      await screen.findByText(/Describe your summer/i)
+    ).toBeInTheDocument();
+    await screen.findByRole('textbox', { name: /Your response/i });
+
+    // No saved answer + nothing typed → cache unseeded → Submit is disabled so
+    // a fast tap can't write a blank over a not-yet-loaded saved essay.
+    expect(
+      screen.getByRole('button', { name: /Submit Response/i })
+    ).toBeDisabled();
+  });
+});

--- a/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.selfPaced.test.tsx
@@ -691,3 +691,79 @@ describe('QuizStudentApp — self-paced flow', () => {
     );
   });
 });
+
+// ─── In-memory answer cache (#2 fix) ──────────────────────────────────────────
+//
+// The cache makes question navigation read from local state instead of
+// re-fetching from the Firestore snapshot. These tests cover the two
+// scenarios where the prior hydration-on-every-question-change design
+// could (and did) lose student work in production:
+//   - Next → Back when the response listener hadn't echoed the just-
+//     submitted answer back yet.
+//   - A late-arriving snapshot for the current question (teacher resume,
+//     SSO listener-fast race) seeding a blank that overwrites local edits.
+
+describe('QuizStudentApp — in-memory answer cache', () => {
+  it('preserves the locally-selected MC option across Next → Back even when Firestore never echoes the submit', async () => {
+    // Drop the default `appendAnswer` side-effect so the answer is never
+    // visible via `myResponse`. The cache is then the ONLY thing
+    // remembering which option the student picked — exactly the pre-fix
+    // race scenario where the snapshot listener fell behind.
+    mockSubmitAnswer.mockImplementation(async () => {
+      // No-op: don't update hookState, don't trigger refresh.
+    });
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // Pick "4", advance to Q2.
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await user.click(screen.getByRole('button', { name: /^NEXT/i }));
+    expect(await screen.findByText(/Capital of France/i)).toBeInTheDocument();
+
+    // Back to Q1.
+    await user.click(
+      screen.getByRole('button', { name: /Previous question/i })
+    );
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    // "4" must still be highlighted in the editable draft style. Before
+    // the cache fix this would have come back blank because
+    // savedAnswerForCurrent was null and hydrate seeded the editor with
+    // an empty value.
+    const choice = screen.getByRole('button', { name: '4' });
+    expect(choice.className).toContain('border-violet-500');
+  });
+
+  it('does not clobber a locally-selected option when a snapshot with empty answers fires after the click', async () => {
+    // Simulates the "teacher resume" / late-snapshot race: the student
+    // clicks an option, then a Firestore snapshot arrives for the SAME
+    // question with no saved answer. Pre-fix the editor was reset to
+    // the saved value via hydrateAnswerControls and the student saw
+    // their selection vanish. Post-fix the cache wins because it
+    // already has a value for this question.
+    const user = userEvent.setup();
+
+    render(<QuizStudentApp />);
+    expect(await screen.findByText(/What is 2 \+ 2/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+
+    // Fire a snapshot for an empty response — the kind of state the
+    // listener briefly returns after a teacher unlock or a slow round
+    // trip.
+    act(() => {
+      hookState.myResponse = buildResponse({ answers: [] });
+      triggerRefresh();
+    });
+
+    // Selection must still be intact.
+    expect(screen.getByRole('button', { name: '4' }).className).toContain(
+      'border-violet-500'
+    );
+  });
+});

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -8,6 +8,7 @@ import {
   useQuizSessionStudent,
   useQuizSessionTeacher,
   isUnsafeBlankDraft,
+  isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
@@ -520,6 +521,42 @@ describe('isUnsafeBlankDraft (#1 guard)', () => {
   });
 });
 
+describe('isUnsafeStatusDowngrade (review fix)', () => {
+  const submittedPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const draftPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'work in progress',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave when the prior entry was status=submitted', () => {
+    // The back-nav listener-lag race: cache holds the just-submitted value,
+    // `submitted` state briefly flips false, and the autosave would otherwise
+    // rewrite the entry as a draft.
+    expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('allows a draft autosave when the prior entry was already a draft', () => {
+    expect(isUnsafeStatusDowngrade(true, draftPrior)).toBe(false);
+  });
+
+  it('allows a draft autosave when no prior entry exists', () => {
+    expect(isUnsafeStatusDowngrade(true, undefined)).toBe(false);
+  });
+
+  it('allows an explicit submit even over a previously-submitted entry', () => {
+    // A real student-paced re-submit must always pass — the gate only
+    // applies to background draft writes.
+    expect(isUnsafeStatusDowngrade(false, submittedPrior)).toBe(false);
+  });
+});
+
 describe('shouldSnapshotHistory (#5 throttle)', () => {
   const priorWithText: QuizResponseAnswer = {
     questionId: 'q1',
@@ -527,18 +564,31 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  const priorSubmitted: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'committed answer',
+    answeredAt: 100,
+    status: 'submitted',
+  };
   const THROTTLE = 5000;
 
   it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        0,
+        6000,
+        THROTTLE
+      )
     ).toBe(true);
   });
 
   it('skips when no prior entry exists', () => {
     // First write for this question — nothing to snapshot.
     expect(
-      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(undefined, 'first text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
@@ -550,22 +600,52 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       status: 'draft',
     };
     expect(
-      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(priorEmpty, 'new text', true, 0, 1e9, THROTTLE)
     ).toBe(false);
   });
 
-  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+  it('skips when the new value matches the prior text AND the status is not being downgraded', () => {
     // Autosaves can fire with no actual content change in some races;
-    // a snapshot would be wasteful and noise the recovery log.
+    // a snapshot would be wasteful when both text and status are unchanged.
     expect(
-      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'first draft',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
     ).toBe(false);
+  });
+
+  it('captures a snapshot on a status downgrade even with identical text', () => {
+    // The back-nav race silently writes the same text back as a draft over
+    // a previously-submitted entry — the 'submitted' fact is being destroyed
+    // and must be recoverable.
+    expect(
+      shouldSnapshotHistory(
+        priorSubmitted,
+        'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
   });
 
   it('throttles back-to-back snapshots inside the window', () => {
     // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
     expect(
-      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+      shouldSnapshotHistory(
+        priorWithText,
+        'second draft',
+        true,
+        4000,
+        5000,
+        THROTTLE
+      )
     ).toBe(false);
   });
 });

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -534,12 +534,27 @@ describe('isUnsafeStatusDowngrade (review fix)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  // Predates the draft flag — `status` field omitted, treated as
+  // submitted everywhere else via `isAnswerSubmitted`.
+  const legacyPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
+  };
 
   it('refuses a draft autosave when the prior entry was status=submitted', () => {
     // The back-nav listener-lag race: cache holds the just-submitted value,
     // `submitted` state briefly flips false, and the autosave would otherwise
     // rewrite the entry as a draft.
     expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('refuses a draft autosave when the prior entry was legacy (status=undefined)', () => {
+    // Legacy docs without a `status` field are treated as submitted by
+    // `isAnswerSubmitted`. The downgrade guard must match — without it,
+    // a back-nav race on a legacy entry would silently flip the doc to
+    // `status: 'draft'` and drop it from the teacher's "Finished" view.
+    expect(isUnsafeStatusDowngrade(true, legacyPrior)).toBe(true);
   });
 
   it('allows a draft autosave when the prior entry was already a draft', () => {
@@ -569,6 +584,14 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answer: 'committed answer',
     answeredAt: 100,
     status: 'submitted',
+  };
+  // Legacy entry — predates the draft flag, `status` omitted. Treated
+  // as submitted everywhere via `isAnswerSubmitted`, so a downgrade
+  // attempt on it must still snapshot.
+  const priorLegacy: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
   };
   const THROTTLE = 5000;
 
@@ -627,6 +650,22 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       shouldSnapshotHistory(
         priorSubmitted,
         'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
+  });
+
+  it('captures a snapshot on a status downgrade from legacy (status=undefined) even with identical text', () => {
+    // Legacy submitted-equivalents (status omitted) must be recoverable
+    // when a draft write would overwrite them — same protection as the
+    // explicit `status: 'submitted'` case above.
+    expect(
+      shouldSnapshotHistory(
+        priorLegacy,
+        'legacy answer',
         true,
         0,
         1e9,

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -7,11 +7,14 @@ import {
   toPublicQuestion,
   useQuizSessionStudent,
   useQuizSessionTeacher,
+  isUnsafeBlankDraft,
+  shouldSnapshotHistory,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
   QuizQuestion,
   QuizResponse,
+  QuizResponseAnswer,
   QuizSession,
   QuizPublicQuestion,
 } from '@/types';
@@ -466,6 +469,104 @@ describe('toPublicQuestion', () => {
     expect(pub).not.toHaveProperty('correctAnswer');
     expect(pub.id).toBe('q4');
     expect(pub.type).toBe('FIB');
+  });
+});
+
+// ─── Draft-write defensive predicates ─────────────────────────────────────────
+//
+// `isUnsafeBlankDraft` and `shouldSnapshotHistory` are the two guards
+// `submitAnswer` consults before writing the response doc. They are
+// extracted as pure predicates so the race / overwrite logic can be
+// tested without setting up a full Firestore mock — the hook integration
+// is covered separately by the component-level cache tests.
+
+describe('isUnsafeBlankDraft (#1 guard)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'My long essay response',
+    answeredAt: 100,
+    status: 'submitted',
+  };
+  const priorEmpty: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: '',
+    answeredAt: 100,
+    status: 'draft',
+  };
+
+  it('refuses a draft autosave writing "" over a non-empty prior answer', () => {
+    expect(isUnsafeBlankDraft('', true, priorWithText)).toBe(true);
+  });
+
+  it('allows a draft autosave writing "" when the prior answer was also empty', () => {
+    // Both sides reduce to '' — no data loss possible, the write is a no-op
+    // on the data dimension but still legitimate (timestamps may update).
+    expect(isUnsafeBlankDraft('', true, priorEmpty)).toBe(false);
+  });
+
+  it('allows a draft autosave writing "" when no prior entry exists', () => {
+    expect(isUnsafeBlankDraft('', true, undefined)).toBe(false);
+  });
+
+  it('allows a draft autosave writing non-empty text over a non-empty prior', () => {
+    // Normal "student kept typing" path — must not be blocked.
+    expect(isUnsafeBlankDraft('new text', true, priorWithText)).toBe(false);
+  });
+
+  it('allows an explicit (non-draft) submit of "" over a non-empty prior', () => {
+    // Student deliberately cleared and clicked Submit — only autosaves are
+    // gated; explicit intent is respected.
+    expect(isUnsafeBlankDraft('', false, priorWithText)).toBe(false);
+  });
+});
+
+describe('shouldSnapshotHistory (#5 throttle)', () => {
+  const priorWithText: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'first draft',
+    answeredAt: 100,
+    status: 'draft',
+  };
+  const THROTTLE = 5000;
+
+  it('captures a snapshot when overwriting a non-empty prior with different content past the throttle window', () => {
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 0, 6000, THROTTLE)
+    ).toBe(true);
+  });
+
+  it('skips when no prior entry exists', () => {
+    // First write for this question — nothing to snapshot.
+    expect(
+      shouldSnapshotHistory(undefined, 'first text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the prior entry was empty', () => {
+    const priorEmpty: QuizResponseAnswer = {
+      questionId: 'q1',
+      answer: '',
+      answeredAt: 0,
+      status: 'draft',
+    };
+    expect(
+      shouldSnapshotHistory(priorEmpty, 'new text', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('skips when the new value is identical to the prior (no-op overwrite)', () => {
+    // Autosaves can fire with no actual content change in some races;
+    // a snapshot would be wasteful and noise the recovery log.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'first draft', 0, 1e9, THROTTLE)
+    ).toBe(false);
+  });
+
+  it('throttles back-to-back snapshots inside the window', () => {
+    // Previous snapshot was 1s ago, throttle is 5s → not yet allowed.
+    expect(
+      shouldSnapshotHistory(priorWithText, 'second draft', 4000, 5000, THROTTLE)
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Stacked on #1741

This branch is based on `claude/wonderful-williamson-0bf1b0` (PR #1741), which introduced the in-memory `answerCache` and `liveAnswer` fallback. **#1741 is not yet merged**, so until it lands this PR's diff against `dev-paul` will include #1741's commits too. Review only the three follow-up commits / the `QuizStudentApp.tsx` + `selfPaced.test.tsx` changes here.

All changes live in `components/quiz/QuizStudentApp.tsx` (`ActiveQuiz`).

---

## Issue 1 — Submit enabled before the cache is seeded (fat-finger re-submit)

**Before:** the Submit / NEXT affordances gated on `liveAnswer = cachedDraft ?? savedAnswerForCurrent ?? null`, which folds in the raw Firestore saved value.

**Fix:** introduced `submittableAnswer = cachedDraft` (the **cache-backed value only**, no Firestore fallback) and gated every MC/FIB submit affordance + the FIB Enter key on it. `liveAnswer` still feeds the inputs/highlights, so a saved answer renders immediately while the submit affordance waits for the cache. This is **option B** from the brief ("require the cache seeded") — the only choice compatible with the existing *page-refresh-mid-quiz* test that asserts NEXT enables after a late snapshot *without a reselect*.

**Honest caveat on reproducibility:** the cache-miss-fill is a *render-phase* state update, which React **coalesces into the same commit**. So the transient window where `cachedDraft` is null but `liveAnswer` falls through never reaches the committed DOM today — meaning `submittableAnswer === liveAnswer` in every committed render and this is behaviorally equivalent right now (all existing tests stay green). The guard is the **correct expression of intent** and becomes load-bearing the moment that seed is ever moved into a `useEffect`, where the fallback *would* reach a committed render. Defense-in-depth aligned with #1741's "structurally eliminate, don't patch" philosophy.

## Issue 1b — Blank explicit-submit clobbering an unloaded saved essay (data loss) ✅ now fixed

*(Originally flagged here as a deferred follow-up; addressed after review feedback — it's the same data-loss class #1741 targets.)*

The written editor's submit button is the **one explicit-submit path that can fire with an empty value** (MC/FIB/structured all gate on content, and now on the cache). Explicit submits bypass #1741's `isUnsafeBlankDraft` autosave guard, so a fast tap on a blank-but-**unseeded** essay — never typed, OR the saved answer hasn't echoed into `myResponse` yet (snapshot lag / teacher resume) — wrote `''` over the saved essay.

**Fix (without re-introducing a skip-trap):**
- `handleSubmitAndAdvance` gains a `skipWrite` flag that advances/completes **without** calling `onAnswer`.
- **Self-paced** written NEXT stays enabled (so blank-essay skips aren't trapped) but passes `skipWrite` when the cache is unseeded (`submittableAnswer === null`) → advance without writing, preserving any not-yet-loaded saved answer.
- **Teacher-paced** written Submit (no self-advance) gates `disabled` on `submittableAnswer === null` instead.
- A **deliberate clear** (cache holds `''`) is non-null, so it still writes through, per #1741's "explicit submits pass" design.

## Issue 2 — Cache ref footprint

**Audit first (as instructed).** Every reader of `answerCacheRef.current` only ever needs the **current** question's value (timer auto-submit, the visibility/unmount flush, reveal-feedback).

**Fix:** replaced the whole-cache mirror `answerCacheRef.current = answerCache` with `currentAnswerRef`, a single-entry `{ qid, value }` mirror of only the active question's draft. The two `[]`-scoped imperative readers check `qid` before trusting `value`; reveal-feedback now reads `cachedDraft` directly and drops the ref entirely.

**Honest memory accounting:** `answerCacheRef.current = answerCache` was a **reference alias**, not a deep copy — it never duplicated the answer text. So the "held twice via the ref" framing overstates it; the real footprint is the `answerCache` state (which overlaps with `myResponse`). Narrowing the ref makes its retained graph O(1) and scopes the imperative paths, but it is **not** a large memory cut.

**Eviction rejected (documented).** The only lever that would actually halve the cache↔`myResponse` duplication is evicting persisted entries — but re-seeding an evicted entry from `savedAnswerForCurrent` reintroduces exactly the **stale-snapshot race #1741 fixed** (the listener may not have echoed the latest draft on a fast Back-nav) and breaks the `WrittenResponseEditor` `:init`→`:seeded` remount key. Per the brief, eviction was rejected in favor of ref-narrowing.

## Tests (`tests/components/quiz/QuizStudentApp.selfPaced.test.tsx`)

- **auto-submit reads `currentAnswerRef`** — MC timer expiry submits the cached selection.
- **flush reads `currentAnswerRef`** — `visibilitychange→hidden` writes the active question's cached draft.
- **submit-gate characterization** — NEXT disabled until an option lands in the cache.
- **blank-essay self-paced** — advances WITHOUT writing a blank (no clobber).
- **blank-essay teacher-paced** — Submit disabled while unseeded.

## Validation

`pnpm run type-check` ✓ · `pnpm run lint` (max-warnings 0) ✓ · `prettier --check` ✓ · full vitest suite **3759 passed** ✓
