### PR TITLE
fix(i18n): add missing admin namespace to DE/ES/FR locales

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -888,5 +888,29 @@
       "improvement": "Verbesserungen",
       "fix": "Fehlerbehebungen"
     }
+  },
+  "admin": {
+    "stickers": {
+      "title": "Globale Sticker-Bibliothek",
+      "uploadDescription": "Sticker für alle Benutzer hochladen",
+      "saveChanges": "Änderungen speichern",
+      "discardChanges": "Änderungen verwerfen",
+      "confirmDiscardChanges": "Du hast ungespeicherte Änderungen. Ohne Speichern schließen?",
+      "description": "Hier hochgeladene Sticker erscheinen im Abschnitt Globale Sammlung des Stickerbuch-Widgets jedes Benutzers.",
+      "dropImages": "Bilder hier ablegen oder zum Durchsuchen klicken",
+      "supportedFiles": "PNG, JPG, GIF, WebP, SVG · Mehrere Dateien unterstützt",
+      "collectionTitle": "Sticker-Sammlung",
+      "clearAll": "Alle Sticker vom Board löschen",
+      "wait": "Warten...",
+      "dropOrPaste": "Bild ablegen oder einfügen",
+      "toAddCustom": "um benutzerdefinierte Sticker hinzuzufügen",
+      "essentials": "Grundlagen",
+      "globalCollection": "Globale Sammlung",
+      "myCollection": "Meine Sammlung",
+      "dragOrClick": "Ziehen oder klicken zum Hinzufügen",
+      "deleteSticker": "Sticker löschen",
+      "dragFromLibrary": "Sticker aus der Bibliothek auf das Board ziehen",
+      "stickerAdded": "Sticker zum Board hinzugefügt!"
+    }
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -1010,5 +1010,29 @@
       "improvement": "Mejoras",
       "fix": "Correcciones"
     }
+  },
+  "admin": {
+    "stickers": {
+      "title": "Biblioteca global de pegatinas",
+      "uploadDescription": "Subir pegatinas para todos los usuarios",
+      "saveChanges": "Guardar cambios",
+      "discardChanges": "Descartar cambios",
+      "confirmDiscardChanges": "Tienes cambios sin guardar. ¿Cerrar sin guardar?",
+      "description": "Las pegatinas subidas aquí aparecen en la sección «Colección global» del widget Libro de pegatinas de cada usuario.",
+      "dropImages": "Suelta imágenes aquí o haz clic para explorar",
+      "supportedFiles": "PNG, JPG, GIF, WebP, SVG · Se admiten varios archivos",
+      "collectionTitle": "Colección de pegatinas",
+      "clearAll": "Borrar todas las pegatinas del tablero",
+      "wait": "Espera...",
+      "dropOrPaste": "Suelta o pega una imagen",
+      "toAddCustom": "para añadir pegatinas personalizadas",
+      "essentials": "Esenciales",
+      "globalCollection": "Colección global",
+      "myCollection": "Mi colección",
+      "dragOrClick": "Arrastra o haz clic para añadir",
+      "deleteSticker": "Eliminar pegatina",
+      "dragFromLibrary": "Arrastra pegatinas de la biblioteca al tablero",
+      "stickerAdded": "¡Pegatina añadida al tablero!"
+    }
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -888,5 +888,29 @@
       "improvement": "Améliorations",
       "fix": "Corrections"
     }
+  },
+  "admin": {
+    "stickers": {
+      "title": "Bibliothèque globale d'autocollants",
+      "uploadDescription": "Télécharger des autocollants pour tous les utilisateurs",
+      "saveChanges": "Enregistrer les modifications",
+      "discardChanges": "Annuler les modifications",
+      "confirmDiscardChanges": "Vous avez des modifications non enregistrées. Fermer sans enregistrer ?",
+      "description": "Les autocollants téléchargés ici apparaissent dans la section « Collection globale » du widget Livre d'autocollants de chaque utilisateur.",
+      "dropImages": "Déposez des images ici ou cliquez pour parcourir",
+      "supportedFiles": "PNG, JPG, GIF, WebP, SVG · Plusieurs fichiers pris en charge",
+      "collectionTitle": "Collection d'autocollants",
+      "clearAll": "Effacer tous les autocollants du tableau",
+      "wait": "Veuillez patienter...",
+      "dropOrPaste": "Déposer ou coller une image",
+      "toAddCustom": "pour ajouter des autocollants personnalisés",
+      "essentials": "Essentiels",
+      "globalCollection": "Collection globale",
+      "myCollection": "Ma collection",
+      "dragOrClick": "Glisser ou cliquer pour ajouter",
+      "deleteSticker": "Supprimer l'autocollant",
+      "dragFromLibrary": "Faites glisser les autocollants de la bibliothèque vers le tableau",
+      "stickerAdded": "Autocollant ajouté au tableau !"
+    }
   }
 }

--- a/tests/i18n/adminLocales.test.ts
+++ b/tests/i18n/adminLocales.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for the missing admin namespace in DE/ES/FR locales.
+ *
+ * The `admin` namespace (admin.stickers.*) was added to the EN locale for the
+ * Global Sticker Library admin feature but was never propagated to DE, ES, or
+ * FR. The keys are used in `components/admin/StickerLibraryModal.tsx` via
+ * direct t() calls WITHOUT `defaultValue` fallbacks:
+ *
+ *   - t('admin.stickers.title')
+ *   - t('admin.stickers.saveChanges')
+ *   - t('admin.stickers.description')
+ *   - t('admin.stickers.supportedFiles')
+ *   - t('admin.stickers.confirmDiscardChanges')
+ *
+ * Because i18next has no defaultValue to fall back on, non-English users see
+ * the raw key path (e.g., "admin.stickers.title") rendered directly in the UI
+ * instead of any translated or even English text.
+ *
+ * This test loads each locale JSON directly so the assertion fires even before
+ * the i18next runtime resolves the missing fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+/** Keys within admin.stickers that components call t() on without defaultValue. */
+const REQUIRED_ADMIN_STICKER_KEYS = [
+  'title',
+  'saveChanges',
+  'discardChanges',
+  'confirmDiscardChanges',
+  'description',
+  'supportedFiles',
+  'uploadDescription',
+  'dropImages',
+  'collectionTitle',
+  'clearAll',
+  'wait',
+  'dropOrPaste',
+  'toAddCustom',
+  'essentials',
+  'globalCollection',
+  'myCollection',
+  'dragOrClick',
+  'deleteSticker',
+  'dragFromLibrary',
+  'stickerAdded',
+] as const;
+
+type LocaleFile = typeof en;
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — admin namespace baseline', () => {
+  it('has an admin section', () => {
+    expect(en).toHaveProperty('admin');
+  });
+
+  it('has an admin.stickers section', () => {
+    expect(en.admin).toHaveProperty('stickers');
+  });
+
+  it('has all required admin.stickers keys', () => {
+    for (const key of REQUIRED_ADMIN_STICKER_KEYS) {
+      expect(
+        en.admin.stickers,
+        `en.admin.stickers.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity ─────────────────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de as unknown as LocaleFile },
+  { code: 'es', locale: es as unknown as LocaleFile },
+  { code: 'fr', locale: fr as unknown as LocaleFile },
+])('$code locale — admin namespace parity with EN', ({ code, locale }) => {
+  it(`${code}: has an admin section`, () => {
+    expect(locale, `${code}.admin section is entirely missing`).toHaveProperty(
+      'admin'
+    );
+  });
+
+  it(`${code}: has an admin.stickers section`, () => {
+    const admin = (locale as Record<string, unknown>).admin as
+      | Record<string, unknown>
+      | undefined;
+    expect(admin, `${code}.admin.stickers section is missing`).toHaveProperty(
+      'stickers'
+    );
+  });
+
+  it(`${code}: has all required admin.stickers keys`, () => {
+    const admin = (locale as Record<string, unknown>).admin as
+      | Record<string, unknown>
+      | undefined;
+    const stickers = admin?.stickers as Record<string, unknown> | undefined;
+    for (const key of REQUIRED_ADMIN_STICKER_KEYS) {
+      expect(
+        stickers,
+        `${code}.admin.stickers.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+});

--- a/tests/i18n/adminLocales.test.ts
+++ b/tests/i18n/adminLocales.test.ts
@@ -50,8 +50,6 @@ const REQUIRED_ADMIN_STICKER_KEYS = [
   'stickerAdded',
 ] as const;
 
-type LocaleFile = typeof en;
-
 // ─── EN baseline ─────────────────────────────────────────────────────────────
 
 describe('EN locale — admin namespace baseline', () => {
@@ -75,10 +73,13 @@ describe('EN locale — admin namespace baseline', () => {
 
 // ─── DE / ES / FR parity ─────────────────────────────────────────────────────
 
+// Vitest's `toHaveProperty` accepts a deep key-path array and safely handles
+// undefined parents, so we can assert the nested shape without casting the
+// other locales to `typeof en` or extracting nested `Record<string, unknown>`s.
 describe.each([
-  { code: 'de', locale: de as unknown as LocaleFile },
-  { code: 'es', locale: es as unknown as LocaleFile },
-  { code: 'fr', locale: fr as unknown as LocaleFile },
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
 ])('$code locale — admin namespace parity with EN', ({ code, locale }) => {
   it(`${code}: has an admin section`, () => {
     expect(locale, `${code}.admin section is entirely missing`).toHaveProperty(
@@ -87,24 +88,17 @@ describe.each([
   });
 
   it(`${code}: has an admin.stickers section`, () => {
-    const admin = (locale as Record<string, unknown>).admin as
-      | Record<string, unknown>
-      | undefined;
-    expect(admin, `${code}.admin.stickers section is missing`).toHaveProperty(
-      'stickers'
-    );
+    expect(locale, `${code}.admin.stickers section is missing`).toHaveProperty([
+      'admin',
+      'stickers',
+    ]);
   });
 
   it(`${code}: has all required admin.stickers keys`, () => {
-    const admin = (locale as Record<string, unknown>).admin as
-      | Record<string, unknown>
-      | undefined;
-    const stickers = admin?.stickers as Record<string, unknown> | undefined;
     for (const key of REQUIRED_ADMIN_STICKER_KEYS) {
-      expect(
-        stickers,
-        `${code}.admin.stickers.${key} is missing`
-      ).toHaveProperty(key);
+      expect(locale, `${code}.admin.stickers.${key} is missing`).toHaveProperty(
+        ['admin', 'stickers', key]
+      );
     }
   });
 });


### PR DESCRIPTION
## Root Cause

The `admin.stickers` namespace (20 keys) was added to `locales/en.json` for the Global Sticker Library admin feature but was never propagated to `locales/de.json`, `locales/es.json`, or `locales/fr.json`. Five `t()` call sites in `StickerLibraryModal.tsx` have no `defaultValue` fallback:

- `t('admin.stickers.title')`
- `t('admin.stickers.saveChanges')`
- `t('admin.stickers.description')`
- `t('admin.stickers.supportedFiles')`
- `t('admin.stickers.confirmDiscardChanges')`

Without a `defaultValue`, i18next renders the raw dotted key path (e.g. `"admin.stickers.title"`) verbatim for any admin user running the app in German, Spanish, or French — appearing in the modal header, description, save button, file-format hint, and unsaved-changes confirmation dialog.

## Band-Aid Rejected

Adding `defaultValue: 'English text'` to each `t()` call would silence the runtime symptom but would leave German/Spanish/French admins seeing English UI in an otherwise localized app. The correct fix is to supply actual translations.

## Fix

Added all 20 `admin.stickers.*` keys with proper translations to `locales/de.json`, `locales/es.json`, and `locales/fr.json`.

## Regression Test

New test at `tests/i18n/adminLocales.test.ts` — verifies:
1. EN locale has the `admin` section and all 20 `admin.stickers` keys (baseline)
2. Each of DE, ES, FR has the `admin` section, `admin.stickers` section, and all 20 required keys

- **Before fix**: 9 failures (3 locales × 3 assertions each — admin section entirely missing)
- **After fix**: 12/12 pass (108 total including pre-existing i18n tests)

## Evidence

`pnpm run validate` — GREEN (379 test files, 3880 tests + 336 functions tests).

## Risk

**contained** — locale JSON additions only. No logic changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvcBwHUqsu5r1aNhcoxer8)_