### PR TITLE
fix(quiz): address code-review on #1742 (FIB clear, history throttle, legacy status)

### DIFF
--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -2009,7 +2009,11 @@ const ActiveQuiz: React.FC<{
               onKeyDown={(e) => {
                 if (e.key !== 'Enter') return;
                 const trimmed = (liveAnswer ?? '').trim();
-                if (!trimmed) return;
+                // Allow an empty Enter when there's a saved answer to
+                // clear — the autosave's deliberate-clear branch refuses
+                // the write and instructs the student to use Submit/Enter,
+                // so blocking here would deadlock the clear path.
+                if (!trimmed && !savedAnswerForCurrent) return;
                 if (isStudentPaced) {
                   void handleSubmitAndAdvance(trimmed);
                 } else if (!submitted) {
@@ -2038,11 +2042,18 @@ const ActiveQuiz: React.FC<{
                   <>
                     {saveError && <SaveErrorBanner message={saveError} />}
                     <button
-                      onClick={() =>
-                        (liveAnswer ?? '').trim() &&
-                        void handleSubmitAndAdvance((liveAnswer ?? '').trim())
+                      onClick={() => {
+                        const trimmed = (liveAnswer ?? '').trim();
+                        // Allow empty submit when there's a saved answer
+                        // to clear — autosave routes the student here for
+                        // the deliberate-clear path.
+                        if (!trimmed && !savedAnswerForCurrent) return;
+                        void handleSubmitAndAdvance(trimmed);
+                      }}
+                      disabled={
+                        submitting ||
+                        (!(liveAnswer ?? '').trim() && !savedAnswerForCurrent)
                       }
-                      disabled={!(liveAnswer ?? '').trim() || submitting}
                       className="w-full py-4 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-black rounded-2xl flex items-center justify-center gap-2 transition-all shadow-lg active:scale-95"
                     >
                       {submitting ? (
@@ -2063,11 +2074,18 @@ const ActiveQuiz: React.FC<{
                 )
               ) : !submitted ? (
                 <button
-                  onClick={() =>
-                    (liveAnswer ?? '').trim() &&
-                    void handleSubmit((liveAnswer ?? '').trim())
+                  onClick={() => {
+                    const trimmed = (liveAnswer ?? '').trim();
+                    // Allow empty submit when there's a saved answer to
+                    // clear — autosave routes the student here for the
+                    // deliberate-clear path.
+                    if (!trimmed && !savedAnswerForCurrent) return;
+                    void handleSubmit(trimmed);
+                  }}
+                  disabled={
+                    submitting ||
+                    (!(liveAnswer ?? '').trim() && !savedAnswerForCurrent)
                   }
-                  disabled={!(liveAnswer ?? '').trim() || submitting}
                   className="w-full py-4 bg-violet-600 hover:bg-violet-500 disabled:opacity-50 text-white font-bold rounded-2xl flex items-center justify-center gap-2 transition-colors"
                 >
                   {submitting ? (

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -140,7 +140,11 @@ export function isUnsafeStatusDowngrade(
   isDraft: boolean,
   priorEntry: QuizResponseAnswer | undefined
 ): boolean {
-  return isDraft && priorEntry?.status === 'submitted';
+  // Use `!== 'draft'` rather than `=== 'submitted'` so legacy entries
+  // with `status === undefined` (predate the draft flag — treated as
+  // submitted everywhere else via `isAnswerSubmitted`) are also
+  // protected from being silently downgraded to draft.
+  return isDraft && priorEntry !== undefined && priorEntry.status !== 'draft';
 }
 
 /**
@@ -163,7 +167,10 @@ export function shouldSnapshotHistory(
   if (!priorEntry) return false;
   if (priorEntry.answer === '') return false;
   const textChanged = priorEntry.answer !== newAnswer;
-  const statusDowngrade = priorEntry.status === 'submitted' && newIsDraft;
+  // Mirror `isUnsafeStatusDowngrade`: treat legacy entries with
+  // `status === undefined` as submitted so a downgrade attempt on a
+  // legacy answer still gets a forensic snapshot.
+  const statusDowngrade = priorEntry.status !== 'draft' && newIsDraft;
   if (!textChanged && !statusDowngrade) return false;
   return now - lastSnapshotAt >= throttleMs;
 }
@@ -2043,9 +2050,71 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       if (isUnsafeBlankDraft(answer, opts?.isDraft === true, priorEntry)) {
         return;
       }
+
+      // #5 history snapshot decision — runs BEFORE the status-downgrade
+      // guard so a rejected downgrade attempt is still recorded as a
+      // forensic snapshot. Without this ordering, the downgrade branch
+      // of `shouldSnapshotHistory` was unreachable in production
+      // (`isUnsafeStatusDowngrade` returns early on the very condition
+      // the snapshot path wants to capture). Keeping it here means the
+      // recovery log records both completed and rejected overwrites.
+      const now = Date.now();
+      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
+      const wantSnapshot =
+        !!priorEntry &&
+        shouldSnapshotHistory(
+          priorEntry,
+          answer,
+          opts?.isDraft === true,
+          lastAt,
+          now
+        );
+      if (wantSnapshot && priorEntry) {
+        // Consume the throttle slot eagerly — BEFORE issuing the addDoc
+        // — so a tap-storm with multiple in-flight writes can't all see
+        // the same stale `lastAt` and slip past the throttle, and an
+        // out-of-order resolution can't move the timestamp backwards.
+        // A one-time failure burns the throttle slot for the window
+        // (logged below); the alternative is unbounded write-
+        // amplification on a flaky network, which is the worse failure
+        // mode for a fire-and-forget safety net.
+        lastHistorySnapshotAtRef.current.set(questionId, now);
+        void addDoc(
+          collection(
+            db,
+            QUIZ_SESSIONS_COLLECTION,
+            sessionId,
+            RESPONSES_COLLECTION,
+            responseKey,
+            RESPONSE_HISTORY_COLLECTION
+          ),
+          {
+            questionId: priorEntry.questionId,
+            answer: priorEntry.answer,
+            // `answeredAt` is typed `number` (required) but Firestore
+            // can return any shape on legacy docs — fall back to `now`
+            // so the rule's required-fields check still passes instead
+            // of crashing on `undefined`.
+            answeredAt: priorEntry.answeredAt ?? now,
+            // Narrow explicitly rather than `?? 'submitted'`: the rule
+            // pins `status in ['draft','submitted']`, so any future
+            // schema value would silently fail every history write.
+            status: priorEntry.status === 'draft' ? 'draft' : 'submitted',
+            snapshotAt: serverTimestamp(),
+          }
+        ).catch((err: unknown) => {
+          // Safety-net write — recovery still works without it, so we
+          // don't surface to the student. But log it: a silently
+          // failing recovery net (e.g. a future rules/schema drift)
+          // should be visible rather than vanish.
+          console.error('[useQuizSession] history snapshot write failed:', err);
+        });
+      }
+
       // Status-downgrade guard — see `isUnsafeStatusDowngrade` doc.
       // Stops the back-nav listener-lag race from silently flipping a
-      // 'submitted' answer back to 'draft' status.
+      // 'submitted' answer back to 'draft' status. Runs AFTER the
+      // history snapshot so the rejected attempt is still recorded.
       if (isUnsafeStatusDowngrade(opts?.isDraft === true, priorEntry)) {
         return;
       }
@@ -2099,62 +2168,6 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
           lastWriteAt: serverTimestamp(),
         }
       );
-
-      // #5 history — see `shouldSnapshotHistory` doc. Fire-and-forget
-      // safety net so a value that turns out to be a regression (stray
-      // blank draft that the #1 guard didn't catch, or a student
-      // retyping after a lockout) can still be recovered.
-      const now = Date.now();
-      const lastAt = lastHistorySnapshotAtRef.current.get(questionId) ?? 0;
-      if (
-        shouldSnapshotHistory(
-          priorEntry,
-          answer,
-          opts?.isDraft === true,
-          lastAt,
-          now
-        ) &&
-        priorEntry
-      ) {
-        void addDoc(
-          collection(
-            db,
-            QUIZ_SESSIONS_COLLECTION,
-            sessionId,
-            RESPONSES_COLLECTION,
-            responseKey,
-            RESPONSE_HISTORY_COLLECTION
-          ),
-          {
-            questionId: priorEntry.questionId,
-            answer: priorEntry.answer,
-            answeredAt: priorEntry.answeredAt,
-            // Narrow explicitly rather than `?? 'submitted'`: the rule
-            // pins `status in ['draft','submitted']`, so any future
-            // schema value would silently fail every history write.
-            status: priorEntry.status === 'draft' ? 'draft' : 'submitted',
-            snapshotAt: serverTimestamp(),
-          }
-        )
-          .then(() => {
-            // Only consume the throttle slot for snapshots that actually
-            // landed. A failed write (offline, rule denial, quota) used
-            // to bump `now` regardless, suppressing the next legitimate
-            // snapshot for the throttle window even though no recovery
-            // doc had been written.
-            lastHistorySnapshotAtRef.current.set(questionId, now);
-          })
-          .catch((err: unknown) => {
-            // Safety-net write — recovery still works without it, so we
-            // don't surface to the student. But log it: a silently
-            // failing recovery net (e.g. a future rules/schema drift)
-            // should be visible rather than vanish.
-            console.error(
-              '[useQuizSession] history snapshot write failed:',
-              err
-            );
-          });
-      }
     },
     []
   );

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -534,12 +534,27 @@ describe('isUnsafeStatusDowngrade (review fix)', () => {
     answeredAt: 100,
     status: 'draft',
   };
+  // Predates the draft flag — `status` field omitted, treated as
+  // submitted everywhere else via `isAnswerSubmitted`.
+  const legacyPrior: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
+  };
 
   it('refuses a draft autosave when the prior entry was status=submitted', () => {
     // The back-nav listener-lag race: cache holds the just-submitted value,
     // `submitted` state briefly flips false, and the autosave would otherwise
     // rewrite the entry as a draft.
     expect(isUnsafeStatusDowngrade(true, submittedPrior)).toBe(true);
+  });
+
+  it('refuses a draft autosave when the prior entry was legacy (status=undefined)', () => {
+    // Legacy docs without a `status` field are treated as submitted by
+    // `isAnswerSubmitted`. The downgrade guard must match — without it,
+    // a back-nav race on a legacy entry would silently flip the doc to
+    // `status: 'draft'` and drop it from the teacher's "Finished" view.
+    expect(isUnsafeStatusDowngrade(true, legacyPrior)).toBe(true);
   });
 
   it('allows a draft autosave when the prior entry was already a draft', () => {
@@ -569,6 +584,14 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
     answer: 'committed answer',
     answeredAt: 100,
     status: 'submitted',
+  };
+  // Legacy entry — predates the draft flag, `status` omitted. Treated
+  // as submitted everywhere via `isAnswerSubmitted`, so a downgrade
+  // attempt on it must still snapshot.
+  const priorLegacy: QuizResponseAnswer = {
+    questionId: 'q1',
+    answer: 'legacy answer',
+    answeredAt: 100,
   };
   const THROTTLE = 5000;
 
@@ -627,6 +650,22 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
       shouldSnapshotHistory(
         priorSubmitted,
         'committed answer',
+        true,
+        0,
+        1e9,
+        THROTTLE
+      )
+    ).toBe(true);
+  });
+
+  it('captures a snapshot on a status downgrade from legacy (status=undefined) even with identical text', () => {
+    // Legacy submitted-equivalents (status omitted) must be recoverable
+    // when a draft write would overwrite them — same protection as the
+    // explicit `status: 'submitted'` case above.
+    expect(
+      shouldSnapshotHistory(
+        priorLegacy,
+        'legacy answer',
         true,
         0,
         1e9,


### PR DESCRIPTION
Follow-up to #1742. Direct push to `dev-paul` is blocked by the env's git proxy, so the review fixes land via this PR onto `dev-paul`.

## Reviewer comments addressed

**Gemini high (×2)** — FIB clear-and-submit UX deadlock (`components/quiz/QuizStudentApp.tsx` self-paced + teacher-paced submit buttons + Enter handler)
The autosave's deliberate-clear branch surfaces "Click Submit to clear it" when a student empties a previously-saved FIB answer, but all three submit affordances gated on `(liveAnswer ?? '').trim()` truthiness — so the button stayed disabled and Enter no-op'd, trapping the student under the banner with no way out. All three paths now accept an empty submit when there is a saved answer to clear.

**Copilot (×2)** — `shouldSnapshotHistory`'s status-downgrade branch was unreachable
`submitAnswer` returned early on `isUnsafeStatusDowngrade` BEFORE the snapshot check, so the function's "snapshot identical-text downgrade" branch was dead code in production. Moved the snapshot decision to BEFORE the downgrade guard so a rejected downgrade attempt is still recorded as a forensic recovery doc. The existing snapshot-on-downgrade test now exercises a reachable path.

**Copilot** — History throttle out-of-order race
The throttle timestamp was bumped in `addDoc(...).then(...)`. Multiple in-flight writes for the same question could all see a stale `lastAt` and slip past the throttle, and an out-of-order resolution could move the timestamp backwards. Now bumped eagerly before `addDoc`. A one-time failure burns the slot for the throttle window (logged), which is the right trade-off for a fire-and-forget safety net vs. unbounded write amplification during a network blip.

**Gemini medium** — `priorEntry.answeredAt` undefined crash on legacy docs
Type marks `answeredAt` as required, but `addDoc(undefined)` crashes — fall back to `Date.now()`.

**Gemini medium** (posted on #1744 but applies equally to dev-paul) — Legacy `status === undefined` not protected
`isUnsafeStatusDowngrade` and `shouldSnapshotHistory` both gated on `=== 'submitted'`, so a legacy answer (no `status` field — treated as submitted via `isAnswerSubmitted` everywhere else) was not protected from a back-nav downgrade. Both predicates now use `!== 'draft'` to match `isAnswerSubmitted`. Added the corresponding test cases for both predicates.

## Validation

- `pnpm run type-check` ✓
- ESLint clean
- Prettier clean
- `tests/hooks/useQuizSession.test.ts`: **96 passed** (+2 new legacy cases)
- `tests/components/quiz/QuizStudentApp.selfPaced.test.tsx`: **14 passed**

https://claude.ai/code/session_01HfHvs1j4eqTmAcUjor4mgm

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfHvs1j4eqTmAcUjor4mgm)_