### PR TITLE
docs(changelog): release entry for 2026-05-29

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,25 @@
 {
   "entries": [
     {
+      "version": "2026.05.29",
+      "date": "2026-05-29",
+      "title": "Translations, typography, and dice fixes",
+      "details": [
+        {
+          "type": "fix",
+          "text": "Translations — the Dock section headers (\"Live\", \"More\", \"More widgets\", \"Open tools\", \"Create folder\") and every label in the What's New modal now appear in German, Spanish, and French. Previously these strings were missing from the non-English translations and either showed as raw text keys or silently fell back to English."
+        },
+        {
+          "type": "fix",
+          "text": "Typography settings — clicking \"Inherit\" on a widget's font picker now properly clears the per-widget font override so the widget picks up the dashboard's global font. Previously the click saved a placeholder value that could leave the widget stuck on the wrong font and prevent later changes to the global font from taking effect."
+        },
+        {
+          "type": "fix",
+          "text": "Dice widget — changing the number of dice from the settings panel while the dice are still rolling now lands on the correct count. Previously, if you bumped the count from 2 to 4 mid-roll, the animation would finish but only the original 2 dice would be saved."
+        }
+      ]
+    },
+    {
       "version": "2026.05.28.4",
       "date": "2026-05-28",
       "title": "Live quiz answer integrity safeguards",


### PR DESCRIPTION
Adds the "What's New" changelog entry for the release batch shipping in #1755 (dev-paul → main).

This PR exists because the changelog routine couldn't push directly to `dev-paul` from the automated environment. Merge this into `dev-paul` before merging #1755 so teachers see the update in the in-app What's New modal after deploy.

## Release theme

3 small, independent user-facing fixes — no overarching theme — so I omitted the curated `overview` and left only `details` (the renderer will show the flat list directly).

## Details (3 fixes)

- **Translations** — Dock section headers ("Live", "More", "More widgets", "Open tools", "Create folder") and every label in the What's New modal now render in German, Spanish, and French. Previously these strings were missing from the non-English locales and either showed as raw key paths or silently fell back to English. _Backs PR #1751._
- **Typography settings — Inherit button** — Clicking "Inherit" on a widget's font picker now properly clears the per-widget font override so the widget picks up the dashboard's global font. Previously the click saved a placeholder value that could leave the widget stuck on the wrong font. _Backs PR #1750._
- **Dice widget — mid-roll count change** — Changing the dice count from the settings panel while the dice are still rolling now lands on the correct number of dice. Previously, bumping the count from 2 to 4 mid-roll left only 2 dice saved when the animation settled. _Backs PR #1749._

## What I left out (and why)

- Classroom Add-ons spike (#1748 area) — explicit throwaway dev page, not user-facing.
- VideoActivity / RandomSettings refactors (#1746, #1747) — internal cleanups, no visible behavior change.
- Sanitize double-quote escape (#1752) — security hardening on AI prompt sanitization; no visible user effect, and per the <80% confidence rule I left it out of the modal.
- URL color palette dedupe (#1754), docs/audit commits, dev-only changes.

## Review

Please sanity-check the copy before merging — particularly the dice fix wording, which I described as the count "lands on the correct number" but the underlying bug was about persistence. Adjust as needed.

## Test plan

- [ ] Run the app, open the What's New modal, confirm the new 2026.05.29 entry renders correctly with 3 fix bullets and no overview disclosure button.
- [ ] Confirm `public/changelog.json` is still valid JSON.

https://claude.ai/code/session_01Fpvmdf98qcCd82xWNcTaNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fpvmdf98qcCd82xWNcTaNw)_