### PR TITLE
D4: plc/home/cards/ ../../sections → @/ alias (4 files)

### DIFF
--- a/components/plc/home/cards/AttentionCard.tsx
+++ b/components/plc/home/cards/AttentionCard.tsx
@@ -21,7 +21,7 @@ import {
 import type { Plc, PlcAssignmentIndexEntry } from '@/types';
 import { usePlcAssignmentIndex } from '@/hooks/usePlcAssignmentIndex';
 import { usePlcContributions } from '@/hooks/usePlcContributions';
-import type { PlcSectionId } from '../../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 
 interface AttentionCardProps {
   plc: Plc;

--- a/components/plc/home/cards/MembersHeaderCluster.tsx
+++ b/components/plc/home/cards/MembersHeaderCluster.tsx
@@ -11,7 +11,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Crown } from 'lucide-react';
 import type { Plc } from '@/types';
-import type { PlcSectionId } from '../../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 
 interface MembersHeaderClusterProps {
   plc: Plc;

--- a/components/plc/home/cards/QuickCreateBar.tsx
+++ b/components/plc/home/cards/QuickCreateBar.tsx
@@ -10,7 +10,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen, Film, FileText, type LucideIcon } from 'lucide-react';
-import type { PlcSectionId } from '../../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 
 interface QuickCreateBarProps {
   onNavigate: (id: PlcSectionId) => void;

--- a/components/plc/home/cards/RecentDocsCard.tsx
+++ b/components/plc/home/cards/RecentDocsCard.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import type { Plc, PlcDoc } from '@/types';
 import { usePlcDocs } from '@/hooks/usePlcDocs';
-import type { PlcSectionId } from '../../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 
 interface RecentDocsCardProps {
   plc: Plc;


### PR DESCRIPTION
## Canonical form

`import type { PlcSectionId } from '@/components/plc/sections'`

Multi-level relative `'../../sections'` from a nested subdirectory (`components/plc/home/cards/`) is the D4 anti-pattern — it escapes the `home/cards/` subtree two levels to reach the plc root. The `@/` alias is unambiguous regardless of nesting depth.

## Instances unified

| File | Before | After |
|---|---|---|
| `components/plc/home/cards/AttentionCard.tsx` | `'../../sections'` | `'@/components/plc/sections'` |
| `components/plc/home/cards/MembersHeaderCluster.tsx` | `'../../sections'` | `'@/components/plc/sections'` |
| `components/plc/home/cards/QuickCreateBar.tsx` | `'../../sections'` | `'@/components/plc/sections'` |
| `components/plc/home/cards/RecentDocsCard.tsx` | `'../../sections'` | `'@/components/plc/sections'` |

Only `../../sections` instances were changed. Single-level `'../sections'` imports in sibling subdirectories (`home/`, `resources/`) are in the gray-zone of D4-E2 and were left alone per canon.

## Enforcement

No new lint rule added (TypeScript path alias enforcement is the existing mechanism). These four files are the clearest anti-pattern in the plc/ subtree (deepest nesting + no ambiguity about cross-directory intent). Further plc/ imports remain in the backlog for future runs.

## Behavior-preservation evidence

- Identical module resolved: `@/components/plc/sections` and `../../sections` (from `components/plc/home/cards/`) both resolve to `/components/plc/sections.ts` — mechanically equivalent.
- Only the import path string changes; the imported type `PlcSectionId` is unchanged.
- `pnpm run validate`: ✅ 17 test files, 336 tests passed.

## Risk tag

**mechanical** — pure path-string equivalence, no logic change.

https://claude.ai/code/session_01KdPPWRurDY3xeHnEnjsLGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdPPWRurDY3xeHnEnjsLGq)_