### PR TITLE
fix(RandomWidget): guard flash/slots setInterval against stale soundEnabled/students closure

### DIFF
--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -575,6 +575,10 @@ describe('RandomWidget', () => {
 
     afterEach(() => {
       vi.useRealTimers();
+      // Restore the vi.spyOn(audioUtils, 'playTick') created inside the test so
+      // the spy wrapper doesn't persist on the module namespace and stack with
+      // spies in other tests (which would inflate recorded call counts).
+      vi.restoreAllMocks();
     });
 
     it('stops calling playTick after soundEnabled is toggled off mid-spin', () => {

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { RandomWidget } from './RandomWidget';
 import { useDashboard } from '@/context/useDashboard';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { WidgetData, RandomConfig } from '@/types';
+import * as audioUtils from './audioUtils';
 
 vi.mock('@/context/useDashboard');
 
@@ -538,6 +539,82 @@ describe('RandomWidget', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  // ── Regression: stale-closure in flash/slots setInterval (PR #1749 parity)
+  //
+  // Before the fix, the setInterval callback in the 'flash' and 'slots' visual
+  // styles captured `soundEnabled` by value at creation time. If the widget
+  // re-rendered with soundEnabled=false mid-spin, the interval still called
+  // playTick on every subsequent tick (stale closure).
+  //
+  // After the fix, the callback reads from soundEnabledRef.current, which is
+  // updated synchronously on every render, so toggling soundEnabled off mid-
+  // spin silences all remaining ticks immediately.
+  describe('stale-closure regression — flash interval reads latest soundEnabled via ref', () => {
+    const makeWidget = (soundEnabled: boolean): WidgetData => ({
+      id: 'sc-test-id',
+      type: 'random',
+      config: {
+        firstNames: 'Alice\nBob\nCharlie',
+        lastNames: '',
+        mode: 'single',
+        visualStyle: 'flash',
+        soundEnabled,
+        rosterMode: 'custom',
+        remainingStudents: [],
+      } as RandomConfig,
+      x: 0,
+      y: 0,
+      w: 400,
+      h: 300,
+      z: 1,
+      flipped: false,
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('stops calling playTick after soundEnabled is toggled off mid-spin', () => {
+      vi.useFakeTimers();
+      const playTickSpy = vi.spyOn(audioUtils, 'playTick');
+
+      const { rerender } = render(<RandomWidget widget={makeWidget(true)} />);
+
+      // Start a spin (flash mode, soundEnabled=true)
+      act(() => {
+        fireEvent.click(
+          screen.getByRole('button', { name: /^Randomize$|^Picking$/ })
+        );
+      });
+
+      // Advance 3 ticks (3 × 80 ms = 240 ms). Each tick should play a sound
+      // because soundEnabled is still true.
+      act(() => {
+        vi.advanceTimersByTime(240);
+      });
+      const ticksWithSoundOn = playTickSpy.mock.calls.length;
+      expect(ticksWithSoundOn).toBeGreaterThan(0);
+
+      // Now toggle soundEnabled off by re-rendering with the updated widget.
+      // The stale-closure bug would have ignored this change and continued
+      // calling playTick for all remaining ticks.
+      playTickSpy.mockClear();
+      rerender(<RandomWidget widget={makeWidget(false)} />);
+
+      // Advance enough time for the remaining ticks (the flash interval fires
+      // for >20 ticks × 80ms = 1680ms total; we are at 240ms, so ~1500ms remain).
+      act(() => {
+        vi.advanceTimersByTime(1600);
+      });
+
+      // With the ref fix: soundEnabledRef.current is false, so playTick must
+      // NOT have been called after the re-render.
+      // Without the fix: playTick would have been called for every remaining
+      // tick because the closure captured soundEnabled=true at creation time.
+      expect(playTickSpy.mock.calls.length).toBe(0);
     });
   });
 });

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -323,6 +323,15 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
     return combined;
   }, [firstNames, lastNames, activeRoster, rosterMode, presentClassStudents]);
 
+  // Keep refs to the latest `students` array and `soundEnabled` flag so the
+  // flash/slots setInterval callbacks always read the current values even if
+  // props/config change mid-animation (stale-closure guard — same pattern as
+  // DiceWidget's diceCountRef/configRef fix in PR #1749).
+  const studentsRef = useRef(students);
+  const soundEnabledRef = useRef(soundEnabled);
+  studentsRef.current = students;
+  soundEnabledRef.current = soundEnabled;
+
   // Inline stepper display: mirror the call-site default so the on-widget
   // controls show what Pick will actually use until the user sets explicit
   // values. groupSize already has its own default applied above.
@@ -997,15 +1006,19 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       if (visualStyle === 'flash') {
         let count = 0;
         const interval = setInterval(() => {
+          // Read from refs so we always have the current students list and
+          // soundEnabled flag — config/props can change between the time
+          // setInterval fires and when it was created (stale-closure fix).
+          const liveStudents = studentsRef.current;
           const randomName =
-            students[Math.floor(Math.random() * students.length)];
+            liveStudents[Math.floor(Math.random() * liveStudents.length)];
           setDisplayResult(randomName);
-          if (soundEnabled) playTick(150 + Math.random() * 50);
+          if (soundEnabledRef.current) playTick(150 + Math.random() * 50);
           count++;
           if (count > 20) {
             clearInterval(interval);
             setDisplayResult(winnerName);
-            if (soundEnabled) playWinner();
+            if (soundEnabledRef.current) playWinner();
             setIsSpinning(false);
             performUpdate(winnerName, nextRemaining);
           }
@@ -1048,15 +1061,19 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         let count = 0;
         const max = 25;
         const interval = setInterval(() => {
+          // Read from refs so we always have the current students list and
+          // soundEnabled flag — config/props can change between the time
+          // setInterval fires and when it was created (stale-closure fix).
+          const liveStudents = studentsRef.current;
           const randomName =
-            students[Math.floor(Math.random() * students.length)];
+            liveStudents[Math.floor(Math.random() * liveStudents.length)];
           setDisplayResult(randomName);
-          if (soundEnabled) playTick(150, 0.05);
+          if (soundEnabledRef.current) playTick(150, 0.05);
           count++;
           if (count > max) {
             clearInterval(interval);
             setDisplayResult(winnerName);
-            if (soundEnabled) playWinner();
+            if (soundEnabledRef.current) playWinner();
             setIsSpinning(false);
             performUpdate(winnerName, nextRemaining);
           }


### PR DESCRIPTION
## Root Cause

`handlePick` in `RandomWidget.tsx` creates `setInterval` callbacks for the `'flash'` and `'slots'` visual styles that close over `students` (the derived name array) and `soundEnabled` (from widget config) **by value at the time `setInterval` is called**. Because `handlePick` is not memoized, any re-render during the ~1.7s animation window (e.g. a Firestore config sync, live roster update) does **not** update what the running interval reads.

Two concrete failure modes:
1. **`soundEnabled` stale**: Teacher toggles sound off in settings mid-spin — the interval keeps calling `playTick()` for every remaining tick because it still reads `soundEnabled = true` from the stale closure.
2. **`students` stale**: A live roster change fires during the spin. The interval indexes into the old student array, displaying names that no longer exist in the current roster.

Same class of bug as `DiceWidget` (fixed PR #1749).

## Fix

Added two refs assigned synchronously in the render body (not in a `useEffect`):

```tsx
const studentsRef = useRef(students);
const soundEnabledRef = useRef(soundEnabled);
studentsRef.current = students;
soundEnabledRef.current = soundEnabled;
```

Both `'flash'` and `'slots'` interval callbacks now read `studentsRef.current` / `soundEnabledRef.current` instead of stale captured values.

## Band-Aid Rejected

Wrapping `handlePick` in `useCallback` would not help — the callback still captures `students` and `soundEnabled` from its closure; `useCallback` only re-creates it when the deps change, but cannot retroactively update a running `setInterval`. The ref pattern is the correct fix.

## Regression Test

`components/widgets/random/RandomWidget.test.tsx` — new test:
- `stale-closure regression — flash interval reads latest soundEnabled via ref — stops calling playTick after soundEnabled is toggled off mid-spin`

**Evidence:**
- FAILS on `dev-paul`: `expected 18 to be 0` — interval called `playTick` 18 times after sound was toggled off (stale `true` in closure)
- PASSES on this branch: 0 calls after toggle; 19/19 tests pass

## Backlog (not fixed in this PR)

- The `'wheel'` visual style uses a recursive `setTimeout` chain that also captures `soundEnabled` by closure. Same class of bug, lower severity (5-second spin, config change during wheel extremely unlikely). Candidate for a follow-up.

## Risk

**Contained.** Affects only the `RandomWidget`'s animation playback during the brief flash/slots spin window. The winner name and updated roster (`nextRemaining`) are computed from the click-time snapshot before `setInterval` is created, so Firestore state is never corrupted. The stale `students` reference only affected cosmetic intermediate names shown during animation.

---
*Nightly code-health run — 2026-05-30*

---
_Generated by [Claude Code](https://claude.ai/code/session_01Up3feHwXJZE3KEQCWXR5jm)_