### PR TITLE
docs(changelog): release entry for 2026-06-01

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,25 @@
 {
   "entries": [
     {
+      "version": "2026.06.01",
+      "date": "2026-06-01",
+      "title": "Delete key, scoring, and translation fixes",
+      "details": [
+        {
+          "type": "fix",
+          "text": "Board canvas — pressing the Delete key while typing in a text field on the board now deletes the character in front of your cursor, the way it does everywhere else. Previously the board treated Delete as a command for the selected widget and swallowed the keystroke, so forward-delete appeared to do nothing while you were editing a widget's settings, a title, or any other text field on the canvas."
+        },
+        {
+          "type": "fix",
+          "text": "Video Activity — a published activity's scores now read correctly when the activity accidentally contains the same question twice (which can happen through a Drive sync hiccup). The duplicate no longer inflates the total possible points, so the percentage students see on a finished, published activity is accurate."
+        },
+        {
+          "type": "fix",
+          "text": "Translations — the admin Sticker Library now appears in German, Spanish, and French. Previously its title, buttons, and descriptions showed raw text keys for admins using one of those languages instead of readable labels."
+        }
+      ]
+    },
+    {
       "version": "2026.05.31",
       "date": "2026-05-31",
       "title": "Settings panel, widget, and translation fixes",


### PR DESCRIPTION
Adds the "What's New" changelog entry for the changes that landed on `dev-paul` after the last release entry (2026.05.31), so they're covered before the `dev-paul → main` release PR #1792 ships to production.

This branch was the session's designated working branch (it tracks the head of the release PR), so this entry is offered as a focused, one-commit PR into `dev-paul` rather than a direct push to the release branch. Merge this into `dev-paul` before merging #1792 so the entry rides along to production.

**New entry — `2026.06.01` "Delete key, scoring, and translation fixes" (details only, no overview — 3 unrelated fixes):**

- **Fix** — Delete key while typing in a board text field is no longer swallowed (#1786).
- **Fix** — Video Activity *published* scores no longer deflated by duplicate questions (#1787).
- **Fix** — Admin Sticker Library now translated in DE/ES/FR instead of showing raw keys (#1788).

Deliberately excluded as not user-facing / too niche: the RandomWidget auto-start-timer stale-closure race (#1785), the SettingsPanel pointerdown null-guard, the IPv6 SSRF guard (#1789), import-alias refactors, locale parity tests, and run logs.

https://claude.ai/code/session_01QLihcbpVK7P7doPgk2M4VQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLihcbpVK7P7doPgk2M4VQ)_