### PR TITLE
fix(i18n): add missing dock, boardNav, and sidebar.nav keys to DE/ES/FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -22,7 +22,7 @@
     "next": "Nächste Tafel",
     "selectBoard": "Tafel auswählen",
     "boardList": "Alle Tafeln",
-    "manageAllBoards": "Alle Boards verwalten…",
+    "manageAllBoards": "Alle Tafeln verwalten…",
     "pinned": "Angeheftet",
     "selectCollection": "Sammlung auswählen"
   },

--- a/locales/de.json
+++ b/locales/de.json
@@ -21,7 +21,10 @@
     "previous": "Vorherige Tafel",
     "next": "Nächste Tafel",
     "selectBoard": "Tafel auswählen",
-    "boardList": "Alle Tafeln"
+    "boardList": "Alle Tafeln",
+    "manageAllBoards": "Alle Boards verwalten…",
+    "pinned": "Angeheftet",
+    "selectCollection": "Sammlung auswählen"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -73,7 +76,8 @@
       "globalStyle": "Globaler Stil",
       "generalSettings": "Allgemeine Einstellungen",
       "whatsNew": "Was ist neu",
-      "whatsNewBadge": "Neu"
+      "whatsNewBadge": "Neu",
+      "whatsNewSrAnnouncement": "Neue Versionshinweise verfügbar"
     },
     "boards": {
       "newBoard": "Neue Tafel",
@@ -315,7 +319,11 @@
     "uploadingToDrive": "Aufnahme wird auf Google Drive hochgeladen...",
     "recordingSavedToDrive": "Aufnahme auf Google Drive gespeichert!",
     "recordingDriveFailed": "Speichern auf Drive fehlgeschlagen. Lokaler Download...",
-    "noGoogleDrive": "Kein Google Drive verbunden. Lokaler Download..."
+    "noGoogleDrive": "Kein Google Drive verbunden. Lokaler Download...",
+    "viewLiveSession": "Informationen zur Live-Sitzung anzeigen",
+    "liveSession": "Live-Sitzung",
+    "provideCode": "Gib diesen Code deinen Schülerinnen und Schülern.",
+    "noAppsSelected": "Standardwerte werden wiederhergestellt…"
   },
   "languages": {
     "en": "English",

--- a/locales/es.json
+++ b/locales/es.json
@@ -21,7 +21,10 @@
     "previous": "Tablero anterior",
     "next": "Tablero siguiente",
     "selectBoard": "Seleccionar tablero",
-    "boardList": "Todos los tableros"
+    "boardList": "Todos los tableros",
+    "manageAllBoards": "Administrar todos los tableros…",
+    "pinned": "Fijado",
+    "selectCollection": "Seleccionar colección"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -73,7 +76,8 @@
       "globalStyle": "Estilo Global",
       "generalSettings": "Ajustes Generales",
       "whatsNew": "Novedades",
-      "whatsNewBadge": "Nuevo"
+      "whatsNewBadge": "Nuevo",
+      "whatsNewSrAnnouncement": "Nuevas notas de versión disponibles"
     },
     "boards": {
       "newBoard": "Nuevo Tablero",
@@ -327,7 +331,11 @@
     "uploadingToDrive": "Subiendo grabación a Google Drive...",
     "recordingSavedToDrive": "¡Grabación guardada en Google Drive!",
     "recordingDriveFailed": "Error al guardar en Drive. Descargando localmente...",
-    "noGoogleDrive": "Sin Google Drive conectado. Descargando localmente..."
+    "noGoogleDrive": "Sin Google Drive conectado. Descargando localmente...",
+    "viewLiveSession": "Ver información de la sesión en vivo",
+    "liveSession": "Sesión en vivo",
+    "provideCode": "Proporciona este código a tus alumnos.",
+    "noAppsSelected": "Restaurando valores predeterminados…"
   },
   "languages": {
     "en": "English",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -21,7 +21,10 @@
     "previous": "Tableau précédent",
     "next": "Tableau suivant",
     "selectBoard": "Sélectionner un tableau",
-    "boardList": "Tous les tableaux"
+    "boardList": "Tous les tableaux",
+    "manageAllBoards": "Gérer tous les tableaux…",
+    "pinned": "Épinglé",
+    "selectCollection": "Sélectionner une collection"
   },
   "boardZoom": {
     "zoomLevel": "Zoom",
@@ -73,7 +76,8 @@
       "globalStyle": "Style global",
       "generalSettings": "Paramètres généraux",
       "whatsNew": "Nouveautés",
-      "whatsNewBadge": "Nouveau"
+      "whatsNewBadge": "Nouveau",
+      "whatsNewSrAnnouncement": "Nouvelles notes de version disponibles"
     },
     "boards": {
       "newBoard": "Nouveau tableau",
@@ -315,7 +319,11 @@
     "uploadingToDrive": "Téléchargement de l'enregistrement sur Google Drive...",
     "recordingSavedToDrive": "Enregistrement sauvegardé sur Google Drive !",
     "recordingDriveFailed": "Échec de la sauvegarde sur Drive. Téléchargement local...",
-    "noGoogleDrive": "Aucun Google Drive connecté. Téléchargement local..."
+    "noGoogleDrive": "Aucun Google Drive connecté. Téléchargement local...",
+    "viewLiveSession": "Voir les informations de la session en direct",
+    "liveSession": "Session en direct",
+    "provideCode": "Donnez ce code à vos élèves.",
+    "noAppsSelected": "Restauration des valeurs par défaut…"
   },
   "languages": {
     "en": "English",

--- a/tests/i18n/dockBoardNavLocales.test.ts
+++ b/tests/i18n/dockBoardNavLocales.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for missing dock live-session and boardNav navigation keys
+ * in non-English locales.
+ *
+ * These keys are rendered in teacher-facing UI:
+ *   - dock.liveSession, dock.provideCode, dock.viewLiveSession, dock.noAppsSelected
+ *     are used in Dock.tsx for the live-session panel and the dock restoration UI.
+ *     None of them use i18next `defaultValue` fallbacks, so missing translations
+ *     render as raw EN strings for German, Spanish, and French teachers.
+ *   - boardNav.manageAllBoards, boardNav.pinned, boardNav.selectCollection
+ *     are used in BoardNavFab.tsx. They use `defaultValue` which silences missing-
+ *     key errors — meaning these bugs are invisible at runtime but break the
+ *     localization contract.
+ *   - sidebar.nav.whatsNewSrAnnouncement is used in Sidebar.tsx as a screen-reader
+ *     announcement rendered via a visually-hidden element; missing translation means
+ *     SR users in non-EN locales hear English text.
+ *
+ * This test loads each locale JSON directly (not via i18next) so it catches
+ * key-presence issues before the i18next runtime silently swallows them with
+ * English fallback values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+type LocaleFile = typeof en;
+
+const NON_EN = [
+  { code: 'de', locale: de as unknown as LocaleFile },
+  { code: 'es', locale: es as unknown as LocaleFile },
+  { code: 'fr', locale: fr as unknown as LocaleFile },
+];
+
+/** dock keys used in Dock.tsx for the live-session panel. */
+const DOCK_LIVE_KEYS = [
+  'liveSession',
+  'provideCode',
+  'viewLiveSession',
+  'noAppsSelected',
+] as const;
+
+/** boardNav keys used in BoardNavFab.tsx. */
+const BOARD_NAV_KEYS = [
+  'manageAllBoards',
+  'pinned',
+  'selectCollection',
+] as const;
+
+describe('EN locale — baseline', () => {
+  it('has all required dock live-session keys', () => {
+    for (const key of DOCK_LIVE_KEYS) {
+      expect(en.dock, `en.dock.${key} missing from EN baseline`).toHaveProperty(
+        key
+      );
+    }
+  });
+
+  it('has all required boardNav navigation keys', () => {
+    for (const key of BOARD_NAV_KEYS) {
+      expect(
+        en.boardNav,
+        `en.boardNav.${key} missing from EN baseline`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has sidebar.nav.whatsNewSrAnnouncement', () => {
+    expect(en.sidebar.nav).toHaveProperty('whatsNewSrAnnouncement');
+  });
+});
+
+describe.each(NON_EN)(
+  '$code locale — dock, boardNav, and sidebar.nav parity with EN',
+  ({ code, locale }) => {
+    it(`${code}: has all dock live-session keys`, () => {
+      const dock = (locale as Record<string, unknown>).dock as
+        | Record<string, unknown>
+        | undefined;
+      for (const key of DOCK_LIVE_KEYS) {
+        expect(dock, `${code}.dock.${key} is missing`).toHaveProperty(key);
+      }
+    });
+
+    it(`${code}: has all boardNav navigation keys`, () => {
+      const boardNav = (locale as Record<string, unknown>).boardNav as
+        | Record<string, unknown>
+        | undefined;
+      for (const key of BOARD_NAV_KEYS) {
+        expect(boardNav, `${code}.boardNav.${key} is missing`).toHaveProperty(
+          key
+        );
+      }
+    });
+
+    it(`${code}: has sidebar.nav.whatsNewSrAnnouncement`, () => {
+      const nav = (
+        (locale as Record<string, unknown>).sidebar as
+          | Record<string, unknown>
+          | undefined
+      )?.nav as Record<string, unknown> | undefined;
+      expect(
+        nav,
+        `${code}.sidebar.nav.whatsNewSrAnnouncement is missing`
+      ).toHaveProperty('whatsNewSrAnnouncement');
+    });
+  }
+);


### PR DESCRIPTION
## Summary

8 keys used in teacher-facing UI were missing from all three non-English locales (`de.json`, `es.json`, `fr.json`):

**`dock.*`** (used in `Dock.tsx` — no `defaultValue` fallback, so missing = raw EN string):
- `liveSession`, `provideCode`, `viewLiveSession`, `noAppsSelected`

**`boardNav.*`** (used in `BoardNavFab.tsx` — uses `defaultValue` which silently masks the bug at runtime):
- `manageAllBoards`, `pinned`, `selectCollection`

**`sidebar.nav.whatsNewSrAnnouncement`** (used in `Sidebar.tsx` as a visually-hidden SR announcement):
- Missing translation means screen-reader users in non-EN locales hear English text

## Regression test added

`tests/i18n/dockBoardNavLocales.test.ts` — imports locale JSON directly (bypasses i18next EN fallback) and asserts key presence in DE, ES, FR for all three groups.

- FAIL on `dev-paul` (9 tests across 3 locales)
- PASS with fix (12/12)

## Test plan

- [ ] Switch UI language to DE/ES/FR; open the Dock and verify live-session labels are translated
- [ ] Verify "What's New" SR announcement is translated (screen reader or inspect SR-only element)
- [ ] Run `pnpm run test -- tests/i18n/` to confirm all locale parity tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_011NXxzJ7Gnqa3TgkHi5hcbJ)_