### PR TITLE
fix(SettingsPanel): Escape inside form fields no longer closes the panel

### DIFF
--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -154,12 +154,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
-      const target = e.target as HTMLElement;
+      const target = e.target as HTMLElement | null;
       const isFormField =
-        target.tagName === 'INPUT' ||
-        target.tagName === 'TEXTAREA' ||
-        target.tagName === 'SELECT' ||
-        target.isContentEditable;
+        !!target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable);
       if (isFormField) return;
       onClose();
     };

--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -148,12 +148,20 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     };
   }, []);
 
-  // Close on Escape key
+  // Close on Escape key — but not when focus is inside a form field.
+  // Pressing Escape inside an input or select should dismiss the field
+  // focus (browser default) without also closing the entire panel.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
+      if (e.key !== 'Escape') return;
+      const target = e.target as HTMLElement;
+      const isFormField =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable;
+      if (isFormField) return;
+      onClose();
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -197,4 +197,119 @@ describe('SettingsPanel', () => {
     // widget.x + widget.w + PANEL_MARGIN = 100 + 200 + 12 = 312
     expect(leftValue).not.toBe(312);
   });
+
+  /**
+   * Regression: pressing Escape inside a form field (input, textarea, select)
+   * inside the settings panel must NOT close the panel.
+   *
+   * Previously the Escape key handler called onClose() unconditionally via a
+   * document-level listener. Because document listeners fire for all key events
+   * (React's stopPropagation on the widget level does not suppress native DOM
+   * events), pressing Escape in a focused input would close the entire panel
+   * instead of simply blurring the field.
+   */
+  it('does not close when Escape is pressed inside a form field', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 100,
+      right: 200,
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+
+    const onClose = vi.fn();
+
+    const HarnessWithInput: React.FC = () => {
+      const widgetRef = React.useRef<HTMLDivElement>(null);
+      return (
+        <>
+          <div ref={widgetRef} data-testid="fake-widget" />
+          <SettingsPanel
+            widget={MOCK_WIDGET}
+            widgetRef={widgetRef}
+            settings={
+              <input
+                data-testid="settings-input"
+                defaultValue="hello"
+                aria-label="test input"
+              />
+            }
+            shouldRenderSettings
+            onClose={onClose}
+            updateWidget={vi.fn()}
+            globalStyle={MOCK_GLOBAL_STYLE}
+            title="Test Widget"
+          />
+        </>
+      );
+    };
+
+    act(() => {
+      render(<HarnessWithInput />);
+    });
+
+    const input = screen.getByTestId('settings-input');
+    input.focus();
+
+    // Escape inside the input should NOT close the panel.
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when Escape is pressed outside any form field', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 100,
+      right: 200,
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+
+    const onClose = vi.fn();
+
+    const HarnessSimple: React.FC = () => {
+      const widgetRef = React.useRef<HTMLDivElement>(null);
+      return (
+        <>
+          <div ref={widgetRef} data-testid="fake-widget" />
+          <SettingsPanel
+            widget={MOCK_WIDGET}
+            widgetRef={widgetRef}
+            settings={<div data-testid="no-input">No form fields</div>}
+            shouldRenderSettings
+            onClose={onClose}
+            updateWidget={vi.fn()}
+            globalStyle={MOCK_GLOBAL_STYLE}
+            title="Test Widget"
+          />
+        </>
+      );
+    };
+
+    act(() => {
+      render(<HarnessSimple />);
+    });
+
+    // Escape fired from document.body (not a form field) should close the panel.
+    act(() => {
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Root Cause

`SettingsPanel` registered a `document.addEventListener('keydown', ...)` handler that called `onClose()` on every `Escape` key event without checking the event's target. Document-level native DOM listeners fire independently of React's synthetic event system — `stopPropagation()` calls inside `DraggableWindow` do **not** suppress them. The result: pressing `Escape` inside any `<input>`, `<textarea>`, or `<select>` in the settings panel closed the entire panel instead of merely blurring the field.

## Fix

In `components/common/SettingsPanel.tsx`, the `handleKeyDown` function now checks `e.target.tagName` and `isContentEditable` before calling `onClose()`. If the key event originated from a form field, the handler returns early and lets the browser's default behavior (field blur) take over.

## Band-Aid Rejected

Adding `e.stopPropagation()` in `DraggableWindow.handleKeyDown` would not work — it only stops React synthetic event propagation, not native DOM events. The fix must live in the listener itself.

## Regression Test

`tests/components/common/SettingsPanel.test.tsx` — two new tests:
- `does not close when Escape is pressed inside a form field` — dispatches a native `keydown` event from a focused `<input>` inside the panel → asserts `onClose` is NOT called
- `closes when Escape is pressed outside any form field` — dispatches from `document.body` → asserts `onClose` IS called once

**Evidence:**
- FAILS on `dev-paul` (old code): `expected "vi.fn()" to not be called at all, but actually been called 1 times`
- PASSES on this branch: 4/4 tests pass

## Risk

**Contained.** Single event-handler guard in `SettingsPanel.tsx`. No API surface changed. `DraggableWindow`'s own Escape handling (widget flip / minimize) is unaffected.

---
*Nightly code-health run — 2026-05-30*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up3feHwXJZE3KEQCWXR5jm)_