### PR TITLE
fix(dice): use refs to prevent stale-closure bug when props change mid-roll

### DIFF
--- a/components/widgets/DiceWidget/Widget.test.tsx
+++ b/components/widgets/DiceWidget/Widget.test.tsx
@@ -97,4 +97,43 @@ describe('DiceWidget', () => {
 
     vi.useRealTimers();
   });
+
+  it('persists lastRoll with the current diceCount when count changes mid-roll', () => {
+    // Regression test for stale-closure bug: roll() captured diceCount from
+    // the render scope. If props changed from 2→4 while the interval was
+    // running, the final updateWidget call used the stale count (2) instead
+    // of the new count (4), persisting a lastRoll array with the wrong length.
+    vi.useFakeTimers();
+
+    const { rerender } = render(<DiceWidget widget={createWidgetData(2)} />);
+
+    const rollButton = screen.getByRole('button', { name: /Roll Dice/i });
+    act(() => {
+      rollButton.click();
+    });
+
+    // Advance mid-roll (interval fires every 80ms, 12 ticks total = 960ms)
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    // Change dice count to 4 while the roll is in-flight
+    rerender(<DiceWidget widget={createWidgetData(4)} />);
+
+    // Complete the roll
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // The last updateWidget call should persist a lastRoll array whose length
+    // matches the NEW diceCount (4), not the stale one (2).
+    const allCalls = mockUpdateWidget.mock.calls;
+    const lastCall = allCalls[allCalls.length - 1];
+    const savedLastRoll = (lastCall[1] as { config: { lastRoll: number[] } })
+      .config.lastRoll;
+
+    expect(savedLastRoll).toHaveLength(4);
+
+    vi.useRealTimers();
+  });
 });

--- a/components/widgets/DiceWidget/Widget.tsx
+++ b/components/widgets/DiceWidget/Widget.tsx
@@ -22,6 +22,14 @@ export const DiceWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const [isRolling, setIsRolling] = useState(false);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Keep refs to the latest prop values so the roll interval always reads the
+  // current diceCount/config even if props change mid-roll.
+  const diceCountRef = useRef(diceCount);
+  const configRef = useRef(config);
+  const widgetIdRef = useRef(widget.id);
+  diceCountRef.current = diceCount;
+  configRef.current = config;
+  widgetIdRef.current = widget.id;
 
   useEffect(() => {
     return () => {
@@ -53,13 +61,18 @@ export const DiceWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           clearInterval(intervalRef.current);
           intervalRef.current = null;
         }
+        // Read from refs so we always use the current values even if props
+        // changed while the roll was in progress.
+        const currentDiceCount = diceCountRef.current;
+        const currentConfig = configRef.current;
+        const currentWidgetId = widgetIdRef.current;
         const finalValues = Array.from(
-          { length: diceCount },
+          { length: currentDiceCount },
           () => Math.floor(Math.random() * 6) + 1
         );
         setAnimatedValues(finalValues);
-        updateWidget(widget.id, {
-          config: { ...config, lastRoll: finalValues } as DiceConfig,
+        updateWidget(currentWidgetId, {
+          config: { ...currentConfig, lastRoll: finalValues } as DiceConfig,
         });
         setIsRolling(false);
       }


### PR DESCRIPTION
## Root Cause

`DiceWidget`'s `roll()` function captured `diceCount`, `config`, and `widget.id` from the render closure at the moment `setInterval` was created. If props changed mid-roll (e.g. the user adjusted diceCount from 2→4 via the settings panel while the animation was running), the final `updateWidget` call at tick 12 used stale captured values — persisting a `lastRoll` array of 2 elements when the widget expected 4.

## Fix Summary

Assign `diceCountRef.current`, `configRef.current`, and `widgetIdRef.current` synchronously in the render body (the canonical React pattern for reading current prop values inside async callbacks). The `setInterval` callback reads from refs at the moment of execution, not from the closure.

## Rejected Band-Aid

Wrapping the interval in a `useEffect` that re-schedules whenever `diceCount` changes would restart the animation from scratch on every re-render mid-roll — worse UX than the original bug.

## Regression Test

`'persists lastRoll with the current diceCount when count changes mid-roll'` in `components/widgets/DiceWidget/Widget.test.tsx`:
- **Before fix**: `expected [ 1, 1 ] to have a length of 4 but got 2` — stale closure persisted old count
- **After fix**: 4/4 tests pass

## Risk

**Contained** — change is local to `DiceWidget`; refs are only read inside the interval callback, no rendering side-effects.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2bZb7zDM1bRRUzrV7LPcq)_