### PR TITLE
fix(notebook): rewrite link page-indices on reorder + relabel move arrows

### DIFF
--- a/components/widgets/SmartNotebook/Widget.tsx
+++ b/components/widgets/SmartNotebook/Widget.tsx
@@ -442,6 +442,18 @@ export const SmartNotebookWidget: React.FC<{
     }
   };
 
+  // Drop any pending autosave for `page` without uploading. Used by the
+  // delete handler: the page is about to disappear, so flushing would
+  // upload the edit to a soon-to-be-deleted storage blob (wasted bandwidth)
+  // and race against persistPageList's updateDoc.
+  const cancelPending = (page: number): void => {
+    if (autosaveTimerRef.current) {
+      clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
+    editedSvgsRef.current.delete(page);
+  };
+
   // Cancel any pending autosave for `page` and fire the upload immediately.
   // Returns true if a flush actually ran, false if there was nothing pending,
   // so structural page-op callers know whether to re-read the doc afterwards.
@@ -654,13 +666,16 @@ export const SmartNotebookWidget: React.FC<{
     if (!confirmed) return;
     setIsPageOp(true);
     try {
-      // Await the flush + re-read fresh state. A fire-and-forget flush would
-      // race against persistPageList's updateDoc and could restore the
-      // 'deleted' pageUrls/pagePaths entry after we'd already cleared it.
-      const fresh = await flushAndReadFresh(currentPage);
-      if (!fresh) return;
-      const linkCountBefore = fresh.objectLinks?.length ?? 0;
-      const { state: next, removedPath } = deletePage(fresh, currentPage);
+      // Cancel rather than flush: the teacher just decided to delete this
+      // page, so any pending edit on it should be discarded (uploading to a
+      // soon-to-be-deleted storage blob would waste bandwidth and race
+      // persistPageList's updateDoc, possibly restoring the page).
+      cancelPending(currentPage);
+      const linkCountBefore = activeNotebook.objectLinks?.length ?? 0;
+      const { state: next, removedPath } = deletePage(
+        activeNotebook,
+        currentPage
+      );
       const droppedLinks = linkCountBefore - (next.objectLinks?.length ?? 0);
       await persistPageList(next);
       if (removedPath) {

--- a/components/widgets/SmartNotebook/Widget.tsx
+++ b/components/widgets/SmartNotebook/Widget.tsx
@@ -24,6 +24,7 @@ import {
   setDoc,
   updateDoc,
   deleteDoc,
+  getDoc,
   query,
   orderBy,
   arrayRemove,
@@ -442,15 +443,25 @@ export const SmartNotebookWidget: React.FC<{
   };
 
   // Cancel any pending autosave for `page` and fire the upload immediately.
-  // Used on page navigation, present-mode toggle, and close so jumping never
-  // strands edits in the debounce window.
-  const flushPending = (page: number): void => {
+  // Returns true if a flush actually ran, false if there was nothing pending,
+  // so structural page-op callers know whether to re-read the doc afterwards.
+  // Used by page navigation/present/close (fire-and-forget via `void`) and by
+  // add/delete/move handlers, which MUST `await` it before mutating the page
+  // list — otherwise flushPage's in-flight uploadFile+updateDoc resolves
+  // after the page-op's updateDoc and clobbers the swap/insert/delete with
+  // its pre-mutation pageUrls/pagePaths snapshot.
+  const flushPending = async (page: number): Promise<boolean> => {
     if (autosaveTimerRef.current) {
       clearTimeout(autosaveTimerRef.current);
       autosaveTimerRef.current = null;
     }
     const svg = editedSvgsRef.current.get(page);
-    if (svg) void flushPage(page, svg);
+    if (!svg) return false;
+    await flushPage(page, svg);
+    // Drop the cached edit so a later page op or navigation doesn't redisplay
+    // the stale SVG against a (possibly shifted) page at the same index.
+    editedSvgsRef.current.delete(page);
+    return true;
   };
 
   // PageEditor emits an updated SVG after each edit. Cache it (ref, no
@@ -470,19 +481,50 @@ export const SmartNotebookWidget: React.FC<{
 
   const navigateToPage = (newPage: number): void => {
     if (newPage === currentPage) return;
-    flushPending(currentPage);
+    void flushPending(currentPage);
     setCurrentPage(newPage);
   };
 
   const togglePresentMode = (): void => {
     // Flush before showing the class — they shouldn't see a stale page.
-    flushPending(currentPage);
+    void flushPending(currentPage);
     setPresentMode((p) => !p);
   };
 
   const handleClose = (): void => {
-    flushPending(currentPage);
+    void flushPending(currentPage);
     updateWidget(widget.id, { config: { ...config, activeNotebookId: null } });
+  };
+
+  // Flush any pending edit for `page`, then return the freshest notebook
+  // state for the structural page op to mutate against. When nothing was
+  // pending we keep using the in-memory snapshot (no extra Firestore read
+  // — page ops happen on manual teacher action, and the budget here is
+  // school-district sensitive); when a flush ran we re-read via getDoc so
+  // the page-op sees the just-uploaded pageUrls[page]=url instead of
+  // overwriting it with the stale React-state copy.
+  const flushAndReadFresh = async (
+    page: number
+  ): Promise<NotebookItem | null> => {
+    if (!user || !activeNotebook) return null;
+    const flushed = await flushPending(page);
+    if (!flushed) return activeNotebook;
+    const snap = await getDoc(
+      doc(db, 'users', user.uid, 'notebooks', activeNotebook.id)
+    );
+    if (!snap.exists()) return activeNotebook;
+    const data = snap.data();
+    return {
+      ...activeNotebook,
+      pageUrls: (data.pageUrls as string[]) ?? activeNotebook.pageUrls,
+      pagePaths: (data.pagePaths as string[]) ?? activeNotebook.pagePaths,
+      sections:
+        (data.sections as NotebookSection[] | undefined) ??
+        activeNotebook.sections,
+      objectLinks:
+        (data.objectLinks as NotebookObjectLink[] | undefined) ??
+        activeNotebook.objectLinks,
+    };
   };
 
   // Add or replace an object→page link. The same {objectId, sourcePage}
@@ -545,19 +587,24 @@ export const SmartNotebookWidget: React.FC<{
   };
 
   // Persist a new page list (urls/paths/sections/objectLinks) to Firestore.
-  // objectLinks are written whenever the source notebook has any — even when
-  // the page op produces an empty list (e.g. all links lived on a deleted
-  // page) — so Firestore reflects the deletion instead of holding stale data.
+  // The objectLinks write is gated on `next.objectLinks` (set by the helper
+  // iff the input notebook had any) — NOT on the live React-state snapshot,
+  // which can lag the Firestore doc when a concurrent arrayUnion link save
+  // hasn't propagated yet. Gating on the helper result keeps the write
+  // aligned with the input the helper actually remapped against. When all
+  // links lived on a deleted page the helper returns `[]` (not undefined),
+  // so the empty array is written through to clear Firestore.
   const persistPageList = async (next: PageListState) => {
     if (!user || !activeNotebook) return;
-    const hadLinks = (activeNotebook.objectLinks ?? []).length > 0;
     await updateDoc(
       doc(db, 'users', user.uid, 'notebooks', activeNotebook.id),
       {
         pageUrls: next.pageUrls,
         pagePaths: next.pagePaths,
         ...(next.sections ? { sections: next.sections } : {}),
-        ...(hadLinks ? { objectLinks: next.objectLinks ?? [] } : {}),
+        ...(next.objectLinks !== undefined
+          ? { objectLinks: next.objectLinks }
+          : {}),
       }
     );
   };
@@ -565,21 +612,20 @@ export const SmartNotebookWidget: React.FC<{
   // Insert a blank page after the current one and navigate to it.
   const handleAddPage = async () => {
     if (!user || !activeNotebook) return;
-    // Flush any pending autosave for the current page before mutating the
-    // page list, otherwise the debounced upload can land on the shifted
-    // pagePaths[currentPage] and overwrite the wrong page's storage blob.
-    flushPending(currentPage);
     setIsPageOp(true);
     const notebookPath = `users/${user.uid}/notebooks/${activeNotebook.id}`;
     const path = `${notebookPath}/page-blank-${crypto.randomUUID()}.svg`;
     try {
+      // Await the flush + re-read fresh state. Doing the flush concurrently
+      // with the page-op write would let flushPage's late updateDoc clobber
+      // the inserted blank.
+      const fresh = await flushAndReadFresh(currentPage);
+      if (!fresh) return;
       const file = new File([blankPageSvg()], 'blank.svg', {
         type: 'image/svg+xml',
       });
       const url = await uploadFile(path, file);
-      await persistPageList(
-        insertBlankPage(activeNotebook, currentPage, url, path)
-      );
+      await persistPageList(insertBlankPage(fresh, currentPage, url, path));
       setCurrentPage(currentPage + 1);
       addToast('Blank page added', 'success');
     } catch (err) {
@@ -606,18 +652,16 @@ export const SmartNotebookWidget: React.FC<{
       confirmLabel: 'Delete',
     });
     if (!confirmed) return;
-    // Flush before delete so a pending autosave can't fire against the
-    // post-delete pagePaths array (which shifts neighbors left).
-    flushPending(currentPage);
     setIsPageOp(true);
     try {
-      const linkCountBefore = activeNotebook.objectLinks?.length ?? 0;
-      const { state: next, removedPath } = deletePage(
-        activeNotebook,
-        currentPage
-      );
-      const droppedLinks =
-        linkCountBefore - (next.objectLinks?.length ?? linkCountBefore);
+      // Await the flush + re-read fresh state. A fire-and-forget flush would
+      // race against persistPageList's updateDoc and could restore the
+      // 'deleted' pageUrls/pagePaths entry after we'd already cleared it.
+      const fresh = await flushAndReadFresh(currentPage);
+      if (!fresh) return;
+      const linkCountBefore = fresh.objectLinks?.length ?? 0;
+      const { state: next, removedPath } = deletePage(fresh, currentPage);
+      const droppedLinks = linkCountBefore - (next.objectLinks?.length ?? 0);
       await persistPageList(next);
       if (removedPath) {
         await deleteFile(removedPath).catch((e) => console.error(e));
@@ -649,13 +693,19 @@ export const SmartNotebookWidget: React.FC<{
       !canMovePage(activeNotebook, currentPage, dir)
     )
       return;
-    // Flush before swap: pageUrls/pagePaths swap together, so a debounced
-    // autosave keyed by the old index would upload the teacher's edit to
-    // the swapped neighbor's storage path.
-    flushPending(currentPage);
     setIsPageOp(true);
     try {
-      await persistPageList(movePage(activeNotebook, currentPage, dir));
+      // Await the flush + re-read fresh state. A fire-and-forget flush would
+      // race against persistPageList's updateDoc — flushPage's late write
+      // (after its uploadFile round-trip) would land with the pre-swap
+      // pageUrls/pagePaths captured from React-state and silently revert
+      // the move while leaving objectLinks remapped (incoherent post-state).
+      const fresh = await flushAndReadFresh(currentPage);
+      if (!fresh) return;
+      // Re-check canMovePage against the fresh state in case the section
+      // shape changed between handler entry and the post-flush read.
+      if (!canMovePage(fresh, currentPage, dir)) return;
+      await persistPageList(movePage(fresh, currentPage, dir));
       setCurrentPage(currentPage + dir);
     } catch (err) {
       console.error('Failed to move page', err);

--- a/components/widgets/SmartNotebook/Widget.tsx
+++ b/components/widgets/SmartNotebook/Widget.tsx
@@ -544,15 +544,20 @@ export const SmartNotebookWidget: React.FC<{
     }
   };
 
-  // Persist a new page list (urls/paths/sections) to Firestore.
+  // Persist a new page list (urls/paths/sections/objectLinks) to Firestore.
+  // objectLinks are written whenever the source notebook has any — even when
+  // the page op produces an empty list (e.g. all links lived on a deleted
+  // page) — so Firestore reflects the deletion instead of holding stale data.
   const persistPageList = async (next: PageListState) => {
     if (!user || !activeNotebook) return;
+    const hadLinks = (activeNotebook.objectLinks ?? []).length > 0;
     await updateDoc(
       doc(db, 'users', user.uid, 'notebooks', activeNotebook.id),
       {
         pageUrls: next.pageUrls,
         pagePaths: next.pagePaths,
         ...(next.sections ? { sections: next.sections } : {}),
+        ...(hadLinks ? { objectLinks: next.objectLinks ?? [] } : {}),
       }
     );
   };
@@ -560,6 +565,10 @@ export const SmartNotebookWidget: React.FC<{
   // Insert a blank page after the current one and navigate to it.
   const handleAddPage = async () => {
     if (!user || !activeNotebook) return;
+    // Flush any pending autosave for the current page before mutating the
+    // page list, otherwise the debounced upload can land on the shifted
+    // pagePaths[currentPage] and overwrite the wrong page's storage blob.
+    flushPending(currentPage);
     setIsPageOp(true);
     const notebookPath = `users/${user.uid}/notebooks/${activeNotebook.id}`;
     const path = `${notebookPath}/page-blank-${crypto.randomUUID()}.svg`;
@@ -597,18 +606,33 @@ export const SmartNotebookWidget: React.FC<{
       confirmLabel: 'Delete',
     });
     if (!confirmed) return;
+    // Flush before delete so a pending autosave can't fire against the
+    // post-delete pagePaths array (which shifts neighbors left).
+    flushPending(currentPage);
     setIsPageOp(true);
     try {
+      const linkCountBefore = activeNotebook.objectLinks?.length ?? 0;
       const { state: next, removedPath } = deletePage(
         activeNotebook,
         currentPage
       );
+      const droppedLinks =
+        linkCountBefore - (next.objectLinks?.length ?? linkCountBefore);
       await persistPageList(next);
       if (removedPath) {
         await deleteFile(removedPath).catch((e) => console.error(e));
       }
       setCurrentPage((p) => Math.min(p, next.pageUrls.length - 1));
-      addToast('Page deleted', 'success');
+      if (droppedLinks > 0) {
+        // Surface the silent data loss (hotspots on / pointing to the
+        // deleted page) so the teacher isn't surprised later.
+        addToast(
+          `Page deleted (also removed ${droppedLinks} hyperlink${droppedLinks === 1 ? '' : 's'})`,
+          'success'
+        );
+      } else {
+        addToast('Page deleted', 'success');
+      }
     } catch (err) {
       console.error('Failed to delete page', err);
       addToast('Failed to delete page', 'error');
@@ -625,6 +649,10 @@ export const SmartNotebookWidget: React.FC<{
       !canMovePage(activeNotebook, currentPage, dir)
     )
       return;
+    // Flush before swap: pageUrls/pagePaths swap together, so a debounced
+    // autosave keyed by the old index would upload the teacher's edit to
+    // the swapped neighbor's storage path.
+    flushPending(currentPage);
     setIsPageOp(true);
     try {
       await persistPageList(movePage(activeNotebook, currentPage, dir));

--- a/components/widgets/SmartNotebook/components/PageEditorOverlay.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditorOverlay.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlertTriangle,
-  ArrowLeft,
-  ArrowRight,
   BringToFront,
   CheckCircle2,
   ChevronDown,
@@ -47,6 +45,7 @@ import {
 } from './pageEditorTypes';
 import { PageJumpMenu } from './PageJumpMenu';
 import { LinkTargetPicker } from './LinkTargetPicker';
+import { ReorderPageControl } from './ReorderPageControl';
 import { useClickOutside } from '@/hooks/useClickOutside';
 
 interface PageEditorOverlayProps {
@@ -296,26 +295,13 @@ export const PageEditorOverlay: React.FC<PageEditorOverlayProps> = ({
               </select>
             )}
             {onMovePage && (
-              <>
-                <button
-                  onClick={() => onMovePage(-1)}
-                  disabled={pageOpBusy || !canMoveEarlier}
-                  className={toolBtnClass}
-                  style={toolBtnStyle}
-                  title="Move page earlier"
-                >
-                  <ArrowLeft style={iconStyle} />
-                </button>
-                <button
-                  onClick={() => onMovePage(1)}
-                  disabled={pageOpBusy || !canMoveLater}
-                  className={toolBtnClass}
-                  style={toolBtnStyle}
-                  title="Move page later"
-                >
-                  <ArrowRight style={iconStyle} />
-                </button>
-              </>
+              <ReorderPageControl
+                onMovePage={onMovePage}
+                pageOpBusy={pageOpBusy}
+                canMoveEarlier={canMoveEarlier}
+                canMoveLater={canMoveLater}
+                iconStyle={iconStyle}
+              />
             )}
             {onAddPage && (
               <button

--- a/components/widgets/SmartNotebook/components/ReorderPageControl.tsx
+++ b/components/widgets/SmartNotebook/components/ReorderPageControl.tsx
@@ -1,6 +1,17 @@
 import React from 'react';
 import { ArrowLeftToLine, ArrowRightToLine } from 'lucide-react';
 
+// Match the surrounding header tool buttons' tap target (min(8px, 2cqmin)
+// padding around a min(16px, 4cqmin) icon) so this control is no harder to
+// hit than the Add/Delete/Present buttons next to it. Disabled treatment
+// uses opacity + grayscale so it still reads as inactive against the
+// slate-100 grouping chip background; transition-all (not -colors) lets the
+// opacity/filter actually animate when the busy flag toggles. Hoisted to
+// module scope so it isn't re-allocated per render.
+const BTN_CLASS =
+  'flex items-center justify-center rounded-lg text-slate-700 hover:bg-white disabled:opacity-30 disabled:grayscale disabled:hover:bg-transparent transition-all';
+const BTN_STYLE: React.CSSProperties = { padding: 'min(8px, 2cqmin)' };
+
 /**
  * Header control that lets the teacher shift the current page earlier or
  * later in the notebook. Visually grouped with a "MOVE" label and bar-arrow
@@ -8,41 +19,39 @@ import { ArrowLeftToLine, ArrowRightToLine } from 'lucide-react';
  * used plain ArrowLeft/ArrowRight icons that were indistinguishable from
  * the footer's prev/next page chevrons, and teachers occasionally clicked
  * them expecting to navigate.
+ *
+ * `canMoveEarlier` / `canMoveLater` are required (no default) so a future
+ * consumer can't silently wire up a permanently-disabled chip — the
+ * disabled treatment is subtle against the chip background and missing
+ * wiring would be hard to spot at a glance.
  */
 export const ReorderPageControl: React.FC<{
   onMovePage: (dir: -1 | 1) => void;
-  pageOpBusy?: boolean;
-  canMoveEarlier?: boolean;
-  canMoveLater?: boolean;
+  pageOpBusy: boolean;
+  canMoveEarlier: boolean;
+  canMoveLater: boolean;
   iconStyle: React.CSSProperties;
-}> = ({
-  onMovePage,
-  pageOpBusy = false,
-  canMoveEarlier = false,
-  canMoveLater = false,
-  iconStyle,
-}) => {
-  // Match the surrounding header tool buttons' tap target (min(8px, 2cqmin)
-  // padding around a min(16px, 4cqmin) icon) so this control is no harder
-  // to hit than the Add/Delete/Present buttons next to it. The disabled
-  // treatment adds a grayscale + lower opacity than the standard 0.4 so it
-  // still reads as disabled against the slate-100 grouping chip background.
-  const btnClass =
-    'flex items-center justify-center rounded-lg text-slate-700 hover:bg-white disabled:opacity-30 disabled:grayscale disabled:hover:bg-transparent transition-colors';
-  const btnStyle: React.CSSProperties = { padding: 'min(8px, 2cqmin)' };
+}> = ({ onMovePage, pageOpBusy, canMoveEarlier, canMoveLater, iconStyle }) => {
+  // When neither direction is movable (e.g. one-page notebook, or a page
+  // alone in its section), dim the whole chip including the "MOVE" label
+  // and the border so it reads as a single inactive control rather than
+  // a styled chip with mysteriously-faded icons.
+  const allDisabled = !canMoveEarlier && !canMoveLater;
   return (
     <div
       role="group"
       aria-label="Reorder page"
-      className="flex items-center rounded-xl bg-slate-100 border border-slate-200 shadow-sm"
+      className={`flex items-center rounded-xl bg-slate-100 border border-slate-200 shadow-sm transition-opacity ${
+        allDisabled ? 'opacity-50' : 'opacity-100'
+      }`}
       style={{ padding: 'min(2px, 0.5cqmin)', gap: 'min(2px, 0.5cqmin)' }}
     >
       <button
         type="button"
         onClick={() => onMovePage(-1)}
         disabled={pageOpBusy || !canMoveEarlier}
-        className={btnClass}
-        style={btnStyle}
+        className={BTN_CLASS}
+        style={BTN_STYLE}
         title="Move this page earlier in the notebook"
         aria-label="Move page earlier"
       >
@@ -62,8 +71,8 @@ export const ReorderPageControl: React.FC<{
         type="button"
         onClick={() => onMovePage(1)}
         disabled={pageOpBusy || !canMoveLater}
-        className={btnClass}
-        style={btnStyle}
+        className={BTN_CLASS}
+        style={BTN_STYLE}
         title="Move this page later in the notebook"
         aria-label="Move page later"
       >

--- a/components/widgets/SmartNotebook/components/ReorderPageControl.tsx
+++ b/components/widgets/SmartNotebook/components/ReorderPageControl.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { ArrowLeftToLine, ArrowRightToLine } from 'lucide-react';
+
+/**
+ * Header control that lets the teacher shift the current page earlier or
+ * later in the notebook. Visually grouped with a "MOVE" label and bar-arrow
+ * icons so it doesn't read as a navigation control — the previous design
+ * used plain ArrowLeft/ArrowRight icons that were indistinguishable from
+ * the footer's prev/next page chevrons, and teachers occasionally clicked
+ * them expecting to navigate.
+ */
+export const ReorderPageControl: React.FC<{
+  onMovePage: (dir: -1 | 1) => void;
+  pageOpBusy?: boolean;
+  canMoveEarlier?: boolean;
+  canMoveLater?: boolean;
+  iconStyle: React.CSSProperties;
+}> = ({
+  onMovePage,
+  pageOpBusy = false,
+  canMoveEarlier = false,
+  canMoveLater = false,
+  iconStyle,
+}) => {
+  // Match the surrounding header tool buttons' tap target (min(8px, 2cqmin)
+  // padding around a min(16px, 4cqmin) icon) so this control is no harder
+  // to hit than the Add/Delete/Present buttons next to it. The disabled
+  // treatment adds a grayscale + lower opacity than the standard 0.4 so it
+  // still reads as disabled against the slate-100 grouping chip background.
+  const btnClass =
+    'flex items-center justify-center rounded-lg text-slate-700 hover:bg-white disabled:opacity-30 disabled:grayscale disabled:hover:bg-transparent transition-colors';
+  const btnStyle: React.CSSProperties = { padding: 'min(8px, 2cqmin)' };
+  return (
+    <div
+      role="group"
+      aria-label="Reorder page"
+      className="flex items-center rounded-xl bg-slate-100 border border-slate-200 shadow-sm"
+      style={{ padding: 'min(2px, 0.5cqmin)', gap: 'min(2px, 0.5cqmin)' }}
+    >
+      <button
+        type="button"
+        onClick={() => onMovePage(-1)}
+        disabled={pageOpBusy || !canMoveEarlier}
+        className={btnClass}
+        style={btnStyle}
+        title="Move this page earlier in the notebook"
+        aria-label="Move page earlier"
+      >
+        <ArrowLeftToLine style={iconStyle} />
+      </button>
+      <span
+        aria-hidden
+        className="font-black text-slate-500 uppercase tracking-widest select-none"
+        style={{
+          fontSize: 'min(9px, 2.2cqmin)',
+          padding: '0 min(4px, 1cqmin)',
+        }}
+      >
+        Move
+      </span>
+      <button
+        type="button"
+        onClick={() => onMovePage(1)}
+        disabled={pageOpBusy || !canMoveLater}
+        className={btnClass}
+        style={btnStyle}
+        title="Move this page later in the notebook"
+        aria-label="Move page later"
+      >
+        <ArrowRightToLine style={iconStyle} />
+      </button>
+    </div>
+  );
+};

--- a/components/widgets/SmartNotebook/components/Viewer.tsx
+++ b/components/widgets/SmartNotebook/components/Viewer.tsx
@@ -7,8 +7,6 @@ import {
   Pencil,
   Plus,
   Trash2,
-  ArrowLeft,
-  ArrowRight,
   Share2,
   X,
 } from 'lucide-react';
@@ -16,6 +14,7 @@ import { NotebookItem, PlacedNotebookAsset } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { PageCanvas } from './PageCanvas';
 import { PageJumpMenu } from './PageJumpMenu';
+import { ReorderPageControl } from './ReorderPageControl';
 
 interface ViewerProps {
   activeNotebook: NotebookItem;
@@ -146,26 +145,13 @@ export const Viewer: React.FC<ViewerProps> = ({
               </select>
             )}
             {onMovePage && (
-              <>
-                <button
-                  onClick={() => onMovePage(-1)}
-                  disabled={pageOpBusy || !canMoveEarlier}
-                  className={toolBtnClass}
-                  style={toolBtnStyle}
-                  title="Move page earlier"
-                >
-                  <ArrowLeft style={iconStyle} />
-                </button>
-                <button
-                  onClick={() => onMovePage(1)}
-                  disabled={pageOpBusy || !canMoveLater}
-                  className={toolBtnClass}
-                  style={toolBtnStyle}
-                  title="Move page later"
-                >
-                  <ArrowRight style={iconStyle} />
-                </button>
-              </>
+              <ReorderPageControl
+                onMovePage={onMovePage}
+                pageOpBusy={pageOpBusy}
+                canMoveEarlier={canMoveEarlier}
+                canMoveLater={canMoveLater}
+                iconStyle={iconStyle}
+              />
             )}
             {onAddPage && (
               <button

--- a/utils/notebookPages.test.ts
+++ b/utils/notebookPages.test.ts
@@ -11,20 +11,27 @@ import {
 } from './notebookPages';
 import { NotebookObjectLink } from '@/types';
 
+// xFrac/yFrac/wFrac/hFrac don't affect any assertion in this file (the
+// page-index rewrite is the only behavior under test) so they're defaulted
+// to small valid values to keep call sites focused on the indices.
 const link = (
   id: string,
   objectId: string,
   sourcePage: number,
-  targetPage: number
+  targetPage: number,
+  xFrac = 0,
+  yFrac = 0,
+  wFrac = 0.1,
+  hFrac = 0.1
 ): NotebookObjectLink => ({
   id,
   objectId,
   sourcePage,
   targetPage,
-  xFrac: 0,
-  yFrac: 0,
-  wFrac: 0.1,
-  hFrac: 0.1,
+  xFrac,
+  yFrac,
+  wFrac,
+  hFrac,
 });
 
 // Pages p0..p4 across two lessons: A=[0,1,2], B=[3,4].

--- a/utils/notebookPages.test.ts
+++ b/utils/notebookPages.test.ts
@@ -9,6 +9,23 @@ import {
   blankPageSvg,
   PageListState,
 } from './notebookPages';
+import { NotebookObjectLink } from '@/types';
+
+const link = (
+  id: string,
+  objectId: string,
+  sourcePage: number,
+  targetPage: number
+): NotebookObjectLink => ({
+  id,
+  objectId,
+  sourcePage,
+  targetPage,
+  xFrac: 0,
+  yFrac: 0,
+  wFrac: 0.1,
+  hFrac: 0.1,
+});
 
 // Pages p0..p4 across two lessons: A=[0,1,2], B=[3,4].
 const state = (): PageListState => ({
@@ -137,6 +154,65 @@ describe('canMovePage / movePage', () => {
   it('blocks moves out of bounds', () => {
     expect(canMovePage(state(), 0, -1)).toBe(false);
     expect(canMovePage(state(), 4, 1)).toBe(false);
+  });
+});
+
+describe('objectLinks rewrite', () => {
+  const withLinks = (): PageListState => ({
+    ...state(),
+    objectLinks: [
+      link('L0', 'obj0', 0, 4), // p0 → p4
+      link('L1', 'obj1', 2, 0), // p2 → p0
+      link('L2', 'obj2', 3, 3), // p3 → p3 (same-page link)
+    ],
+  });
+
+  it('insertBlankPage shifts link indices at or after the insert point', () => {
+    // Insert after index 1 -> insertAt = 2. Pages 2,3,4 shift to 3,4,5.
+    const next = insertBlankPage(withLinks(), 1, 'NEW', 'NEWP');
+    expect(next.objectLinks).toEqual([
+      link('L0', 'obj0', 0, 5), // target 4 -> 5
+      link('L1', 'obj1', 3, 0), // source 2 -> 3
+      link('L2', 'obj2', 4, 4), // source 3 -> 4, target 3 -> 4
+    ]);
+  });
+
+  it('insertBlankPage leaves links untouched when inserting after them all', () => {
+    // Insert after index 4 -> insertAt = 5, past every page.
+    const next = insertBlankPage(withLinks(), 4, 'NEW', 'NEWP');
+    expect(next.objectLinks).toEqual(withLinks().objectLinks);
+  });
+
+  it('deletePage drops links whose source page is deleted', () => {
+    const { state: next } = deletePage(withLinks(), 0);
+    // L0 (sourcePage 0) and L1 (targetPage 0) are both gone.
+    // L2 survives: 3 -> 2 (both indices shift left).
+    expect(next.objectLinks).toEqual([link('L2', 'obj2', 2, 2)]);
+  });
+
+  it('deletePage drops links whose target page is deleted', () => {
+    const { state: next } = deletePage(withLinks(), 4);
+    // L0 targeted page 4 -> dropped. L1 (2->0) survives unchanged.
+    // L2 (3->3) survives unchanged (both < 4).
+    expect(next.objectLinks).toEqual([
+      link('L1', 'obj1', 2, 0),
+      link('L2', 'obj2', 3, 3),
+    ]);
+  });
+
+  it('movePage swaps page indices on both source and target of every link', () => {
+    // Move p2 left to p1 (both in section A). Indices 1 and 2 swap.
+    const next = movePage(withLinks(), 2, -1);
+    expect(next.objectLinks).toEqual([
+      link('L0', 'obj0', 0, 4), // unaffected
+      link('L1', 'obj1', 1, 0), // source 2 -> 1
+      link('L2', 'obj2', 3, 3), // unaffected
+    ]);
+  });
+
+  it('movePage with no objectLinks leaves the field undefined', () => {
+    const next = movePage(state(), 0, 1);
+    expect(next.objectLinks).toBeUndefined();
   });
 });
 

--- a/utils/notebookPages.ts
+++ b/utils/notebookPages.ts
@@ -1,20 +1,48 @@
-import { NotebookSection } from '@/types';
+import { NotebookObjectLink, NotebookSection } from '@/types';
 
 /**
  * Pure page-list + lesson-section operations for the SMART Notebook widget
  * (add / delete / reorder pages). Kept separate from Firestore/Storage so the
- * tricky part — keeping the contiguous lesson sections correct as pages move —
- * is fully unit-testable. The Widget applies the result, then persists.
+ * tricky parts — keeping the contiguous lesson sections correct AND rewriting
+ * objectLinks' page indices as pages move — are fully unit-testable. The
+ * Widget applies the result, then persists.
  */
 
 export interface PageListState {
   pageUrls: string[];
   pagePaths: string[];
   sections?: NotebookSection[];
+  /**
+   * Object→page hyperlinks. Stored on PageListState (rather than passed in
+   * separately) so the three structural operations can keep the link
+   * sourcePage/targetPage indices coherent in a single pass alongside
+   * pageUrls and sections.
+   */
+  objectLinks?: NotebookObjectLink[];
 }
 
 const cloneSections = (sections?: NotebookSection[]): NotebookSection[] =>
   (sections ?? []).map((s) => ({ ...s }));
+
+/**
+ * Apply a per-page-index transform to every link's sourcePage and targetPage.
+ * Returning `null` for a given index drops any link that touches it (used by
+ * deletePage to discard links whose source page or target page is gone).
+ */
+const remapLinkPages = (
+  links: NotebookObjectLink[] | undefined,
+  remap: (page: number) => number | null
+): NotebookObjectLink[] | undefined => {
+  if (!links) return links;
+  const next: NotebookObjectLink[] = [];
+  for (const link of links) {
+    const source = remap(link.sourcePage);
+    const target = remap(link.targetPage);
+    if (source === null || target === null) continue;
+    next.push({ ...link, sourcePage: source, targetPage: target });
+  }
+  return next;
+};
 
 /**
  * Clamp a current page index to a (possibly changed) page count. Guards the
@@ -58,10 +86,16 @@ export const insertBlankPage = (
     return s;
   });
 
+  // Any page at or after the insertion point shifts right by one.
+  const objectLinks = remapLinkPages(state.objectLinks, (p) =>
+    p >= insertAt ? p + 1 : p
+  );
+
   return {
     pageUrls,
     pagePaths,
     sections: state.sections ? sections : undefined,
+    objectLinks,
   };
 };
 
@@ -84,11 +118,21 @@ export const deletePage = (
     })
     .filter((s) => s.pageCount > 0);
 
+  // Links whose source page or target page is the deleted page are dropped
+  // (the source object is gone with the page, and a hotspot to a missing
+  // page would jump to nothing). Surviving links pointing past `index`
+  // shift left by one.
+  const objectLinks = remapLinkPages(state.objectLinks, (p) => {
+    if (p === index) return null;
+    return p > index ? p - 1 : p;
+  });
+
   return {
     state: {
       pageUrls,
       pagePaths,
       sections: state.sections ? sections : undefined,
+      objectLinks,
     },
     removedPath,
   };
@@ -114,7 +158,9 @@ export const canMovePage = (
 };
 
 /** Swap page `index` with its neighbor in `dir`. Sections are unchanged
- * (movement is constrained to within a section by `canMovePage`). */
+ * (movement is constrained to within a section by `canMovePage`). Links
+ * on either swapped page have their source/target indices swapped in
+ * lockstep so they keep pointing at the same page content. */
 export const movePage = (
   state: PageListState,
   index: number,
@@ -126,7 +172,19 @@ export const movePage = (
   const pagePaths = [...state.pagePaths];
   [pageUrls[index], pageUrls[target]] = [pageUrls[target], pageUrls[index]];
   [pagePaths[index], pagePaths[target]] = [pagePaths[target], pagePaths[index]];
-  return { pageUrls, pagePaths, sections: state.sections };
+
+  const objectLinks = remapLinkPages(state.objectLinks, (p) => {
+    if (p === index) return target;
+    if (p === target) return index;
+    return p;
+  });
+
+  return {
+    pageUrls,
+    pagePaths,
+    sections: state.sections,
+    objectLinks,
+  };
 };
 
 /** A blank white page SVG (renders via <img> and is editable like any page). */


### PR DESCRIPTION
## Summary

- **Bug A — link misalignment on reorder.** The SMART Notebook page ops (`movePage`, `insertBlankPage`, `deletePage` in [utils/notebookPages.ts](utils/notebookPages.ts)) only rewrote `pageUrls`/`pagePaths`/`sections`. `NotebookObjectLink.sourcePage`/`.targetPage` are 0-based page indices, so every reorder/insert/delete left hotspots anchored to stale indices — hotspots ended up on the wrong page, or jumped to the wrong target. Now fixed via a `remapLinkPages` helper that rewrites both endpoints (or drops the link when its source/target page is deleted) in lockstep with the page list mutation.
- **Bug B — misleading header arrows.** The header's `ArrowLeft`/`ArrowRight` "Move page earlier/later" buttons looked identical to navigation arrows. Replaced both editor and viewer call sites with a shared `ReorderPageControl` chip: `ArrowLeftToLine`/`ArrowRightToLine` icons flanking an uppercase "MOVE" label in a tinted bordered container.
- **Adjacent autosave fix.** `handleAddPage` / `handleDeletePage` / `handleMovePage` now call `flushPending(currentPage)` before mutating the page list — without this, a debounced autosave could fire after the array shifted and upload the teacher's edit to the wrong page's storage path.
- **UX surface.** `handleDeletePage` now shows a "removed N hyperlinks" toast when links were orphaned by the delete, so the (intentional) drop isn't silent.

## Test plan

- [x] `pnpm run type-check`
- [x] `pnpm exec eslint components/widgets/SmartNotebook utils/notebookPages.ts utils/notebookPages.test.ts --max-warnings 0`
- [x] `pnpm exec vitest run utils/notebookPages.test.ts components/widgets/SmartNotebook` — 30/30 passing, includes 6 new `objectLinks rewrite` tests covering insert/delete/move + the no-links passthrough
- [x] `pnpm exec prettier --check` on all edited files
- [ ] Manual: open a notebook with several hotspots, reorder a page that owns one — confirm the hotspot moves with its page and the target jump still lands correctly
- [ ] Manual: delete a page that has hotspots pointing TO it from other pages — confirm the toast shows the removed-hyperlink count
- [ ] Manual: confirm the "MOVE" chip visually reads as a reorder control vs. nav (header) and the footer chevrons still navigate normally

## Known limitations (follow-ups, not in this PR)

- `persistPageList` overwrites `objectLinks` as a full array; `handleSaveObjectLink`/`Batch`/`Remove` use `arrayUnion`/`arrayRemove`. A multi-tab race between a link save and a reorder could clobber the new link. Single-tab use is unaffected. Fix would wrap the page op in `runTransaction`.
- `PlacedNotebookAsset.page` is also a raw page index and is not yet remapped — stickers strand on the wrong page after reorder. Same bug class, different persistence path (widget config rather than the notebook doc). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)