### PR TITLE
fix(DashboardView): guard global Delete handler against focused input fields

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1235,6 +1235,17 @@ export const DashboardView: React.FC = () => {
 
       // Delete: Handle clear board if shift or alt is pressed, otherwise target focused/top widget
       if (e.key === 'Delete') {
+        // Don't intercept Delete when the user is typing in an input, textarea,
+        // or contentEditable — let the browser's default deletion behaviour run.
+        // This mirrors the Escape key guard above and fixes a bug where pressing
+        // Delete inside any text field on the board would be silently swallowed
+        // (e.preventDefault() was called before this check was added).
+        const activeEl = document.activeElement as HTMLElement;
+        const isTypingField =
+          ['INPUT', 'TEXTAREA'].includes(activeEl?.tagName || '') ||
+          activeEl?.isContentEditable;
+        if (isTypingField) return;
+
         e.preventDefault();
 
         if (e.shiftKey || e.altKey) {

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -437,18 +437,13 @@ describe('Global Escape Interaction', () => {
       bubbles: true,
       cancelable: true,
     });
-    let prevented = false;
-    deleteEvent.preventDefault = () => {
-      prevented = true;
-    };
-
     act(() => {
       window.dispatchEvent(deleteEvent);
     });
 
     // The global handler must NOT call preventDefault while an input is focused —
     // doing so blocks the browser from deleting the character the user intended.
-    expect(prevented).toBe(false);
+    expect(deleteEvent.defaultPrevented).toBe(false);
   });
 
   it('does call preventDefault and dispatch widget-keyboard-action when Delete is pressed outside a text input', () => {
@@ -489,17 +484,12 @@ describe('Global Escape Interaction', () => {
       bubbles: true,
       cancelable: true,
     });
-    let prevented = false;
-    deleteEvent.preventDefault = () => {
-      prevented = true;
-    };
-
     act(() => {
       window.dispatchEvent(deleteEvent);
     });
 
     // The handler should prevent default (browser may otherwise navigate back).
-    expect(prevented).toBe(true);
+    expect(deleteEvent.defaultPrevented).toBe(true);
 
     // And it should dispatch a widget-keyboard-action for the top widget.
     expect(dispatchSpy).toHaveBeenCalledWith(

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -398,4 +398,115 @@ describe('Global Escape Interaction', () => {
       })
     );
   });
+
+  /**
+   * Regression: the global Delete key handler in DashboardView called
+   * e.preventDefault() before checking whether the active element was an
+   * input/textarea/contentEditable. This silently swallowed Delete keystrokes
+   * in any text field on the board (widget settings inputs, title editors, etc.),
+   * because the window-level native listener fired even when the user was typing.
+   *
+   * Fix: added an `isTypingField` guard that returns early (without preventDefault)
+   * when Delete is pressed while a form field has focus, matching the pattern
+   * already used for the Escape key handler above it.
+   */
+  it('does not call preventDefault when Delete is pressed while a text input is focused', () => {
+    const dashboard = createMockDashboard([]);
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: dashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+        <input data-testid="text-input" />
+      </DashboardContext.Provider>
+    );
+
+    const input = screen.getByTestId('text-input');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    // Fire Delete from the window (as the global keydown handler receives it).
+    const deleteEvent = new KeyboardEvent('keydown', {
+      key: 'Delete',
+      bubbles: true,
+      cancelable: true,
+    });
+    let prevented = false;
+    deleteEvent.preventDefault = () => {
+      prevented = true;
+    };
+
+    act(() => {
+      window.dispatchEvent(deleteEvent);
+    });
+
+    // The global handler must NOT call preventDefault while an input is focused —
+    // doing so blocks the browser from deleting the character the user intended.
+    expect(prevented).toBe(false);
+  });
+
+  it('does call preventDefault and dispatch widget-keyboard-action when Delete is pressed outside a text input', () => {
+    const widgets: WidgetData[] = [
+      {
+        id: 'w1',
+        type: 'clock',
+        x: 0,
+        y: 0,
+        w: 100,
+        h: 100,
+        z: 1,
+        flipped: false,
+        config: {},
+      } as unknown as WidgetData,
+    ];
+    const dashboard = createMockDashboard(widgets);
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: dashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+      </DashboardContext.Provider>
+    );
+
+    // No input focused — focus is on document.body.
+    expect(document.activeElement).toBe(document.body);
+
+    const deleteEvent = new KeyboardEvent('keydown', {
+      key: 'Delete',
+      bubbles: true,
+      cancelable: true,
+    });
+    let prevented = false;
+    deleteEvent.preventDefault = () => {
+      prevented = true;
+    };
+
+    act(() => {
+      window.dispatchEvent(deleteEvent);
+    });
+
+    // The handler should prevent default (browser may otherwise navigate back).
+    expect(prevented).toBe(true);
+
+    // And it should dispatch a widget-keyboard-action for the top widget.
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'widget-keyboard-action',
+        detail: expect.objectContaining({ key: 'Delete', widgetId: 'w1' }),
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Root Cause

The global `window` keydown handler in `DashboardView.tsx` called `e.preventDefault()` for the `Delete` key unconditionally — before any guard checked whether a text field had focus. This caused the browser's native delete-character behaviour to be suppressed whenever the user pressed `Delete` inside any `<input>`, `<textarea>`, or `contentEditable` element on the board (widget settings text fields, title editors, search boxes, etc.). Characters could not be deleted while typing.

The `Escape` branch immediately above already had the correct guard:

```js
const isInput = ['INPUT', 'TEXTAREA'].includes(activeElement?.tagName || '')
             || activeElement?.isContentEditable;
if (isInput) { activeElement.blur(); return; }
```

The `Delete` branch simply never received the same treatment.

## Band-Aid Rejected

Moving the listener from `window` to individual widget elements would distribute the "am I focused?" coordination into every widget and break the global `Shift+Delete` clear-board shortcut. The correct fix is a targeted early-return guard on the `Delete` branch that mirrors the existing Escape pattern.

## Fix

Added an `isTypingField` guard to the `Delete` branch in `DashboardView.tsx` that returns early (without calling `preventDefault`) when an input, textarea, or contentEditable has focus. All other Delete behaviour (widget keyboard action, clear-board shortcut) is unchanged.

## Regression Test

`tests/escapeInteraction.test.tsx` — new test: *"does not call preventDefault when Delete is pressed while a text input is focused"*

- **Before fix**: `e.preventDefault()` was called → test failed
- **After fix**: `e.preventDefault()` is not called → 6/6 pass

## Evidence

`pnpm run validate` — GREEN (379 test files, 3880 tests + 336 functions tests).

## Risk

**contained** — single guard added in `DashboardView.tsx`. The existing Delete behaviour for non-input contexts is preserved and tested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvcBwHUqsu5r1aNhcoxer8)_