### PR TITLE
fix(plc): deduplicate question IDs in buildContributionDoc to prevent score inflation

### DIFF
--- a/tests/utils/plcContributions.test.ts
+++ b/tests/utils/plcContributions.test.ts
@@ -183,4 +183,56 @@ describe('buildContributionDoc', () => {
     expect(doc.responses[0].pin).toBe('zeta');
     expect(doc.responses[1].pin).toBe('alpha');
   });
+
+  it('deduplicates duplicate question IDs before computing maxPoints and pointsEarned (Drive-sync duplication guard)', () => {
+    // Drive-sync or arrayUnion races can write the same question twice.
+    // Without a dedup fence, maxPoints inflates and pointsEarned double-counts
+    // for questions whose graded answer is non-zero.
+    //
+    // Scenario A: q1 correct (2 pts, duplicated), q2 wrong (1 pt)
+    //   Bug:  maxPoints=5, pointsEarned=4, scorePercent=80
+    //   Fix:  maxPoints=3, pointsEarned=2, scorePercent=67
+    const quizA = makeQuiz([
+      makeMcQuestion('q1', 'Q1', 'a', 2),
+      makeMcQuestion('q1', 'Q1', 'a', 2), // duplicate — same id, same shape
+      makeMcQuestion('q2', 'Q2', 'b', 1),
+    ]);
+    const docA = buildContributionDoc({
+      plcId: 'plc-A',
+      teacherUid: 'teacher-1',
+      teacherName: 'Teacher One',
+      quiz: quizA,
+      responses: [
+        makeResponse({ pin: '1', answers: { q1: 'a', q2: 'x' } }), // q1 correct, q2 wrong
+      ],
+    });
+    expect(docA.responses[0].maxPoints).toBe(3);
+    expect(docA.responses[0].pointsEarned).toBe(2);
+    expect(docA.responses[0].scorePercent).toBe(67);
+
+    // Scenario B: q1 wrong (2 pts, duplicated), q2 correct (1 pt)
+    //   Bug:  maxPoints=5, pointsEarned=1, scorePercent=20
+    //   Fix:  maxPoints=3, pointsEarned=1, scorePercent=33
+    const quizB = makeQuiz([
+      makeMcQuestion('q1', 'Q1', 'a', 2),
+      makeMcQuestion('q1', 'Q1', 'a', 2), // duplicate
+      makeMcQuestion('q2', 'Q2', 'b', 1),
+    ]);
+    const docB = buildContributionDoc({
+      plcId: 'plc-A',
+      teacherUid: 'teacher-1',
+      teacherName: 'Teacher One',
+      quiz: quizB,
+      responses: [
+        makeResponse({ pin: '2', answers: { q1: 'x', q2: 'b' } }), // q1 wrong, q2 correct
+      ],
+    });
+    expect(docB.responses[0].maxPoints).toBe(3);
+    expect(docB.responses[0].pointsEarned).toBe(1);
+    expect(docB.responses[0].scorePercent).toBe(33);
+
+    // questionsSnapshot should also deduplicate (no repeated entry)
+    expect(docA.questionsSnapshot).toHaveLength(2);
+    expect(docA.questionsSnapshot.map((q) => q.id)).toEqual(['q1', 'q2']);
+  });
 });

--- a/utils/plcContributions.ts
+++ b/utils/plcContributions.ts
@@ -148,8 +148,24 @@ export function buildContributionDoc(
     byStudentUid,
   } = args;
   const id = `${quiz.id}_${teacherUid}`;
-  const maxPoints = quiz.questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
-  const questionsSnapshot: PlcContributionQuestion[] = quiz.questions.map(
+
+  // Drive-sync duplication and arrayUnion races can write the same question id
+  // twice into `quiz.questions`. Without dedup, `maxPoints` inflates and
+  // `buildContributionResponse` double-counts `pointsEarned` for any question
+  // whose answer graded non-zero. The same bug was fixed in the export path
+  // (`assignmentExportShared.ts`) — this fence applies the identical guard.
+  const seenQuestionIds = new Set<string>();
+  const dedupedQuestions = quiz.questions.filter((q) => {
+    if (seenQuestionIds.has(q.id)) return false;
+    seenQuestionIds.add(q.id);
+    return true;
+  });
+
+  const maxPoints = dedupedQuestions.reduce(
+    (sum, q) => sum + (q.points ?? 1),
+    0
+  );
+  const questionsSnapshot: PlcContributionQuestion[] = dedupedQuestions.map(
     (q) => ({
       id: q.id,
       text: q.text,
@@ -159,7 +175,7 @@ export function buildContributionDoc(
   const contributionResponses = responses.map((r) =>
     buildContributionResponse(
       r,
-      quiz.questions,
+      dedupedQuestions,
       maxPoints,
       pinToName,
       byStudentUid


### PR DESCRIPTION
## Summary

`buildContributionDoc` in `utils/plcContributions.ts` passed raw `quiz.questions` to both the `maxPoints` reducer and the `questionsSnapshot` mapper without deduplicating by question ID first. Duplicate question IDs (caused by Drive-sync / `arrayUnion` races, the same pattern as PR #1728 and `assignmentExportShared.ts`) inflated `maxPoints` and double-counted `pointsEarned` in the PLC contribution record.

Fix: build a `Set<string>` of seen IDs and filter before computing `maxPoints` and building `questionsSnapshot`. Same pattern already used in `computeVideoActivityScorePct` and `assignmentExportShared.ts`.

## Regression test added

`tests/utils/plcContributions.test.ts` — constructs a quiz with a duplicate question ID and asserts that `maxPoints` equals the deduplicated total (not the raw sum) and that `questionsSnapshot` contains each question exactly once.

## Test plan

- [ ] Trigger a PLC quiz contribution with a quiz that has been Drive-synced (may have duplicate IDs); verify the score percentage is correct
- [ ] Run `pnpm run test -- tests/utils/plcContributions` to confirm the dedup test passes

---
_Generated by [Claude Code](https://claude.ai/code/session_011NXxzJ7Gnqa3TgkHi5hcbJ)_