### PR TITLE
fix(RandomWidget): use activeDashboardRef to prevent stale-closure in performUpdate

### DIFF
--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -1248,7 +1248,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             id: g.id ?? '',
             name: `Expert Group ${i + 1}`,
           }));
-          const existing = activeDashboard?.sharedGroups ?? [];
+          const existing = activeDashboardRef.current?.sharedGroups ?? [];
           // Preserve user renames/colors on ids that survive — only drop
           // entries for ids that vanished entirely on this regenerate.
           const newIdSet = new Set(

--- a/components/widgets/random/RandomWidget.tsx
+++ b/components/widgets/random/RandomWidget.tsx
@@ -203,6 +203,16 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const soundEnabledRef = useRef(soundEnabled);
   soundEnabledRef.current = soundEnabled;
 
+  // Ref kept in sync with the latest `activeDashboard` value on every render.
+  // performUpdate (defined inside handlePick) closes over `activeDashboard` at
+  // click time. For flash/slots mode the deferred setInterval fires ~1.7 s
+  // later; if the dashboard mutated in the interim (Firestore update, widget
+  // added/removed) the stale snapshot would cause autoStartTimer to target the
+  // wrong time-tool widget. Reading from this ref instead guarantees we always
+  // act on the current dashboard state when performUpdate fires.
+  const activeDashboardRef = useRef(activeDashboard);
+  activeDashboardRef.current = activeDashboard;
+
   // Sync displayResult when config.lastResult changes (e.g. mode switch clears
   // it) using the "adjusting state while rendering" pattern. Doing this in a
   // useEffect would leave displayResult stale for one render, which crashed
@@ -938,7 +948,7 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             name: `Group ${i + 1}`,
           }));
 
-          const existing = activeDashboard?.sharedGroups ?? [];
+          const existing = activeDashboardRef.current?.sharedGroups ?? [];
           // IDs that are being reused on this randomize carry the user's
           // rename + color — never drop those, only prune the truly dead
           // ones (e.g. group count went from 6 → 4 and the last 2 ids
@@ -974,8 +984,11 @@ export const RandomWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         updateWidget(widget.id, { config: updates as WidgetConfig });
 
         // Nexus: Auto-Start Timer Logic
-        if (autoStartTimer && activeDashboard && mode === 'single') {
-          const timeWidget = activeDashboard.widgets.find(
+        // Read from activeDashboardRef so we always act on the current
+        // dashboard state, not the stale snapshot captured at click time.
+        const liveDashboard = activeDashboardRef.current;
+        if (autoStartTimer && liveDashboard && mode === 'single') {
+          const timeWidget = liveDashboard.widgets.find(
             (w) => w.type === 'time-tool'
           );
 

--- a/tests/components/widgets/RandomWidget.test.tsx
+++ b/tests/components/widgets/RandomWidget.test.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WidgetData } from '@/types';
 import { RandomWidget } from '@/components/widgets/random/RandomWidget';
 
 const mockUpdateWidget = vi.fn();
+const mockUpdateDashboard = vi.fn();
+
+// Mutable reference so individual tests can swap in a different activeDashboard
+// between the pick click and the deferred performUpdate call (stale-closure test).
+let mockActiveDashboard: {
+  widgets: { id: string; type: string; config: Record<string, unknown> }[];
+} = {
+  widgets: [],
+};
 
 vi.mock('@/context/useDashboard', () => ({
   useDashboard: () => ({
     updateWidget: mockUpdateWidget,
-    updateDashboard: vi.fn(),
+    updateDashboard: mockUpdateDashboard,
     rosters: [],
     activeRosterId: null,
-    activeDashboard: {
-      widgets: [],
-    },
+    activeDashboard: mockActiveDashboard,
+    addToast: vi.fn(),
+    addWidget: vi.fn(),
   }),
 }));
 
@@ -69,6 +78,12 @@ describe('RandomWidget', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockActiveDashboard = { widgets: [] };
+  });
+
+  afterEach(() => {
+    // Restore real timers if a test installed fake ones
+    vi.useRealTimers();
   });
 
   it('renders the remaining count when in single mode', () => {
@@ -308,6 +323,101 @@ describe('RandomWidget', () => {
         .getAttribute('data-font-size');
 
       expect(fontSize).toBe('min(15cqw, 60cqh)');
+    });
+  });
+
+  describe('autoStartTimer stale-closure fix', () => {
+    // Regression test for the stale-closure bug in handlePick's performUpdate.
+    //
+    // PROBLEM: performUpdate is defined inside handlePick and closes over
+    // `activeDashboard` at the moment the teacher clicks Pick. For the flash
+    // animation the callback fires ~1.7 s later (21 × 80 ms). If the dashboard
+    // mutates in the interim — e.g. a time-tool widget is added, removed, or
+    // replaced — the stale snapshot is used to locate the time-tool widget,
+    // so autoStartTimer silently targets the wrong (or non-existent) widget.
+    //
+    // FIX: an `activeDashboardRef` is kept in sync with the latest value on
+    // every render (same pattern as `soundEnabledRef` / `studentsRef`).
+    // performUpdate reads `activeDashboardRef.current` instead of the
+    // closure-captured `activeDashboard`.
+    //
+    // TEST SCENARIO:
+    //  1. Dashboard starts with time-tool widget id "timer-old".
+    //  2. Teacher clicks Pick (animation starts, flash runs for 21 ticks).
+    //  3. BEFORE the animation ends, the dashboard is replaced with a new
+    //     object containing time-tool widget id "timer-new" (simulating a
+    //     real-time Firestore update / another widget being removed + re-added).
+    //  4. Animation finishes → performUpdate fires.
+    //  STALE (broken): updateWidget called with "timer-old"   ← test FAILS
+    //  FIXED (correct): updateWidget called with "timer-new"  ← test PASSES
+    it('reads the live activeDashboard when autoStartTimer fires after a flash animation', () => {
+      vi.useFakeTimers();
+
+      // Step 1 – dashboard has timer-old at click time.
+      const oldTimerWidget = {
+        id: 'timer-old',
+        type: 'time-tool',
+        config: { isRunning: false },
+      };
+      mockActiveDashboard = { widgets: [oldTimerWidget] };
+
+      const autoTimerWidget: WidgetData = {
+        id: 'random-1',
+        type: 'random',
+        x: 0,
+        y: 0,
+        w: 400,
+        h: 400,
+        z: 1,
+        flipped: false,
+        config: {
+          mode: 'single',
+          firstNames: 'Alice\nBob',
+          lastNames: '',
+          remainingStudents: [],
+          lastResult: null,
+          autoStartTimer: true,
+          visualStyle: 'flash',
+          soundEnabled: false,
+        },
+      };
+
+      const { rerender } = render(<RandomWidget widget={autoTimerWidget} />);
+
+      // Step 2 – click Pick to start the flash animation.
+      const pickButton = screen.getByTitle('Randomize');
+      fireEvent.click(pickButton);
+
+      // Step 3 – dashboard mutates before the animation ends:
+      // Firestore delivers an update that replaces timer-old with timer-new.
+      const newTimerWidget = {
+        id: 'timer-new',
+        type: 'time-tool',
+        config: { isRunning: false },
+      };
+      mockActiveDashboard = { widgets: [newTimerWidget] };
+      // Re-render so the component receives the updated activeDashboard and
+      // can update its ref before performUpdate fires.
+      act(() => {
+        rerender(<RandomWidget widget={autoTimerWidget} />);
+      });
+
+      // Step 4 – advance fake timers past the 21-tick flash animation
+      // (21 ticks × 80 ms = 1 680 ms; use 2 000 ms to be safe).
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      // The autoStartTimer branch should have called updateWidget with the
+      // CURRENT time-tool widget id ("timer-new"), not the stale one.
+      const timerCalls = mockUpdateWidget.mock.calls.filter(
+        (args: unknown[]) => args[0] === 'timer-new' || args[0] === 'timer-old'
+      );
+      expect(timerCalls.length).toBeGreaterThan(0);
+      // Every timer call must target the live widget ("timer-new").
+      for (const args of timerCalls) {
+        expect(args[0]).toBe('timer-new');
+      }
     });
   });
 });


### PR DESCRIPTION
## Root Cause

`handlePick`'s inner `performUpdate` function closed over `activeDashboard` at click time. For the flash and slots visual styles, `performUpdate` fires inside a `setInterval` callback that runs for ~1.7–2.5 seconds after the click. During that interval, Firestore can deliver a real-time dashboard update that replaces `activeDashboard` in React state — but the already-running closure still holds the old snapshot.

The most impactful consequence: the `autoStartTimer` path uses `activeDashboard.widgets.find(w => w.type === 'time-tool')` to locate the time-tool widget. If the dashboard mutated in the interim (time-tool widget removed and re-added, or its ID changed via an external Firestore update), the stale snapshot either targets the wrong widget or finds nothing, and the timer silently fails to start. The same stale read affected `activeDashboard?.sharedGroups` in the groups-mode path.

## Band-Aid Rejected

Wrapping `handlePick` in a `useCallback` with `activeDashboard` in its dependency array would not help: already-running timers hold a reference to the old closure function — swapping the function reference doesn't update the interval's captured value.

## Fix

Added `activeDashboardRef` (a `useRef`) assigned synchronously in the render body (`activeDashboardRef.current = activeDashboard`). All deferred callbacks now read from `activeDashboardRef.current` instead of closing over `activeDashboard`. This mirrors the existing `soundEnabledRef` and `studentsRef` pattern already in this widget.

## Regression Test

`tests/components/widgets/RandomWidget.test.tsx` — new test: *"reads the live activeDashboard when autoStartTimer fires after a flash animation"*

- **Before fix**: `updateWidget` called with `'timer-old'` (stale widget ID captured at click time) → `AssertionError: expected 'timer-old' to be 'timer-new'`
- **After fix**: `updateWidget` called with `'timer-new'` → 12/12 pass

## Evidence

`pnpm run validate` — GREEN (379 test files, 3880 tests + 336 functions tests).

## Risk

**contained** — change is confined to `RandomWidget.tsx`. The ref pattern is already used in 2 other places in the same file (`soundEnabledRef`, `studentsRef`). No behaviour change for the common case where the dashboard does not mutate during the spin animation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvcBwHUqsu5r1aNhcoxer8)_