### PR TITLE
fix(spotify): eliminate Web Playback SDK 'ready' vs Connect registration race

### DIFF
--- a/components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { WidgetData, MusicConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { useDashboard } from '@/context/useDashboard';
@@ -43,10 +43,20 @@ export const PersonalSpotifyBrowser: React.FC<Props> = ({ widget }) => {
   // Holds a tap-to-play pick when the user taps a row BEFORE the SDK device
   // has been confirmed-registered by useSpotifyWebPlayback's polling. The
   // effect below flushes it the moment `playback.deviceId` becomes available.
-  // Without this, taps during the 0-15s registration window silently no-op
-  // (handlePlay's `if (!playback.deviceId) return`), which reads to the
-  // teacher as "nothing happened — let me click again."
+  // Without this, taps during the 0-15s registration window silently no-op,
+  // which reads to the teacher as "nothing happened — let me click again."
   const pendingPickRef = useRef<SpotifyPlayablePick | null>(null);
+  // Mirror playback.deviceId into a ref so async paths (handlePlay's
+  // post-await check, the flush effect's post-await re-check) always see
+  // the current value rather than the closure-captured stale one. Synced
+  // via useLayoutEffect to match the codebase pattern (and satisfy the
+  // 'no ref access in render' lint rule); useLayoutEffect commits before
+  // any callback that the next render queues, so the ref is fresh by the
+  // time any user-triggered handler runs.
+  const latestDeviceIdRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    latestDeviceIdRef.current = playback.deviceId;
+  });
 
   const startPick = useCallback(
     async (pick: SpotifyPlayablePick, token: string, deviceId: string) => {
@@ -71,22 +81,23 @@ export const PersonalSpotifyBrowser: React.FC<Props> = ({ widget }) => {
       if (!isPremium) return;
       const token = await getAccessToken();
       if (!token) return;
-      if (!playback.deviceId) {
+      // Read through the ref AFTER the await — playback.deviceId may have
+      // flipped (not_ready cleared it, or registration just finished)
+      // between callback creation and now. Captured-by-closure would be
+      // stale.
+      const currentDeviceId = latestDeviceIdRef.current;
+      if (!currentDeviceId) {
         // Device not yet confirmed by Spotify Connect — queue the pick and
         // let the effect flush it as soon as deviceId arrives.
         pendingPickRef.current = pick;
         return;
       }
-      await startPick(pick, token, playback.deviceId);
+      await startPick(pick, token, currentDeviceId);
     },
-    [
-      updateWidget,
-      widget.id,
-      isPremium,
-      getAccessToken,
-      playback.deviceId,
-      startPick,
-    ]
+    // playback.deviceId is intentionally omitted: we read it through
+    // latestDeviceIdRef.current, which is always fresh. Including it would
+    // recreate the callback on every device change for no benefit.
+    [updateWidget, widget.id, isPremium, getAccessToken, startPick]
   );
 
   // Flush a queued tap when the SDK device finally registers. Only fires
@@ -99,9 +110,9 @@ export const PersonalSpotifyBrowser: React.FC<Props> = ({ widget }) => {
     void (async () => {
       const token = await getAccessToken();
       if (!token) return;
-      // Re-check deviceId after the token await — could have been cleared
+      // Re-check via the ref — playback.deviceId may have been cleared
       // (not_ready, sign-out) while we were resolving the token.
-      const id = playback.deviceId;
+      const id = latestDeviceIdRef.current;
       if (!id) {
         pendingPickRef.current = queued;
         return;

--- a/components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx
+++ b/components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { WidgetData, MusicConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { useDashboard } from '@/context/useDashboard';
@@ -40,6 +40,27 @@ export const PersonalSpotifyBrowser: React.FC<Props> = ({ widget }) => {
     await connect();
   }, [disconnect, connect]);
 
+  // Holds a tap-to-play pick when the user taps a row BEFORE the SDK device
+  // has been confirmed-registered by useSpotifyWebPlayback's polling. The
+  // effect below flushes it the moment `playback.deviceId` becomes available.
+  // Without this, taps during the 0-15s registration window silently no-op
+  // (handlePlay's `if (!playback.deviceId) return`), which reads to the
+  // teacher as "nothing happened — let me click again."
+  const pendingPickRef = useRef<SpotifyPlayablePick | null>(null);
+
+  const startPick = useCallback(
+    async (pick: SpotifyPlayablePick, token: string, deviceId: string) => {
+      const payload =
+        pick.type === 'track' ? { uris: [pick.uri] } : { contextUri: pick.uri };
+      try {
+        await playOnDevice(token, deviceId, payload);
+      } catch (err) {
+        console.warn('[PersonalSpotifyBrowser.handlePlay] play failed', err);
+      }
+    },
+    []
+  );
+
   const handlePlay = useCallback(
     async (pick: SpotifyPlayablePick) => {
       updateWidget(widget.id, {
@@ -49,17 +70,45 @@ export const PersonalSpotifyBrowser: React.FC<Props> = ({ widget }) => {
       // after a row tap), so nothing to do here for navigation.
       if (!isPremium) return;
       const token = await getAccessToken();
-      if (!token || !playback.deviceId) return;
-      const payload =
-        pick.type === 'track' ? { uris: [pick.uri] } : { contextUri: pick.uri };
-      try {
-        await playOnDevice(token, playback.deviceId, payload);
-      } catch (err) {
-        console.warn('[PersonalSpotifyBrowser.handlePlay] play failed', err);
+      if (!token) return;
+      if (!playback.deviceId) {
+        // Device not yet confirmed by Spotify Connect — queue the pick and
+        // let the effect flush it as soon as deviceId arrives.
+        pendingPickRef.current = pick;
+        return;
       }
+      await startPick(pick, token, playback.deviceId);
     },
-    [updateWidget, widget.id, isPremium, getAccessToken, playback.deviceId]
+    [
+      updateWidget,
+      widget.id,
+      isPremium,
+      getAccessToken,
+      playback.deviceId,
+      startPick,
+    ]
   );
+
+  // Flush a queued tap when the SDK device finally registers. Only fires
+  // when there's something to flush — no-op on every other render.
+  useEffect(() => {
+    if (!playback.deviceId) return;
+    const queued = pendingPickRef.current;
+    if (!queued) return;
+    pendingPickRef.current = null;
+    void (async () => {
+      const token = await getAccessToken();
+      if (!token) return;
+      // Re-check deviceId after the token await — could have been cleared
+      // (not_ready, sign-out) while we were resolving the token.
+      const id = playback.deviceId;
+      if (!id) {
+        pendingPickRef.current = queued;
+        return;
+      }
+      await startPick(queued, token, id);
+    })();
+  }, [playback.deviceId, getAccessToken, startPick]);
 
   // Shared playback props handed to the leaf player surfaces.
   const playbackProps = {

--- a/hooks/useSpotifyWebPlayback.ts
+++ b/hooks/useSpotifyWebPlayback.ts
@@ -39,6 +39,7 @@ import {
   playOnDevice,
   setRepeatMode,
   setShuffle,
+  waitForDeviceRegistration,
 } from '@/utils/spotifyAuth';
 
 export interface SpotifyPlaybackTrack {
@@ -123,9 +124,40 @@ export function useSpotifyWebPlayback(
     if (!enabled) return;
 
     let destroyed = false;
+    // Generation counter bumped on every event that invalidates an in-flight
+    // device-registration poll: re-emit of `ready` (SDK reconnects with a new
+    // device_id), `not_ready` (device gone), or `failSdk` (any fatal listener).
+    // The poll closure captures the generation at start and bails on resolve
+    // if it has moved on — without this, a stale poll's `.then()` would
+    // resurrect a dead device_id over the current null/failed state.
+    let pollGeneration = 0;
+
+    // Forward-declare playerRef-disconnect into a local so failSdk can use it
+    // without piercing the outer ref. We assign `player` below once connect()
+    // wires up the SDK.
+    const disconnectActivePlayer = () => {
+      try {
+        playerRef.current?.disconnect();
+      } catch {
+        /* SDK can throw during teardown — best-effort */
+      }
+      playerRef.current = null;
+    };
 
     const failSdk = () => {
       if (destroyed) return;
+      // Invalidate any in-flight registration poll before flipping the flag,
+      // so a poll that resolves between here and the next render can't
+      // overwrite sdkFailed=true with a stale setDeviceId.
+      pollGeneration++;
+      // The SDK player is still connected to Spotify Connect even after we
+      // give up on it — without an explicit disconnect, the orphan device
+      // hogs the user's active-device slot and can later "steal" playback
+      // from the embed iframe fallback. Tear it down here, mirroring the
+      // unmount cleanup path.
+      disconnectActivePlayer();
+      deviceIdRef.current = null;
+      setDeviceId(null);
       setSdkFailed(true);
     };
 
@@ -152,11 +184,53 @@ export function useSpotifyWebPlayback(
 
         player.addListener('ready', ({ device_id }) => {
           if (destroyed) return;
-          deviceIdRef.current = device_id;
-          setDeviceId(device_id);
+          // Don't expose device_id to the UI until Spotify Connect has actually
+          // registered it server-side. The SDK fires 'ready' as soon as the
+          // local device object exists, but server-side registration lags by
+          // 1-3 seconds; calling /play, /repeat, /shuffle, or even /me/player
+          // (transfer) before then returns 404 "Device not found". Polling
+          // /v1/me/player/devices until the id is visible is the canonical fix.
+          //
+          // The poll captures its own generation. `not_ready`, a second
+          // `ready`, and `failSdk` all bump pollGeneration so a late-resolving
+          // poll can't write its (now stale) device_id back over the current
+          // state.
+          const myGeneration = ++pollGeneration;
+          const isStillCurrent = () =>
+            !destroyed && pollGeneration === myGeneration;
+          void waitForDeviceRegistration(
+            () => getAccessTokenRef.current(),
+            device_id,
+            () => !isStillCurrent()
+          )
+            .then((registered) => {
+              if (!isStillCurrent()) return;
+              if (registered) {
+                deviceIdRef.current = device_id;
+                setDeviceId(device_id);
+              } else {
+                // Device never appeared on Spotify Connect within the polling
+                // window — fall back to the embed iframe.
+                failSdk();
+              }
+            })
+            .catch(() => {
+              // waitForDeviceRegistration is defensive (fetchSpotifyDevices
+              // swallows its own errors), so this catch is belt-and-suspenders
+              // for an unexpected rejection (e.g. getAccessToken throwing).
+              // Without it, an unhandled rejection would leave the hook stuck
+              // — deviceId null AND sdkFailed false — the exact silent broken
+              // state this patch was built to prevent.
+              if (!isStillCurrent()) return;
+              failSdk();
+            });
         });
         player.addListener('not_ready', () => {
           if (destroyed) return;
+          // Invalidate any in-flight registration poll: the device the poll
+          // was tracking is gone, and we must not let its eventual resolve
+          // setDeviceId back to the now-dead id.
+          pollGeneration++;
           deviceIdRef.current = null;
           setDeviceId(null);
         });
@@ -205,11 +279,26 @@ export function useSpotifyWebPlayback(
             return;
           }
           if (!connected) {
+            // Disconnect the local player BEFORE failSdk: at this point
+            // playerRef.current is still null, so failSdk's disconnect helper
+            // would no-op and leak the orphan SDK device.
+            try {
+              player.disconnect();
+            } catch {
+              /* best-effort */
+            }
             failSdk();
             return;
           }
           playerRef.current = player;
         } catch {
+          // Same orphan-cleanup concern as the !connected path: player exists
+          // but isn't in playerRef yet.
+          try {
+            player.disconnect();
+          } catch {
+            /* best-effort */
+          }
           failSdk();
         }
       },
@@ -221,12 +310,9 @@ export function useSpotifyWebPlayback(
 
     return () => {
       destroyed = true;
-      try {
-        playerRef.current?.disconnect();
-      } catch {
-        /* SDK can throw during teardown — best-effort */
-      }
-      playerRef.current = null;
+      // Invalidate any in-flight registration poll so its .then() bails.
+      pollGeneration++;
+      disconnectActivePlayer();
       // Reset device/playback so a re-enable starts clean.
       deviceIdRef.current = null;
       setDeviceId(null);

--- a/tests/components/widgets/MusicWidget/PersonalSpotifyBrowser.test.tsx
+++ b/tests/components/widgets/MusicWidget/PersonalSpotifyBrowser.test.tsx
@@ -138,3 +138,63 @@ describe('PersonalSpotifyBrowser', () => {
     });
   });
 });
+
+// ── Queue-and-flush: tap-to-play before SDK device is registered ─────────────
+// A separate describe block with its own useSpotifyWebPlayback mock so we can
+// flip deviceId from null → 'dev1' between renders. Without queueing, a tap
+// during the registration window (up to ~15s) silently no-ops because
+// handlePlay's `if (!playback.deviceId) return` short-circuits before
+// playOnDevice ever runs.
+
+describe('PersonalSpotifyBrowser — tap-before-device-ready queue-and-flush', () => {
+  it('queues the pick and flushes it when deviceId arrives', async () => {
+    playMock.mockClear();
+    mockUpdateWidget.mockClear();
+
+    // Dynamic state for the playback mock so we can transition deviceId.
+    let currentDeviceId: string | null = null;
+    vi.doMock('@/hooks/useSpotifyWebPlayback', () => ({
+      useSpotifyWebPlayback: () => ({
+        deviceId: currentDeviceId,
+        isReady: currentDeviceId !== null,
+        sdkFailed: false,
+        currentTrack: null,
+        isPlaying: false,
+        repeatMode: 0,
+        shuffle: false,
+        togglePlay: vi.fn(),
+        next: vi.fn(),
+        previous: vi.fn(),
+        cycleRepeat: vi.fn(),
+        toggleShuffle: vi.fn(),
+      }),
+    }));
+    // Re-import the component so it picks up the doMock'd hook.
+    const { PersonalSpotifyBrowser: Browser } =
+      await import('@/components/widgets/MusicWidget/PersonalSpotifyBrowser');
+    const { rerender } = render(
+      <Browser widget={makeWidget({ layout: 'default' }) as never} />
+    );
+
+    // Tap a row while deviceId is still null (registration polling in flight).
+    fireEvent.click(screen.getByText('mock-play-track'));
+    // URI is persisted regardless — that's the user's intent, captured.
+    expect(mockUpdateWidget).toHaveBeenCalledWith('w1', {
+      config: { personalSpotifyUrl: 'spotify:track:t1' },
+    });
+    // But playback should NOT have started yet — there's no device.
+    expect(playMock).not.toHaveBeenCalled();
+
+    // Device finally registers. Re-render so the hook returns the new id;
+    // the queue-flush useEffect should fire and call playOnDevice.
+    currentDeviceId = 'dev1';
+    rerender(<Browser widget={makeWidget({ layout: 'default' }) as never} />);
+    // The flush is async (await getAccessToken inside). Microtask wait.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(playMock).toHaveBeenCalledWith('tok', 'dev1', {
+      uris: ['spotify:track:t1'],
+    });
+    vi.doUnmock('@/hooks/useSpotifyWebPlayback');
+  });
+});

--- a/tests/hooks/useSpotifyWebPlayback.test.ts
+++ b/tests/hooks/useSpotifyWebPlayback.test.ts
@@ -28,10 +28,13 @@ vi.mock('@/utils/spotifyPlaybackSdk', async () => {
 // ── spotifyAuth mock ──────────────────────────────────────────────────────────
 // The hook now starts the saved URI on first play via playOnDevice; keep the
 // real parseSpotifyResource (so payload selection is exercised) and stub the
-// network call.
+// network calls. waitForDeviceRegistration is also stubbed because the real
+// implementation polls /v1/me/player/devices over real timers — every test
+// that emits 'ready' would otherwise hit real fetch.
 const playOnDeviceMock = vi.fn().mockResolvedValue(undefined);
 const setRepeatModeMock = vi.fn().mockResolvedValue(undefined);
 const setShuffleMock = vi.fn().mockResolvedValue(undefined);
+const waitForDeviceRegistrationMock = vi.fn().mockResolvedValue(true);
 vi.mock('@/utils/spotifyAuth', async () => {
   const actual = await vi.importActual<typeof import('@/utils/spotifyAuth')>(
     '@/utils/spotifyAuth'
@@ -44,6 +47,8 @@ vi.mock('@/utils/spotifyAuth', async () => {
       setRepeatModeMock(...args) as Promise<void>,
     setShuffle: (...args: unknown[]): Promise<void> =>
       setShuffleMock(...args) as Promise<void>,
+    waitForDeviceRegistration: (...args: unknown[]): Promise<boolean> =>
+      waitForDeviceRegistrationMock(...args) as Promise<boolean>,
   };
 });
 
@@ -92,6 +97,12 @@ beforeEach(() => {
   playOnDeviceMock.mockClear();
   setRepeatModeMock.mockClear();
   setShuffleMock.mockClear();
+  // mockReset (not mockClear) is required here because individual tests
+  // override with mockImplementation/mockRejectedValue/mockResolvedValue(false).
+  // Without resetting, the override would leak into the next test. The
+  // mockResolvedValue(true) re-establishes the happy-path default.
+  waitForDeviceRegistrationMock.mockReset();
+  waitForDeviceRegistrationMock.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -111,7 +122,7 @@ describe('useSpotifyWebPlayback', () => {
     expect(result.current.isPlaying).toBe(false);
   });
 
-  it('loads the SDK and sets deviceId when the ready event fires', async () => {
+  it('loads the SDK and sets deviceId once Spotify Connect registers it', async () => {
     installFakeSdk();
     const { result } = renderHook(() =>
       useSpotifyWebPlayback(true, getToken, null)
@@ -124,8 +135,123 @@ describe('useSpotifyWebPlayback', () => {
     act(() => {
       fakePlayer.emit('ready', { device_id: 'device-123' });
     });
-    expect(result.current.deviceId).toBe('device-123');
+    // waitForDeviceRegistration is mocked to resolve(true) — the .then()
+    // callback still has to flush before deviceId is exposed.
+    await waitFor(() => expect(result.current.deviceId).toBe('device-123'));
     expect(result.current.isReady).toBe(true);
+    expect(waitForDeviceRegistrationMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      'device-123',
+      expect.any(Function)
+    );
+  });
+
+  it('falls back to sdkFailed AND disconnects the orphan player when device registration times out', async () => {
+    installFakeSdk();
+    waitForDeviceRegistrationMock.mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useSpotifyWebPlayback(true, getToken, null)
+    );
+    await waitFor(() => expect(fakePlayer.connect).toHaveBeenCalled());
+
+    act(() => {
+      fakePlayer.emit('ready', { device_id: 'device-zzz' });
+    });
+    // Registration never confirmed → caller is told the SDK is unusable so it
+    // can swap in the embed iframe instead of leaving play permanently broken.
+    await waitFor(() => expect(result.current.sdkFailed).toBe(true));
+    expect(result.current.deviceId).toBeNull();
+    // Crucially, the orphan SDK player must be disconnected too — otherwise
+    // it keeps a Spotify Connect device slot and can steal playback from
+    // the embed-iframe fallback when it eventually registers late.
+    expect(fakePlayer.disconnect).toHaveBeenCalled();
+  });
+
+  it('falls back to sdkFailed when waitForDeviceRegistration itself rejects', async () => {
+    installFakeSdk();
+    waitForDeviceRegistrationMock.mockRejectedValue(
+      new Error('unexpected fetch rejection')
+    );
+    const { result } = renderHook(() =>
+      useSpotifyWebPlayback(true, getToken, null)
+    );
+    await waitFor(() => expect(fakePlayer.connect).toHaveBeenCalled());
+
+    act(() => {
+      fakePlayer.emit('ready', { device_id: 'device-err' });
+    });
+    // Belt-and-suspenders .catch must engage so the hook doesn't end up
+    // with deviceId=null AND sdkFailed=false (the silent-broken state).
+    await waitFor(() => expect(result.current.sdkFailed).toBe(true));
+    expect(result.current.deviceId).toBeNull();
+  });
+
+  it("cancels an in-flight registration poll when 'not_ready' fires before it resolves", async () => {
+    installFakeSdk();
+    // Hold the registration mock open so we can race not_ready against its
+    // resolution.
+    let resolveRegistration: ((v: boolean) => void) | null = null;
+    waitForDeviceRegistrationMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRegistration = resolve;
+        })
+    );
+    const { result } = renderHook(() =>
+      useSpotifyWebPlayback(true, getToken, null)
+    );
+    await waitFor(() => expect(fakePlayer.connect).toHaveBeenCalled());
+
+    act(() => {
+      fakePlayer.emit('ready', { device_id: 'device-A' });
+    });
+    // Simulate the SDK losing the device mid-poll.
+    act(() => {
+      fakePlayer.emit('not_ready', { device_id: 'device-A' });
+    });
+    // Now the racing poll finally resolves "registered". The bumped poll
+    // generation must make the .then() callback bail — otherwise it would
+    // resurrect device-A over the now-correct null state.
+    act(() => {
+      resolveRegistration?.(true);
+    });
+    await Promise.resolve();
+    expect(result.current.deviceId).toBeNull();
+    expect(result.current.sdkFailed).toBe(false);
+  });
+
+  it("cancels an in-flight registration poll when a second 'ready' fires for a new device", async () => {
+    installFakeSdk();
+    const resolvers: Array<(v: boolean) => void> = [];
+    waitForDeviceRegistrationMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const { result } = renderHook(() =>
+      useSpotifyWebPlayback(true, getToken, null)
+    );
+    await waitFor(() => expect(fakePlayer.connect).toHaveBeenCalled());
+
+    // Two ready emissions: SDK reconnected with a new device_id.
+    act(() => {
+      fakePlayer.emit('ready', { device_id: 'device-A' });
+      fakePlayer.emit('ready', { device_id: 'device-B' });
+    });
+    // Poll-B resolves first with true — UI should show device-B.
+    act(() => {
+      resolvers[1]?.(true);
+    });
+    await waitFor(() => expect(result.current.deviceId).toBe('device-B'));
+    // Now poll-A (stale) finally resolves true. The generation bump from
+    // the second 'ready' must make it bail; otherwise the dead device-A
+    // would overwrite device-B and subsequent /play calls would 404.
+    act(() => {
+      resolvers[0]?.(true);
+    });
+    await Promise.resolve();
+    expect(result.current.deviceId).toBe('device-B');
   });
 
   it('updates currentTrack and isPlaying on player_state_changed', async () => {
@@ -224,6 +350,7 @@ describe('useSpotifyWebPlayback', () => {
     act(() => {
       fakePlayer.emit('ready', { device_id: 'device-123' });
     });
+    await waitFor(() => expect(result.current.deviceId).toBe('device-123'));
     expect(result.current.currentTrack).toBeNull();
 
     await act(async () => {
@@ -245,6 +372,7 @@ describe('useSpotifyWebPlayback', () => {
     act(() => {
       fakePlayer.emit('ready', { device_id: 'device-123' });
     });
+    await waitFor(() => expect(result.current.deviceId).toBe('device-123'));
 
     await act(async () => {
       await result.current.togglePlay();
@@ -346,6 +474,7 @@ describe('useSpotifyWebPlayback', () => {
     act(() => {
       fakePlayer.emit('ready', { device_id: 'device-123' });
     });
+    await waitFor(() => expect(result.current.deviceId).toBe('device-123'));
 
     // Starts at off(0) → first cycle should request 'track'.
     await act(async () => {
@@ -401,6 +530,7 @@ describe('useSpotifyWebPlayback', () => {
     act(() => {
       fakePlayer.emit('ready', { device_id: 'device-123' });
     });
+    await waitFor(() => expect(result.current.deviceId).toBe('device-123'));
 
     // Default shuffle off → toggle requests true.
     await act(async () => {

--- a/tests/utils/spotifyDeviceRegistration.test.ts
+++ b/tests/utils/spotifyDeviceRegistration.test.ts
@@ -1,0 +1,212 @@
+/**
+ * fetchSpotifyDevices + waitForDeviceRegistration — the registration probe
+ * that lets useSpotifyWebPlayback hold back the device id until Spotify
+ * Connect has actually registered the SDK device.
+ *
+ * Why this matters
+ * ----------------
+ * The Web Playback SDK's `ready` event fires the instant the local device
+ * object exists, but server-side propagation lags 1-3 seconds. During that
+ * window every REST call targeting the device returns 404 — including the
+ * transfer call the existing self-heal uses, so retries 404 identically.
+ * The fix is to poll /v1/me/player/devices until the id appears, and only
+ * then expose deviceId to the UI. These tests lock in that contract.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  fetchSpotifyDevices,
+  waitForDeviceRegistration,
+  DEVICE_REGISTRATION_POLL_DELAYS_MS,
+} from '@/utils/spotifyAuth';
+
+const DEVICES_URL = 'https://api.spotify.com/v1/me/player/devices';
+
+const okJson = (body: unknown) =>
+  ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+const failStatus = (status: number) =>
+  ({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  }) as unknown as Response;
+
+describe('fetchSpotifyDevices', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('GETs the devices endpoint with a bearer token and returns the parsed list', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      okJson({
+        devices: [
+          { id: 'dev-1', name: 'SpartBoard' },
+          { id: 'dev-2', name: 'Phone' },
+        ],
+      })
+    );
+
+    const devices = await fetchSpotifyDevices('tok');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(DEVICES_URL);
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init?.headers).toEqual({ Authorization: 'Bearer tok' });
+    expect(devices).toEqual([
+      { id: 'dev-1', name: 'SpartBoard' },
+      { id: 'dev-2', name: 'Phone' },
+    ]);
+  });
+
+  it('returns an empty list when the body has no devices field', async () => {
+    vi.mocked(fetch).mockResolvedValue(okJson({}));
+    await expect(fetchSpotifyDevices('tok')).resolves.toEqual([]);
+  });
+
+  it('returns an empty list on a non-2xx response (transient errors are caller-retry territory)', async () => {
+    vi.mocked(fetch).mockResolvedValue(failStatus(500));
+    // The waitForDeviceRegistration loop is what retries — fetchSpotifyDevices
+    // itself just reports "no devices visible right now."
+    await expect(fetchSpotifyDevices('tok')).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when fetch itself rejects (offline / DNS / CORS)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
+    // Without this resilience the polling loop's await throws and the
+    // hook's .then() chain rejects unhandled — leaving deviceId null AND
+    // sdkFailed false. Resolving to [] keeps the loop polling.
+    await expect(fetchSpotifyDevices('tok')).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when Spotify serves a 200 with a non-JSON body', async () => {
+    // Captive portals and CDN error pages routinely serve HTML with 200 OK.
+    // Pre-fix this would reject with SyntaxError and bubble through
+    // waitForDeviceRegistration as an unhandled rejection.
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new SyntaxError('Unexpected token <')),
+    } as unknown as Response);
+    await expect(fetchSpotifyDevices('tok')).resolves.toEqual([]);
+  });
+});
+
+describe('waitForDeviceRegistration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const tokenProvider = (token: string | null) =>
+    vi.fn<() => Promise<string | null>>().mockResolvedValue(token);
+
+  it('resolves true on the first attempt when the device is already registered', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      okJson({ devices: [{ id: 'dev-1', name: 'SpartBoard' }] })
+    );
+
+    const registered = await waitForDeviceRegistration(
+      tokenProvider('tok'),
+      'dev-1',
+      () => false
+    );
+
+    expect(registered).toBe(true);
+  });
+
+  it('keeps polling until the device shows up, then resolves true', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(okJson({ devices: [] }))
+      .mockResolvedValueOnce(okJson({ devices: [{ id: 'other', name: 'x' }] }))
+      .mockResolvedValueOnce(
+        okJson({ devices: [{ id: 'dev-1', name: 'SpartBoard' }] })
+      );
+
+    const promise = waitForDeviceRegistration(
+      tokenProvider('tok'),
+      'dev-1',
+      () => false
+    );
+    // Advance past enough of the backoff schedule for three attempts.
+    await vi.advanceTimersByTimeAsync(DEVICE_REGISTRATION_POLL_DELAYS_MS[1]);
+    await vi.advanceTimersByTimeAsync(DEVICE_REGISTRATION_POLL_DELAYS_MS[2]);
+    await expect(promise).resolves.toBe(true);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+  });
+
+  it('resolves false when the device never appears within the backoff schedule', async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch).mockResolvedValue(okJson({ devices: [] }));
+
+    const promise = waitForDeviceRegistration(
+      tokenProvider('tok'),
+      'dev-1',
+      () => false
+    );
+    // Run through the full delay budget.
+    const total = DEVICE_REGISTRATION_POLL_DELAYS_MS.reduce(
+      (sum, d) => sum + d,
+      0
+    );
+    await vi.advanceTimersByTimeAsync(total + 100);
+    await expect(promise).resolves.toBe(false);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(
+      DEVICE_REGISTRATION_POLL_DELAYS_MS.length
+    );
+  });
+
+  it('bails out early when isCancelled flips true (hook teardown)', async () => {
+    vi.useFakeTimers();
+    let cancelled = false;
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(okJson({ devices: [] }));
+
+    const promise = waitForDeviceRegistration(
+      tokenProvider('tok'),
+      'dev-1',
+      () => cancelled
+    );
+    cancelled = true;
+    // Even before any await microtasks settle, the first cancel check after
+    // the no-op initial delay must abort. Verify both the resolved value AND
+    // that fetch was never reached — without the latter, a future change to
+    // DEVICE_REGISTRATION_POLL_DELAYS_MS[0] (from 0 to e.g. 100ms) could let
+    // this test pass via setTimeout yielding alone, hiding a regression in
+    // pre-first-iteration cancellation.
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(promise).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips fetching when the token provider returns null but keeps polling', async () => {
+    vi.useFakeTimers();
+    // First attempt: no token → no fetch. Second attempt: token + device.
+    const getToken = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('tok');
+    vi.mocked(fetch).mockResolvedValue(
+      okJson({ devices: [{ id: 'dev-1', name: 'SpartBoard' }] })
+    );
+
+    const promise = waitForDeviceRegistration(getToken, 'dev-1', () => false);
+    await vi.advanceTimersByTimeAsync(DEVICE_REGISTRATION_POLL_DELAYS_MS[1]);
+    await expect(promise).resolves.toBe(true);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    expect(getToken).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/utils/spotifyRepeatShuffle.test.ts
+++ b/tests/utils/spotifyRepeatShuffle.test.ts
@@ -100,6 +100,47 @@ describe('setRepeatMode', () => {
     await vi.advanceTimersByTimeAsync(500);
     await assertion;
   });
+
+  it('still retries the original PUT when transfer itself returns a transient non-2xx', async () => {
+    // Registration polling in useSpotifyWebPlayback now eliminates the
+    // "device-not-yet-registered" race upstream, so transfer rarely fails
+    // by the time this self-heal path is reached. When it does (a transient
+    // 5xx CDN blip mid-play), the caller's retry of the original endpoint
+    // is what surfaces the real, actionable error — so transfer's non-2xx
+    // responses (except 403) are deliberately silent here. This preserves
+    // the pre-PR recovery path where a flaky transfer didn't permanently
+    // block the retry.
+    vi.useFakeTimers();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(resp(404)) // first repeat PUT
+      .mockResolvedValueOnce(resp(502)) // transfer transient 5xx (swallowed)
+      .mockResolvedValueOnce(resp(204)); // retry succeeds
+
+    const promise = setRepeatMode('tok', 'dev1', 'track');
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('translates transfer 403 to spotify-premium-required', async () => {
+    // Transfer 403 means the same thing as a 403 on the play endpoint:
+    // the account isn't Premium. Without this mapping, the caller would
+    // see a generic 'transfer returned 403' that misses the exact-string
+    // check in useSpotifyWebPlayback.togglePlay (line 290) — and the UI
+    // would never swap to the embed-iframe fallback for non-Premium users
+    // who reach the transfer path.
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(resp(404)) // first repeat PUT
+      .mockResolvedValueOnce(resp(403)); // transfer → premium required
+
+    await expect(setRepeatMode('tok', 'dev1', 'off')).rejects.toThrow(
+      'spotify-premium-required'
+    );
+    // No retry should have run — there's no point retrying a Premium issue.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('setShuffle', () => {

--- a/utils/spotifyAuth.ts
+++ b/utils/spotifyAuth.ts
@@ -856,12 +856,25 @@ export async function fetchRecentlyPlayed(
  * with the device id makes Spotify treat it as the active device. We pass
  * `play: false` so this only activates without forcing a resume; the caller
  * issues the real `play` (with the desired context/tracks) right after.
+ *
+ * Error policy
+ * ------------
+ * - 403 → throw 'spotify-premium-required'. The transfer endpoint returns
+ *   403 for non-Premium accounts; if we surface the raw status, togglePlay's
+ *   exact-string fallback misses it and the UI never swaps to the embed
+ *   iframe. The 403 here means the same thing as a 403 on the play endpoint.
+ * - Other non-2xx (transient 5xx, 429, 401, 404) → return silently. The
+ *   caller (`putWithDeviceActivation`) will still retry the original PUT
+ *   after the activation wait, and the retry's own error message is more
+ *   actionable than a generic "transfer returned X." Pre-PR this helper
+ *   swallowed all responses; preserving that recovery path for transient
+ *   errors avoids breaking flows that historically self-healed.
  */
 async function transferPlaybackToDevice(
   accessToken: string,
   deviceId: string
 ): Promise<void> {
-  await fetch('https://api.spotify.com/v1/me/player', {
+  const res = await fetch('https://api.spotify.com/v1/me/player', {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -869,6 +882,91 @@ async function transferPlaybackToDevice(
     },
     body: JSON.stringify({ device_ids: [deviceId], play: false }),
   });
+  if (res.status === 403) {
+    throw new Error('spotify-premium-required');
+  }
+  // Any other non-2xx: let the caller's retry of the original endpoint
+  // surface the real error. res.ok already covers 200-299 (including 204).
+}
+
+/**
+ * Lists Spotify Connect devices visible to the access token's user.
+ *
+ * Used by `waitForDeviceRegistration` to confirm that a freshly-`ready` Web
+ * Playback SDK device has propagated server-side before the UI starts
+ * targeting it via REST. Returns an empty list on any non-2xx so the caller
+ * just keeps polling — a transient 5xx shouldn't burn the registration wait.
+ */
+export async function fetchSpotifyDevices(
+  accessToken: string
+): Promise<Array<{ id: string; name: string }>> {
+  let res: Response;
+  try {
+    res = await fetch('https://api.spotify.com/v1/me/player/devices', {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  } catch {
+    // Network failure (offline, DNS, CORS error) — return empty so the
+    // polling loop keeps trying instead of rejecting up through .then().
+    return [];
+  }
+  if (!res.ok) return [];
+  // Spotify edge/CDN occasionally serves a 200 + HTML error page during
+  // incidents (and captive portals do the same). Wrap json() so a parse
+  // failure doesn't reject the whole helper — `waitForDeviceRegistration`
+  // would then escape past the hook's .then() as an unhandled rejection.
+  try {
+    const body = (await res.json()) as {
+      devices?: Array<{ id: string; name: string }>;
+    };
+    return body.devices ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Backoff schedule (ms before each attempt) for `waitForDeviceRegistration`.
+ * Front-loaded so the common case (registration completes in <1s) resolves
+ * fast; tail extended to ~15s for slow-propagating accounts. Exported for
+ * the unit test so it doesn't have to hard-code the timing.
+ */
+export const DEVICE_REGISTRATION_POLL_DELAYS_MS: ReadonlyArray<number> = [
+  0, 300, 600, 1000, 1500, 2500, 4000, 5000,
+];
+
+/**
+ * Polls `GET /v1/me/player/devices` until the given device id appears in the
+ * caller's Spotify Connect device list, or until `isCancelled()` returns true.
+ *
+ * The Web Playback SDK's `ready` event fires the instant the local device
+ * object exists — but Spotify Connect's server-side registration lags by
+ * 1-3 seconds. Calling `play?device_id=` (or `transfer`) before registration
+ * completes returns 404 "Device not found"; the existing transfer-then-retry
+ * self-heal can't recover when the underlying device hasn't propagated
+ * because transfer 404s for the same reason.
+ *
+ * Polling the devices endpoint until the id is visible is the canonical fix.
+ * Returns true once the device appears, false on timeout or cancellation.
+ */
+export async function waitForDeviceRegistration(
+  getAccessToken: () => Promise<string | null>,
+  deviceId: string,
+  isCancelled: () => boolean
+): Promise<boolean> {
+  for (const delay of DEVICE_REGISTRATION_POLL_DELAYS_MS) {
+    if (delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+    if (isCancelled()) return false;
+    const token = await getAccessToken();
+    if (isCancelled()) return false;
+    if (!token) continue;
+    const devices = await fetchSpotifyDevices(token);
+    if (isCancelled()) return false;
+    if (devices.some((d) => d.id === deviceId)) return true;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

The Spotify Music widget was broken — every REST call (`/play`, `/repeat`, `/shuffle`, `/transfer`) was returning **404**, and the existing 404 self-heal couldn't recover because the transfer call it relied on was 404-ing for the same reason. Root cause: the Web Playback SDK fires `ready` the instant the local device object exists, but Spotify Connect's server-side registration lags 1–3 seconds. Every server-side call during that window targets a device Spotify doesn't yet know about.

This PR eliminates the race by polling `GET /v1/me/player/devices` until the SDK's device id is actually visible to Spotify Connect, and only then exposes `deviceId` to the UI.

## What changed

**Race elimination** ([utils/spotifyAuth.ts](utils/spotifyAuth.ts), [hooks/useSpotifyWebPlayback.ts](hooks/useSpotifyWebPlayback.ts))
- New `fetchSpotifyDevices` + `waitForDeviceRegistration` helpers. Front-loaded backoff: `[0, 300, 600, 1000, 1500, 2500, 4000, 5000]ms` (~15s total budget; typical success in <1s on the first attempt).
- The hook's `ready` handler defers `setDeviceId` until registration is confirmed. On timeout it flips `sdkFailed` AND disconnects the orphan SDK device so it can't steal playback from the embed-iframe fallback later.

**Cancellation discipline** ([hooks/useSpotifyWebPlayback.ts](hooks/useSpotifyWebPlayback.ts))
- A `pollGeneration` counter bumped on `not_ready`, a second `ready` (SDK reconnect with new device_id), `failSdk`, and effect teardown. Each poll closure captures its generation and bails on resolve if it has moved on — without this, a stale poll's `.then()` would resurrect a dead device id over the current null/failed state.

**Correctness fixes from extra-high-effort code review** (9 parallel finders + verification + sweep)
- `transferPlaybackToDevice` 403 → throws `'spotify-premium-required'` so the UI's exact-string fallback still engages for non-Premium accounts that reach the transfer path.
- Other transfer non-2xx (transient 5xx/429) return silently; the caller's retry of the original endpoint surfaces the real error. Preserves pre-PR recovery for flaky-CDN scenarios.
- `fetchSpotifyDevices` wraps `fetch` AND `res.json()` in try/catch so a captive-portal HTML 200, offline network, or CORS error can't reject upward through the hook as an unhandled rejection.
- The hook's poll `.then()` chain now has a `.catch()` that calls `failSdk` — no more silent broken state.

**User-facing UX fix** ([components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx](components/widgets/MusicWidget/PersonalSpotifyBrowser.tsx))
- `handlePlay` now queues taps that land during the registration window and flushes them when `deviceId` arrives. Pre-fix, a teacher tapping a song during the polling window saw nothing happen and had to tap again.

## Why

The console logs Paul shared showed every Spotify REST call 404-ing in repeating chains: `play → transfer → retry-play`, all 404. Same for `/shuffle` and `/repeat`. The transfer was supposed to be the recovery step, but it was silently 404-ing too — the original code didn't check the transfer's response status. The race between SDK-local "ready" and Spotify Connect server-side registration was the root cause; the self-heal was solving the wrong layer.

## Test plan

- [x] `pnpm validate` clean (375 root test files / 3803 tests + 17 functions / 321 tests, all passing; zero TS / ESLint / Prettier issues)
- [x] New tests cover: device registration backoff, poll cancellation, transfer transient-error vs Premium-required routing, fetchSpotifyDevices network/JSON resilience, hook cancel-predicate (not_ready and second-ready races), PersonalSpotifyBrowser queue-and-flush.
- [ ] **Dev preview manual verification (Paul):** Sign in with Premium Spotify account, tap a track immediately on widget mount → confirm playback starts (no silent no-op). Watch console for the absence of the 404 chain. Verify repeat/shuffle work after first play.

## Notes for reviewer

- End-to-end browser verification isn't possible from my side — it requires a real Premium OAuth session against the registered redirect URI, plus a real Spotify Connect race to trigger. Unit tests lock the contracts; dev-preview hands-on test catches anything the contracts miss.
- The original code-review findings list (13 surfaced; 10 applied; 3 skipped with justification) is in the conversation transcript.
- Skipped findings: (a) fetchSpotifyDevices distinguishing 401 from other non-2xx — the hook's `authentication_error` listener already catches token revocation; (b) `setTimeout` not cancellable mid-delay — React 19 strict-mode double-mount is dev-only and the stale timer no-ops via the generation check; (c) full per-effect generation isolation — the existing counter covers the dominant case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)