### PR TITLE
D4: settingsModal/sections — @/ alias for SettingsSectionHeader imports

### DIFF
--- a/components/settingsModal/sections/AppearanceSection.tsx
+++ b/components/settingsModal/sections/AppearanceSection.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { CheckSquare, ChevronRight, Palette, RotateCcw } from 'lucide-react';
 import { GlobalFontFamily, GlobalStyle, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { GlobalStyleEditor } from '@/hooks/useGlobalStyleEditor';
-import { SettingsSectionHeader } from '../SettingsSectionHeader';
+import { SettingsSectionHeader } from '@/components/settingsModal/SettingsSectionHeader';
 
 const FONT_OPTIONS: { id: GlobalFontFamily; label: string; font: string }[] = [
   { id: 'sans', label: 'Modern Sans', font: 'font-sans' },

--- a/components/settingsModal/sections/BehaviorSection.tsx
+++ b/components/settingsModal/sections/BehaviorSection.tsx
@@ -10,7 +10,7 @@ import { MousePointerClick, ShieldX, SlidersHorizontal } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
 import { Card } from '@/components/common/Card';
 import { useAuth } from '@/context/useAuth';
-import { SettingsSectionHeader } from '../SettingsSectionHeader';
+import { SettingsSectionHeader } from '@/components/settingsModal/SettingsSectionHeader';
 
 export const BehaviorSection: React.FC = () => {
   const { t } = useTranslation();

--- a/components/settingsModal/sections/DockSection.tsx
+++ b/components/settingsModal/sections/DockSection.tsx
@@ -14,7 +14,7 @@ import { CheckSquare, Minimize } from 'lucide-react';
 import { DockPosition, GlobalStyle } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { GlobalStyleEditor } from '@/hooks/useGlobalStyleEditor';
-import { SettingsSectionHeader } from '../SettingsSectionHeader';
+import { SettingsSectionHeader } from '@/components/settingsModal/SettingsSectionHeader';
 
 interface DockSectionProps {
   editor: GlobalStyleEditor;

--- a/components/settingsModal/sections/LanguageSection.tsx
+++ b/components/settingsModal/sections/LanguageSection.tsx
@@ -9,7 +9,7 @@ import { Globe } from 'lucide-react';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
 import { SUPPORTED_LANGUAGES } from '@/i18n';
-import { SettingsSectionHeader } from '../SettingsSectionHeader';
+import { SettingsSectionHeader } from '@/components/settingsModal/SettingsSectionHeader';
 
 export const LanguageSection: React.FC = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
## Canonical form
`import { X } from '@/components/settingsModal/SettingsSectionHeader'`

## Instances unified
4 files in `components/settingsModal/sections/`, each with one cross-directory relative import:

| File | Before | After |
|------|--------|-------|
| `AppearanceSection.tsx` | `'../SettingsSectionHeader'` | `'@/components/settingsModal/SettingsSectionHeader'` |
| `BehaviorSection.tsx` | `'../SettingsSectionHeader'` | `'@/components/settingsModal/SettingsSectionHeader'` |
| `DockSection.tsx` | `'../SettingsSectionHeader'` | `'@/components/settingsModal/SettingsSectionHeader'` |
| `LanguageSection.tsx` | `'../SettingsSectionHeader'` | `'@/components/settingsModal/SettingsSectionHeader'` |

After this change, `grep -rn '\.\.\/'` on `components/settingsModal/sections/` returns empty — no remaining cross-directory relative imports.

## Enforcement added
No new rule — `@/` alias enforcement is the documented D4 canon. The exhaustive sweep of this specific subdirectory eliminates recurrence from these 4 files.

## Behavior-preservation evidence
- Pure import path change; TypeScript resolves both forms to the same module (`components/settingsModal/SettingsSectionHeader.tsx` confirmed to exist)
- No runtime behavior affected — bundler resolves both to the same chunk
- TypeScript: ✅ zero errors | ESLint: ✅ zero warnings

## Risk
**mechanical** — import path alias substitution only; zero behavioral delta

https://claude.ai/code/session_01Qrq4SHeHmdzxNxt3Gndiwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qrq4SHeHmdzxNxt3Gndiwz)_