### PR TITLE
fix(i18n): add missing plcDashboard namespace to DE, ES, and FR locales

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -239,6 +239,270 @@
     },
     "confirmClearBoard": "Bist du sicher, dass du ALLE Widget-Fenster schließen möchtest?"
   },
+  "plcDashboard": {
+    "subtitle": "PLG-Dashboard",
+    "backToMenu": "Zurück",
+    "close": "Schließen",
+    "tabs": {
+      "overview": "Übersicht",
+      "quizzes": "Quizze",
+      "videoActivities": "Videoaktivitäten",
+      "notes": "Notizen",
+      "todos": "Aufgabenliste",
+      "sharedBoards": "Geteilte Tafeln",
+      "settings": "Einstellungen",
+      "home": "Startseite",
+      "members": "Mitglieder",
+      "sharedData": "Geteilte Daten",
+      "docs": "Dokumente",
+      "resources": "Ressourcen"
+    },
+    "assignmentsSubTabs": {
+      "label": "Aufgabenansichten",
+      "library": "Bibliothek",
+      "inProgress": "Laufend",
+      "completed": "Abgeschlossen"
+    },
+    "quizzesSubTabs": {
+      "label": "Quizansichten",
+      "library": "Bibliothek",
+      "inProgress": "Laufend",
+      "completed": "Abgeschlossen"
+    },
+    "videoActivitiesSubTabs": {
+      "label": "Videoaktivitätsansichten",
+      "library": "Bibliothek",
+      "inProgress": "Laufend",
+      "completed": "Abgeschlossen"
+    },
+    "assignmentsLibrary": {
+      "bySharer": "geteilt von {{name}}",
+      "unknownSharer": "einem Teammitglied",
+      "addToMyBoard": "Zu meiner Tafel hinzufügen",
+      "unshareAction": "Freigabe aufheben",
+      "unshareTitle": "Aufgabenvorlage nicht mehr teilen",
+      "unshareConfirm": "„{{title}}“ aus dieser PLG entfernen? Teammitglieder, die es bereits zu ihrer Tafel hinzugefügt haben, behalten ihre Kopie.",
+      "unshareTooltip": "Aus PLG entfernen (jedes Mitglied kann die Freigabe aufheben; bestehende Importe bleiben funktionsfähig)",
+      "unshared": "„{{title}}“ aus dieser PLG entfernt.",
+      "unshareFailed": "Freigabe der Aufgabenvorlage konnte nicht aufgehoben werden.",
+      "importedSync": "„{{title}}“ zu deiner Tafel hinzugefügt (pausiert, synchronisiert).",
+      "importedCopy": "„{{title}}“ zu deiner Tafel kopiert (pausiert).",
+      "importFailed": "Aufgabe konnte nicht zur Tafel hinzugefügt werden.",
+      "assignedToClasses_one": "{{count}} Klasse zugewiesen.",
+      "assignedToClasses_other": "{{count}} Klassen zugewiesen.",
+      "assignFailed": "Klassenauswahl konnte nicht gespeichert werden.",
+      "driveRequired": "Verbinde Google Drive in deinem Konto, um PLG-Aufgaben zu übernehmen.",
+      "driveDisconnected": "Verbinde Google Drive, um PLG-Aufgaben zu deiner Tafel hinzuzufügen.",
+      "emptyTitle": "Noch keine Aufgabenvorlagen",
+      "emptySubtitle": "Aktiviere „Mit PLG teilen“ bei einer Quiz-Aufgabe – sie erscheint dann hier, damit Teammitglieder sie auf ihre eigene Tafel übernehmen können."
+    },
+    "assignmentsInProgress": {
+      "heading": "Live im Team",
+      "count_one": "{{count}} läuft",
+      "count_other": "{{count}} laufen",
+      "statusActive": "Aktiv",
+      "statusPaused": "Pausiert",
+      "emptyTitle": "Keine laufenden Aufgaben",
+      "emptySubtitle": "Wenn du oder ein Teammitglied eine PLG-Aufgabe startet, erscheint sie hier. Pausiere oder stoppe sie von deiner Tafel, und die Zeile aktualisiert sich in Echtzeit."
+    },
+    "meta": {
+      "members_one": "{{count}} Mitglied",
+      "members_other": "{{count}} Mitglieder",
+      "youLead": "Du leitest diese PLG"
+    },
+    "completedAssignments": {
+      "heading": "Geteilte Ergebnisse",
+      "count_one": "{{count}} Aufgabe",
+      "count_other": "{{count}} Aufgaben",
+      "byOwner": "von {{name}}",
+      "openSheet": "Tabelle öffnen",
+      "unsafeSheet": "Kein Link",
+      "emptyTitle": "Noch keine abgeschlossenen Aufgaben",
+      "emptySubtitle": "Wenn eine PLG-Aufgabe von einer Tafel eines Teammitglieds gestoppt wird, erscheint sie hier mit einem Link zur geteilten Ergebnistabelle."
+    },
+    "placeholder": {
+      "comingSoon": "Demnächst verfügbar"
+    },
+    "settings": {
+      "heading": "Dashboard-Bereiche",
+      "description": "Wähle, welche Bereiche im Dashboard dieser PLG angezeigt werden. Jedes PLG-Mitglied kann diese Einstellungen ändern.",
+      "saveFailed": "Einstellungen konnten nicht gespeichert werden",
+      "quizzes": {
+        "title": "Quiz-Bibliothek",
+        "description": "Teile Quizze mit der PLG. Mitglieder können Bearbeitungen synchronisieren oder ein Quiz in ihre eigene Bibliothek kopieren."
+      },
+      "videoActivities": {
+        "title": "Videoaktivitäten",
+        "description": "Teile videobasierte Aktivitäten und aggregiere Abschlussdaten mit der PLG."
+      },
+      "notes": {
+        "title": "Notizen",
+        "description": "Ein geteiltes Notizbuch für die PLG."
+      },
+      "todos": {
+        "title": "Aufgabenliste",
+        "description": "Eine geteilte Checkliste, damit die PLG Aufgaben verfolgen kann."
+      },
+      "sharedBoards": {
+        "title": "Geteilte Tafeln",
+        "description": "Zeigt Tafeln, die mit dieser PLG geteilt wurden."
+      }
+    },
+    "overview": {
+      "heading": "Übersicht",
+      "editLayout": "Layout bearbeiten",
+      "doneEditing": "Fertig",
+      "reset": "Zurücksetzen",
+      "editHint": "Kacheln am Griff ziehen, Ecke anklicken zum Skalieren, Auge anklicken zum Ausblenden.",
+      "confirmReset": "Dein Bento-Layout auf die Standardanordnung zurücksetzen? Kachelgrößen und -reihenfolge werden wiederhergestellt.",
+      "confirmResetTitle": "Layout zurücksetzen",
+      "dragHandle": "Zum Neuanordnen ziehen",
+      "hideTile": "Kachel ausblenden",
+      "unhideTile": "{{kind}}-Kachel wiederherstellen",
+      "resizeTile": "Kachel skalieren (aktuell: {{size}})",
+      "hiddenTiles": "Ausgeblendete Kacheln",
+      "hiddenTilesHint": "zum Wiederherstellen anklicken",
+      "tiles": {
+        "comingSoon": "Phase {{phase}} · demnächst",
+        "plcInfo": {
+          "label": "Professionelle Lerngemeinschaft",
+          "members": "Mitglieder",
+          "lead": "Leitung",
+          "you": "Du",
+          "created": "Erstellt",
+          "openSettings": "Einstellungen öffnen"
+        },
+        "members": {
+          "heading": "Mitglieder"
+        },
+        "completedAssignments": {
+          "heading": "Aktuelle Ergebnisse",
+          "empty": "Noch keine Aufgaben durchgeführt",
+          "emptySubtitle": "Quizze, die du im PLG-Modus durchführst, erscheinen hier.",
+          "viewAll": "Alle anzeigen"
+        },
+        "notes": {
+          "heading": "Notizen",
+          "empty": "Noch keine Notizen",
+          "emptySubtitle": "Besprechungsnotizen, Entscheidungen, Ideen festhalten.",
+          "untitled": "Ohne Titel",
+          "openAll": "Notizen öffnen",
+          "justNow": "gerade eben",
+          "minutesAgo_one": "vor {{count}} Min.",
+          "minutesAgo_other": "vor {{count}} Min.",
+          "hoursAgo_one": "vor {{count}} Std.",
+          "hoursAgo_other": "vor {{count}} Std.",
+          "daysAgo_one": "vor {{count}} Tag",
+          "daysAgo_other": "vor {{count}} Tagen"
+        },
+        "todos": {
+          "heading": "Aufgabenliste",
+          "empty": "Nichts zu erledigen",
+          "emptySubtitle": "Füge Aufgaben im Aufgaben-Tab hinzu.",
+          "openAll": "Liste öffnen",
+          "toggle": "„{{text}}“ als erledigt markieren",
+          "moreCount_one": "+{{count}} weitere",
+          "moreCount_other": "+{{count}} weitere"
+        },
+        "sharedSheet": {
+          "heading": "Geteilte Tabelle",
+          "connectedHint": "Aggregierte PLG-Ergebnisse landen in dieser Google-Tabelle. Alle Mitglieder können sie öffnen.",
+          "unsetHint": "Noch keine geteilte Tabelle – sie wird automatisch erstellt, wenn das erste PLG-Quiz durchgeführt wird.",
+          "open": "Tabelle öffnen",
+          "notReady": "Noch nicht erstellt"
+        },
+        "quickActions": {
+          "heading": "Schnellaktionen",
+          "addNote": "Notiz hinzufügen",
+          "addTodo": "Aufgabe hinzufügen"
+        },
+        "quizLibrary": {
+          "title": "Quiz-Bibliothek",
+          "teaser": "Teile Quizze mit deiner PLG.",
+          "heading": "Quiz-Bibliothek",
+          "empty": "Keine geteilten Quizze",
+          "emptySubtitle": "Teile ein Quiz über das Menü auf seiner Bibliothekskarte.",
+          "questionCount_one": "{{count}} Frage",
+          "questionCount_other": "{{count}} Fragen",
+          "bySharer": "geteilt von {{name}}",
+          "openAll": "Bibliothek öffnen"
+        },
+        "activeAssignments": {
+          "title": "Aktive Aufgaben",
+          "teaser": "Von PLG erstellte Aufgaben, die noch übernommen werden müssen."
+        },
+        "videoActivities": {
+          "title": "Videoaktivitäten",
+          "teaser": "Teile Videoaktivitäten mit der PLG."
+        },
+        "sharedBoards": {
+          "title": "Geteilte Tafeln",
+          "teaser": "Mit dieser PLG geteilte Tafeln."
+        }
+      }
+    },
+    "notes": {
+      "heading": "Notizen",
+      "newNote": "Neu",
+      "untitled": "Ohne Titel",
+      "empty": "Leere Notiz",
+      "emptyTitle": "Noch keine Notizen",
+      "emptySubtitle": "Erstelle die erste, um loszulegen.",
+      "titlePlaceholder": "Notiztitel",
+      "bodyPlaceholder": "Deine Notizen…",
+      "deleteNote": "Notiz löschen",
+      "confirmDelete": "Diese Notiz löschen? Dies kann nicht rückgängig gemacht werden.",
+      "confirmDeleteTitle": "Notiz löschen",
+      "lastEdited": "Zuletzt bearbeitet {{when}}",
+      "pickOrCreate": "Wähle eine Notiz zum Bearbeiten oder erstelle eine neue."
+    },
+    "todos": {
+      "addPlaceholder": "Aufgabe für die PLG hinzufügen…",
+      "add": "Hinzufügen",
+      "openHeading": "Zu erledigen",
+      "doneHeading": "Erledigt",
+      "allDone": "Nichts auf der Liste",
+      "toggle": "„{{text}}“ als erledigt markieren",
+      "deleteTodo": "Aufgabe löschen",
+      "confirmDelete": "Diese Aufgabe löschen?",
+      "confirmDeleteTitle": "Aufgabe löschen"
+    },
+    "quizLibrary": {
+      "heading": "Geteilte Quizze",
+      "count_one": "{{count}} Quiz",
+      "count_other": "{{count}} Quizze",
+      "emptyTitle": "Noch keine geteilten Quizze",
+      "emptySubtitle": "Öffne das Quiz-Widget in deinem Dashboard, klicke auf das Menü bei einem Quiz und wähle „Mit PLG teilen“.",
+      "bySharer": "geteilt von {{name}}",
+      "unknownSharer": "einem Teammitglied",
+      "questionCount_one": "{{count}} Frage",
+      "questionCount_other": "{{count}} Fragen",
+      "addToMyLibrary": "Zu meiner Bibliothek hinzufügen",
+      "reimport": "Erneut importieren",
+      "inLibrary": "In deiner Bibliothek",
+      "alreadySynced": "„{{title}}“ ist bereits mit deiner Bibliothek synchronisiert.",
+      "unshareAction": "Freigabe aufheben",
+      "unshareYours": "Freigabe aus PLG aufheben",
+      "unshareTeammate": "Freigabe aus PLG aufheben (jedes Mitglied kann entfernen)",
+      "unshareTitle": "Quiz-Freigabe aufheben",
+      "unshareConfirm": "„{{title}}“ aus dieser PLG entfernen? Andere Teammitglieder verlieren den Zugriff auf den geteilten Bibliothekseintrag. Persönliche Kopien (falls vorhanden) bleiben funktionsfähig.",
+      "unshared": "„{{title}}“ aus dieser PLG entfernt.",
+      "unshareFailed": "Quiz-Freigabe konnte nicht aufgehoben werden.",
+      "importedSync": "„{{title}}“ zu deiner Bibliothek hinzugefügt (synchronisiert).",
+      "importedCopy": "„{{title}}“ in deine Bibliothek kopiert.",
+      "importFailed": "Quiz konnte nicht importiert werden.",
+      "editAction": "Bearbeiten",
+      "editTooltip": "Gemeinsam bearbeiten (Änderungen werden mit Teammitgliedern synchronisiert)",
+      "editTooltipAutoImport": "Gemeinsam bearbeiten – wird beim ersten Bearbeiten zu deiner Bibliothek hinzugefügt",
+      "editAutoImported": "„{{title}}“ zu deiner Bibliothek hinzugefügt – Editor wird geöffnet.",
+      "editSaved": "Quiz gespeichert – Teammitglieder synchronisieren automatisch.",
+      "editConflict": "Ein anderer Lehrer hat ein Update für dieses Quiz veröffentlicht. Wir haben seine Änderungen übernommen; deine nicht gespeicherten Änderungen wurden nicht gespeichert. Öffne das Quiz erneut, um sie neu anzuwenden.",
+      "editFailed": "Editor konnte nicht geöffnet werden.",
+      "driveRequired": "Verbinde Google Drive in deinem Konto, um PLG-Quizze zu importieren.",
+      "driveRequiredForEdit": "Verbinde Google Drive in deinem Konto, um PLG-Quizze zu bearbeiten.",
+      "driveDisconnected": "Verbinde Google Drive, um PLG-Quizze in deine persönliche Bibliothek zu importieren."
+    }
+  },
   "widgetWindow": {
     "closeWidget": "Widget schließen? Daten gehen verloren.",
     "settings": "Einstellungen",

--- a/locales/es.json
+++ b/locales/es.json
@@ -242,6 +242,270 @@
     },
     "confirmClearBoard": "¿Estás seguro de que deseas cerrar TODAS las ventanas de widgets?"
   },
+  "plcDashboard": {
+    "subtitle": "Panel de la Comunidad",
+    "backToMenu": "Atrás",
+    "close": "Cerrar",
+    "tabs": {
+      "overview": "Resumen",
+      "quizzes": "Cuestionarios",
+      "videoActivities": "Actividades de Video",
+      "notes": "Notas",
+      "todos": "Lista de Tareas",
+      "sharedBoards": "Tableros Compartidos",
+      "settings": "Configuración",
+      "home": "Inicio",
+      "members": "Miembros",
+      "sharedData": "Datos Compartidos",
+      "docs": "Documentos",
+      "resources": "Recursos"
+    },
+    "assignmentsSubTabs": {
+      "label": "Vistas de tareas",
+      "library": "Biblioteca",
+      "inProgress": "En progreso",
+      "completed": "Completado"
+    },
+    "quizzesSubTabs": {
+      "label": "Vistas de cuestionarios",
+      "library": "Biblioteca",
+      "inProgress": "En progreso",
+      "completed": "Completado"
+    },
+    "videoActivitiesSubTabs": {
+      "label": "Vistas de actividades de video",
+      "library": "Biblioteca",
+      "inProgress": "En progreso",
+      "completed": "Completado"
+    },
+    "assignmentsLibrary": {
+      "bySharer": "compartido por {{name}}",
+      "unknownSharer": "un compañero",
+      "addToMyBoard": "Agregar a mi tablero",
+      "unshareAction": "Dejar de compartir",
+      "unshareTitle": "Dejar de compartir plantilla de tarea",
+      "unshareConfirm": "¿Eliminar \"{{title}}\" de esta Comunidad? Los compañeros que ya lo agregaron a su tablero conservan su copia.",
+      "unshareTooltip": "Eliminar de la Comunidad (cualquier miembro puede dejar de compartir; las importaciones existentes siguen funcionando)",
+      "unshared": "\"{{title}}\" eliminado de esta Comunidad.",
+      "unshareFailed": "No se pudo dejar de compartir la plantilla de tarea.",
+      "importedSync": "\"{{title}}\" agregado a tu tablero (pausado, sincronizado).",
+      "importedCopy": "\"{{title}}\" copiado a tu tablero (pausado).",
+      "importFailed": "No se pudo agregar la tarea a tu tablero.",
+      "assignedToClasses_one": "Asignado a {{count}} clase.",
+      "assignedToClasses_other": "Asignado a {{count}} clases.",
+      "assignFailed": "No se pudo guardar la selección de clases.",
+      "driveRequired": "Conecta Google Drive en tu cuenta para tomar tareas de la Comunidad.",
+      "driveDisconnected": "Conecta Google Drive para agregar tareas de la Comunidad a tu tablero.",
+      "emptyTitle": "Aún no hay plantillas de tareas",
+      "emptySubtitle": "Activa \"Compartir con la Comunidad\" en cualquier tarea de cuestionario que crees — aparecerá aquí para que los compañeros puedan agregarla a sus propios tableros."
+    },
+    "assignmentsInProgress": {
+      "heading": "En Vivo en el Equipo",
+      "count_one": "{{count}} en progreso",
+      "count_other": "{{count}} en progreso",
+      "statusActive": "Activo",
+      "statusPaused": "Pausado",
+      "emptyTitle": "No hay tareas en progreso",
+      "emptySubtitle": "Cuando tú o un compañero inicia una tarea en modo Comunidad, aparece aquí. Pausa o detén desde tu tablero y la fila se actualiza en tiempo real."
+    },
+    "meta": {
+      "members_one": "{{count}} Miembro",
+      "members_other": "{{count}} Miembros",
+      "youLead": "Tú lideras esta Comunidad"
+    },
+    "completedAssignments": {
+      "heading": "Resultados Compartidos",
+      "count_one": "{{count}} tarea",
+      "count_other": "{{count}} tareas",
+      "byOwner": "por {{name}}",
+      "openSheet": "Abrir Hoja",
+      "unsafeSheet": "Sin enlace",
+      "emptyTitle": "Aún no hay tareas completadas",
+      "emptySubtitle": "Cuando se detiene una tarea en modo Comunidad desde el tablero de cualquier compañero, aparece aquí con un enlace a la hoja de resultados compartida."
+    },
+    "placeholder": {
+      "comingSoon": "Próximamente"
+    },
+    "settings": {
+      "heading": "Secciones del Panel",
+      "description": "Elige qué secciones aparecen en el panel de esta Comunidad. Cualquier miembro puede actualizar estas opciones.",
+      "saveFailed": "No se pudo guardar la configuración",
+      "quizzes": {
+        "title": "Biblioteca de Cuestionarios",
+        "description": "Comparte cuestionarios con la Comunidad. Los miembros pueden sincronizar ediciones o copiar un cuestionario a su propia biblioteca."
+      },
+      "videoActivities": {
+        "title": "Actividades de Video",
+        "description": "Comparte actividades basadas en video y agrega datos de finalización con la Comunidad."
+      },
+      "notes": {
+        "title": "Notas",
+        "description": "Un cuaderno compartido para la Comunidad."
+      },
+      "todos": {
+        "title": "Lista de Tareas",
+        "description": "Una lista de verificación compartida para que la Comunidad pueda hacer seguimiento de las acciones."
+      },
+      "sharedBoards": {
+        "title": "Tableros Compartidos",
+        "description": "Muestra tableros compartidos con esta Comunidad."
+      }
+    },
+    "overview": {
+      "heading": "Resumen",
+      "editLayout": "Editar diseño",
+      "doneEditing": "Listo",
+      "reset": "Restablecer",
+      "editHint": "Arrastra las fichas por el asa, haz clic en la esquina para redimensionar, haz clic en el ojo para ocultar.",
+      "confirmReset": "¿Restablecer tu diseño bento al arreglo predeterminado? Se restaurarán los tamaños y el orden de las fichas.",
+      "confirmResetTitle": "Restablecer diseño",
+      "dragHandle": "Arrastra para reordenar",
+      "hideTile": "Ocultar ficha",
+      "unhideTile": "Restaurar ficha de {{kind}}",
+      "resizeTile": "Redimensionar ficha (actual: {{size}})",
+      "hiddenTiles": "Fichas ocultas",
+      "hiddenTilesHint": "haz clic para restaurar",
+      "tiles": {
+        "comingSoon": "Fase {{phase}} · pronto",
+        "plcInfo": {
+          "label": "Comunidad de Aprendizaje Profesional",
+          "members": "Miembros",
+          "lead": "Líder",
+          "you": "Tú",
+          "created": "Creado",
+          "openSettings": "Abrir configuración"
+        },
+        "members": {
+          "heading": "Miembros"
+        },
+        "completedAssignments": {
+          "heading": "Resultados recientes",
+          "empty": "Aún no se han ejecutado tareas",
+          "emptySubtitle": "Los cuestionarios que ejecutas en modo Comunidad aparecen aquí.",
+          "viewAll": "Ver todos"
+        },
+        "notes": {
+          "heading": "Notas",
+          "empty": "Aún no hay notas",
+          "emptySubtitle": "Captura notas de reunión, decisiones, ideas.",
+          "untitled": "Sin título",
+          "openAll": "Abrir notas",
+          "justNow": "ahora mismo",
+          "minutesAgo_one": "hace {{count}} min",
+          "minutesAgo_other": "hace {{count}} min",
+          "hoursAgo_one": "hace {{count}} h",
+          "hoursAgo_other": "hace {{count}} h",
+          "daysAgo_one": "hace {{count}} día",
+          "daysAgo_other": "hace {{count}} días"
+        },
+        "todos": {
+          "heading": "Lista de tareas",
+          "empty": "Nada pendiente",
+          "emptySubtitle": "Agrega elementos en la pestaña de Tareas.",
+          "openAll": "Abrir lista",
+          "toggle": "Marcar \"{{text}}\" como completado",
+          "moreCount_one": "+{{count}} más",
+          "moreCount_other": "+{{count}} más"
+        },
+        "sharedSheet": {
+          "heading": "Hoja compartida",
+          "connectedHint": "Los resultados agregados de la Comunidad se guardan en esta Hoja de Google. Todos los miembros pueden abrirla.",
+          "unsetHint": "Aún no hay hoja compartida — se creará automáticamente cuando se ejecute el primer cuestionario de la Comunidad.",
+          "open": "Abrir hoja",
+          "notReady": "Aún no creada"
+        },
+        "quickActions": {
+          "heading": "Acciones rápidas",
+          "addNote": "Agregar nota",
+          "addTodo": "Agregar tarea"
+        },
+        "quizLibrary": {
+          "title": "Biblioteca de cuestionarios",
+          "teaser": "Comparte cuestionarios con tu Comunidad.",
+          "heading": "Biblioteca de Cuestionarios",
+          "empty": "No hay cuestionarios compartidos",
+          "emptySubtitle": "Comparte un cuestionario desde el menú de su tarjeta de biblioteca.",
+          "questionCount_one": "{{count}} preg.",
+          "questionCount_other": "{{count}} preg.",
+          "bySharer": "compartido por {{name}}",
+          "openAll": "Abrir biblioteca"
+        },
+        "activeAssignments": {
+          "title": "Tareas activas",
+          "teaser": "Tareas creadas por la Comunidad en espera de ser tomadas."
+        },
+        "videoActivities": {
+          "title": "Actividades de video",
+          "teaser": "Comparte actividades de video con la Comunidad."
+        },
+        "sharedBoards": {
+          "title": "Tableros compartidos",
+          "teaser": "Tableros compartidos con esta Comunidad."
+        }
+      }
+    },
+    "notes": {
+      "heading": "Notas",
+      "newNote": "Nueva",
+      "untitled": "Sin título",
+      "empty": "Nota vacía",
+      "emptyTitle": "Aún no hay notas",
+      "emptySubtitle": "Crea la primera para comenzar.",
+      "titlePlaceholder": "Título de la nota",
+      "bodyPlaceholder": "Escribe tus notas…",
+      "deleteNote": "Eliminar nota",
+      "confirmDelete": "¿Eliminar esta nota? Esta acción no se puede deshacer.",
+      "confirmDeleteTitle": "Eliminar nota",
+      "lastEdited": "Última edición {{when}}",
+      "pickOrCreate": "Selecciona una nota para editar o crea una nueva."
+    },
+    "todos": {
+      "addPlaceholder": "Agregar una tarea para la Comunidad…",
+      "add": "Agregar",
+      "openHeading": "Por hacer",
+      "doneHeading": "Hecho",
+      "allDone": "Nada en la lista",
+      "toggle": "Marcar \"{{text}}\" como completado",
+      "deleteTodo": "Eliminar tarea",
+      "confirmDelete": "¿Eliminar esta tarea?",
+      "confirmDeleteTitle": "Eliminar tarea"
+    },
+    "quizLibrary": {
+      "heading": "Cuestionarios Compartidos",
+      "count_one": "{{count}} cuestionario",
+      "count_other": "{{count}} cuestionarios",
+      "emptyTitle": "Aún no hay cuestionarios compartidos",
+      "emptySubtitle": "Abre el widget de Cuestionario en tu tablero, haz clic en el menú de cualquier cuestionario y elige \"Compartir con la Comunidad\" para agregarlo aquí.",
+      "bySharer": "compartido por {{name}}",
+      "unknownSharer": "un compañero",
+      "questionCount_one": "{{count}} pregunta",
+      "questionCount_other": "{{count}} preguntas",
+      "addToMyLibrary": "Agregar a mi biblioteca",
+      "reimport": "Reimportar",
+      "inLibrary": "En tu biblioteca",
+      "alreadySynced": "\"{{title}}\" ya está sincronizado con tu biblioteca.",
+      "unshareAction": "Dejar de compartir",
+      "unshareYours": "Dejar de compartir en la Comunidad",
+      "unshareTeammate": "Dejar de compartir en la Comunidad (cualquier miembro puede eliminar)",
+      "unshareTitle": "Dejar de compartir cuestionario",
+      "unshareConfirm": "¿Eliminar \"{{title}}\" de esta Comunidad? Los demás compañeros perderán acceso a la entrada de biblioteca compartida. Las copias personales (si las hay) seguirán funcionando.",
+      "unshared": "\"{{title}}\" eliminado de esta Comunidad.",
+      "unshareFailed": "No se pudo dejar de compartir el cuestionario.",
+      "importedSync": "\"{{title}}\" agregado a tu biblioteca (sincronizado).",
+      "importedCopy": "\"{{title}}\" copiado a tu biblioteca.",
+      "importFailed": "No se pudo importar el cuestionario.",
+      "editAction": "Editar",
+      "editTooltip": "Editar en colaboración (los cambios se sincronizan con los compañeros)",
+      "editTooltipAutoImport": "Editar en colaboración — se agrega a tu biblioteca en la primera edición",
+      "editAutoImported": "\"{{title}}\" agregado a tu biblioteca — abriendo editor.",
+      "editSaved": "Cuestionario guardado — los compañeros se sincronizarán automáticamente.",
+      "editConflict": "Otro profesor publicó una actualización de este cuestionario. Incorporamos sus cambios; tus ediciones no guardadas no se guardaron. Vuelve a abrir el cuestionario para volver a aplicarlas.",
+      "editFailed": "No se pudo abrir el editor.",
+      "driveRequired": "Conecta Google Drive en tu cuenta para importar cuestionarios de la Comunidad.",
+      "driveRequiredForEdit": "Conecta Google Drive en tu cuenta para editar cuestionarios de la Comunidad.",
+      "driveDisconnected": "Conecta Google Drive para importar cuestionarios de la Comunidad a tu biblioteca personal."
+    }
+  },
   "widgetWindow": {
     "closeWidget": "¿Cerrar widget? Se perderán los datos.",
     "settings": "Configuración",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -239,6 +239,270 @@
     },
     "confirmClearBoard": "Êtes-vous sûr de vouloir fermer TOUTES les fenêtres de widgets ?"
   },
+  "plcDashboard": {
+    "subtitle": "Tableau de la Communauté",
+    "backToMenu": "Retour",
+    "close": "Fermer",
+    "tabs": {
+      "overview": "Vue d'ensemble",
+      "quizzes": "Quiz",
+      "videoActivities": "Activités vidéo",
+      "notes": "Notes",
+      "todos": "Liste de tâches",
+      "sharedBoards": "Tableaux partagés",
+      "settings": "Paramètres",
+      "home": "Accueil",
+      "members": "Membres",
+      "sharedData": "Données partagées",
+      "docs": "Documents",
+      "resources": "Ressources"
+    },
+    "assignmentsSubTabs": {
+      "label": "Vues des activités",
+      "library": "Bibliothèque",
+      "inProgress": "En cours",
+      "completed": "Terminé"
+    },
+    "quizzesSubTabs": {
+      "label": "Vues des quiz",
+      "library": "Bibliothèque",
+      "inProgress": "En cours",
+      "completed": "Terminé"
+    },
+    "videoActivitiesSubTabs": {
+      "label": "Vues des activités vidéo",
+      "library": "Bibliothèque",
+      "inProgress": "En cours",
+      "completed": "Terminé"
+    },
+    "assignmentsLibrary": {
+      "bySharer": "partagé par {{name}}",
+      "unknownSharer": "un collègue",
+      "addToMyBoard": "Ajouter à mon tableau",
+      "unshareAction": "Ne plus partager",
+      "unshareTitle": "Ne plus partager le modèle d'activité",
+      "unshareConfirm": "Retirer « {{title}} » de cette Communauté ? Les collègues qui l'ont déjà ajouté à leur tableau conservent leur copie.",
+      "unshareTooltip": "Retirer de la Communauté (tout membre peut arrêter le partage ; les imports existants continuent de fonctionner)",
+      "unshared": "« {{title}} » retiré de cette Communauté.",
+      "unshareFailed": "Impossible d'arrêter le partage du modèle d'activité.",
+      "importedSync": "« {{title}} » ajouté à votre tableau (pausé, synchronisé).",
+      "importedCopy": "« {{title}} » copié dans votre tableau (pausé).",
+      "importFailed": "Impossible d'ajouter l'activité à votre tableau.",
+      "assignedToClasses_one": "Attribuée à {{count}} classe.",
+      "assignedToClasses_other": "Attribuée à {{count}} classes.",
+      "assignFailed": "Impossible d'enregistrer la sélection de classes.",
+      "driveRequired": "Connectez Google Drive dans votre compte pour récupérer les activités de la Communauté.",
+      "driveDisconnected": "Connectez Google Drive pour ajouter des activités de la Communauté à votre tableau.",
+      "emptyTitle": "Aucun modèle d'activité pour l'instant",
+      "emptySubtitle": "Activez « Partager avec la Communauté » sur n'importe quelle activité de quiz que vous créez — elle apparaîtra ici pour que vos collègues puissent l'ajouter à leurs propres tableaux."
+    },
+    "assignmentsInProgress": {
+      "heading": "En direct dans l'équipe",
+      "count_one": "{{count}} en cours",
+      "count_other": "{{count}} en cours",
+      "statusActive": "Actif",
+      "statusPaused": "Pausé",
+      "emptyTitle": "Aucune activité en cours",
+      "emptySubtitle": "Quand vous ou un collègue démarrez une activité en mode Communauté, elle apparaît ici. Mettez-la en pause ou arrêtez-la depuis votre tableau, et la ligne se met à jour en temps réel."
+    },
+    "meta": {
+      "members_one": "{{count}} Membre",
+      "members_other": "{{count}} Membres",
+      "youLead": "Vous dirigez cette Communauté"
+    },
+    "completedAssignments": {
+      "heading": "Résultats partagés",
+      "count_one": "{{count}} activité",
+      "count_other": "{{count}} activités",
+      "byOwner": "par {{name}}",
+      "openSheet": "Ouvrir la feuille",
+      "unsafeSheet": "Pas de lien",
+      "emptyTitle": "Aucune activité terminée pour l'instant",
+      "emptySubtitle": "Quand une activité en mode Communauté est arrêtée depuis le tableau d'un collègue, elle apparaît ici avec un lien vers la feuille de résultats partagée."
+    },
+    "placeholder": {
+      "comingSoon": "Bientôt disponible"
+    },
+    "settings": {
+      "heading": "Sections du tableau",
+      "description": "Choisissez les sections qui apparaissent dans le tableau de cette Communauté. Tout membre peut mettre à jour ces paramètres.",
+      "saveFailed": "Impossible d'enregistrer les paramètres",
+      "quizzes": {
+        "title": "Bibliothèque de quiz",
+        "description": "Partagez des quiz avec la Communauté. Les membres peuvent synchroniser les modifications ou copier un quiz dans leur propre bibliothèque."
+      },
+      "videoActivities": {
+        "title": "Activités vidéo",
+        "description": "Partagez des activités basées sur la vidéo et agrégez les données de complétion avec la Communauté."
+      },
+      "notes": {
+        "title": "Notes",
+        "description": "Un carnet de notes partagé pour la Communauté."
+      },
+      "todos": {
+        "title": "Liste de tâches",
+        "description": "Une liste de contrôle partagée pour que la Communauté puisse suivre les actions à mener."
+      },
+      "sharedBoards": {
+        "title": "Tableaux partagés",
+        "description": "Affiche les tableaux partagés avec cette Communauté."
+      }
+    },
+    "overview": {
+      "heading": "Vue d'ensemble",
+      "editLayout": "Modifier la mise en page",
+      "doneEditing": "Terminé",
+      "reset": "Réinitialiser",
+      "editHint": "Faites glisser les tuiles par la poignée, cliquez sur le coin pour redimensionner, cliquez sur l'œil pour masquer.",
+      "confirmReset": "Réinitialiser votre mise en page bento à l'arrangement par défaut ? Les tailles et l'ordre des tuiles seront restaurés.",
+      "confirmResetTitle": "Réinitialiser la mise en page",
+      "dragHandle": "Faire glisser pour réorganiser",
+      "hideTile": "Masquer la tuile",
+      "unhideTile": "Restaurer la tuile {{kind}}",
+      "resizeTile": "Redimensionner la tuile (actuel : {{size}})",
+      "hiddenTiles": "Tuiles masquées",
+      "hiddenTilesHint": "cliquer pour restaurer",
+      "tiles": {
+        "comingSoon": "Phase {{phase}} · bientôt",
+        "plcInfo": {
+          "label": "Communauté d'Apprentissage Professionnel",
+          "members": "Membres",
+          "lead": "Responsable",
+          "you": "Vous",
+          "created": "Créé",
+          "openSettings": "Ouvrir les paramètres"
+        },
+        "members": {
+          "heading": "Membres"
+        },
+        "completedAssignments": {
+          "heading": "Résultats récents",
+          "empty": "Aucune activité effectuée",
+          "emptySubtitle": "Les quiz que vous exécutez en mode Communauté apparaissent ici.",
+          "viewAll": "Tout afficher"
+        },
+        "notes": {
+          "heading": "Notes",
+          "empty": "Aucune note pour l'instant",
+          "emptySubtitle": "Capturez les notes de réunion, décisions, idées.",
+          "untitled": "Sans titre",
+          "openAll": "Ouvrir les notes",
+          "justNow": "à l'instant",
+          "minutesAgo_one": "il y a {{count}} min",
+          "minutesAgo_other": "il y a {{count}} min",
+          "hoursAgo_one": "il y a {{count}} h",
+          "hoursAgo_other": "il y a {{count}} h",
+          "daysAgo_one": "il y a {{count}} jour",
+          "daysAgo_other": "il y a {{count}} jours"
+        },
+        "todos": {
+          "heading": "Liste de tâches",
+          "empty": "Rien à faire",
+          "emptySubtitle": "Ajoutez des éléments dans l'onglet Tâches.",
+          "openAll": "Ouvrir la liste",
+          "toggle": "Marquer « {{text}} » comme terminé",
+          "moreCount_one": "+{{count}} de plus",
+          "moreCount_other": "+{{count}} de plus"
+        },
+        "sharedSheet": {
+          "heading": "Feuille partagée",
+          "connectedHint": "Les résultats agrégés de la Communauté se trouvent dans cette Feuille Google. Tous les membres peuvent l'ouvrir.",
+          "unsetHint": "Pas encore de feuille partagée — elle sera créée automatiquement lors du premier quiz de la Communauté.",
+          "open": "Ouvrir la feuille",
+          "notReady": "Pas encore créée"
+        },
+        "quickActions": {
+          "heading": "Actions rapides",
+          "addNote": "Ajouter une note",
+          "addTodo": "Ajouter une tâche"
+        },
+        "quizLibrary": {
+          "title": "Bibliothèque de quiz",
+          "teaser": "Partagez des quiz avec votre Communauté.",
+          "heading": "Bibliothèque de Quiz",
+          "empty": "Aucun quiz partagé",
+          "emptySubtitle": "Partagez un quiz depuis le menu de sa carte de bibliothèque.",
+          "questionCount_one": "{{count}} q",
+          "questionCount_other": "{{count}} q",
+          "bySharer": "partagé par {{name}}",
+          "openAll": "Ouvrir la bibliothèque"
+        },
+        "activeAssignments": {
+          "title": "Activités actives",
+          "teaser": "Activités créées par la Communauté en attente d'être prises."
+        },
+        "videoActivities": {
+          "title": "Activités vidéo",
+          "teaser": "Partagez des activités vidéo avec la Communauté."
+        },
+        "sharedBoards": {
+          "title": "Tableaux partagés",
+          "teaser": "Tableaux partagés avec cette Communauté."
+        }
+      }
+    },
+    "notes": {
+      "heading": "Notes",
+      "newNote": "Nouveau",
+      "untitled": "Sans titre",
+      "empty": "Note vide",
+      "emptyTitle": "Aucune note pour l'instant",
+      "emptySubtitle": "Créez la première pour commencer.",
+      "titlePlaceholder": "Titre de la note",
+      "bodyPlaceholder": "Écrivez vos notes…",
+      "deleteNote": "Supprimer la note",
+      "confirmDelete": "Supprimer cette note ? Cette action est irréversible.",
+      "confirmDeleteTitle": "Supprimer la note",
+      "lastEdited": "Dernière modification {{when}}",
+      "pickOrCreate": "Sélectionnez une note à modifier ou créez-en une nouvelle."
+    },
+    "todos": {
+      "addPlaceholder": "Ajouter une tâche pour la Communauté…",
+      "add": "Ajouter",
+      "openHeading": "À faire",
+      "doneHeading": "Terminé",
+      "allDone": "Rien sur la liste",
+      "toggle": "Marquer « {{text}} » comme terminé",
+      "deleteTodo": "Supprimer la tâche",
+      "confirmDelete": "Supprimer cette tâche ?",
+      "confirmDeleteTitle": "Supprimer la tâche"
+    },
+    "quizLibrary": {
+      "heading": "Quiz partagés",
+      "count_one": "{{count}} quiz",
+      "count_other": "{{count}} quiz",
+      "emptyTitle": "Aucun quiz partagé pour l'instant",
+      "emptySubtitle": "Ouvrez le widget Quiz dans votre tableau, cliquez sur le menu d'un quiz et choisissez « Partager avec la Communauté » pour l'ajouter ici.",
+      "bySharer": "partagé par {{name}}",
+      "unknownSharer": "un collègue",
+      "questionCount_one": "{{count}} question",
+      "questionCount_other": "{{count}} questions",
+      "addToMyLibrary": "Ajouter à ma bibliothèque",
+      "reimport": "Réimporter",
+      "inLibrary": "Dans votre bibliothèque",
+      "alreadySynced": "« {{title}} » est déjà synchronisé avec votre bibliothèque.",
+      "unshareAction": "Ne plus partager",
+      "unshareYours": "Ne plus partager dans la Communauté",
+      "unshareTeammate": "Ne plus partager dans la Communauté (tout membre peut supprimer)",
+      "unshareTitle": "Ne plus partager le quiz",
+      "unshareConfirm": "Retirer « {{title}} » de cette Communauté ? Les autres collègues perdront l'accès à l'entrée de bibliothèque partagée. Leurs copies personnelles (le cas échéant) continueront de fonctionner.",
+      "unshared": "« {{title}} » retiré de cette Communauté.",
+      "unshareFailed": "Impossible d'arrêter le partage du quiz.",
+      "importedSync": "« {{title}} » ajouté à votre bibliothèque (synchronisé).",
+      "importedCopy": "« {{title}} » copié dans votre bibliothèque.",
+      "importFailed": "Impossible d'importer le quiz.",
+      "editAction": "Modifier",
+      "editTooltip": "Modifier en collaboration (les modifications se synchronisent avec les collègues)",
+      "editTooltipAutoImport": "Modifier en collaboration — s'ajoute à votre bibliothèque à la première modification",
+      "editAutoImported": "« {{title}} » ajouté à votre bibliothèque — ouverture de l'éditeur.",
+      "editSaved": "Quiz enregistré — les collègues se synchroniseront automatiquement.",
+      "editConflict": "Un autre enseignant a publié une mise à jour de ce quiz. Nous avons récupéré ses modifications ; vos modifications non enregistrées n'ont pas été sauvegardées. Rouvrez le quiz pour les appliquer à nouveau.",
+      "editFailed": "Impossible d'ouvrir l'éditeur.",
+      "driveRequired": "Connectez Google Drive dans votre compte pour importer les quiz de la Communauté.",
+      "driveRequiredForEdit": "Connectez Google Drive dans votre compte pour modifier les quiz de la Communauté.",
+      "driveDisconnected": "Connectez Google Drive pour importer les quiz de la Communauté dans votre bibliothèque personnelle."
+    }
+  },
   "widgetWindow": {
     "closeWidget": "Fermer le widget ? Les données seront perdues.",
     "settings": "Paramètres",

--- a/tests/i18n/plcDashboardLocales.test.ts
+++ b/tests/i18n/plcDashboardLocales.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Regression test for the missing plcDashboard locale namespace in DE/ES/FR.
+ *
+ * The plcDashboard namespace (~200 keys) was added to the EN locale as part of
+ * the PLC Dashboard feature (PlcDashboard.tsx, PLC tabs, notes, todos, quiz
+ * library, bento overview layout). The namespace was never propagated to DE,
+ * ES, or FR — all three non-English languages silently fall back to English for
+ * the entire PLC Dashboard UI, breaking the localisation contract.
+ *
+ * This test loads each locale JSON directly (not via i18next) so it catches
+ * key-presence issues before the i18next runtime silently swallows them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+/** Top-level sub-sections that must exist under plcDashboard. */
+const REQUIRED_TOP_LEVEL_SECTIONS = [
+  'subtitle',
+  'backToMenu',
+  'close',
+  'tabs',
+  'assignmentsSubTabs',
+  'quizzesSubTabs',
+  'videoActivitiesSubTabs',
+  'assignmentsLibrary',
+  'assignmentsInProgress',
+  'meta',
+  'completedAssignments',
+  'placeholder',
+  'settings',
+  'overview',
+  'notes',
+  'todos',
+  'quizLibrary',
+] as const;
+
+/** Keys within plcDashboard.tabs */
+const REQUIRED_TABS_KEYS = [
+  'overview',
+  'quizzes',
+  'videoActivities',
+  'notes',
+  'todos',
+  'sharedBoards',
+  'settings',
+  'home',
+  'members',
+  'sharedData',
+  'docs',
+  'resources',
+] as const;
+
+/** Keys within plcDashboard.quizLibrary */
+const REQUIRED_QUIZ_LIBRARY_KEYS = [
+  'heading',
+  'count_one',
+  'count_other',
+  'emptyTitle',
+  'emptySubtitle',
+  'bySharer',
+  'unknownSharer',
+  'questionCount_one',
+  'questionCount_other',
+  'addToMyLibrary',
+  'reimport',
+  'inLibrary',
+  'alreadySynced',
+  'unshareAction',
+  'unshareTitle',
+  'unshareConfirm',
+  'unshared',
+  'unshareFailed',
+  'importedSync',
+  'importedCopy',
+  'importFailed',
+  'editAction',
+  'editTooltip',
+  'editSaved',
+  'editFailed',
+  'driveRequired',
+  'driveDisconnected',
+] as const;
+
+/** Keys within plcDashboard.notes */
+const REQUIRED_NOTES_KEYS = [
+  'heading',
+  'newNote',
+  'untitled',
+  'empty',
+  'emptyTitle',
+  'emptySubtitle',
+  'titlePlaceholder',
+  'bodyPlaceholder',
+  'deleteNote',
+  'confirmDelete',
+  'confirmDeleteTitle',
+  'lastEdited',
+  'pickOrCreate',
+] as const;
+
+/** Keys within plcDashboard.todos */
+const REQUIRED_TODOS_KEYS = [
+  'addPlaceholder',
+  'add',
+  'openHeading',
+  'doneHeading',
+  'allDone',
+  'toggle',
+  'deleteTodo',
+  'confirmDelete',
+  'confirmDeleteTitle',
+] as const;
+
+/** Keys within plcDashboard.settings */
+const REQUIRED_SETTINGS_KEYS = [
+  'heading',
+  'description',
+  'saveFailed',
+] as const;
+
+/** Keys within plcDashboard.overview */
+const REQUIRED_OVERVIEW_KEYS = [
+  'heading',
+  'editLayout',
+  'doneEditing',
+  'reset',
+  'editHint',
+  'confirmReset',
+  'confirmResetTitle',
+  'dragHandle',
+  'hideTile',
+  'unhideTile',
+  'resizeTile',
+  'hiddenTiles',
+  'hiddenTilesHint',
+  'tiles',
+] as const;
+
+type LocaleFile = typeof en;
+
+// ─── EN baseline ────────────────────────────────────────────────────────────
+
+describe('EN locale — plcDashboard baseline', () => {
+  it('has a plcDashboard section', () => {
+    expect(en).toHaveProperty('plcDashboard');
+  });
+
+  it('has all required top-level sections', () => {
+    for (const key of REQUIRED_TOP_LEVEL_SECTIONS) {
+      expect(
+        en.plcDashboard,
+        `en.plcDashboard.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has all required plcDashboard.tabs keys', () => {
+    for (const key of REQUIRED_TABS_KEYS) {
+      expect(
+        en.plcDashboard.tabs,
+        `en.plcDashboard.tabs.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has all required plcDashboard.quizLibrary keys', () => {
+    for (const key of REQUIRED_QUIZ_LIBRARY_KEYS) {
+      expect(
+        en.plcDashboard.quizLibrary,
+        `en.plcDashboard.quizLibrary.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has all required plcDashboard.notes keys', () => {
+    for (const key of REQUIRED_NOTES_KEYS) {
+      expect(
+        en.plcDashboard.notes,
+        `en.plcDashboard.notes.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has all required plcDashboard.todos keys', () => {
+    for (const key of REQUIRED_TODOS_KEYS) {
+      expect(
+        en.plcDashboard.todos,
+        `en.plcDashboard.todos.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity ────────────────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de as unknown as LocaleFile },
+  { code: 'es', locale: es as unknown as LocaleFile },
+  { code: 'fr', locale: fr as unknown as LocaleFile },
+])('$code locale — plcDashboard parity with EN', ({ code, locale }) => {
+  it(`${code}: has a plcDashboard section`, () => {
+    expect(
+      locale,
+      `${code}.plcDashboard section is entirely missing`
+    ).toHaveProperty('plcDashboard');
+  });
+
+  it(`${code}: has all required top-level sections`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_TOP_LEVEL_SECTIONS) {
+      expect(plc, `${code}.plcDashboard.${key} is missing`).toHaveProperty(
+        key
+      );
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.tabs keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const tabs = plc?.tabs as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_TABS_KEYS) {
+      expect(
+        tabs,
+        `${code}.plcDashboard.tabs.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.quizLibrary keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const ql = plc?.quizLibrary as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_QUIZ_LIBRARY_KEYS) {
+      expect(
+        ql,
+        `${code}.plcDashboard.quizLibrary.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.notes keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const notes = plc?.notes as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_NOTES_KEYS) {
+      expect(
+        notes,
+        `${code}.plcDashboard.notes.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.todos keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const todos = plc?.todos as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_TODOS_KEYS) {
+      expect(
+        todos,
+        `${code}.plcDashboard.todos.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.settings keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const settings = plc?.settings as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_SETTINGS_KEYS) {
+      expect(
+        settings,
+        `${code}.plcDashboard.settings.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it(`${code}: has all required plcDashboard.overview keys`, () => {
+    const plc = (locale as Record<string, unknown>)
+      .plcDashboard as Record<string, unknown> | undefined;
+    const overview = plc?.overview as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_OVERVIEW_KEYS) {
+      expect(
+        overview,
+        `${code}.plcDashboard.overview.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+});

--- a/tests/i18n/plcDashboardLocales.test.ts
+++ b/tests/i18n/plcDashboardLocales.test.ts
@@ -70,6 +70,8 @@ const REQUIRED_QUIZ_LIBRARY_KEYS = [
   'inLibrary',
   'alreadySynced',
   'unshareAction',
+  'unshareYours',
+  'unshareTeammate',
   'unshareTitle',
   'unshareConfirm',
   'unshared',
@@ -79,9 +81,13 @@ const REQUIRED_QUIZ_LIBRARY_KEYS = [
   'importFailed',
   'editAction',
   'editTooltip',
+  'editTooltipAutoImport',
+  'editAutoImported',
   'editSaved',
+  'editConflict',
   'editFailed',
   'driveRequired',
+  'driveRequiredForEdit',
   'driveDisconnected',
 ] as const;
 

--- a/tests/i18n/plcDashboardLocales.test.ts
+++ b/tests/i18n/plcDashboardLocales.test.ts
@@ -210,18 +210,18 @@ describe.each([
   });
 
   it(`${code}: has all required top-level sections`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     for (const key of REQUIRED_TOP_LEVEL_SECTIONS) {
-      expect(plc, `${code}.plcDashboard.${key} is missing`).toHaveProperty(
-        key
-      );
+      expect(plc, `${code}.plcDashboard.${key} is missing`).toHaveProperty(key);
     }
   });
 
   it(`${code}: has all required plcDashboard.tabs keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const tabs = plc?.tabs as Record<string, unknown> | undefined;
     for (const key of REQUIRED_TABS_KEYS) {
       expect(
@@ -232,8 +232,9 @@ describe.each([
   });
 
   it(`${code}: has all required plcDashboard.quizLibrary keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const ql = plc?.quizLibrary as Record<string, unknown> | undefined;
     for (const key of REQUIRED_QUIZ_LIBRARY_KEYS) {
       expect(
@@ -244,8 +245,9 @@ describe.each([
   });
 
   it(`${code}: has all required plcDashboard.notes keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const notes = plc?.notes as Record<string, unknown> | undefined;
     for (const key of REQUIRED_NOTES_KEYS) {
       expect(
@@ -256,8 +258,9 @@ describe.each([
   });
 
   it(`${code}: has all required plcDashboard.todos keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const todos = plc?.todos as Record<string, unknown> | undefined;
     for (const key of REQUIRED_TODOS_KEYS) {
       expect(
@@ -268,8 +271,9 @@ describe.each([
   });
 
   it(`${code}: has all required plcDashboard.settings keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const settings = plc?.settings as Record<string, unknown> | undefined;
     for (const key of REQUIRED_SETTINGS_KEYS) {
       expect(
@@ -280,8 +284,9 @@ describe.each([
   });
 
   it(`${code}: has all required plcDashboard.overview keys`, () => {
-    const plc = (locale as Record<string, unknown>)
-      .plcDashboard as Record<string, unknown> | undefined;
+    const plc = (locale as Record<string, unknown>).plcDashboard as
+      | Record<string, unknown>
+      | undefined;
     const overview = plc?.overview as Record<string, unknown> | undefined;
     for (const key of REQUIRED_OVERVIEW_KEYS) {
       expect(


### PR DESCRIPTION
## Root Cause

The `plcDashboard` i18n namespace (200 keys covering PLC Dashboard tabs, notes, todos, quiz library, bento overview, settings panels, and all action/confirmation dialogs) was added to `locales/en.json` but never propagated to `locales/de.json`, `locales/es.json`, or `locales/fr.json`. Non-English users saw the entire PLC Dashboard UI silently fall back to English via i18next's quiet `defaultValue` fallback.

## Fix

Added all 200 `plcDashboard` keys to DE, ES, and FR locale files. Translations follow existing terminology conventions:
- DE: `PLG-Dashboard` / `PLG-Bibliothek` — consistent with `sidebar.plcs` DE translations; German typographic quotes (`„..."`) applied correctly
- ES: `Comunidad` terminology matching existing ES PLC translations
- FR: `Communauté` terminology matching existing FR PLC translations

## Band-Aid Rejected

Adding `defaultValue` props to every component call that renders PLC Dashboard strings would mask the fallback but not fix the root cause — non-EN users would still see English text. The fix is to translate the strings.

## Regression Test

`tests/i18n/plcDashboardLocales.test.ts` — 30 assertions covering top-level section presence, tabs keys, quizLibrary keys, notes keys, todos keys, settings keys, and overview keys for each of DE/ES/FR.

**Evidence:**
- FAILS on `dev-paul` (missing namespace): 24/30 tests failing (`fr.plcDashboard section is entirely missing`, etc.)
- PASSES on this branch: 30/30 tests pass; full i18n suite 76/76 passing

## Risk

**Contained.** JSON-only changes to `locales/` files; no TypeScript, no logic. Worst-case impact is a mistranslation (easily corrected), not a runtime error.

---
*Nightly code-health run — 2026-05-30*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up3feHwXJZE3KEQCWXR5jm)_