### PR TITLE
fix(widgets): countdown midnight drift + RandomWidget stale-closure sound bug

### DIFF
--- a/components/widgets/Countdown/Widget.test.tsx
+++ b/components/widgets/Countdown/Widget.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CountdownWidget } from './Widget';
 import { CountdownConfig, WidgetData } from '@/types';
 
@@ -45,6 +45,10 @@ describe('CountdownWidget', () => {
     vi.setSystemTime(new Date('2026-04-03T09:00:00.000Z'));
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('shows the current day as excluded in grid mode when countToday is off', () => {
     render(
       <CountdownWidget
@@ -81,5 +85,23 @@ describe('CountdownWidget', () => {
     const titleEl = screen.getByText('Field Trip');
     expect(titleEl).toHaveStyle({ color: '#2d3f89' });
     expect(titleEl).not.toHaveClass('text-brand-blue-primary');
+  });
+
+  it('recalculates the count when midnight passes without a config change', () => {
+    // Start on April 3. Event is April 6. countToday=true, includeWeekends=true.
+    // Days remaining: Apr 3, Apr 4, Apr 5 → 3
+    render(<CountdownWidget widget={buildWidget({ countToday: true })} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+
+    // Advance 25 hours so the system clock crosses midnight into April 4.
+    // Days remaining: Apr 4, Apr 5 → 2
+    act(() => {
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+    });
+
+    // The widget must re-render and show the updated count.
+    // Without an internal ticker that re-triggers the useMemo, this fails.
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
   });
 });

--- a/components/widgets/Countdown/Widget.tsx
+++ b/components/widgets/Countdown/Widget.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { WidgetData, CountdownConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { WidgetLayout } from '../WidgetLayout';
 import { getFontClass, hexToRgba } from '@/utils/styles';
@@ -46,10 +46,24 @@ export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
 
   const fontClass = getFontClass(fontFamily, globalStyle.fontFamily);
 
+  // Stable "today at midnight" timestamp, refreshed every minute so the
+  // widget recomputes automatically when the calendar day changes. Without
+  // this ticker the useMemo dependency arrays never change at midnight and
+  // the countdown stays frozen until the user edits a config field.
+  const [todayMidnightMs, setTodayMidnightMs] = useState(() =>
+    normalizeDate(new Date()).getTime()
+  );
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTodayMidnightMs(normalizeDate(new Date()).getTime());
+    }, 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const calculatedDays = useMemo(() => {
     const start = normalizeDate(new Date(startDate));
     const event = normalizeDate(new Date(eventDate));
-    const todayAtMidnight = normalizeDate(new Date());
+    const todayAtMidnight = new Date(todayMidnightMs);
 
     const countStart = new Date(
       Math.max(todayAtMidnight.getTime(), start.getTime())
@@ -75,12 +89,12 @@ export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
     }
 
     return days;
-  }, [startDate, eventDate, includeWeekends, countToday]);
+  }, [startDate, eventDate, includeWeekends, countToday, todayMidnightMs]);
 
   const gridData = useMemo(() => {
     const start = normalizeDate(new Date(startDate));
     const event = normalizeDate(new Date(eventDate));
-    const today = normalizeDate(new Date());
+    const today = new Date(todayMidnightMs);
     const countStart = new Date(Math.max(today.getTime(), start.getTime()));
 
     if (!countToday && countStart.getTime() === today.getTime()) {
@@ -125,7 +139,7 @@ export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
       ...item,
       number: countdownNumbers.get(item.date.getTime()),
     }));
-  }, [startDate, eventDate, includeWeekends, countToday]);
+  }, [startDate, eventDate, includeWeekends, countToday, todayMidnightMs]);
 
   return (
     <WidgetLayout

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -472,6 +472,7 @@ describe('RandomWidget', () => {
       type: 'random',
       config: {
         firstNames: 'Alice\nBob\nCharlie',
+        lastNames: '',
         rosterMode: 'custom',
         mode: 'single',
         visualStyle,

--- a/components/widgets/random/RandomWidget.test.tsx
+++ b/components/widgets/random/RandomWidget.test.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { RandomWidget } from './RandomWidget';
 import { useDashboard } from '@/context/useDashboard';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { WidgetData, RandomConfig } from '@/types';
+import * as audioUtils from './audioUtils';
 
 vi.mock('@/context/useDashboard');
 
@@ -447,6 +448,112 @@ describe('RandomWidget', () => {
       expect.stringMatching(/scoreboard/i),
       'success'
     );
+  });
+
+  describe('stale-closure regression: soundEnabled read from ref mid-spin', () => {
+    // Regression test for the stale-closure bug where setInterval callbacks in
+    // handlePick (a click handler) captured `soundEnabled` from the closure at
+    // click time. If the teacher toggled sound OFF mid-spin, the interval still
+    // played ticks using the stale `soundEnabled = true` value from when the
+    // spin started.
+    //
+    // The fix: assign `soundEnabledRef.current = soundEnabled` synchronously in
+    // the render body and read `soundEnabledRef.current` inside the callbacks.
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const makeWidget = (
+      visualStyle: string,
+      soundEnabled: boolean
+    ): WidgetData => ({
+      id: 'test-id',
+      type: 'random',
+      config: {
+        firstNames: 'Alice\nBob\nCharlie',
+        rosterMode: 'custom',
+        mode: 'single',
+        visualStyle,
+        soundEnabled,
+        remainingStudents: [],
+      } as RandomConfig,
+      x: 0,
+      y: 0,
+      w: 300,
+      h: 200,
+      z: 1,
+      flipped: false,
+    });
+
+    it('flash: stops playing ticks when soundEnabled is toggled off mid-spin', () => {
+      vi.useFakeTimers();
+      const playTick = vi.mocked(audioUtils.playTick);
+
+      const { rerender } = render(
+        <RandomWidget widget={makeWidget('flash', true)} />
+      );
+
+      // Start the spin with soundEnabled = true
+      act(() => {
+        fireEvent.click(
+          screen.getByRole('button', { name: /^Randomize$|^Picking$/ })
+        );
+      });
+
+      // Let a few ticks fire (interval is 80ms, so 5 ticks ≈ 400ms)
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(playTick.mock.calls.length).toBeGreaterThan(0);
+
+      // Teacher toggles sound OFF mid-spin
+      rerender(<RandomWidget widget={makeWidget('flash', false)} />);
+      playTick.mockClear();
+
+      // Advance time enough for more interval ticks but not past the 20-tick finish
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+
+      // With the fix: the interval reads soundEnabledRef.current, which is now
+      // false, so no further ticks should fire.
+      // Without the fix: stale closure still sees soundEnabled=true.
+      expect(playTick).not.toHaveBeenCalled();
+    });
+
+    it('slots: stops playing ticks when soundEnabled is toggled off mid-spin', () => {
+      vi.useFakeTimers();
+      const playTick = vi.mocked(audioUtils.playTick);
+
+      const { rerender } = render(
+        <RandomWidget widget={makeWidget('slots', true)} />
+      );
+
+      act(() => {
+        fireEvent.click(
+          screen.getByRole('button', { name: /^Randomize$|^Picking$/ })
+        );
+      });
+
+      // Let a few ticks fire (interval is 100ms, so 3 ticks ≈ 300ms)
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(playTick.mock.calls.length).toBeGreaterThan(0);
+
+      // Toggle sound OFF mid-spin
+      rerender(<RandomWidget widget={makeWidget('slots', false)} />);
+      playTick.mockClear();
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(playTick).not.toHaveBeenCalled();
+    });
   });
 
   describe('Randomize with locks (no sit-out tray)', () => {

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -194,6 +194,14 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   // and bail before clobbering the new state.
   const spinGenRef = useRef(0);
 
+  // Ref kept in sync with the latest `soundEnabled` prop value on every render.
+  // setInterval/setTimeout callbacks in handlePick are created inside a click
+  // handler (not a useEffect), so they capture a stale closure. Reading from
+  // this ref instead of the closure-captured `soundEnabled` ensures the callback
+  // always sees the current value even if the teacher toggles sound mid-spin.
+  const soundEnabledRef = useRef(soundEnabled);
+  soundEnabledRef.current = soundEnabled;
+
   // Sync displayResult when config.lastResult changes (e.g. mode switch clears
   // it) using the "adjusting state while rendering" pattern. Doing this in a
   // useEffect would leave displayResult stale for one render, which crashed
@@ -1000,12 +1008,12 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const randomName =
             students[Math.floor(Math.random() * students.length)];
           setDisplayResult(randomName);
-          if (soundEnabled) playTick(150 + Math.random() * 50);
+          if (soundEnabledRef.current) playTick(150 + Math.random() * 50);
           count++;
           if (count > 20) {
             clearInterval(interval);
             setDisplayResult(winnerName);
-            if (soundEnabled) playWinner();
+            if (soundEnabledRef.current) playWinner();
             setIsSpinning(false);
             performUpdate(winnerName, nextRemaining);
           }
@@ -1031,12 +1039,12 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const elapsed = Date.now() - startTime;
           if (elapsed >= duration) {
             setDisplayResult(winnerName);
-            if (soundEnabled) playWinner();
+            if (soundEnabledRef.current) playWinner();
             setIsSpinning(false);
             performUpdate(winnerName, nextRemaining);
             return;
           }
-          if (soundEnabled) playTick(150);
+          if (soundEnabledRef.current) playTick(150);
           const progress = elapsed / duration;
           const nextInterval = 50 + Math.pow(progress, 2) * 400;
           setTimeout(() => {
@@ -1051,12 +1059,12 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           const randomName =
             students[Math.floor(Math.random() * students.length)];
           setDisplayResult(randomName);
-          if (soundEnabled) playTick(150, 0.05);
+          if (soundEnabledRef.current) playTick(150, 0.05);
           count++;
           if (count > max) {
             clearInterval(interval);
             setDisplayResult(winnerName);
-            if (soundEnabled) playWinner();
+            if (soundEnabledRef.current) playWinner();
             setIsSpinning(false);
             performUpdate(winnerName, nextRemaining);
           }
@@ -1192,7 +1200,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           );
         }
 
-        if (soundEnabled) playWinner();
+        if (soundEnabledRef.current) playWinner();
         // Wrap home-group state updates in a View Transition so chips
         // visibly move from old groups to new ones on re-randomize.
         withViewTransition(() => {
@@ -1344,7 +1352,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             }
           }
         }
-        if (soundEnabled) playWinner();
+        if (soundEnabledRef.current) playWinner();
         // Wrap the state updates in a View Transition so chips slide from
         // their old positions to new ones (groups + shuffle modes) instead
         // of snapping. Falls back to a plain update on browsers without


### PR DESCRIPTION
## Summary

- **CountdownWidget midnight drift** (`components/widgets/Countdown/Widget.tsx`): Both `calculatedDays` and `gridData` useMemos called `new Date()` in their bodies without tracking day boundaries. After midnight the displayed count never updated until the user changed a config value. Fix: added `todayMidnightMs` state (initialized to midnight, ticked every 60 s via `setInterval`) so both memos recompute automatically when the day rolls over.

- **RandomWidget stale-closure sound** (`components/widgets/random/RandomWidget.tsx`): `handlePick`'s `setInterval` / `setTimeout` callbacks captured `soundEnabled` at click time via closure. If the teacher toggled sound mid-spin the in-flight callbacks used the stale value. Fix: added `soundEnabledRef` assigned synchronously in the render body; all 8 callback sites now read `soundEnabledRef.current`.

- **Test fixture TS fix** (`components/widgets/random/RandomWidget.test.tsx`): New stale-closure regression test's `makeWidget` helper was missing the required `lastNames` field from `RandomConfig` (TS2352). Added `lastNames: ''`.

## Regression tests added

| Test file | What it covers |
|---|---|
| `components/widgets/Countdown/Widget.test.tsx` | Advances fake timers 25 h, asserts day count decrements without any config change |
| `components/widgets/random/RandomWidget.test.tsx` | Toggles `soundEnabled` mid-spin; asserts the in-flight callback uses the current value |

## Verification

- `pnpm run validate` green on this branch
- New CountdownWidget test: FAIL on `dev-paul`, PASS with fix
- New RandomWidget test: FAIL on `dev-paul`, PASS with fix

## Test plan

- [ ] Add a CountdownWidget targeting tomorrow; wait past midnight (or advance system clock); confirm count decrements automatically
- [ ] Add a RandomWidget; start a spin with sound on; toggle sound off mid-spin; confirm sound stops immediately
- [ ] Run `pnpm run test` to confirm all widget tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_011NXxzJ7Gnqa3TgkHi5hcbJ)_