### PR TITLE
refactor(D1): VideoActivityWidget guard states → ScaledEmptyState

### DIFF
--- a/components/widgets/VideoActivityWidget/Widget.tsx
+++ b/components/widgets/VideoActivityWidget/Widget.tsx
@@ -42,7 +42,8 @@ import { Results } from './components/Results';
 import { VideoActivityLiveMonitor } from './components/VideoActivityLiveMonitor';
 import { VideoActivityEditorModal } from './components/VideoActivityEditorModal';
 import { getVideoActivityBehavior } from '@/utils/videoActivityBehavior';
-import { Loader2, AlertTriangle, LogIn } from 'lucide-react';
+import { AlertTriangle, Loader2, LogIn } from 'lucide-react';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 
 /**
@@ -325,53 +326,21 @@ export const VideoActivityWidget: React.FC<{ widget: WidgetData }> = ({
 
   if (!user) {
     return (
-      <div
-        className="flex flex-col items-center justify-center h-full text-slate-400 text-center"
-        style={{ gap: 'min(12px, 3cqmin)', padding: 'min(24px, 6cqmin)' }}
-      >
-        <LogIn
-          className="opacity-40"
-          style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
-        />
-        <p
-          className="font-medium text-slate-300"
-          style={{ fontSize: 'min(13px, 4.5cqmin)' }}
-        >
-          Sign in required
-        </p>
-        <p
-          className="text-slate-500"
-          style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-        >
-          Sign in with Google to use Video Activities.
-        </p>
-      </div>
+      <ScaledEmptyState
+        icon={LogIn}
+        title="Sign in required"
+        subtitle="Sign in with Google to use Video Activities."
+      />
     );
   }
 
   if (!isDriveConnected && !googleAccessToken) {
     return (
-      <div
-        className="flex flex-col items-center justify-center h-full text-slate-400 text-center"
-        style={{ gap: 'min(12px, 3cqmin)', padding: 'min(24px, 6cqmin)' }}
-      >
-        <AlertTriangle
-          className="opacity-40"
-          style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
-        />
-        <p
-          className="font-medium text-slate-300"
-          style={{ fontSize: 'min(13px, 4.5cqmin)' }}
-        >
-          Drive access needed
-        </p>
-        <p
-          className="text-slate-500"
-          style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-        >
-          Sign out and sign in again to grant Google Drive access.
-        </p>
-      </div>
+      <ScaledEmptyState
+        icon={AlertTriangle}
+        title="Drive access needed"
+        subtitle="Sign out and sign in again to grant Google Drive access."
+      />
     );
   }
 


### PR DESCRIPTION
## Canonical Form

`<ScaledEmptyState icon={X} title="..." subtitle="..." />` from `@/components/common/ScaledEmptyState` — replaces hand-rolled centered-div + icon + text patterns in widget front-face guard states.

## Instances Unified

**File:** `components/widgets/VideoActivityWidget/Widget.tsx`

Two guard returns converted:

1. **`!user` guard** (lines ~324–348 before) — hand-rolled `<div>` with inline `cqmin` sizing, `<LogIn>` icon, two `<p>` elements → `<ScaledEmptyState icon={LogIn} title="Sign in required" subtitle="Sign in with Google to use Video Activities." />`

2. **`!isDriveConnected && !googleAccessToken` guard** (lines ~350–376 before) — same pattern with `<AlertTriangle>` → `<ScaledEmptyState icon={AlertTriangle} title="Drive access needed" subtitle="Sign out and sign in again to grant Google Drive access." />`

Each conversion reduced ~16 lines of hand-rolled JSX to 4 lines using the shared component.

`AlertTriangle` and `LogIn` imports retained — they are passed as `icon` prop values. `ScaledEmptyState` import added via `@/` alias.

## Enforcement Added

No new lint rule needed — `ScaledEmptyState` already exists and is documented in CLAUDE.md as the canonical pattern. The shared component is self-enforcing by being the path of least resistance.

## Behavior-Preservation Evidence

- Text content (title, subtitle strings) preserved exactly
- Logical guard conditions unchanged
- `getVideoActivityBehavior` import from dev-paul's recent changes preserved in conflict resolution
- Type-check: `pnpm exec tsc --noEmit` — clean (no output)
- Lint: `pnpm exec eslint components/widgets/VideoActivityWidget/Widget.tsx --max-warnings 0` — 0 warnings
- Build: `✓ built in ~30s`

## Risk Tag

**visual-risk** — Icon slightly larger at medium widget sizes (ScaledEmptyState uses `min(48px, 15cqmin)` vs the hand-rolled `min(32px, 8cqmin)`); title becomes uppercase/bold per ScaledEmptyState's canonical style. This is the intended canonical presentation, not a regression — the visual change is the point of the unification.

---
_Generated by [Claude Code](https://claude.ai/code/session_018fBZzEZRsS2yqd8VJyBGFf)_