### PR TITLE
fix(typography): write undefined instead of 'global' sentinel when Inherit is clicked

### DIFF
--- a/components/common/TypographySettings.tsx
+++ b/components/common/TypographySettings.tsx
@@ -26,9 +26,17 @@ export const TypographySettings = <
           {FONTS.map((f) => (
             <button
               key={f.id}
-              onClick={() => updateConfig({ fontFamily: f.id } as Partial<T>)}
+              onClick={() =>
+                updateConfig({
+                  // 'global' is a sentinel meaning "inherit dashboard font".
+                  // Write undefined (clear the override) instead of persisting
+                  // the literal string 'global', which is not a valid
+                  // GlobalFontFamily value and would pollute saved configs.
+                  fontFamily: f.id === 'global' ? undefined : f.id,
+                } as Partial<T>)
+              }
               className={`p-2 rounded-lg border-2 flex flex-col items-center gap-1 transition-[border-color,background-color] ${
-                fontFamily === f.id || (!fontFamily && f.id === 'global')
+                fontFamily === f.id
                   ? 'border-brand-blue-primary bg-brand-blue-lighter'
                   : 'border-slate-100 hover:border-slate-200'
               }`}

--- a/tests/components/common/TypographySettings.test.tsx
+++ b/tests/components/common/TypographySettings.test.tsx
@@ -93,7 +93,7 @@ describe('TypographySettings', () => {
     fireEvent.click(screen.getByRole('button', { name: /inherit/i }));
 
     expect(updateConfig).toHaveBeenCalledOnce();
-    const [calledWith] = updateConfig.mock.calls[0];
+    const [calledWith] = updateConfig.mock.calls[0] as [Partial<TestConfig>];
 
     // Must NOT write the 'global' sentinel — that string is not a valid
     // GlobalFontFamily value and must not be persisted to Firestore.
@@ -114,7 +114,7 @@ describe('TypographySettings', () => {
     fireEvent.click(screen.getByRole('button', { name: /digital/i }));
 
     expect(updateConfig).toHaveBeenCalledOnce();
-    const [calledWith] = updateConfig.mock.calls[0];
+    const [calledWith] = updateConfig.mock.calls[0] as [Partial<TestConfig>];
     expect(calledWith.fontFamily).toBe('font-mono');
   });
 });

--- a/tests/components/common/TypographySettings.test.tsx
+++ b/tests/components/common/TypographySettings.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for TypographySettings.
+ *
+ * BUG: Clicking the "Inherit" (global) font button called
+ *   updateConfig({ fontFamily: 'global' })
+ * which wrote the literal sentinel string 'global' into the widget config.
+ * Several config types (CountdownConfig, BreathingConfig, ActivityWallConfig,
+ * etc.) type fontFamily as `GlobalFontFamily`, a union that does NOT include
+ * 'global'. Persisting 'global' to Firestore therefore violates the declared
+ * type contract. Additionally, a dead-code condition
+ *   (!fontFamily && f.id === 'global')
+ * on the selected-button check was unreachable because the fontFamily
+ * destructuring default ('global') prevents fontFamily from ever being falsy.
+ *
+ * FIX: The onClick handler now writes `undefined` (clearing the override)
+ * when the user selects the "Inherit" (global) button, consistent with how
+ * other reset actions work (e.g. UniversalStyleSettings' font reset).
+ * The dead-code branch was removed from the selected-state condition.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TypographySettings } from '@/components/common/TypographySettings';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal config that satisfies TypographySettings' generic constraint. */
+type TestConfig = { fontFamily?: string; fontColor?: string };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TypographySettings', () => {
+  it('highlights the Inherit button when fontFamily is undefined (no override set)', () => {
+    const config: TestConfig = { fontFamily: undefined };
+    const updateConfig = vi.fn();
+
+    render(<TypographySettings config={config} updateConfig={updateConfig} />);
+
+    // The "Inherit" button should be visually selected
+    const inheritButton = screen.getByRole('button', { name: /inherit/i });
+    expect(inheritButton.className).toContain('border-brand-blue-primary');
+  });
+
+  it('highlights the Inherit button when fontFamily is explicitly "global"', () => {
+    // Legacy configs may have 'global' persisted; the button must still show as
+    // selected (fontFamily = 'global' default in destructuring handles this).
+    const config: TestConfig = { fontFamily: 'global' };
+    const updateConfig = vi.fn();
+
+    render(<TypographySettings config={config} updateConfig={updateConfig} />);
+
+    const inheritButton = screen.getByRole('button', { name: /inherit/i });
+    expect(inheritButton.className).toContain('border-brand-blue-primary');
+  });
+
+  it('highlights a specific font button when that font is selected', () => {
+    const config: TestConfig = { fontFamily: 'font-mono' };
+    const updateConfig = vi.fn();
+
+    render(<TypographySettings config={config} updateConfig={updateConfig} />);
+
+    const monoButton = screen.getByRole('button', { name: /digital/i });
+    expect(monoButton.className).toContain('border-brand-blue-primary');
+
+    // Inherit button must NOT be selected when a specific font is active
+    const inheritButton = screen.getByRole('button', { name: /inherit/i });
+    expect(inheritButton.className).not.toContain('border-brand-blue-primary');
+  });
+
+  /**
+   * Core regression: clicking "Inherit" must write `undefined` to the config,
+   * NOT the literal string `'global'`.
+   *
+   * Before the fix: updateConfig was called with { fontFamily: 'global' },
+   * violating the GlobalFontFamily type contract and polluting Firestore with
+   * an invalid sentinel value.
+   *
+   * After the fix: updateConfig is called with { fontFamily: undefined },
+   * which properly clears any font override so the widget inherits the
+   * dashboard global font.
+   */
+  it('writes undefined (not "global") when the Inherit button is clicked', () => {
+    const config: TestConfig = { fontFamily: 'font-sans' };
+    const updateConfig = vi.fn();
+
+    render(<TypographySettings config={config} updateConfig={updateConfig} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /inherit/i }));
+
+    expect(updateConfig).toHaveBeenCalledOnce();
+    const [calledWith] = updateConfig.mock.calls[0];
+
+    // Must NOT write the 'global' sentinel — that string is not a valid
+    // GlobalFontFamily value and must not be persisted to Firestore.
+    expect(calledWith.fontFamily).not.toBe('global');
+
+    // Must write undefined to clear the override so the widget inherits the
+    // dashboard's global font via its own destructuring default.
+    expect(calledWith.fontFamily).toBeUndefined();
+  });
+
+  it('writes the font id when a named font button is clicked', () => {
+    const config: TestConfig = { fontFamily: undefined };
+    const updateConfig = vi.fn();
+
+    render(<TypographySettings config={config} updateConfig={updateConfig} />);
+
+    // "Digital" is the label for font-mono
+    fireEvent.click(screen.getByRole('button', { name: /digital/i }));
+
+    expect(updateConfig).toHaveBeenCalledOnce();
+    const [calledWith] = updateConfig.mock.calls[0];
+    expect(calledWith.fontFamily).toBe('font-mono');
+  });
+});


### PR DESCRIPTION
## Root Cause

`TypographySettings` called `updateConfig({ fontFamily: f.id })` for every font button including the synthetic `'global'` Inherit button. Several config types (`CountdownConfig`, `BreathingConfig`, `ActivityWallConfig`, etc.) declare `fontFamily` as `GlobalFontFamily`, a union of valid font IDs that does **not** include the string `'global'`. Persisting that literal value to Firestore violated the declared type contract and could corrupt configs for widgets that branch on specific font IDs.

A secondary dead-code condition `(!fontFamily && f.id === 'global')` on the selected-state check was unreachable because the destructuring default (`fontFamily = 'global'`) ensures `fontFamily` is never falsy.

## Fix Summary

- **`onClick`**: Write `fontFamily: undefined` when the Inherit button is clicked (clears the override so the widget inherits the dashboard global font via its destructuring default). Named font buttons still write their `f.id`.
- **Selected-state check**: Remove the dead-code `(!fontFamily && f.id === 'global')` branch — `fontFamily === f.id` is sufficient.

## Rejected Band-Aid

Adding a post-process sanitizer in each widget's `updateConfig` handler to strip `'global'` would require touching ~30 widget settings panels and would leave `TypographySettings` with a broken contract for any future caller.

## Regression Test

`'writes undefined (not "global") when the Inherit button is clicked'` in `tests/components/common/TypographySettings.test.tsx`:
- **Before fix**: `AssertionError: expected 'global' not to be 'global'`
- **After fix**: 5/5 tests pass

## Risk

**Contained** — change is in one shared component. Widgets that already had `fontFamily: 'global'` in their configs continue to display correctly (the `fontFamily` destructuring default catches the string `'global'` as the fallback case and renders the global font). Only newly saved configs will write `undefined` instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2bZb7zDM1bRRUzrV7LPcq)_