### PR TITLE
feat(classroom-addon): brand-polish iframes, GC due-date sync, student results, in-iframe grading

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -70,6 +70,12 @@ const ClassroomAddonTeacherSpike = lazy(() =>
     })
   )
 );
+// Classroom Add-on teacher VIEW — in-iframe quiz grading (no addOnToken launch).
+const ClassroomAddonTeacherReview = lazy(() =>
+  import('./components/classroomAddon/TeacherReviewRoute').then((module) => ({
+    default: module.ClassroomAddonTeacherReview,
+  }))
+);
 const ActivityWallStudentApp = lazy(() =>
   import('./components/activityWall/ActivityWallStudentApp').then((module) => ({
     default: module.ActivityWallStudentApp,
@@ -468,11 +474,22 @@ const App: React.FC = () => {
     // token) to list/load quizzes and create a class-targeted assignment, so it
     // mounts AuthProvider. (No DashboardProvider — no dashboard listeners.)
     if (isTeacherDiscovery) {
+      // The discovery (attach) iframe carries an addOnToken; the teacher VIEW of
+      // an already-created attachment does not. Mount the lean in-iframe grader
+      // for the view (its quiz-library + session hooks shouldn't run during
+      // attach), and the attach flow otherwise.
+      const isAttachFlow =
+        typeof window !== 'undefined' &&
+        new URLSearchParams(window.location.search).has('addOnToken');
       return (
         <DialogProvider>
           <AuthProvider>
             <Suspense fallback={<FullPageLoader />}>
-              <ClassroomAddonTeacherSpike />
+              {isAttachFlow ? (
+                <ClassroomAddonTeacherSpike />
+              ) : (
+                <ClassroomAddonTeacherReview />
+              )}
             </Suspense>
           </AuthProvider>
           <DialogContainer />

--- a/components/classroomAddon/AddonShell.tsx
+++ b/components/classroomAddon/AddonShell.tsx
@@ -6,10 +6,12 @@
  * a `min-h-full` inner centers short content and scrolls tall content — the same
  * pattern QuizStudentApp's period picker uses.
  *
- * The visual language is SpartBoard's: calm dark glassmorphism, Lexend (`font-
- * sans`), brand-blue accents, generous spacing, restrained motion. None of the
- * spike-era debug tables / log panels live here; raw diagnostics are confined to
- * <AddonDevPanel>, which renders only in DEV builds.
+ * The visual language is SpartBoard's, tuned for the LIGHT context it lives in:
+ * Classroom's chrome is white, so these surfaces are light (matching SpartBoard's
+ * student-facing / login screens) with brand-blue accents, Lexend (`font-sans`),
+ * generous spacing, and restrained motion — clean white cards rather than the
+ * teacher dashboard's dark glass. No spike-era debug tables/logs: only friendly
+ * status + branded error banners are ever shown to teachers/students.
  */
 import React, { useRef, useState } from 'react';
 import {
@@ -22,8 +24,8 @@ import {
 import { useClickOutside } from '@/hooks/useClickOutside';
 
 /**
- * Full-bleed branded page wrapper. Fills the Classroom iframe, paints the calm
- * slate gradient + a subtle brand glow, and owns the vertical scroll so content
+ * Full-bleed branded page wrapper. Fills the Classroom iframe, paints a calm
+ * light background + a faint brand glow, and owns the vertical scroll so content
  * taller than the iframe is always reachable.
  */
 export const AddonShell: React.FC<{
@@ -31,11 +33,11 @@ export const AddonShell: React.FC<{
   /** Max content width. Defaults to a comfortable single-column card width. */
   maxWidthClassName?: string;
 }> = ({ children, maxWidthClassName = 'max-w-xl' }) => (
-  <div className="h-screen overflow-y-auto bg-gradient-to-b from-slate-900 via-slate-900 to-slate-950 font-sans text-slate-100">
+  <div className="h-screen overflow-y-auto bg-gradient-to-b from-white to-slate-100 font-sans text-slate-900">
     {/* Decorative brand glow — purely atmospheric, behind the content. */}
     <div
       aria-hidden="true"
-      className="pointer-events-none fixed inset-x-0 top-0 h-64 bg-brand-blue-primary/20 blur-3xl"
+      className="pointer-events-none fixed inset-x-0 top-0 h-48 bg-brand-blue-light/10 blur-3xl"
     />
     <div className="relative min-h-full px-4 py-8 sm:px-6">
       <div className={`mx-auto w-full ${maxWidthClassName}`}>{children}</div>
@@ -53,27 +55,29 @@ export const AddonHeader: React.FC<{
   subtitle?: string;
 }> = ({ icon: Icon, title, subtitle }) => (
   <header className="mb-6 flex items-start gap-3.5">
-    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-blue-light to-brand-blue-primary shadow-lg shadow-brand-blue-primary/30">
+    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-blue-light to-brand-blue-primary shadow-lg shadow-brand-blue-primary/20">
       <Icon className="h-5 w-5 text-white" strokeWidth={2.25} />
     </div>
     <div className="min-w-0">
       <div className="flex items-center gap-2">
-        <h1 className="text-xl font-bold tracking-tight text-white">{title}</h1>
+        <h1 className="text-xl font-bold tracking-tight text-slate-900">
+          {title}
+        </h1>
       </div>
       {subtitle && (
-        <p className="mt-0.5 text-sm leading-snug text-slate-400">{subtitle}</p>
+        <p className="mt-0.5 text-sm leading-snug text-slate-500">{subtitle}</p>
       )}
     </div>
   </header>
 );
 
-/** A frosted-glass surface — the standard content container for these screens. */
+/** A clean white surface — the standard content container for these screens. */
 export const AddonCard: React.FC<{
   children: React.ReactNode;
   className?: string;
 }> = ({ children, className = '' }) => (
   <div
-    className={`rounded-2xl border border-white/10 bg-white/[0.06] shadow-xl shadow-black/30 backdrop-blur-xl ${className}`}
+    className={`rounded-2xl border border-slate-200 bg-white shadow-sm shadow-slate-900/5 ${className}`}
   >
     {children}
   </div>
@@ -83,11 +87,11 @@ type ButtonVariant = 'primary' | 'secondary' | 'ghost';
 
 const BUTTON_VARIANT: Record<ButtonVariant, string> = {
   primary:
-    'bg-gradient-to-r from-brand-blue-primary to-brand-blue-light text-white shadow-lg shadow-brand-blue-primary/25 hover:brightness-110 focus-visible:ring-brand-blue-light',
+    'bg-gradient-to-r from-brand-blue-primary to-brand-blue-light text-white shadow-sm shadow-brand-blue-primary/25 hover:brightness-110 focus-visible:ring-brand-blue-light',
   secondary:
-    'border border-white/15 bg-white/5 text-slate-100 hover:bg-white/10 focus-visible:ring-white/30',
+    'border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 focus-visible:ring-brand-blue-light',
   ghost:
-    'text-slate-300 hover:bg-white/10 hover:text-white focus-visible:ring-white/30',
+    'text-slate-600 hover:bg-slate-100 hover:text-slate-900 focus-visible:ring-brand-blue-light',
 };
 
 /** Brand button with a built-in loading spinner + consistent focus ring. */
@@ -109,7 +113,7 @@ export const AddonButton: React.FC<
   <button
     type="button"
     disabled={(disabled ?? false) || loading}
-    className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50 ${BUTTON_VARIANT[variant]} ${className}`}
+    className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 ${BUTTON_VARIANT[variant]} ${className}`}
     {...rest}
   >
     {loading ? (
@@ -134,11 +138,11 @@ export const AddonStatus: React.FC<{
   return (
     <div
       aria-live="polite"
-      className="flex items-center gap-2 text-sm text-slate-400"
+      className="flex items-center gap-2 text-sm text-slate-500"
     >
       {busy && (
         <Loader2
-          className="h-4 w-4 shrink-0 animate-spin text-brand-blue-light"
+          className="h-4 w-4 shrink-0 animate-spin text-brand-blue-primary"
           aria-hidden="true"
         />
       )}
@@ -152,9 +156,9 @@ export const AddonError: React.FC<{ message: string | null }> = ({
   message,
 }) =>
   message ? (
-    <div className="flex items-start gap-2.5 rounded-xl border border-brand-red-light/40 bg-brand-red-primary/15 p-3 text-sm text-red-100">
+    <div className="flex items-start gap-2.5 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
       <AlertTriangle
-        className="mt-0.5 h-4 w-4 shrink-0 text-brand-red-light"
+        className="mt-0.5 h-4 w-4 shrink-0 text-red-500"
         aria-hidden="true"
       />
       <span className="min-w-0 break-words">{message}</span>
@@ -168,12 +172,11 @@ export interface AddonSelectOption {
 
 /**
  * Brand-styled single-select dropdown. A native `<select>`'s open option list is
- * OS-rendered (unstyled, overflows the control, jarring against the dark glass),
- * so this is a custom listbox: a glass trigger + a popover that is pinned to the
- * trigger's width (`left-0 right-0`) and scrolls (`max-h-60`) instead of
- * spilling past its container. Click-outside + Escape close it; long labels
- * truncate. Empty option lists show a muted placeholder row rather than a
- * zero-height popup.
+ * OS-rendered (unstyled, overflows the control), so this is a custom listbox: a
+ * trigger + a popover pinned to the trigger's width (`left-0 right-0`) that
+ * scrolls (`max-h-60`) instead of spilling past its container. Click-outside +
+ * Escape close it; long labels truncate. Empty option lists show a muted
+ * placeholder row rather than a zero-height popup.
  */
 export const AddonSelect: React.FC<{
   value: string;
@@ -214,10 +217,10 @@ export const AddonSelect: React.FC<{
             setOpen(true);
           }
         }}
-        className="flex w-full items-center gap-2 rounded-xl border border-white/15 bg-slate-900/50 px-3.5 py-2.5 text-left text-sm transition hover:bg-slate-900/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex w-full items-center gap-2 rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-left text-sm transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
       >
         <span
-          className={`min-w-0 flex-1 truncate ${selected ? 'text-white' : 'text-slate-500'}`}
+          className={`min-w-0 flex-1 truncate ${selected ? 'text-slate-900' : 'text-slate-400'}`}
         >
           {selected ? selected.label : placeholder}
         </span>
@@ -231,10 +234,10 @@ export const AddonSelect: React.FC<{
         <ul
           role="listbox"
           aria-label={ariaLabel}
-          className="absolute left-0 right-0 z-50 mt-2 max-h-60 overflow-y-auto rounded-xl border border-white/10 bg-slate-800/95 p-1 shadow-2xl shadow-black/50 backdrop-blur-xl"
+          className="absolute left-0 right-0 z-50 mt-2 max-h-60 overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg shadow-slate-900/10"
         >
           {options.length === 0 ? (
-            <li className="px-3 py-2 text-sm text-slate-500">
+            <li className="px-3 py-2 text-sm text-slate-400">
               Nothing to choose yet
             </li>
           ) : (
@@ -250,14 +253,14 @@ export const AddonSelect: React.FC<{
                     }}
                     className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition ${
                       active
-                        ? 'bg-brand-blue-primary/20 text-white'
-                        : 'text-slate-200 hover:bg-white/10'
+                        ? 'bg-brand-blue-lighter text-brand-blue-primary'
+                        : 'text-slate-700 hover:bg-slate-100'
                     }`}
                   >
                     <span className="min-w-0 flex-1 truncate">{o.label}</span>
                     {active && (
                       <Check
-                        className="h-4 w-4 shrink-0 text-brand-blue-light"
+                        className="h-4 w-4 shrink-0 text-brand-blue-primary"
                         aria-hidden="true"
                       />
                     )}

--- a/components/classroomAddon/AddonShell.tsx
+++ b/components/classroomAddon/AddonShell.tsx
@@ -11,8 +11,15 @@
  * spike-era debug tables / log panels live here; raw diagnostics are confined to
  * <AddonDevPanel>, which renders only in DEV builds.
  */
-import React from 'react';
-import { Loader2, AlertTriangle, type LucideIcon } from 'lucide-react';
+import React, { useRef, useState } from 'react';
+import {
+  Loader2,
+  AlertTriangle,
+  ChevronDown,
+  Check,
+  type LucideIcon,
+} from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 
 /**
  * Full-bleed branded page wrapper. Fills the Classroom iframe, paints the calm
@@ -153,3 +160,114 @@ export const AddonError: React.FC<{ message: string | null }> = ({
       <span className="min-w-0 break-words">{message}</span>
     </div>
   ) : null;
+
+export interface AddonSelectOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Brand-styled single-select dropdown. A native `<select>`'s open option list is
+ * OS-rendered (unstyled, overflows the control, jarring against the dark glass),
+ * so this is a custom listbox: a glass trigger + a popover that is pinned to the
+ * trigger's width (`left-0 right-0`) and scrolls (`max-h-60`) instead of
+ * spilling past its container. Click-outside + Escape close it; long labels
+ * truncate. Empty option lists show a muted placeholder row rather than a
+ * zero-height popup.
+ */
+export const AddonSelect: React.FC<{
+  value: string;
+  onChange: (value: string) => void;
+  options: AddonSelectOption[];
+  placeholder: string;
+  disabled?: boolean;
+  id?: string;
+  ariaLabel?: string;
+}> = ({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled = false,
+  id,
+  ariaLabel,
+}) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, () => setOpen(false));
+  const selected = options.find((o) => o.value === value) ?? null;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        id={id}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setOpen(false);
+          else if (e.key === 'ArrowDown' && !open) {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        className="flex w-full items-center gap-2 rounded-xl border border-white/15 bg-slate-900/50 px-3.5 py-2.5 text-left text-sm transition hover:bg-slate-900/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <span
+          className={`min-w-0 flex-1 truncate ${selected ? 'text-white' : 'text-slate-500'}`}
+        >
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-slate-400 transition-transform ${open ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label={ariaLabel}
+          className="absolute left-0 right-0 z-50 mt-2 max-h-60 overflow-y-auto rounded-xl border border-white/10 bg-slate-800/95 p-1 shadow-2xl shadow-black/50 backdrop-blur-xl"
+        >
+          {options.length === 0 ? (
+            <li className="px-3 py-2 text-sm text-slate-500">
+              Nothing to choose yet
+            </li>
+          ) : (
+            options.map((o) => {
+              const active = o.value === value;
+              return (
+                <li key={o.value} role="option" aria-selected={active}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(o.value);
+                      setOpen(false);
+                    }}
+                    className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition ${
+                      active
+                        ? 'bg-brand-blue-primary/20 text-white'
+                        : 'text-slate-200 hover:bg-white/10'
+                    }`}
+                  >
+                    <span className="min-w-0 flex-1 truncate">{o.label}</span>
+                    {active && (
+                      <Check
+                        className="h-4 w-4 shrink-0 text-brand-blue-light"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/components/classroomAddon/AddonShell.tsx
+++ b/components/classroomAddon/AddonShell.tsx
@@ -1,0 +1,155 @@
+/**
+ * Shared, brand-aligned UI kit for the Google Classroom add-on iframes
+ * (teacher attachment-setup + student view). These screens render inside
+ * Classroom's fixed-height iframe, so the shell owns the scroll (the document
+ * body is `overflow: hidden` globally): an `h-screen overflow-y-auto` outer with
+ * a `min-h-full` inner centers short content and scrolls tall content — the same
+ * pattern QuizStudentApp's period picker uses.
+ *
+ * The visual language is SpartBoard's: calm dark glassmorphism, Lexend (`font-
+ * sans`), brand-blue accents, generous spacing, restrained motion. None of the
+ * spike-era debug tables / log panels live here; raw diagnostics are confined to
+ * <AddonDevPanel>, which renders only in DEV builds.
+ */
+import React from 'react';
+import { Loader2, AlertTriangle, type LucideIcon } from 'lucide-react';
+
+/**
+ * Full-bleed branded page wrapper. Fills the Classroom iframe, paints the calm
+ * slate gradient + a subtle brand glow, and owns the vertical scroll so content
+ * taller than the iframe is always reachable.
+ */
+export const AddonShell: React.FC<{
+  children: React.ReactNode;
+  /** Max content width. Defaults to a comfortable single-column card width. */
+  maxWidthClassName?: string;
+}> = ({ children, maxWidthClassName = 'max-w-xl' }) => (
+  <div className="h-screen overflow-y-auto bg-gradient-to-b from-slate-900 via-slate-900 to-slate-950 font-sans text-slate-100">
+    {/* Decorative brand glow — purely atmospheric, behind the content. */}
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 h-64 bg-brand-blue-primary/20 blur-3xl"
+    />
+    <div className="relative min-h-full px-4 py-8 sm:px-6">
+      <div className={`mx-auto w-full ${maxWidthClassName}`}>{children}</div>
+    </div>
+  </div>
+);
+
+/**
+ * Brand lockup + page title. A small gradient tile carries the section icon so
+ * the screen reads as SpartBoard at a glance even inside Classroom's chrome.
+ */
+export const AddonHeader: React.FC<{
+  icon: LucideIcon;
+  title: string;
+  subtitle?: string;
+}> = ({ icon: Icon, title, subtitle }) => (
+  <header className="mb-6 flex items-start gap-3.5">
+    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-blue-light to-brand-blue-primary shadow-lg shadow-brand-blue-primary/30">
+      <Icon className="h-5 w-5 text-white" strokeWidth={2.25} />
+    </div>
+    <div className="min-w-0">
+      <div className="flex items-center gap-2">
+        <h1 className="text-xl font-bold tracking-tight text-white">{title}</h1>
+      </div>
+      {subtitle && (
+        <p className="mt-0.5 text-sm leading-snug text-slate-400">{subtitle}</p>
+      )}
+    </div>
+  </header>
+);
+
+/** A frosted-glass surface — the standard content container for these screens. */
+export const AddonCard: React.FC<{
+  children: React.ReactNode;
+  className?: string;
+}> = ({ children, className = '' }) => (
+  <div
+    className={`rounded-2xl border border-white/10 bg-white/[0.06] shadow-xl shadow-black/30 backdrop-blur-xl ${className}`}
+  >
+    {children}
+  </div>
+);
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+const BUTTON_VARIANT: Record<ButtonVariant, string> = {
+  primary:
+    'bg-gradient-to-r from-brand-blue-primary to-brand-blue-light text-white shadow-lg shadow-brand-blue-primary/25 hover:brightness-110 focus-visible:ring-brand-blue-light',
+  secondary:
+    'border border-white/15 bg-white/5 text-slate-100 hover:bg-white/10 focus-visible:ring-white/30',
+  ghost:
+    'text-slate-300 hover:bg-white/10 hover:text-white focus-visible:ring-white/30',
+};
+
+/** Brand button with a built-in loading spinner + consistent focus ring. */
+export const AddonButton: React.FC<
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: ButtonVariant;
+    loading?: boolean;
+    icon?: LucideIcon;
+  }
+> = ({
+  variant = 'primary',
+  loading = false,
+  icon: Icon,
+  disabled,
+  className = '',
+  children,
+  ...rest
+}) => (
+  <button
+    type="button"
+    disabled={(disabled ?? false) || loading}
+    className={`inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50 ${BUTTON_VARIANT[variant]} ${className}`}
+    {...rest}
+  >
+    {loading ? (
+      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+    ) : (
+      Icon && <Icon className="h-4 w-4" aria-hidden="true" />
+    )}
+    {children}
+  </button>
+);
+
+/**
+ * Single-line progress indicator — replaces the spike's scrolling log. Shows the
+ * current step with a spinner while work is in flight; an idle/last message
+ * otherwise. `aria-live` so screen readers hear step changes.
+ */
+export const AddonStatus: React.FC<{
+  message: string | null;
+  busy?: boolean;
+}> = ({ message, busy = false }) => {
+  if (!message) return null;
+  return (
+    <div
+      aria-live="polite"
+      className="flex items-center gap-2 text-sm text-slate-400"
+    >
+      {busy && (
+        <Loader2
+          className="h-4 w-4 shrink-0 animate-spin text-brand-blue-light"
+          aria-hidden="true"
+        />
+      )}
+      <span>{message}</span>
+    </div>
+  );
+};
+
+/** Branded inline error banner. */
+export const AddonError: React.FC<{ message: string | null }> = ({
+  message,
+}) =>
+  message ? (
+    <div className="flex items-start gap-2.5 rounded-xl border border-brand-red-light/40 bg-brand-red-primary/15 p-3 text-sm text-red-100">
+      <AlertTriangle
+        className="mt-0.5 h-4 w-4 shrink-0 text-brand-red-light"
+        aria-hidden="true"
+      />
+      <span className="min-w-0 break-words">{message}</span>
+    </div>
+  ) : null;

--- a/components/classroomAddon/DueDatePicker.tsx
+++ b/components/classroomAddon/DueDatePicker.tsx
@@ -160,13 +160,13 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2.5 rounded-xl border border-white/15 bg-white/5 px-3.5 py-2.5 text-left text-sm transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+        className="flex w-full items-center gap-2.5 rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-left text-sm transition hover:bg-slate-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
       >
         <Calendar
-          className="h-4 w-4 shrink-0 text-brand-blue-light"
+          className="h-4 w-4 shrink-0 text-brand-blue-primary"
           aria-hidden="true"
         />
-        <span className={value === null ? 'text-slate-500' : 'text-white'}>
+        <span className={value === null ? 'text-slate-400' : 'text-slate-900'}>
           {formatTrigger(value)}
         </span>
         {value !== null && (
@@ -185,7 +185,7 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                 onChange(null);
               }
             }}
-            className="ml-auto rounded-md p-0.5 text-slate-500 transition hover:bg-white/10 hover:text-slate-200"
+            className="ml-auto rounded-md p-0.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
           >
             <X className="h-3.5 w-3.5" aria-hidden="true" />
           </span>
@@ -199,7 +199,7 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
           onKeyDown={(e) => {
             if (e.key === 'Escape') close();
           }}
-          className="absolute left-0 z-50 mt-2 w-[20rem] max-w-[calc(100vw-2rem)] rounded-2xl border border-white/10 bg-slate-800/95 p-3 shadow-2xl shadow-black/50 backdrop-blur-xl"
+          className="absolute left-0 z-50 mt-2 w-[20rem] max-w-[calc(100vw-2rem)] rounded-2xl border border-slate-200 bg-white p-3 shadow-xl shadow-slate-900/10"
         >
           {/* Quick presets */}
           <div className="mb-3 flex flex-wrap gap-1.5">
@@ -212,7 +212,7 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                 key={p.label}
                 type="button"
                 onClick={() => applyPreset(p.days)}
-                className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-medium text-slate-300 transition hover:bg-white/10 hover:text-white"
+                className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
               >
                 {p.label}
               </button>
@@ -225,25 +225,25 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
               type="button"
               aria-label="Previous month"
               onClick={() => stepMonth(-1)}
-              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-white/10 hover:text-white"
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
             >
               <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             </button>
-            <span className="text-sm font-semibold text-white">
+            <span className="text-sm font-semibold text-slate-900">
               {MONTHS[viewMonth]} {viewYear}
             </span>
             <button
               type="button"
               aria-label="Next month"
               onClick={() => stepMonth(1)}
-              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-white/10 hover:text-white"
+              className="rounded-lg p-1.5 text-slate-500 transition hover:bg-slate-100 hover:text-slate-900"
             >
               <ChevronRight className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
 
           {/* Weekday labels */}
-          <div className="mb-1 grid grid-cols-7 gap-1 text-center text-xs font-medium text-slate-500">
+          <div className="mb-1 grid grid-cols-7 gap-1 text-center text-xs font-medium text-slate-400">
             {WEEKDAYS.map((w) => (
               <span key={w}>{w}</span>
             ))}
@@ -268,12 +268,12 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                   disabled={isPast}
                   aria-pressed={isSelected}
                   onClick={() => pickDay(day)}
-                  className={`flex h-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent ${
+                  className={`flex h-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:text-slate-300 disabled:hover:bg-transparent ${
                     isSelected
                       ? 'bg-brand-blue-primary font-semibold text-white'
                       : isToday
-                        ? 'text-brand-blue-light ring-1 ring-inset ring-brand-blue-light/50 hover:bg-white/10'
-                        : 'text-slate-200 hover:bg-white/10'
+                        ? 'text-brand-blue-primary ring-1 ring-inset ring-brand-blue-primary/40 hover:bg-slate-100'
+                        : 'text-slate-700 hover:bg-slate-100'
                   }`}
                 >
                   {day}
@@ -283,8 +283,8 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
           </div>
 
           {/* Time of day */}
-          <div className="mt-3 flex items-center gap-2 border-t border-white/10 pt-3">
-            <span className="text-xs font-medium text-slate-400">Due time</span>
+          <div className="mt-3 flex items-center gap-2 border-t border-slate-200 pt-3">
+            <span className="text-xs font-medium text-slate-500">Due time</span>
             <div className="ml-auto flex items-center gap-1.5">
               <select
                 aria-label="Hour"
@@ -292,7 +292,7 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                 onChange={(e) =>
                   changeTime(to24(Number(e.target.value), ampm), minutes)
                 }
-                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+                className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
               >
                 {Array.from({ length: 12 }, (_, i) => i + 1).map((h) => (
                   <option key={h} value={h}>
@@ -300,12 +300,12 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                   </option>
                 ))}
               </select>
-              <span className="text-slate-500">:</span>
+              <span className="text-slate-400">:</span>
               <select
                 aria-label="Minute"
                 value={minutes}
                 onChange={(e) => changeTime(hours, Number(e.target.value))}
-                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+                className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
               >
                 {MINUTE_OPTIONS.map((m) => (
                   <option key={m} value={m}>
@@ -319,7 +319,7 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
                 onChange={(e) =>
                   changeTime(to24(hour12, e.target.value), minutes)
                 }
-                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+                className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-sm text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
               >
                 <option value="AM">AM</option>
                 <option value="PM">PM</option>
@@ -328,14 +328,14 @@ export const DueDatePicker: React.FC<DueDatePickerProps> = ({
           </div>
 
           {/* Footer actions */}
-          <div className="mt-3 flex items-center justify-between border-t border-white/10 pt-3">
+          <div className="mt-3 flex items-center justify-between border-t border-slate-200 pt-3">
             <button
               type="button"
               onClick={() => {
                 onChange(null);
                 close();
               }}
-              className="text-xs font-medium text-slate-400 transition hover:text-slate-200"
+              className="text-xs font-medium text-slate-500 transition hover:text-slate-700"
             >
               Clear
             </button>

--- a/components/classroomAddon/DueDatePicker.tsx
+++ b/components/classroomAddon/DueDatePicker.tsx
@@ -1,0 +1,354 @@
+/**
+ * DueDatePicker — a brand-aligned date + time picker for the Classroom add-on
+ * attachment-setup screen. Replaces the generic native `datetime-local` control
+ * so the due date "feels custom like everything else": a glass trigger, a popover
+ * month calendar, 12-hour time selects, and quick presets.
+ *
+ * Value model matches the rest of the assign flow: epoch-ms or `null` (no due
+ * date). All math is local-time via the native `Date` (no date library is a
+ * project dependency); the caller converts to UTC at the API boundary.
+ *
+ * Past days are disabled — Google Classroom requires a due date in the future,
+ * and an assignment due in the past is never the intent.
+ */
+import React, { useMemo, useRef, useState } from 'react';
+import { Calendar, ChevronLeft, ChevronRight, X } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
+
+interface DueDatePickerProps {
+  /** Selected due date as epoch-ms, or null for no due date. */
+  value: number | null;
+  onChange: (ms: number | null) => void;
+  disabled?: boolean;
+  id?: string;
+}
+
+const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const MONTHS = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+// Quarter-hour minute options keep the menu short while covering the common
+// "due at :00/:15/:30/:45" cases teachers actually pick.
+const MINUTE_OPTIONS = [0, 15, 30, 45];
+// Default due time when a day is picked before any time is chosen: end of day,
+// matching Google Classroom's own "11:59 PM" default for a date-only due date.
+const DEFAULT_HOURS = 23;
+const DEFAULT_MINUTES = 59;
+
+/** Midnight today — the earliest selectable day. */
+function startOfToday(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function formatTrigger(value: number | null): string {
+  if (value === null) return 'No due date';
+  return new Date(value).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+export const DueDatePicker: React.FC<DueDatePickerProps> = ({
+  value,
+  onChange,
+  disabled = false,
+  id,
+}) => {
+  const [open, setOpen] = useState(false);
+  const selected = value !== null ? new Date(value) : null;
+
+  // Calendar view month. Initialized to the selected month (or current) and
+  // tracked separately so navigating months doesn't change the selection.
+  const initialView = selected ?? new Date();
+  const [viewYear, setViewYear] = useState(initialView.getFullYear());
+  const [viewMonth, setViewMonth] = useState(initialView.getMonth());
+
+  // Time-of-day, kept independent of the day so changing one doesn't reset the
+  // other. Seeded from the value (or the end-of-day default).
+  const [hours, setHours] = useState(selected?.getHours() ?? DEFAULT_HOURS);
+  const [minutes, setMinutes] = useState(
+    selected?.getMinutes() ?? DEFAULT_MINUTES
+  );
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const close = () => setOpen(false);
+  useClickOutside(wrapperRef, close);
+
+  const today = startOfToday();
+
+  const cells = useMemo(() => {
+    const firstWeekday = new Date(viewYear, viewMonth, 1).getDay();
+    const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+    const out: (number | null)[] = [];
+    for (let i = 0; i < firstWeekday; i++) out.push(null);
+    for (let d = 1; d <= daysInMonth; d++) out.push(d);
+    return out;
+  }, [viewYear, viewMonth]);
+
+  const emit = (
+    year: number,
+    month: number,
+    day: number,
+    h: number,
+    m: number
+  ) => {
+    onChange(new Date(year, month, day, h, m, 0, 0).getTime());
+  };
+
+  const pickDay = (day: number) => {
+    emit(viewYear, viewMonth, day, hours, minutes);
+  };
+
+  const changeTime = (h: number, m: number) => {
+    setHours(h);
+    setMinutes(m);
+    // Re-emit against the already-selected day so the time edit takes effect
+    // immediately; if nothing is selected yet, the time is held until a day is
+    // picked.
+    if (selected) {
+      emit(
+        selected.getFullYear(),
+        selected.getMonth(),
+        selected.getDate(),
+        h,
+        m
+      );
+    }
+  };
+
+  const applyPreset = (daysFromToday: number) => {
+    const d = startOfToday();
+    d.setDate(d.getDate() + daysFromToday);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+    emit(d.getFullYear(), d.getMonth(), d.getDate(), hours, minutes);
+  };
+
+  const stepMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  const ampm = hours >= 12 ? 'PM' : 'AM';
+  const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+  const to24 = (h12: number, period: string) =>
+    (h12 % 12) + (period === 'PM' ? 12 : 0);
+
+  return (
+    <div className="relative" ref={wrapperRef}>
+      <button
+        type="button"
+        id={id}
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2.5 rounded-xl border border-white/15 bg-white/5 px-3.5 py-2.5 text-left text-sm transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Calendar
+          className="h-4 w-4 shrink-0 text-brand-blue-light"
+          aria-hidden="true"
+        />
+        <span className={value === null ? 'text-slate-500' : 'text-white'}>
+          {formatTrigger(value)}
+        </span>
+        {value !== null && (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label="Clear due date"
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onChange(null);
+              }
+            }}
+            className="ml-auto rounded-md p-0.5 text-slate-500 transition hover:bg-white/10 hover:text-slate-200"
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Choose a due date"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') close();
+          }}
+          className="absolute left-0 z-50 mt-2 w-[20rem] max-w-[calc(100vw-2rem)] rounded-2xl border border-white/10 bg-slate-800/95 p-3 shadow-2xl shadow-black/50 backdrop-blur-xl"
+        >
+          {/* Quick presets */}
+          <div className="mb-3 flex flex-wrap gap-1.5">
+            {[
+              { label: 'Today', days: 0 },
+              { label: 'Tomorrow', days: 1 },
+              { label: 'In a week', days: 7 },
+            ].map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => applyPreset(p.days)}
+                className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-medium text-slate-300 transition hover:bg-white/10 hover:text-white"
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Month navigation */}
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => stepMonth(-1)}
+              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-white/10 hover:text-white"
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            </button>
+            <span className="text-sm font-semibold text-white">
+              {MONTHS[viewMonth]} {viewYear}
+            </span>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => stepMonth(1)}
+              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-white/10 hover:text-white"
+            >
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+
+          {/* Weekday labels */}
+          <div className="mb-1 grid grid-cols-7 gap-1 text-center text-xs font-medium text-slate-500">
+            {WEEKDAYS.map((w) => (
+              <span key={w}>{w}</span>
+            ))}
+          </div>
+
+          {/* Day grid */}
+          <div className="grid grid-cols-7 gap-1">
+            {cells.map((day, i) => {
+              if (day === null) return <span key={`blank-${i}`} />;
+              const cellDate = new Date(viewYear, viewMonth, day);
+              const isPast = cellDate < today;
+              const isToday = cellDate.getTime() === today.getTime();
+              const isSelected =
+                selected !== null &&
+                selected.getFullYear() === viewYear &&
+                selected.getMonth() === viewMonth &&
+                selected.getDate() === day;
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  disabled={isPast}
+                  aria-pressed={isSelected}
+                  onClick={() => pickDay(day)}
+                  className={`flex h-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:text-slate-600 disabled:hover:bg-transparent ${
+                    isSelected
+                      ? 'bg-brand-blue-primary font-semibold text-white'
+                      : isToday
+                        ? 'text-brand-blue-light ring-1 ring-inset ring-brand-blue-light/50 hover:bg-white/10'
+                        : 'text-slate-200 hover:bg-white/10'
+                  }`}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Time of day */}
+          <div className="mt-3 flex items-center gap-2 border-t border-white/10 pt-3">
+            <span className="text-xs font-medium text-slate-400">Due time</span>
+            <div className="ml-auto flex items-center gap-1.5">
+              <select
+                aria-label="Hour"
+                value={hour12}
+                onChange={(e) =>
+                  changeTime(to24(Number(e.target.value), ampm), minutes)
+                }
+                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+              >
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((h) => (
+                  <option key={h} value={h}>
+                    {h}
+                  </option>
+                ))}
+              </select>
+              <span className="text-slate-500">:</span>
+              <select
+                aria-label="Minute"
+                value={minutes}
+                onChange={(e) => changeTime(hours, Number(e.target.value))}
+                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+              >
+                {MINUTE_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m.toString().padStart(2, '0')}
+                  </option>
+                ))}
+              </select>
+              <select
+                aria-label="AM or PM"
+                value={ampm}
+                onChange={(e) =>
+                  changeTime(to24(hour12, e.target.value), minutes)
+                }
+                className="rounded-lg border border-white/15 bg-slate-900/60 px-2 py-1 text-sm text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light"
+              >
+                <option value="AM">AM</option>
+                <option value="PM">PM</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Footer actions */}
+          <div className="mt-3 flex items-center justify-between border-t border-white/10 pt-3">
+            <button
+              type="button"
+              onClick={() => {
+                onChange(null);
+                close();
+              }}
+              className="text-xs font-medium text-slate-400 transition hover:text-slate-200"
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={close}
+              className="rounded-lg bg-brand-blue-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-brand-blue-light"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/classroomAddon/StudentSpikeRoute.tsx
+++ b/components/classroomAddon/StudentSpikeRoute.tsx
@@ -279,12 +279,14 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
   const hasRunner = isVideoActivity || code !== '';
   const RunnerIcon = isVideoActivity ? Video : ClipboardList;
 
+  // "Open" (not "Start") works whether the student is taking the activity for
+  // the first time or returning to review published results.
   const startLabel = busy
-    ? 'Starting…'
+    ? 'Opening…'
     : hasRunner
       ? isVideoActivity
-        ? 'Start activity'
-        : 'Start quiz'
+        ? 'Open activity'
+        : 'Open quiz'
       : 'Sign in';
 
   return (

--- a/components/classroomAddon/StudentSpikeRoute.tsx
+++ b/components/classroomAddon/StudentSpikeRoute.tsx
@@ -25,8 +25,17 @@
 import React, { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { signInWithCustomToken } from 'firebase/auth';
+import { ClipboardList, Video, ArrowRight } from 'lucide-react';
 import { auth, functions } from '@/config/firebase';
 import { ensureGis, requestAccessToken } from './gisOAuth';
+import {
+  AddonShell,
+  AddonHeader,
+  AddonCard,
+  AddonButton,
+  AddonStatus,
+  AddonError,
+} from './AddonShell';
 
 // QuizStudentApp is the real quiz runner. It reads `?code=` from the URL and,
 // because our handshake already signed the student in with a studentRole custom
@@ -50,7 +59,7 @@ const VideoActivityStudentApp = lazy(() =>
 );
 
 const FullPage: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="flex min-h-screen items-center justify-center bg-slate-900 text-slate-100">
+  <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-slate-900 via-slate-900 to-slate-950 font-sans text-slate-100">
     {children}
   </div>
 );
@@ -98,7 +107,11 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
   const sessionId = params.get('sessionId') ?? '';
   const isVideoActivity = kind === 'va' && sessionId !== '';
 
-  const [log, setLog] = useState<string[]>([]);
+  // User-facing progress line + sticky error banner (replace the spike's
+  // always-visible session dump + scrolling log; no raw diagnostics are ever
+  // shown to students).
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [session, setSession] = useState<SessionInfo | null>(null);
   // True only after a handshake completes IN THIS page load. We gate the runner
@@ -108,7 +121,7 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
   const [handshakeDone, setHandshakeDone] = useState(false);
 
   const append = useCallback((line: string) => {
-    setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${line}`]);
+    setStatusMsg(line);
   }, []);
 
   // Report whatever Firebase session is already present on mount — this is the
@@ -150,10 +163,15 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
 
   const runHandshake = useCallback(async () => {
     setBusy(true);
+    setErrorMsg(null);
     try {
       if (!courseId || !itemId) {
         append(
           'Missing courseId/itemId in the URL — set them as query params.'
+        );
+        setErrorMsg(
+          'This assignment is missing its Classroom context. Re-open it from ' +
+            'the Classroom assignment.'
         );
         return;
       }
@@ -198,7 +216,9 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
       append('Signed in.');
       setHandshakeDone(true);
     } catch (err) {
-      append(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
+      const message = err instanceof Error ? err.message : String(err);
+      append(`ERROR: ${message}`);
+      setErrorMsg(`Something went wrong: ${message}`);
     } finally {
       setBusy(false);
     }
@@ -257,98 +277,55 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
   }
 
   const hasRunner = isVideoActivity || code !== '';
+  const RunnerIcon = isVideoActivity ? Video : ClipboardList;
+
+  const startLabel = busy
+    ? 'Starting…'
+    : hasRunner
+      ? isVideoActivity
+        ? 'Start activity'
+        : 'Start quiz'
+      : 'Sign in';
 
   return (
-    <div className="min-h-screen bg-slate-900 text-slate-100 p-6 font-sans">
-      <div className="mx-auto max-w-2xl space-y-4">
-        <div>
-          <h1 className="text-xl font-bold">SpartBoard — Classroom Add-on</h1>
-          <p className="text-sm text-slate-400">
-            Sign in to start your{' '}
-            {isVideoActivity ? 'video activity' : 'assignment'}. This confirms
-            who you are inside Classroom.
-          </p>
-        </div>
+    <AddonShell maxWidthClassName="max-w-md">
+      <AddonHeader
+        icon={RunnerIcon}
+        title={isVideoActivity ? 'Your video activity' : 'Your quiz'}
+        subtitle="Sign in with your school account to begin — this confirms who you are inside Classroom."
+      />
 
-        <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-          <div className="grid grid-cols-[8rem_1fr] gap-y-1">
-            <span className="text-slate-400">courseId</span>
-            <span className="font-mono break-all">
-              {courseId === '' ? '(missing)' : courseId}
-            </span>
-            <span className="text-slate-400">itemId</span>
-            <span className="font-mono break-all">
-              {itemId === '' ? '(missing)' : itemId}
-            </span>
-            <span className="text-slate-400">itemType</span>
-            <span className="font-mono">{itemType}</span>
-            <span className="text-slate-400">attachmentId</span>
-            <span className="font-mono break-all">
-              {attachmentId === '' ? '(missing)' : attachmentId}
-            </span>
-            <span className="text-slate-400">kind</span>
-            <span className="font-mono">
-              {isVideoActivity ? 'video-activity' : 'quiz'}
-            </span>
-            <span className="text-slate-400">login_hint</span>
-            <span className="font-mono break-all">{loginHint ?? '(none)'}</span>
+      <AddonCard className="p-6">
+        <div className="flex flex-col items-center gap-5 text-center">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-blue-primary/15 ring-1 ring-brand-blue-light/30">
+            <RunnerIcon
+              className="h-7 w-7 text-brand-blue-light"
+              aria-hidden="true"
+            />
           </div>
-        </div>
-
-        <div className="flex gap-3">
-          <button
-            type="button"
+          <p className="max-w-xs text-sm text-slate-400">
+            {hasRunner
+              ? 'When you’re ready, open your assignment below. Your progress saves automatically.'
+              : 'Sign in below to continue.'}
+          </p>
+          <AddonButton
             onClick={() => void runHandshake()}
-            disabled={busy}
-            className="rounded bg-blue-500 px-4 py-2 font-medium text-white transition hover:bg-blue-600 disabled:opacity-50"
+            loading={busy}
+            className="w-full"
           >
-            {busy
-              ? 'Working…'
-              : hasRunner
-                ? isVideoActivity
-                  ? 'Start activity'
-                  : 'Start quiz'
-                : 'Sign in'}
-          </button>
-          <button
-            type="button"
-            onClick={() => window.location.reload()}
-            className="rounded border border-white/20 px-4 py-2 font-medium transition hover:bg-white/10"
-          >
-            Reload
-          </button>
+            {startLabel}
+            {!busy && hasRunner && (
+              <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            )}
+          </AddonButton>
         </div>
+      </AddonCard>
 
-        <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-          <h2 className="mb-2 font-semibold">Current Firebase session</h2>
-          {session ? (
-            <div className="grid grid-cols-[8rem_1fr] gap-y-1">
-              <span className="text-slate-400">uid</span>
-              <span className="font-mono break-all">{session.uid}</span>
-              <span className="text-slate-400">isAnonymous</span>
-              <span className="font-mono">{String(session.isAnonymous)}</span>
-              <span className="text-slate-400">studentRole</span>
-              <span className="font-mono">{String(session.studentRole)}</span>
-              <span className="text-slate-400">classIds</span>
-              <span className="font-mono break-all">
-                {JSON.stringify(session.classIds)}
-              </span>
-            </div>
-          ) : (
-            <p className="text-slate-400">
-              No Firebase user yet — sign in above to begin.
-            </p>
-          )}
-        </div>
-
-        <div className="rounded-lg border border-white/10 bg-black/30 p-4">
-          <h2 className="mb-2 text-sm font-semibold">Log</h2>
-          <pre className="whitespace-pre-wrap break-all font-mono text-xs text-slate-300">
-            {log.length ? log.join('\n') : '(no output yet)'}
-          </pre>
-        </div>
+      <div className="mt-4 space-y-2">
+        <AddonError message={errorMsg} />
+        {busy && <AddonStatus message={statusMsg} busy />}
       </div>
-    </div>
+    </AddonShell>
   );
 };
 

--- a/components/classroomAddon/StudentSpikeRoute.tsx
+++ b/components/classroomAddon/StudentSpikeRoute.tsx
@@ -297,13 +297,13 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
 
       <AddonCard className="p-6">
         <div className="flex flex-col items-center gap-5 text-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-blue-primary/15 ring-1 ring-brand-blue-light/30">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-blue-lighter ring-1 ring-brand-blue-light/20">
             <RunnerIcon
-              className="h-7 w-7 text-brand-blue-light"
+              className="h-7 w-7 text-brand-blue-primary"
               aria-hidden="true"
             />
           </div>
-          <p className="max-w-xs text-sm text-slate-400">
+          <p className="max-w-xs text-sm text-slate-500">
             {hasRunner
               ? 'When you’re ready, open your assignment below. Your progress saves automatically.'
               : 'Sign in below to continue.'}

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -71,6 +71,11 @@ const ADDON_TEACHER_SCOPES = [
   'https://www.googleapis.com/auth/userinfo.email',
   'https://www.googleapis.com/auth/userinfo.profile',
   'https://www.googleapis.com/auth/classroom.addons.teacher',
+  // Lets the attach flow PATCH the parent courseWork's due date so the date the
+  // teacher picks here becomes THE Classroom assignment due date (entered once).
+  // Sensitive scope, but the Orono OAuth consent screen is Internal, so it's
+  // exempt from verification/CASA.
+  'https://www.googleapis.com/auth/classroom.coursework.students',
 ].join(' ');
 
 // Conservative PLAYER defaults for an async Classroom attachment — mirrors the
@@ -89,6 +94,8 @@ const VA_SESSION_SETTINGS: VideoActivitySessionSettings = {
 
 interface CreateAttachmentResult {
   attachmentId: string;
+  /** True iff the CF also synced the due date onto the parent courseWork. */
+  dueDateSynced?: boolean;
 }
 
 // Params the callable accepts. `quizCode` (quiz) and `sessionId`+`kind:'va'`
@@ -112,6 +119,12 @@ interface CreateAttachmentParams {
    * callable defaults to 100 when omitted (video-activity path).
    */
   maxPoints?: number;
+  /**
+   * Due date as epoch-ms (from the custom <DueDatePicker>). When present on a
+   * courseWork attachment, the callable PATCHes the parent courseWork's
+   * dueDate/dueTime so it shows as the Classroom assignment due date.
+   */
+  dueAtMs?: number;
 }
 
 type ContentKind = 'quiz' | 'va';
@@ -327,12 +340,22 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         addOnToken,
         origin: window.location.origin,
         title,
+        // Sync the picked due date onto the parent Classroom assignment.
+        ...(dueAt !== null ? { dueAtMs: dueAt } : {}),
         ...contentParams,
       });
       setAttachmentId(data.attachmentId);
+      if (dueAt !== null) {
+        append(
+          data.dueDateSynced
+            ? 'Set the Classroom assignment due date.'
+            : "Couldn't set the Classroom due date automatically — set it in " +
+                'Classroom if you need one.'
+        );
+      }
       return data.attachmentId;
     },
-    [append, courseId, itemId, itemType, addOnToken, loginHint]
+    [append, courseId, itemId, itemType, addOnToken, loginHint, dueAt]
   );
 
   // Build the PLC linkage when the teacher opted into "Share with PLC" and

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -60,6 +60,7 @@ import {
   AddonButton,
   AddonStatus,
   AddonError,
+  AddonSelect,
 } from './AddonShell';
 import { DueDatePicker } from './DueDatePicker';
 
@@ -732,9 +733,6 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     { value: 'va', label: 'Video Activity', icon: Video },
   ];
 
-  const selectClassName =
-    'w-full rounded-xl border border-white/15 bg-slate-900/50 px-3 py-2.5 text-sm text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50';
-
   return (
     <AddonShell>
       <AddonHeader
@@ -797,52 +795,50 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
 
           {/* Library picker */}
           <AddonCard className="p-4">
-            <label className="block">
-              <span className="mb-1.5 block text-sm font-medium text-slate-300">
-                {kind === 'quiz' ? 'Quiz' : 'Video Activity'}
-              </span>
-              {kind === 'quiz' ? (
-                <select
-                  value={selectedQuizId}
-                  onChange={(e) => setSelectedQuizId(e.target.value)}
-                  disabled={busy || quizzesLoading}
-                  className={selectClassName}
-                >
-                  <option value="">
-                    {quizzesLoading
-                      ? 'Loading your quizzes…'
-                      : quizzes.length === 0
-                        ? 'No quizzes in your library yet'
-                        : 'Select a quiz…'}
-                  </option>
-                  {quizzes.map((q) => (
-                    <option key={q.id} value={q.id}>
-                      {q.title}
-                    </option>
-                  ))}
-                </select>
-              ) : (
-                <select
-                  value={selectedActivityId}
-                  onChange={(e) => setSelectedActivityId(e.target.value)}
-                  disabled={busy || activitiesLoading}
-                  className={selectClassName}
-                >
-                  <option value="">
-                    {activitiesLoading
-                      ? 'Loading your video activities…'
-                      : activities.length === 0
-                        ? 'No video activities in your library yet'
-                        : 'Select a video activity…'}
-                  </option>
-                  {activities.map((a) => (
-                    <option key={a.id} value={a.id}>
-                      {a.title}
-                    </option>
-                  ))}
-                </select>
-              )}
+            <label
+              htmlFor={
+                kind === 'quiz' ? 'addon-quiz-select' : 'addon-va-select'
+              }
+              className="mb-1.5 block text-sm font-medium text-slate-300"
+            >
+              {kind === 'quiz' ? 'Quiz' : 'Video Activity'}
             </label>
+            {kind === 'quiz' ? (
+              <AddonSelect
+                id="addon-quiz-select"
+                ariaLabel="Quiz"
+                value={selectedQuizId}
+                onChange={setSelectedQuizId}
+                disabled={busy || quizzesLoading}
+                placeholder={
+                  quizzesLoading
+                    ? 'Loading your quizzes…'
+                    : quizzes.length === 0
+                      ? 'No quizzes in your library yet'
+                      : 'Select a quiz…'
+                }
+                options={quizzes.map((q) => ({ value: q.id, label: q.title }))}
+              />
+            ) : (
+              <AddonSelect
+                id="addon-va-select"
+                ariaLabel="Video Activity"
+                value={selectedActivityId}
+                onChange={setSelectedActivityId}
+                disabled={busy || activitiesLoading}
+                placeholder={
+                  activitiesLoading
+                    ? 'Loading your video activities…'
+                    : activities.length === 0
+                      ? 'No video activities in your library yet'
+                      : 'Select a video activity…'
+                }
+                options={activities.map((a) => ({
+                  value: a.id,
+                  label: a.title,
+                }))}
+              />
+            )}
           </AddonCard>
 
           {/* Per-assignment settings — parity with the normal SpartBoard
@@ -929,20 +925,17 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                     Share results with a PLC
                   </label>
                   {plcShareEnabled && (
-                    <select
+                    <AddonSelect
+                      ariaLabel="PLC to share results with"
                       value={selectedPlcId}
-                      onChange={(e) => setSelectedPlcId(e.target.value)}
+                      onChange={setSelectedPlcId}
                       disabled={busy}
-                      aria-label="PLC to share results with"
-                      className={selectClassName}
-                    >
-                      <option value="">Select a PLC…</option>
-                      {plcs.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </select>
+                      placeholder="Select a PLC…"
+                      options={plcs.map((p) => ({
+                        value: p.id,
+                        label: p.name,
+                      }))}
+                    />
                   )}
                 </div>
               )}

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -744,8 +744,8 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
       {existingAttachmentId ? (
         <AddonCard className="p-5">
           <div className="flex items-start gap-3">
-            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
-            <p className="text-sm leading-relaxed text-slate-300">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+            <p className="text-sm leading-relaxed text-slate-600">
               This activity is already attached. Students open it from the
               assignment to complete it.
             </p>
@@ -753,7 +753,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         </AddonCard>
       ) : !user ? (
         <AddonCard className="p-6">
-          <p className="mb-4 text-sm text-slate-400">
+          <p className="mb-4 text-sm text-slate-500">
             Sign in with your school Google account to load your SpartBoard
             library.
           </p>
@@ -767,7 +767,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
           <div
             role="tablist"
             aria-label="Activity type"
-            className="grid grid-cols-2 gap-1 rounded-xl border border-white/10 bg-white/5 p-1"
+            className="grid grid-cols-2 gap-1 rounded-xl border border-slate-200 bg-slate-100 p-1"
           >
             {KIND_TABS.map((tab) => {
               const active = kind === tab.value;
@@ -783,7 +783,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                   className={`flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition disabled:opacity-50 ${
                     active
                       ? 'bg-gradient-to-r from-brand-blue-primary to-brand-blue-light text-white shadow'
-                      : 'text-slate-300 hover:bg-white/10'
+                      : 'text-slate-600 hover:bg-white'
                   }`}
                 >
                   <Icon className="h-4 w-4" aria-hidden="true" />
@@ -799,7 +799,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
               htmlFor={
                 kind === 'quiz' ? 'addon-quiz-select' : 'addon-va-select'
               }
-              className="mb-1.5 block text-sm font-medium text-slate-300"
+              className="mb-1.5 block text-sm font-medium text-slate-700"
             >
               {kind === 'quiz' ? 'Quiz' : 'Video Activity'}
             </label>
@@ -847,15 +847,15 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
               Classroom course link, so there's no class/roster picker here. */}
           {canAttach && (
             <AddonCard className="space-y-4 p-4">
-              <h2 className="text-sm font-semibold text-white">
+              <h2 className="text-sm font-semibold text-slate-900">
                 Assignment settings
               </h2>
 
               {behaviorSummary && (
-                <p className="text-xs text-slate-400">
+                <p className="text-xs text-slate-500">
                   Inherits this {kind === 'quiz' ? 'quiz' : 'activity'}
                   &rsquo;s settings:{' '}
-                  <span className="font-medium text-slate-300">
+                  <span className="font-medium text-slate-700">
                     {behaviorSummary}
                   </span>
                 </p>
@@ -864,7 +864,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
               <div>
                 <label
                   htmlFor="addon-due-date"
-                  className="mb-1.5 block text-sm font-medium text-slate-300"
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
                 >
                   Due date{' '}
                   <span className="font-normal text-slate-500">(optional)</span>
@@ -883,7 +883,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
               <div>
                 <label
                   htmlFor="addon-teacher-name"
-                  className="mb-1.5 block text-sm font-medium text-slate-300"
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
                 >
                   Your name{' '}
                   <span className="font-normal text-slate-500">
@@ -897,7 +897,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                   onChange={(e) => setTeacherName(e.target.value)}
                   placeholder={defaultTeacherName || 'Teacher name'}
                   disabled={busy}
-                  className="w-full rounded-xl border border-white/15 bg-slate-900/50 px-3 py-2.5 text-sm text-white transition placeholder:text-slate-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
                 />
               </div>
 
@@ -906,7 +906,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                   drives the quiz and VA attach paths. */}
               {plcs.length > 0 && (
                 <div className="space-y-2">
-                  <label className="flex items-center gap-2.5 text-sm text-slate-300">
+                  <label className="flex items-center gap-2.5 text-sm text-slate-700">
                     <input
                       type="checkbox"
                       checked={plcShareEnabled}
@@ -954,12 +954,12 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
       )}
 
       {attachmentId && (
-        <AddonCard className="mt-4 border-emerald-400/30 bg-emerald-400/10 p-4">
+        <AddonCard className="mt-4 border-emerald-200 bg-emerald-50 p-4">
           <div className="flex items-start gap-2.5">
-            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
             <div>
-              <p className="text-sm font-semibold text-white">Attached</p>
-              <p className="text-sm text-slate-300">
+              <p className="text-sm font-semibold text-slate-900">Attached</p>
+              <p className="text-sm text-slate-600">
                 Students can now open and complete this activity inside
                 Classroom.
               </p>

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -46,6 +46,22 @@ import {
 import { buildPlcLinkage } from '@/utils/plcLinkage';
 import { logError } from '@/utils/logError';
 import { ensureGis, requestAccessToken } from './gisOAuth';
+import {
+  ClipboardList,
+  Video,
+  Paperclip,
+  CheckCircle2,
+  type LucideIcon,
+} from 'lucide-react';
+import {
+  AddonShell,
+  AddonHeader,
+  AddonCard,
+  AddonButton,
+  AddonStatus,
+  AddonError,
+} from './AddonShell';
+import { DueDatePicker } from './DueDatePicker';
 
 // The teacher/discovery iframe creates attachments → needs the teacher scope.
 // (The SpartBoard sign-in above grants Drive separately, via AuthContext.)
@@ -69,17 +85,6 @@ const VA_SESSION_SETTINGS: VideoActivitySessionSettings = {
   requireCorrectAnswer: true,
   allowSkipping: false,
 };
-
-/**
- * Parse a `<input type="datetime-local">` value into an epoch-ms due date.
- * Returns `undefined` for an empty / unparseable value so callers can omit
- * `dueAt` entirely (absent = no due date) rather than persisting `NaN`.
- */
-function parseDueAt(local: string): number | undefined {
-  if (!local) return undefined;
-  const ms = new Date(local).getTime();
-  return Number.isFinite(ms) ? ms : undefined;
-}
 
 interface CreateAttachmentResult {
   attachmentId: string;
@@ -153,7 +158,11 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   // (mounted on this route) — no DashboardProvider required.
   const { plcs } = usePlcs();
 
-  const [log, setLog] = useState<string[]>([]);
+  // User-facing progress line (the latest step) + a sticky error banner. These
+  // replace the spike's always-visible scrolling log; no raw diagnostics are
+  // ever shown to teachers.
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [kind, setKind] = useState<ContentKind>('quiz');
   const [selectedQuizId, setSelectedQuizId] = useState('');
@@ -163,9 +172,9 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   // ── Per-assignment settings (parity with the normal SpartBoard assign flow).
   // All optional — a teacher can attach with no due date / no PLC. Class
   // targeting is NOT here; it's auto-derived from the Classroom course link.
-  // `dueAtLocal` is the raw <input type="datetime-local"> value; parsed to
-  // epoch-ms only at attach time.
-  const [dueAtLocal, setDueAtLocal] = useState('');
+  // `dueAt` is epoch-ms (or null = no due date), produced directly by the
+  // custom <DueDatePicker> — no datetime-local string parsing.
+  const [dueAt, setDueAt] = useState<number | null>(null);
   // Default the teacher name from the signed-in profile (used for PLC sheet
   // attribution). Falls back to the email local-part, then empty.
   const defaultTeacherName =
@@ -175,8 +184,9 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const [plcShareEnabled, setPlcShareEnabled] = useState(false);
   const [selectedPlcId, setSelectedPlcId] = useState('');
 
+  // Records the current step as the user-facing status message.
   const append = useCallback((line: string) => {
-    setLog((prev) => [...prev, `${new Date().toLocaleTimeString()}  ${line}`]);
+    setStatusMsg(line);
   }, []);
 
   const selectedQuiz = useMemo(
@@ -206,12 +216,15 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
 
   const signIn = useCallback(async () => {
     setBusy(true);
+    setErrorMsg(null);
     try {
       append('Signing in to SpartBoard…');
       await signInWithGoogle();
       append('Signed in. Pick something to attach.');
     } catch (err) {
-      append(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
+      const message = err instanceof Error ? err.message : String(err);
+      append(`ERROR: ${message}`);
+      setErrorMsg(`Couldn't sign in: ${message}`);
     } finally {
       setBusy(false);
     }
@@ -398,7 +411,6 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     const { sessionMode, sessionOptions, attemptLimit } =
       getQuizBehavior(selectedQuiz);
 
-    const dueAt = parseDueAt(dueAtLocal);
     const effectiveTeacherName = teacherName.trim() || defaultTeacherName;
 
     // Build the PLC linkage when the teacher opted into "Share with PLC" and
@@ -425,7 +437,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         sessionMode,
         sessionOptions,
         attemptLimit,
-        ...(dueAt !== undefined ? { dueAt } : {}),
+        ...(dueAt !== null ? { dueAt } : {}),
         ...(effectiveTeacherName ? { teacherName: effectiveTeacherName } : {}),
         ...(plcLinkage ? { plc: plcLinkage } : {}),
         ...(targeting.periodNames.length > 0
@@ -512,7 +524,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     courseId,
     itemId,
     kind,
-    dueAtLocal,
+    dueAt,
     teacherName,
     defaultTeacherName,
   ]);
@@ -547,12 +559,11 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     // sharing exactly like the quiz path — the sheet creator (`buildPlcLinkage`)
     // is widget-agnostic — so we build the same linkage and pass it on settings.
     const behavior = getVideoActivityBehavior(selectedActivity);
-    const dueAt = parseDueAt(dueAtLocal);
     const effectiveTeacherName = teacherName.trim() || defaultTeacherName;
     const sessionOptions: VideoActivitySessionOptions = {
       ...behavior.sessionOptions,
       attemptLimit: behavior.attemptLimit,
-      ...(dueAt !== undefined ? { dueAt } : {}),
+      ...(dueAt !== null ? { dueAt } : {}),
     };
 
     // Build the PLC linkage when the teacher opted into "Share with PLC" and
@@ -663,22 +674,31 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     courseId,
     itemId,
     kind,
-    dueAtLocal,
+    dueAt,
     teacherName,
     defaultTeacherName,
   ]);
 
   const runAttach = useCallback(async () => {
     setBusy(true);
+    setErrorMsg(null);
     try {
       if (!courseId || !itemId) {
         append('Missing courseId/itemId in the URL.');
+        setErrorMsg(
+          'This assignment is missing its Classroom context. Re-open the ' +
+            'SpartBoard add-on from the assignment.'
+        );
         return;
       }
       if (!addOnToken) {
         append(
           'Missing addOnToken — this route must be opened as the Attachment ' +
             'Setup URI (discovery), not the teacher view.'
+        );
+        setErrorMsg(
+          'This screen must be opened from the Classroom assignment’s add-on ' +
+            'menu to attach an activity.'
         );
         return;
       }
@@ -688,7 +708,9 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         await attachVideoActivity();
       }
     } catch (err) {
-      append(`ERROR: ${err instanceof Error ? err.message : String(err)}`);
+      const message = err instanceof Error ? err.message : String(err);
+      append(`ERROR: ${message}`);
+      setErrorMsg(`Something went wrong: ${message}`);
     } finally {
       setBusy(false);
     }
@@ -702,84 +724,89 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     attachVideoActivity,
   ]);
 
-  const tabBtn = (value: ContentKind, label: string) => (
-    <button
-      type="button"
-      onClick={() => setKind(value)}
-      disabled={busy}
-      aria-pressed={kind === value}
-      className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition disabled:opacity-50 ${
-        kind === value
-          ? 'bg-blue-500 text-white'
-          : 'text-slate-300 hover:bg-white/10'
-      }`}
-    >
-      {label}
-    </button>
-  );
-
   const canAttach = kind === 'quiz' ? !!selectedQuizId : !!selectedActivityId;
 
+  // Branded segmented selector for the activity type.
+  const KIND_TABS: { value: ContentKind; label: string; icon: LucideIcon }[] = [
+    { value: 'quiz', label: 'Quiz', icon: ClipboardList },
+    { value: 'va', label: 'Video Activity', icon: Video },
+  ];
+
+  const selectClassName =
+    'w-full rounded-xl border border-white/15 bg-slate-900/50 px-3 py-2.5 text-sm text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50';
+
   return (
-    <div className="min-h-screen bg-slate-900 p-6 font-sans text-slate-100">
-      <div className="mx-auto max-w-2xl space-y-4">
-        <div>
-          <h1 className="text-xl font-bold">Attach a SpartBoard activity</h1>
-          <p className="text-sm text-slate-400">
-            Pick a quiz or video activity from your library to attach to this
-            Classroom assignment. Students complete it inside Classroom.
+    <AddonShell>
+      <AddonHeader
+        icon={Paperclip}
+        title="Attach a SpartBoard activity"
+        subtitle="Pick a quiz or video activity from your library. Students complete it right inside Classroom."
+      />
+
+      {existingAttachmentId ? (
+        <AddonCard className="p-5">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+            <p className="text-sm leading-relaxed text-slate-300">
+              This activity is already attached. Students open it from the
+              assignment to complete it.
+            </p>
+          </div>
+        </AddonCard>
+      ) : !user ? (
+        <AddonCard className="p-6">
+          <p className="mb-4 text-sm text-slate-400">
+            Sign in with your school Google account to load your SpartBoard
+            library.
           </p>
-        </div>
-
-        <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm">
-          <div className="grid grid-cols-[8rem_1fr] gap-y-1">
-            <span className="text-slate-400">courseId</span>
-            <span className="break-all font-mono">
-              {courseId === '' ? '(missing)' : courseId}
-            </span>
-            <span className="text-slate-400">itemId</span>
-            <span className="break-all font-mono">
-              {itemId === '' ? '(missing)' : itemId}
-            </span>
-            <span className="text-slate-400">itemType</span>
-            <span className="font-mono">{itemType}</span>
-            <span className="text-slate-400">addOnToken</span>
-            <span className="break-all font-mono">
-              {addOnToken === '' ? '(none — teacher view?)' : '(present)'}
-            </span>
-          </div>
-        </div>
-
-        {existingAttachmentId ? (
-          <div className="rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-4 text-sm">
-            This is the teacher view of an existing attachment (
-            <span className="font-mono">{existingAttachmentId}</span>). Students
-            open it to complete the attached activity.
-          </div>
-        ) : !user ? (
-          <button
-            type="button"
-            onClick={() => void signIn()}
-            disabled={busy}
-            className="rounded bg-blue-500 px-4 py-2 font-medium text-white transition hover:bg-blue-600 disabled:opacity-50"
+          <AddonButton onClick={() => void signIn()} loading={busy}>
+            Sign in to SpartBoard
+          </AddonButton>
+        </AddonCard>
+      ) : (
+        <div className="space-y-4">
+          {/* Segmented Quiz / Video Activity selector */}
+          <div
+            role="tablist"
+            aria-label="Activity type"
+            className="grid grid-cols-2 gap-1 rounded-xl border border-white/10 bg-white/5 p-1"
           >
-            {busy ? 'Working…' : 'Sign in to SpartBoard'}
-          </button>
-        ) : (
-          <div className="space-y-3">
-            <div className="flex gap-1 rounded-lg border border-white/10 bg-white/5 p-1">
-              {tabBtn('quiz', 'Quiz')}
-              {tabBtn('va', 'Video Activity')}
-            </div>
+            {KIND_TABS.map((tab) => {
+              const active = kind === tab.value;
+              const Icon = tab.icon;
+              return (
+                <button
+                  key={tab.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  disabled={busy}
+                  onClick={() => setKind(tab.value)}
+                  className={`flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold transition disabled:opacity-50 ${
+                    active
+                      ? 'bg-gradient-to-r from-brand-blue-primary to-brand-blue-light text-white shadow'
+                      : 'text-slate-300 hover:bg-white/10'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
 
-            {kind === 'quiz' ? (
-              <label className="block text-sm">
-                <span className="mb-1 block text-slate-400">Quiz</span>
+          {/* Library picker */}
+          <AddonCard className="p-4">
+            <label className="block">
+              <span className="mb-1.5 block text-sm font-medium text-slate-300">
+                {kind === 'quiz' ? 'Quiz' : 'Video Activity'}
+              </span>
+              {kind === 'quiz' ? (
                 <select
                   value={selectedQuizId}
                   onChange={(e) => setSelectedQuizId(e.target.value)}
                   disabled={busy || quizzesLoading}
-                  className="w-full rounded border border-slate-600 bg-slate-800 px-3 py-2 text-white"
+                  className={selectClassName}
                 >
                   <option value="">
                     {quizzesLoading
@@ -794,17 +821,12 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                     </option>
                   ))}
                 </select>
-              </label>
-            ) : (
-              <label className="block text-sm">
-                <span className="mb-1 block text-slate-400">
-                  Video Activity
-                </span>
+              ) : (
                 <select
                   value={selectedActivityId}
                   onChange={(e) => setSelectedActivityId(e.target.value)}
                   disabled={busy || activitiesLoading}
-                  className="w-full rounded border border-slate-600 bg-slate-800 px-3 py-2 text-white"
+                  className={selectClassName}
                 >
                   <option value="">
                     {activitiesLoading
@@ -819,133 +841,145 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                     </option>
                   ))}
                 </select>
-              </label>
-            )}
+              )}
+            </label>
+          </AddonCard>
 
-            {/* Per-assignment settings — parity with the normal SpartBoard
-                assign flow. Shown only once something is selected; all fields
-                are optional. Class targeting is auto-derived from the
-                Classroom course link, so there's no class/roster picker here. */}
-            {canAttach && (
-              <div className="space-y-3 rounded-lg border border-white/10 bg-white/5 p-4">
-                <h2 className="text-sm font-semibold text-slate-200">
-                  Assignment settings
-                </h2>
+          {/* Per-assignment settings — parity with the normal SpartBoard
+              assign flow. Shown only once something is selected; all fields
+              are optional. Class targeting is auto-derived from the
+              Classroom course link, so there's no class/roster picker here. */}
+          {canAttach && (
+            <AddonCard className="space-y-4 p-4">
+              <h2 className="text-sm font-semibold text-white">
+                Assignment settings
+              </h2>
 
-                {behaviorSummary && (
-                  <p className="text-xs text-slate-400">
-                    Inherits this {kind === 'quiz' ? 'quiz' : 'activity'}
-                    &rsquo;s settings:{' '}
-                    <span className="font-medium text-slate-300">
-                      {behaviorSummary}
-                    </span>
-                  </p>
-                )}
-
-                <label className="block text-sm">
-                  <span className="mb-1 block text-slate-400">
-                    Due date <span className="text-slate-500">(optional)</span>
+              {behaviorSummary && (
+                <p className="text-xs text-slate-400">
+                  Inherits this {kind === 'quiz' ? 'quiz' : 'activity'}
+                  &rsquo;s settings:{' '}
+                  <span className="font-medium text-slate-300">
+                    {behaviorSummary}
                   </span>
-                  <input
-                    type="datetime-local"
-                    value={dueAtLocal}
-                    onChange={(e) => setDueAtLocal(e.target.value)}
-                    disabled={busy}
-                    className="w-full rounded border border-slate-600 bg-slate-800 px-3 py-2 text-white disabled:opacity-50 [color-scheme:dark]"
-                  />
-                </label>
+                </p>
+              )}
 
-                <label className="block text-sm">
-                  <span className="mb-1 block text-slate-400">
-                    Your name{' '}
-                    <span className="text-slate-500">
-                      (optional — shown on shared PLC results)
-                    </span>
-                  </span>
-                  <input
-                    type="text"
-                    value={teacherName}
-                    onChange={(e) => setTeacherName(e.target.value)}
-                    placeholder={defaultTeacherName || 'Teacher name'}
-                    disabled={busy}
-                    className="w-full rounded border border-slate-600 bg-slate-800 px-3 py-2 text-white placeholder:text-slate-500 disabled:opacity-50"
-                  />
+              <div>
+                <label
+                  htmlFor="addon-due-date"
+                  className="mb-1.5 block text-sm font-medium text-slate-300"
+                >
+                  Due date{' '}
+                  <span className="font-normal text-slate-500">(optional)</span>
                 </label>
-
-                {/* PLC sharing applies to BOTH quizzes and video activities —
-                    `buildPlcLinkage` is widget-agnostic, so the same control
-                    drives the quiz and VA attach paths. */}
-                {plcs.length > 0 && (
-                  <div className="space-y-2">
-                    <label className="flex items-center gap-2 text-sm text-slate-300">
-                      <input
-                        type="checkbox"
-                        checked={plcShareEnabled}
-                        onChange={(e) => {
-                          const on = e.target.checked;
-                          setPlcShareEnabled(on);
-                          // Preselect the sole PLC so a one-PLC teacher doesn't
-                          // have to also pick from a single-item list.
-                          if (on && !selectedPlcId && plcs.length === 1) {
-                            setSelectedPlcId(plcs[0].id);
-                          }
-                        }}
-                        disabled={busy}
-                        className="h-4 w-4 accent-blue-500"
-                      />
-                      Share results with a PLC
-                    </label>
-                    {plcShareEnabled && (
-                      <select
-                        value={selectedPlcId}
-                        onChange={(e) => setSelectedPlcId(e.target.value)}
-                        disabled={busy}
-                        aria-label="PLC to share results with"
-                        className="w-full rounded border border-slate-600 bg-slate-800 px-3 py-2 text-white disabled:opacity-50"
-                      >
-                        <option value="">Select a PLC…</option>
-                        {plcs.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
-                )}
+                <DueDatePicker
+                  id="addon-due-date"
+                  value={dueAt}
+                  onChange={setDueAt}
+                  disabled={busy}
+                />
+                <p className="mt-1.5 text-xs text-slate-500">
+                  Also sets the due date on the Classroom assignment.
+                </p>
               </div>
-            )}
 
-            <button
-              type="button"
-              onClick={() => void runAttach()}
-              disabled={busy || !canAttach}
-              className="rounded bg-blue-500 px-4 py-2 font-medium text-white transition hover:bg-blue-600 disabled:opacity-50"
-            >
-              {busy
-                ? 'Working…'
-                : kind === 'quiz'
-                  ? 'Attach quiz'
-                  : 'Attach video activity'}
-            </button>
-          </div>
-        )}
+              <div>
+                <label
+                  htmlFor="addon-teacher-name"
+                  className="mb-1.5 block text-sm font-medium text-slate-300"
+                >
+                  Your name{' '}
+                  <span className="font-normal text-slate-500">
+                    (optional — shown on shared PLC results)
+                  </span>
+                </label>
+                <input
+                  id="addon-teacher-name"
+                  type="text"
+                  value={teacherName}
+                  onChange={(e) => setTeacherName(e.target.value)}
+                  placeholder={defaultTeacherName || 'Teacher name'}
+                  disabled={busy}
+                  className="w-full rounded-xl border border-white/15 bg-slate-900/50 px-3 py-2.5 text-sm text-white transition placeholder:text-slate-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
 
-        {attachmentId && (
-          <div className="rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-4 text-sm">
-            <h2 className="mb-1 font-semibold">Attached ✓</h2>
-            <p className="break-all font-mono">{attachmentId}</p>
-          </div>
-        )}
+              {/* PLC sharing applies to BOTH quizzes and video activities —
+                  `buildPlcLinkage` is widget-agnostic, so the same control
+                  drives the quiz and VA attach paths. */}
+              {plcs.length > 0 && (
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2.5 text-sm text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={plcShareEnabled}
+                      onChange={(e) => {
+                        const on = e.target.checked;
+                        setPlcShareEnabled(on);
+                        // Preselect the sole PLC so a one-PLC teacher doesn't
+                        // have to also pick from a single-item list.
+                        if (on && !selectedPlcId && plcs.length === 1) {
+                          setSelectedPlcId(plcs[0].id);
+                        }
+                      }}
+                      disabled={busy}
+                      className="h-4 w-4 rounded accent-brand-blue-light"
+                    />
+                    Share results with a PLC
+                  </label>
+                  {plcShareEnabled && (
+                    <select
+                      value={selectedPlcId}
+                      onChange={(e) => setSelectedPlcId(e.target.value)}
+                      disabled={busy}
+                      aria-label="PLC to share results with"
+                      className={selectClassName}
+                    >
+                      <option value="">Select a PLC…</option>
+                      {plcs.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              )}
+            </AddonCard>
+          )}
 
-        <div className="rounded-lg border border-white/10 bg-black/30 p-4">
-          <h2 className="mb-2 text-sm font-semibold">Log</h2>
-          <pre className="whitespace-pre-wrap break-all font-mono text-xs text-slate-300">
-            {log.length ? log.join('\n') : '(no output yet)'}
-          </pre>
+          <AddonButton
+            onClick={() => void runAttach()}
+            loading={busy}
+            disabled={!canAttach}
+            icon={Paperclip}
+          >
+            {kind === 'quiz' ? 'Attach quiz' : 'Attach video activity'}
+          </AddonButton>
         </div>
+      )}
+
+      {attachmentId && (
+        <AddonCard className="mt-4 border-emerald-400/30 bg-emerald-400/10 p-4">
+          <div className="flex items-start gap-2.5">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+            <div>
+              <p className="text-sm font-semibold text-white">Attached</p>
+              <p className="text-sm text-slate-300">
+                Students can now open and complete this activity inside
+                Classroom.
+              </p>
+            </div>
+          </div>
+        </AddonCard>
+      )}
+
+      <div className="mt-4 space-y-2">
+        <AddonError message={errorMsg} />
+        {busy && <AddonStatus message={statusMsg} busy />}
       </div>
-    </div>
+    </AddonShell>
   );
 };
 

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -182,6 +182,10 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const [selectedQuizId, setSelectedQuizId] = useState('');
   const [selectedActivityId, setSelectedActivityId] = useState('');
   const [attachmentId, setAttachmentId] = useState('');
+  // Whether the due date synced onto the Classroom assignment (null = no due
+  // date was set, so the success card stays silent about it). Surfaced durably
+  // on the success card so a failed/best-effort sync isn't lost when busy clears.
+  const [dueDateSynced, setDueDateSynced] = useState<boolean | null>(null);
 
   // ── Per-assignment settings (parity with the normal SpartBoard assign flow).
   // All optional — a teacher can attach with no due date / no PLC. Class
@@ -345,13 +349,10 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         ...contentParams,
       });
       setAttachmentId(data.attachmentId);
+      // Record the due-date sync outcome so the success card can show it durably
+      // (a best-effort failure must not vanish when the busy spinner clears).
       if (dueAt !== null) {
-        append(
-          data.dueDateSynced
-            ? 'Set the Classroom assignment due date.'
-            : "Couldn't set the Classroom due date automatically — set it in " +
-                'Classroom if you need one.'
-        );
+        setDueDateSynced(data.dueDateSynced ?? false);
       }
       return data.attachmentId;
     },
@@ -706,6 +707,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const runAttach = useCallback(async () => {
     setBusy(true);
     setErrorMsg(null);
+    setDueDateSynced(null);
     try {
       if (!courseId || !itemId) {
         append('Missing courseId/itemId in the URL.');
@@ -986,6 +988,17 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                 Students can now open and complete this activity inside
                 Classroom.
               </p>
+              {dueDateSynced !== null && (
+                <p
+                  className={`mt-1 text-sm ${
+                    dueDateSynced ? 'text-slate-600' : 'text-amber-700'
+                  }`}
+                >
+                  {dueDateSynced
+                    ? 'Due date set on the Classroom assignment.'
+                    : 'Couldn’t set the Classroom due date automatically — set it in Classroom if you need one.'}
+                </p>
+              )}
             </div>
           </div>
         </AddonCard>
@@ -993,7 +1006,10 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
 
       <div className="mt-4 space-y-2">
         <AddonError message={errorMsg} />
-        {busy && <AddonStatus message={statusMsg} busy />}
+        {/* Persistent (not busy-gated) so the terminal status — including a
+            non-fatal warning like a failed grade-push linkage write — stays
+            visible after the spinner clears. */}
+        <AddonStatus message={statusMsg} busy={busy} />
       </div>
     </AddonShell>
   );

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -48,11 +48,11 @@ import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { resolveResponseDisplayName } from '@/components/widgets/QuizWidget/utils/resolveDisplayName';
 import {
   getDisplayScore,
-  getEarnedPoints,
   getScoreSuffix,
 } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
 import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
 import {
+  buildQuizClassroomGradeEntries,
   pushClassroomGradesForAssignment,
   formatGradePushToast,
 } from '@/utils/classroomGradePush';
@@ -145,7 +145,11 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     };
   }, [kind, code, user]);
 
-  const { session, responses } = useQuizSessionTeacher(sessionId);
+  const {
+    session,
+    responses,
+    loading: sessionLoading,
+  } = useQuizSessionTeacher(sessionId);
 
   // Load the full quiz (answers + points) for the grader + score math. The
   // session carries quizId; match it to the teacher's library for the Drive id.
@@ -276,6 +280,15 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
       setStatusMsg('No completed responses to push yet.');
       return;
     }
+    // Guard the grade scale BEFORE the OAuth popup: a malformed/stale attachment
+    // could carry 0/NaN maxPoints, which would scale every grade to 0 (or NaN).
+    if (!Number.isFinite(attachment.maxPoints) || attachment.maxPoints <= 0) {
+      setErrorMsg(
+        'This assignment is missing its Classroom point total — re-attach it ' +
+          'to push grades.'
+      );
+      return;
+    }
     setBusy(true);
     setErrorMsg(null);
     try {
@@ -285,26 +298,14 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
       );
 
       // Scale each completed student's earned points onto the attachment's grade
-      // scale (== the quiz's total points), mirroring the dashboard monitor.
-      const total =
-        questions.reduce((s, q) => s + (q.points ?? 1), 0) ||
-        attachment.maxPoints;
-      const grades = responses
-        .filter((r) => r.status === 'completed')
-        .map((r) => {
-          const earned = getEarnedPoints(r, questions, session ?? undefined);
-          const scaled =
-            total > 0 ? (earned / total) * attachment.maxPoints : 0;
-          return {
-            pseudonymUid: r.studentUid,
-            pointsEarned: Math.max(
-              0,
-              Math.min(attachment.maxPoints, Math.round(scaled))
-            ),
-          };
-        })
-        .filter((g) => !!g.pseudonymUid);
-
+      // scale (== the quiz's total points) via the shared builder — same scaling
+      // the dashboard monitor (QuizResults) uses, so they can't drift.
+      const grades = buildQuizClassroomGradeEntries(
+        responses,
+        questions,
+        session,
+        attachment.maxPoints
+      );
       if (grades.length === 0) {
         setStatusMsg('No completed responses to push yet.');
         return;
@@ -385,8 +386,12 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     );
   }
 
-  const loading = resolvingSession || (sessionId !== null && !session);
-  const notFound = !resolvingSession && sessionId === null;
+  // Loading while resolving the code, or while the session doc is streaming.
+  // Once both finish with no session (empty-code query, a doc deleted between
+  // resolve and snapshot, or a listener error the hook swallowed), fall to the
+  // not-found state rather than spinning forever.
+  const loading = resolvingSession || (sessionId !== null && sessionLoading);
+  const notFound = !loading && !session;
 
   return (
     <AddonShell>

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -104,7 +104,7 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const loginHint = params.get('login_hint') ?? undefined;
 
   const { user, signInWithGoogle, googleAccessToken, orgId } = useAuth();
-  const { quizzes, loadQuizData } = useQuiz(user?.uid);
+  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
   const { publishAssignmentScores } = useQuizAssignments(user?.uid);
 
   const [busy, setBusy] = useState(false);
@@ -152,9 +152,22 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const [quizData, setQuizData] = useState<QuizData | null>(null);
   useEffect(() => {
     const quizId = session?.quizId;
-    if (!quizId || quizzes.length === 0 || !googleAccessToken) return;
+    // Wait for the library to finish loading (quizzesLoading) rather than for a
+    // non-empty list — an empty library is a legitimate "not found" signal, not
+    // "still loading".
+    if (!quizId || quizzesLoading || !googleAccessToken) return;
     const meta = quizzes.find((q) => q.id === quizId);
-    if (!meta?.driveFileId) return;
+    if (!meta) {
+      // The session's quiz isn't in this teacher's library (e.g. a co-teacher
+      // who doesn't own it) — say so, rather than leaving the grading controls
+      // silently disabled.
+      setErrorMsg(
+        'This quiz isn’t in your SpartBoard library, so it can’t be graded ' +
+          'here. The teacher who created it can grade and push grades.'
+      );
+      return;
+    }
+    if (!meta.driveFileId) return;
     let active = true;
     void (async () => {
       try {
@@ -169,7 +182,13 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     return () => {
       active = false;
     };
-  }, [session?.quizId, quizzes, googleAccessToken, loadQuizData]);
+  }, [
+    session?.quizId,
+    quizzes,
+    quizzesLoading,
+    googleAccessToken,
+    loadQuizData,
+  ]);
 
   const pseudonyms = useAssignmentPseudonymsMulti(
     sessionId,
@@ -251,6 +270,12 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const pushGrades = useCallback(async () => {
     const attachment = session?.classroomAttachment;
     if (!attachment || !quizData) return;
+    // Check for gradeable work BEFORE the OAuth popup — don't prompt the teacher
+    // for Classroom permission only to tell them there's nothing to push.
+    if (!responses.some((r) => r.status === 'completed')) {
+      setStatusMsg('No completed responses to push yet.');
+      return;
+    }
     setBusy(true);
     setErrorMsg(null);
     try {

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -1,0 +1,530 @@
+/**
+ * Google Classroom Add-on TEACHER VIEW — in-iframe quiz grading.
+ *
+ * Route: /classroom-addon/teacher  WITHOUT an addOnToken (Classroom opens the
+ * teacher view of an already-created attachment). The teacher-view URI carries
+ * the quiz join `code` (embedded at attach time), so this view can resolve the
+ * session and let the teacher grade right inside Classroom — no round-trip to
+ * the SpartBoard dashboard.
+ *
+ * LEAN by design (chosen over mounting the full QuizResults): it runs on the
+ * teacher session hook + the quiz library only — NO DashboardProvider, so it
+ * adds no dashboard Firestore listeners. It reuses the real WrittenResponseGrader
+ * modal and the existing publish-scores / push-grades plumbing.
+ *
+ * Flow:
+ *   1. Teacher signs into SpartBoard (Google) — gives the Firebase uid (owns the
+ *      session) + a Drive token (loads the full quiz for grading).
+ *   2. Resolve the quiz_sessions doc id from the join code.
+ *   3. Stream the session + responses (useQuizSessionTeacher) and load the full
+ *      QuizData from Drive (needed: WrittenResponseGrader + score math read the
+ *      real questions/answers, not the answer-stripped publicQuestions).
+ *   4. The teacher can: grade written responses, publish scores to students
+ *      (so the student view shows results — see QuizStudentApp), and push grades
+ *      to Classroom (a DRAFT grade; the final "Return" stays in Classroom — an
+ *      add-on cannot publish final grades).
+ */
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+} from 'firebase/firestore';
+import { ClipboardList, GraduationCap, Send, Eye } from 'lucide-react';
+import { db, functions } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import {
+  useQuizSessionTeacher,
+  getResponseDocKey,
+  QUIZ_SESSIONS_COLLECTION,
+  RESPONSES_COLLECTION,
+} from '@/hooks/useQuizSession';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+import { resolveResponseDisplayName } from '@/components/widgets/QuizWidget/utils/resolveDisplayName';
+import {
+  getDisplayScore,
+  getEarnedPoints,
+  getScoreSuffix,
+} from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
+import {
+  pushClassroomGradesForAssignment,
+  formatGradePushToast,
+} from '@/utils/classroomGradePush';
+import { requestClassroomTeacherToken } from './gisOAuth';
+import { logError } from '@/utils/logError';
+import {
+  isWrittenQuestionType,
+  type QuizData,
+  type QuizScoreVisibility,
+} from '@/types';
+import {
+  AddonShell,
+  AddonHeader,
+  AddonCard,
+  AddonButton,
+  AddonStatus,
+  AddonError,
+  AddonSelect,
+} from './AddonShell';
+
+// Visibility levels the teacher can publish (excludes 'none' = unpublished).
+const PUBLISH_OPTIONS: {
+  value: Exclude<QuizScoreVisibility, 'none'>;
+  label: string;
+}[] = [
+  { value: 'score-only', label: 'Score only' },
+  { value: 'score-and-responses', label: 'Score + their answers' },
+  {
+    value: 'score-responses-and-answers',
+    label: 'Score + answers + correct answers',
+  },
+];
+
+/** Resolve the quiz_sessions doc id from a join code (mirrors the student lookup). */
+function normalizeCode(code: string): string {
+  return code
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+}
+
+export const ClassroomAddonTeacherReview: React.FC = () => {
+  const params =
+    typeof window === 'undefined'
+      ? new URLSearchParams()
+      : new URLSearchParams(window.location.search);
+  const code = params.get('code') ?? '';
+  const kind = params.get('kind') ?? 'quiz';
+  const loginHint = params.get('login_hint') ?? undefined;
+
+  const { user, signInWithGoogle, googleAccessToken, orgId } = useAuth();
+  const { quizzes, loadQuizData } = useQuiz(user?.uid);
+  const { publishAssignmentScores } = useQuizAssignments(user?.uid);
+
+  const [busy, setBusy] = useState(false);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // Resolve the session id from the join code (Firestore query → external sync,
+  // so an effect is the right tool here).
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [resolvingSession, setResolvingSession] = useState(true);
+  useEffect(() => {
+    if (kind !== 'quiz' || !code || !user) {
+      setResolvingSession(false);
+      return;
+    }
+    let active = true;
+    setResolvingSession(true);
+    void (async () => {
+      try {
+        const snap = await getDocs(
+          query(
+            collection(db, QUIZ_SESSIONS_COLLECTION),
+            where('code', '==', normalizeCode(code))
+          )
+        );
+        if (!active) return;
+        setSessionId(snap.empty ? null : snap.docs[0].id);
+      } catch (err) {
+        if (!active) return;
+        logError('ClassroomAddonTeacherReview.resolveSession', err, { code });
+        setErrorMsg("Couldn't load this assignment's responses.");
+      } finally {
+        if (active) setResolvingSession(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [kind, code, user]);
+
+  const { session, responses } = useQuizSessionTeacher(sessionId);
+
+  // Load the full quiz (answers + points) for the grader + score math. The
+  // session carries quizId; match it to the teacher's library for the Drive id.
+  const [quizData, setQuizData] = useState<QuizData | null>(null);
+  useEffect(() => {
+    const quizId = session?.quizId;
+    if (!quizId || quizzes.length === 0 || !googleAccessToken) return;
+    const meta = quizzes.find((q) => q.id === quizId);
+    if (!meta?.driveFileId) return;
+    let active = true;
+    void (async () => {
+      try {
+        const data = await loadQuizData(meta.driveFileId);
+        if (active) setQuizData(data);
+      } catch (err) {
+        if (!active) return;
+        logError('ClassroomAddonTeacherReview.loadQuiz', err, { quizId });
+        setErrorMsg("Couldn't load the quiz for grading.");
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [session?.quizId, quizzes, googleAccessToken, loadQuizData]);
+
+  const pseudonyms = useAssignmentPseudonymsMulti(
+    sessionId,
+    session?.classIds ?? null,
+    orgId
+  );
+
+  const questions = useMemo(() => quizData?.questions ?? [], [quizData]);
+  const hasWritten = useMemo(
+    () => questions.some((q) => isWrittenQuestionType(q.type)),
+    [questions]
+  );
+  const scoreSuffix = getScoreSuffix(session ?? undefined);
+
+  // Per-response display name keyed by the deterministic response-doc key (same
+  // key WrittenResponseGrader + the grade write use). Classroom students are
+  // SSO, so their real name resolves via the pseudonym map (no roster needed);
+  // PIN names would need rosters we don't have in the iframe, so they fall back.
+  const displayNameByResponseKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of responses) {
+      map.set(
+        getResponseDocKey(r),
+        resolveResponseDisplayName(r, {}, pseudonyms.byStudentUid)
+      );
+    }
+    return map;
+  }, [responses, pseudonyms.byStudentUid]);
+
+  const [showGrader, setShowGrader] = useState(false);
+  const [publishVisibility, setPublishVisibility] = useState<
+    Exclude<QuizScoreVisibility, 'none'>
+  >('score-and-responses');
+
+  const saveWrittenGrade = useCallback<
+    React.ComponentProps<typeof WrittenResponseGrader>['onSaveGrade']
+  >(
+    async (responseKey, questionId, grade) => {
+      if (!sessionId) return;
+      await updateDoc(
+        doc(
+          db,
+          QUIZ_SESSIONS_COLLECTION,
+          sessionId,
+          RESPONSES_COLLECTION,
+          responseKey
+        ),
+        { [`grading.${questionId}`]: grade }
+      );
+    },
+    [sessionId]
+  );
+
+  const publish = useCallback(async () => {
+    if (!sessionId || !quizData) return;
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      setStatusMsg('Publishing scores to students…');
+      const { responsesUpdated } = await publishAssignmentScores(
+        sessionId,
+        quizData,
+        publishVisibility
+      );
+      setStatusMsg(
+        `Published — ${responsesUpdated} student${
+          responsesUpdated === 1 ? '' : 's'
+        } can now see their results.`
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logError('ClassroomAddonTeacherReview.publish', err, { sessionId });
+      setErrorMsg(`Couldn't publish scores: ${message}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [sessionId, quizData, publishVisibility, publishAssignmentScores]);
+
+  const pushGrades = useCallback(async () => {
+    const attachment = session?.classroomAttachment;
+    if (!attachment || !quizData) return;
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      setStatusMsg('Granting Classroom permission…');
+      const accessToken = await requestClassroomTeacherToken(
+        user?.email ?? loginHint
+      );
+
+      // Scale each completed student's earned points onto the attachment's grade
+      // scale (== the quiz's total points), mirroring the dashboard monitor.
+      const total =
+        questions.reduce((s, q) => s + (q.points ?? 1), 0) ||
+        attachment.maxPoints;
+      const grades = responses
+        .filter((r) => r.status === 'completed')
+        .map((r) => {
+          const earned = getEarnedPoints(r, questions, session ?? undefined);
+          const scaled =
+            total > 0 ? (earned / total) * attachment.maxPoints : 0;
+          return {
+            pseudonymUid: r.studentUid,
+            pointsEarned: Math.max(
+              0,
+              Math.min(attachment.maxPoints, Math.round(scaled))
+            ),
+          };
+        })
+        .filter((g) => !!g.pseudonymUid);
+
+      if (grades.length === 0) {
+        setStatusMsg('No completed responses to push yet.');
+        return;
+      }
+
+      setStatusMsg('Pushing grades to Google Classroom…');
+      const data = await pushClassroomGradesForAssignment(functions, {
+        courseId: attachment.courseId,
+        itemId: attachment.itemId,
+        attachmentId: attachment.attachmentId,
+        accessToken,
+        grades,
+      });
+      setStatusMsg(`${formatGradePushToast(data)} Return them in Classroom.`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logError('ClassroomAddonTeacherReview.pushGrades', err, {
+        sessionId,
+      });
+      setErrorMsg(`Couldn't push grades: ${message}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    session,
+    quizData,
+    questions,
+    responses,
+    user?.email,
+    loginHint,
+    sessionId,
+  ]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (kind !== 'quiz') {
+    // Video-activity grading-in-iframe is a separate runner (its own Results
+    // component) — out of scope for this lean quiz grader.
+    return (
+      <AddonShell maxWidthClassName="max-w-md">
+        <AddonHeader
+          icon={GraduationCap}
+          title="Review in SpartBoard"
+          subtitle="Open this video activity's results from the SpartBoard dashboard to grade and push grades."
+        />
+      </AddonShell>
+    );
+  }
+
+  if (!user) {
+    return (
+      <AddonShell maxWidthClassName="max-w-md">
+        <AddonHeader
+          icon={GraduationCap}
+          title="Grade this assignment"
+          subtitle="Sign in with your school Google account to review and grade student work right here."
+        />
+        <AddonCard className="p-6">
+          <AddonButton
+            onClick={() => {
+              setErrorMsg(null);
+              void signInWithGoogle().catch((err: unknown) => {
+                setErrorMsg(
+                  `Couldn't sign in: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`
+                );
+              });
+            }}
+          >
+            Sign in to SpartBoard
+          </AddonButton>
+        </AddonCard>
+        <div className="mt-4">
+          <AddonError message={errorMsg} />
+        </div>
+      </AddonShell>
+    );
+  }
+
+  const loading = resolvingSession || (sessionId !== null && !session);
+  const notFound = !resolvingSession && sessionId === null;
+
+  return (
+    <AddonShell>
+      <AddonHeader
+        icon={GraduationCap}
+        title="Grade this assignment"
+        subtitle={session?.quizTitle ?? 'Review and grade student work.'}
+      />
+
+      {loading ? (
+        <AddonCard className="p-6">
+          <AddonStatus message="Loading responses…" busy />
+        </AddonCard>
+      ) : notFound ? (
+        <AddonError message="This assignment's session is no longer available." />
+      ) : (
+        <div className="space-y-4">
+          {/* Response list */}
+          <AddonCard className="p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-sm font-semibold text-slate-900">
+                Responses
+              </h2>
+              <span className="text-xs text-slate-500">
+                {responses.length} student{responses.length === 1 ? '' : 's'}
+              </span>
+            </div>
+            {responses.length === 0 ? (
+              <p className="text-sm text-slate-500">
+                No responses yet — students who open and complete the assignment
+                in Classroom will appear here.
+              </p>
+            ) : (
+              <ul className="divide-y divide-slate-100">
+                {responses.map((r) => {
+                  const key = getResponseDocKey(r);
+                  const name = displayNameByResponseKey.get(key) ?? 'Student';
+                  const done = r.status === 'completed';
+                  return (
+                    <li
+                      key={key}
+                      className="flex items-center justify-between gap-3 py-2.5 text-sm"
+                    >
+                      <span className="min-w-0 truncate text-slate-700">
+                        {name}
+                      </span>
+                      <span className="flex shrink-0 items-center gap-2">
+                        <span className="font-semibold text-slate-900">
+                          {Math.round(
+                            getDisplayScore(r, questions, session ?? undefined)
+                          )}
+                          {scoreSuffix}
+                        </span>
+                        <span
+                          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                            done
+                              ? 'bg-emerald-50 text-emerald-700'
+                              : 'bg-slate-100 text-slate-500'
+                          }`}
+                        >
+                          {done ? 'Done' : 'In progress'}
+                        </span>
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </AddonCard>
+
+          {/* Actions */}
+          <AddonCard className="space-y-4 p-4">
+            {hasWritten && (
+              <div>
+                <p className="mb-1.5 text-sm font-medium text-slate-700">
+                  Written responses
+                </p>
+                <AddonButton
+                  variant="secondary"
+                  icon={ClipboardList}
+                  disabled={!quizData || responses.length === 0}
+                  onClick={() => setShowGrader(true)}
+                >
+                  Grade written responses
+                </AddonButton>
+              </div>
+            )}
+
+            <div>
+              <label
+                htmlFor="addon-publish-visibility"
+                className="mb-1.5 block text-sm font-medium text-slate-700"
+              >
+                Show results to students
+              </label>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <div className="sm:flex-1">
+                  <AddonSelect
+                    id="addon-publish-visibility"
+                    ariaLabel="What students can see"
+                    value={publishVisibility}
+                    onChange={(v) =>
+                      setPublishVisibility(
+                        v as Exclude<QuizScoreVisibility, 'none'>
+                      )
+                    }
+                    placeholder="What students see"
+                    options={PUBLISH_OPTIONS}
+                  />
+                </div>
+                <AddonButton
+                  variant="secondary"
+                  icon={Eye}
+                  loading={busy}
+                  disabled={!quizData}
+                  onClick={() => void publish()}
+                >
+                  Publish scores
+                </AddonButton>
+              </div>
+              <p className="mt-1.5 text-xs text-slate-500">
+                Students see their results when they reopen the assignment.
+              </p>
+            </div>
+
+            {session?.classroomAttachment && (
+              <div className="border-t border-slate-100 pt-4">
+                <AddonButton
+                  icon={Send}
+                  loading={busy}
+                  disabled={!quizData}
+                  onClick={() => void pushGrades()}
+                >
+                  Push grades to Classroom
+                </AddonButton>
+                <p className="mt-1.5 text-xs text-slate-500">
+                  Sends each student a draft grade. Open the assignment in
+                  Classroom to review and Return them.
+                </p>
+              </div>
+            )}
+          </AddonCard>
+        </div>
+      )}
+
+      <div className="mt-4 space-y-2">
+        <AddonError message={errorMsg} />
+        {busy && <AddonStatus message={statusMsg} busy />}
+        {!busy && statusMsg && !errorMsg && <AddonStatus message={statusMsg} />}
+      </div>
+
+      {showGrader && quizData && sessionId && user?.uid && (
+        <WrittenResponseGrader
+          quiz={quizData}
+          responses={responses}
+          displayNameByResponseKey={displayNameByResponseKey}
+          teacherUid={user.uid}
+          onSaveGrade={saveWrittenGrade}
+          onClose={() => setShowGrader(false)}
+        />
+      )}
+    </AddonShell>
+  );
+};
+
+export default ClassroomAddonTeacherReview;

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -645,6 +645,26 @@ const QuizJoinFlow: React.FC<{ isStudentRole: boolean }> = ({
     myResponse &&
     (myResponse.status === 'completed' || atCap)
   ) {
+    // If the teacher has PUBLISHED results to students (scoreVisibility set on
+    // the archived assignment via "Publish Scores"), a completed student should
+    // see their results immediately — even while the session is still 'active'.
+    // A self-paced / async assignment (e.g. a Google Classroom attachment) never
+    // gets "ended" by a live teacher, so without this a completed student is
+    // stranded on the "waiting for the teacher to end the quiz" screen and can
+    // never see the score the teacher already published. Until results are
+    // published (scoreVisibility 'none'), fall back to the submitted-wait
+    // screen as before. Mirrors the post-end ResultsScreen branch.
+    const publishedVisibility = session.scoreVisibility ?? 'none';
+    if (publishedVisibility !== 'none' && myResponse.status === 'completed') {
+      return (
+        <PublishedScoreReview
+          session={session}
+          myResponse={myResponse}
+          visibility={publishedVisibility}
+          pin={pin}
+        />
+      );
+    }
     return (
       <QuizSubmittedWaitScreen
         session={session}

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -68,6 +68,7 @@ import { WrittenResponseGrader } from './WrittenResponseGrader';
 import { doc, updateDoc } from 'firebase/firestore';
 import { db, functions } from '@/config/firebase';
 import {
+  buildQuizClassroomGradeEntries,
   pushClassroomGradesForAssignment,
   formatGradePushToast,
 } from '@/utils/classroomGradePush';
@@ -1075,34 +1076,18 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     );
     if (!confirmed) return;
 
-    // The current quiz total can drift from the Classroom denominator
-    // (`maxPoints`, frozen at attach time) if the quiz was edited after
-    // attaching. Scale each student's earned score onto the frozen denominator
-    // so the pushed ratio stays correct. When the quiz is unchanged
-    // (`currentTotal === maxPoints`) the scale is a no-op and this equals the
-    // raw earned points (preserves the original "same number" behavior); when
-    // edited, it pushes the correct ratio against the frozen denominator.
-    // Computed AFTER the confirm so it reflects any edit that landed while the
-    // dialog was open.
-    const currentTotal = quiz.questions.reduce(
-      (s, q) => s + (q.points ?? 1),
-      0
+    // Build the PII-free grade payload via the shared scaler (the single source
+    // of truth also used by the in-iframe grader, TeacherReviewRoute, so the two
+    // can't drift): each completed student's raw earned points are scaled onto
+    // the frozen Classroom denominator (`maxPoints`), then rounded + clamped to
+    // [0, maxPoints], with a non-finite score treated as 0. Built AFTER the
+    // confirm so it reflects any edit that landed while the dialog was open.
+    const grades = buildQuizClassroomGradeEntries(
+      completed,
+      quiz.questions,
+      session,
+      maxPoints
     );
-
-    // Build the PII-free grade payload: one entry per completed, scored
-    // response. `getEarnedPoints` returns the raw points on the current scale;
-    // scale onto the Classroom denominator, then round + clamp to [0, maxPoints].
-    const grades = eligible.map((r) => {
-      // Guard against a non-finite score (e.g. missing answers) so it can't
-      // propagate NaN through the clamp and make the CF reject the entry.
-      const rawPoints = getEarnedPoints(r, quiz.questions, session);
-      const earned = Number.isFinite(rawPoints) ? rawPoints : 0;
-      const scaled = currentTotal > 0 ? (earned / currentTotal) * maxPoints : 0;
-      return {
-        pseudonymUid: r.studentUid,
-        pointsEarned: Math.max(0, Math.min(maxPoints, Math.round(scaled))),
-      };
-    });
 
     setPushingGrades(true);
     try {

--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -466,7 +466,7 @@ describe('classroomAddonLoginV1 (spike)', () => {
 // never be able to create an attachment.
 const callAttach = createClassroomAttachment as unknown as (req: {
   data: unknown;
-}) => Promise<{ attachmentId: string }>;
+}) => Promise<{ attachmentId: string; dueDateSynced?: boolean }>;
 
 const TEACHER_CTX = {
   ok: true,
@@ -691,6 +691,77 @@ describe('createClassroomAttachment (spike)', () => {
       code: 'internal',
     });
   });
+
+  it('PATCHes the parent courseWork due date (UTC) when dueAtMs is provided', async () => {
+    vi.spyOn(classroomAddonNet, 'fetchAddOnContext').mockResolvedValue(
+      TEACHER_CTX
+    );
+    vi.spyOn(classroomAddonNet, 'createAttachment').mockResolvedValue({
+      ok: true,
+      status: 200,
+      id: 'ATT123',
+    });
+    const dueSpy = vi
+      .spyOn(classroomAddonNet, 'patchCourseWorkDueDate')
+      .mockResolvedValue({ ok: true, status: 200 });
+
+    // A fixed absolute instant: 2026-06-04 20:06 UTC. The CF extracts the UTC
+    // wall-clock, so the asserted fields are timezone-independent.
+    const dueAtMs = Date.UTC(2026, 5, 4, 20, 6, 0, 0);
+    const res = await callAttach({ data: { ...attachData, dueAtMs } });
+
+    expect(res.attachmentId).toBe('ATT123');
+    expect(res.dueDateSynced).toBe(true);
+    // courseWorkId == itemId; month is 1-based for the Classroom API.
+    expect(dueSpy).toHaveBeenCalledWith(
+      'teacher-at',
+      'C1',
+      'I1',
+      { year: 2026, month: 6, day: 4 },
+      { hours: 20, minutes: 6 }
+    );
+  });
+
+  it('does NOT patch the due date when dueAtMs is absent', async () => {
+    vi.spyOn(classroomAddonNet, 'fetchAddOnContext').mockResolvedValue(
+      TEACHER_CTX
+    );
+    vi.spyOn(classroomAddonNet, 'createAttachment').mockResolvedValue({
+      ok: true,
+      status: 200,
+      id: 'ATT123',
+    });
+    const dueSpy = vi.spyOn(classroomAddonNet, 'patchCourseWorkDueDate');
+
+    const res = await callAttach({ data: attachData });
+
+    expect(res.attachmentId).toBe('ATT123');
+    expect(dueSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the attachment when the due-date patch fails (non-fatal)', async () => {
+    vi.spyOn(classroomAddonNet, 'fetchAddOnContext').mockResolvedValue(
+      TEACHER_CTX
+    );
+    vi.spyOn(classroomAddonNet, 'createAttachment').mockResolvedValue({
+      ok: true,
+      status: 200,
+      id: 'ATT123',
+    });
+    vi.spyOn(classroomAddonNet, 'patchCourseWorkDueDate').mockResolvedValue({
+      ok: false,
+      status: 403,
+    });
+
+    const res = await callAttach({
+      data: { ...attachData, dueAtMs: Date.UTC(2026, 5, 4, 20, 6, 0, 0) },
+    });
+
+    // The attachment is created regardless; only the optional due-date sync
+    // failed (e.g. missing scope) — the attach flow does not throw.
+    expect(res.attachmentId).toBe('ATT123');
+    expect(res.dueDateSynced).toBe(false);
+  });
 });
 
 // Regression: every other test stubs fetchAddOnContext wholesale, so the real
@@ -802,6 +873,43 @@ describe('classroomAddonNet.patchStudentSubmissionGrade URL construction', () =>
     );
     expect(calledInit.method).toBe('PATCH');
     expect(JSON.parse(calledInit.body ?? '{}')).toEqual({ pointsEarned: 8 });
+    vi.unstubAllGlobals();
+  });
+});
+
+// The courseWork due-date PATCH seam used to sync the add-on picker's date onto
+// the parent assignment. The createClassroomAttachment tests stub this seam, so
+// this standalone test pins the real URL/updateMask/body it builds against a
+// stubbed fetch (mirrors the addOnContext / studentSubmissions URL tests).
+describe('classroomAddonNet.patchCourseWorkDueDate URL construction', () => {
+  it('issues the correct courseWork PATCH URL, updateMask, and body (real seam)', async () => {
+    let calledUrl = '';
+    let calledInit: { method?: string; body?: string } = {};
+    const fetchMock = vi.fn(async (url: unknown, init: unknown) => {
+      calledUrl = url as string;
+      calledInit = init as { method?: string; body?: string };
+      return { ok: true, status: 200, json: async () => ({}) };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await classroomAddonNet.patchCourseWorkDueDate(
+      'tok',
+      'C1',
+      'I1',
+      { year: 2026, month: 6, day: 4 },
+      { hours: 20, minutes: 6 }
+    );
+
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(calledUrl).toBe(
+      'https://classroom.googleapis.com/v1/courses/C1/courseWork/I1' +
+        '?updateMask=dueDate,dueTime'
+    );
+    expect(calledInit.method).toBe('PATCH');
+    expect(JSON.parse(calledInit.body ?? '{}')).toEqual({
+      dueDate: { year: 2026, month: 6, day: 4 },
+      dueTime: { hours: 20, minutes: 6 },
+    });
     vi.unstubAllGlobals();
   });
 });

--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -513,8 +513,10 @@ describe('createClassroomAttachment (spike)', () => {
       studentWorkReviewUri?: { uri: string };
       maxPoints?: number;
     };
+    // The teacher view now carries the SAME content ref as the student view so
+    // the iframe can resolve the session and render the in-place grading view.
     expect(body.teacherViewUri.uri).toBe(
-      'https://spartboard.web.app/classroom-addon/teacher'
+      'https://spartboard.web.app/classroom-addon/teacher?code=ABC123&kind=quiz'
     );
     // The studentViewUri carries the quiz join code so the student route can
     // hand it to QuizStudentApp (which SSO-auto-joins by ?code=). `code` MUST
@@ -554,11 +556,16 @@ describe('createClassroomAttachment (spike)', () => {
     expect(res.attachmentId).toBe('ATT-VA');
     const body = createSpy.mock.calls[0][5] as {
       studentViewUri: { uri: string };
+      teacherViewUri: { uri: string };
       studentWorkReviewUri?: { uri: string };
       maxPoints?: number;
     };
     expect(body.studentViewUri.uri).toBe(
       'https://spartboard.web.app/classroom-addon/student?kind=va&sessionId=sess_AB-12'
+    );
+    // The teacher view carries the same VA content ref for in-place review.
+    expect(body.teacherViewUri.uri).toBe(
+      'https://spartboard.web.app/classroom-addon/teacher?kind=va&sessionId=sess_AB-12'
     );
     // No `code=` for the VA runner.
     expect(body.studentViewUri.uri).not.toContain('code=');

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -152,6 +152,10 @@ interface CreateAttachmentData {
   // the attachment is created grade-sync capable (studentWorkReviewUri +
   // maxPoints); the DRAFT grade later populates via pushClassroomGrade.
   maxPoints?: unknown;
+  // Optional due date (epoch-ms, from the add-on's custom picker). When present
+  // on a courseWork item, we PATCH the PARENT courseWork's dueDate/dueTime so it
+  // shows as THE Classroom assignment due date — the teacher enters it once.
+  dueAtMs?: unknown;
 }
 
 /**
@@ -423,6 +427,49 @@ export const classroomAddonNet = {
     } catch (err) {
       console.warn(
         '[pushClassroomGrade] studentSubmissions.patch failed:',
+        err
+      );
+      return { ok: false, status: 0 };
+    }
+  },
+
+  /**
+   * PATCH the PARENT courseWork's due date so the date the teacher picks in the
+   * add-on shows as THE Classroom assignment due date (not just a SpartBoard
+   * value) — they enter it once. Requires the teacher's access token to carry
+   * the `classroom.coursework.students` scope. `updateMask=dueDate,dueTime`
+   * scopes the PATCH to those two fields; both are UTC, as the Classroom API
+   * requires. Seam so tests can stub it without a live course.
+   */
+  async patchCourseWorkDueDate(
+    accessToken: string,
+    courseId: string,
+    courseWorkId: string,
+    dueDate: { year: number; month: number; day: number },
+    dueTime: { hours: number; minutes: number }
+  ): Promise<{ ok: boolean; status: number }> {
+    const url =
+      `${CLASSROOM_API}/courses/${encodeURIComponent(courseId)}` +
+      `/courseWork/${encodeURIComponent(courseWorkId)}` +
+      `?updateMask=dueDate,dueTime`;
+    try {
+      const res = await fetch(url, {
+        method: 'PATCH',
+        headers: { ...bearer(accessToken), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dueDate, dueTime }),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        console.warn(
+          `[createClassroomAttachment] courseWork.patch dueDate ${res.status} ` +
+            `${courseId}/${courseWorkId}`
+        );
+        return { ok: false, status: res.status };
+      }
+      return { ok: true, status: res.status };
+    } catch (err) {
+      console.warn(
+        '[createClassroomAttachment] courseWork.patch dueDate failed:',
         err
       );
       return { ok: false, status: 0 };
@@ -817,7 +864,36 @@ export const createClassroomAttachment = onCall(
       );
     }
 
-    return { attachmentId: createResult.id };
+    // Optionally sync the teacher's chosen due date onto the PARENT courseWork
+    // so it shows as the Classroom assignment due date (one entry — they don't
+    // re-type it in Classroom's own composer). Only courseWork has a due date,
+    // and it requires the classroom.coursework.students scope on the teacher
+    // token. Best-effort: a failure here NEVER fails the attach — the activity
+    // is already attached and the teacher can set the date manually. `dueAtMs`
+    // is an absolute instant; UTC extraction gives the UTC wall-clock the
+    // Classroom API expects.
+    let dueDateSynced = false;
+    const dueAtMs =
+      typeof data.dueAtMs === 'number' && Number.isFinite(data.dueAtMs)
+        ? data.dueAtMs
+        : null;
+    if (dueAtMs !== null && itemType === 'courseWork') {
+      const d = new Date(dueAtMs);
+      const patchResult = await classroomAddonNet.patchCourseWorkDueDate(
+        accessToken,
+        courseId,
+        itemId,
+        {
+          year: d.getUTCFullYear(),
+          month: d.getUTCMonth() + 1,
+          day: d.getUTCDate(),
+        },
+        { hours: d.getUTCHours(), minutes: d.getUTCMinutes() }
+      );
+      dueDateSynced = patchResult.ok;
+    }
+
+    return { attachmentId: createResult.id, dueDateSynced };
   }
 );
 

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -752,10 +752,10 @@ export const createClassroomAttachment = onCall(
       throw new HttpsError('invalid-argument', 'origin is missing or invalid.');
     }
 
-    // Build the runner-specific studentViewUri. Each identifier is embedded
-    // verbatim into the stored URI, so each is charset-constrained — never
-    // relay arbitrary client text into a stored URI.
-    let studentViewUri: string;
+    // Build the runner-specific content query shared by BOTH view URIs. Each
+    // identifier is embedded verbatim into the stored URI, so each is
+    // charset-constrained — never relay arbitrary client text into a stored URI.
+    let contentQuery: string;
     if (kind === 'va') {
       // Video Activity session ids are SpartBoard-minted; allow the alnum + _-
       // charset Firestore session ids use.
@@ -765,9 +765,7 @@ export const createClassroomAttachment = onCall(
           'sessionId is required and malformed for a video-activity attachment.'
         );
       }
-      studentViewUri =
-        `${origin}/classroom-addon/student?kind=va` +
-        `&sessionId=${encodeURIComponent(sessionId)}`;
+      contentQuery = `kind=va&sessionId=${encodeURIComponent(sessionId)}`;
     } else {
       // Quiz: join codes are short uppercase alphanumerics. `code` is kept for
       // backward compatibility; `kind=quiz` is appended but non-load-bearing.
@@ -777,10 +775,13 @@ export const createClassroomAttachment = onCall(
           'quizCode is missing or malformed.'
         );
       }
-      studentViewUri =
-        `${origin}/classroom-addon/student?code=${encodeURIComponent(quizCode)}` +
-        `&kind=quiz`;
+      contentQuery = `code=${encodeURIComponent(quizCode)}&kind=quiz`;
     }
+    const studentViewUri = `${origin}/classroom-addon/student?${contentQuery}`;
+    // The teacher view carries the SAME content ref so, when a teacher opens the
+    // attachment, the iframe can resolve the session and render the grading view
+    // in-place (no round-trip to the SpartBoard dashboard).
+    const teacherViewUri = `${origin}/classroom-addon/teacher?${contentQuery}`;
 
     // Title is display-only; cap length and fall back to a sensible default.
     const title = (rawTitle || 'SpartBoard activity').slice(0, 200);
@@ -829,7 +830,7 @@ export const createClassroomAttachment = onCall(
 
     const body: AddOnAttachmentBody = {
       title,
-      teacherViewUri: { uri: `${origin}/classroom-addon/teacher` },
+      teacherViewUri: { uri: teacherViewUri },
       studentViewUri: { uri: studentViewUri },
     };
     // Make the attachment grade-sync capable. `maxPoints` is invalid without

--- a/tests/components/quiz/QuizStudentApp.publishedResults.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.publishedResults.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Coverage for the "published results on a still-active session" gate in
+ * QuizStudentApp (QuizJoinFlow). A Google Classroom attachment runs self-paced,
+ * so the session never transitions to 'ended' — without this gate a completed
+ * student is stranded on the "waiting for the teacher to end the quiz" screen
+ * and can never see a score the teacher already published.
+ *
+ * The gate (paraphrased): when status==='active' && myResponse is completed (or
+ * at the attempt cap), render PublishedScoreReview iff the teacher has published
+ * (scoreVisibility !== 'none') AND the response is actually completed; otherwise
+ * fall back to QuizSubmittedWaitScreen.
+ *
+ * Discriminators: PublishedScoreReview renders <h1>Your Results</h1>;
+ * QuizSubmittedWaitScreen renders <h1>Quiz Submitted!</h1>.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type { QuizSession, QuizResponse, QuizPublicQuestion } from '@/types';
+
+const { mockAuth, mockJoinQuizSession, hookState } = vi.hoisted(() => {
+  type MockUser = {
+    uid: string;
+    isAnonymous: boolean;
+    displayName: string | null;
+    getIdTokenResult: () => Promise<{ claims: Record<string, unknown> }>;
+  };
+  return {
+    mockAuth: {
+      onAuthStateChanged: vi.fn(),
+      authStateReady: vi.fn().mockResolvedValue(undefined),
+      currentUser: null as MockUser | null,
+    },
+    mockJoinQuizSession: vi.fn(),
+    hookState: {
+      session: null as QuizSession | null,
+      myResponse: null as QuizResponse | null,
+    },
+  };
+});
+
+vi.mock('@/config/firebase', () => ({
+  isConfigured: false,
+  isAuthBypass: false,
+  app: {},
+  db: {},
+  auth: mockAuth,
+  storage: {},
+  functions: {},
+  GOOGLE_OAUTH_SCOPES: [] as string[],
+  googleProvider: {},
+}));
+
+vi.mock('firebase/auth', () => ({
+  signInAnonymously: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => () => undefined),
+}));
+
+vi.mock('@/hooks/useQuizSession', () => ({
+  useQuizSessionStudent: () => ({
+    session: hookState.session,
+    myResponse: hookState.myResponse,
+    loading: false,
+    error: null,
+    lookupSession: vi.fn(),
+    joinQuizSession: mockJoinQuizSession,
+    subscribeForReview: vi.fn(),
+    submitAnswer: vi.fn(),
+    completeQuiz: vi.fn(),
+    reportTabSwitch: vi.fn(),
+    warningCount: 0,
+  }),
+  normalizeAnswer: (s: string) => s,
+}));
+
+import { QuizStudentApp } from '@/components/quiz/QuizStudentApp';
+
+const QUESTIONS: QuizPublicQuestion[] = [
+  { id: 'q1', type: 'MC', text: '2 + 2?', timeLimit: 0, choices: ['3', '4'] },
+];
+
+function buildSession(overrides: Partial<QuizSession> = {}): QuizSession {
+  return {
+    id: 'session-1',
+    assignmentId: 'asn-1',
+    quizId: 'quiz-1',
+    quizTitle: 'Test quiz',
+    teacherUid: 'teacher-1',
+    status: 'active',
+    sessionMode: 'student',
+    currentQuestionIndex: 0,
+    startedAt: 1,
+    endedAt: null,
+    code: 'ABC123',
+    totalQuestions: QUESTIONS.length,
+    publicQuestions: QUESTIONS,
+    ...overrides,
+  };
+}
+
+function buildResponse(overrides: Partial<QuizResponse> = {}): QuizResponse {
+  return {
+    studentUid: 'sso-uid-1',
+    joinedAt: 1,
+    status: 'completed',
+    answers: [],
+    score: 80,
+    submittedAt: 2,
+    completedAttempts: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuth.currentUser = {
+    uid: 'sso-uid-1',
+    isAnonymous: false,
+    displayName: 'Test Student',
+    getIdTokenResult: () => Promise.resolve({ claims: { studentRole: true } }),
+  };
+  mockJoinQuizSession.mockResolvedValue('session-1');
+  window.history.replaceState({}, '', '/quiz?code=ABC123');
+});
+
+describe('QuizStudentApp — published results on an active (self-paced) session', () => {
+  it('shows the results review to a completed student once scores are published', async () => {
+    hookState.session = buildSession({ scoreVisibility: 'score-only' });
+    hookState.myResponse = buildResponse({ status: 'completed' });
+
+    render(<QuizStudentApp />);
+
+    expect(await screen.findByText('Your Results')).toBeInTheDocument();
+    expect(screen.queryByText('Quiz Submitted!')).not.toBeInTheDocument();
+  });
+
+  it('keeps a completed student on the submitted-wait screen until scores are published', async () => {
+    // scoreVisibility absent (defaults to 'none') → not yet published.
+    hookState.session = buildSession();
+    hookState.myResponse = buildResponse({ status: 'completed' });
+
+    render(<QuizStudentApp />);
+
+    expect(await screen.findByText('Quiz Submitted!')).toBeInTheDocument();
+    expect(screen.queryByText('Your Results')).not.toBeInTheDocument();
+  });
+
+  it('does NOT show results for an at-cap response that is not actually completed (even if published)', async () => {
+    // atCap (1/1 attempts) but the response status is still 'joined' — the gate
+    // must require status==='completed' to reveal the published review.
+    hookState.session = buildSession({
+      scoreVisibility: 'score-only',
+      attemptLimit: 1,
+    });
+    hookState.myResponse = buildResponse({
+      status: 'joined',
+      completedAttempts: 1,
+    });
+
+    render(<QuizStudentApp />);
+
+    expect(await screen.findByText('Quiz Submitted!')).toBeInTheDocument();
+    expect(screen.queryByText('Your Results')).not.toBeInTheDocument();
+  });
+});

--- a/tests/utils/classroomGradePush.test.ts
+++ b/tests/utils/classroomGradePush.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit coverage for buildQuizClassroomGradeEntries — the shared scaling that
+ * turns quiz responses into the Classroom grade payload. This is the single
+ * source of truth for both QuizResults (dashboard) and TeacherReviewRoute
+ * (in-iframe grader), so the scaling/clamp/finite-guard behavior is pinned here
+ * once. getEarnedPoints is mocked to a controllable per-response value so these
+ * tests exercise the scaling layer, not the (separately tested) scoring engine.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { QuizQuestion, QuizResponse } from '@/types';
+
+vi.mock('@/components/widgets/QuizWidget/utils/quizScoreboard', () => ({
+  // Return the test-only `__earned` field stashed on each response.
+  getEarnedPoints: (r: { __earned: number }) => r.__earned,
+}));
+
+import { buildQuizClassroomGradeEntries } from '@/utils/classroomGradePush';
+
+/** Minimal question carrying only the `points` the scaler reads. */
+const q = (points: number): QuizQuestion =>
+  ({ id: `q${points}`, type: 'MC', points }) as unknown as QuizQuestion;
+
+/** Minimal response carrying status/studentUid + a stubbed earned score. */
+const resp = (
+  studentUid: string,
+  status: QuizResponse['status'],
+  earned: number
+): QuizResponse =>
+  ({ studentUid, status, __earned: earned }) as unknown as QuizResponse;
+
+describe('buildQuizClassroomGradeEntries', () => {
+  it('is an identity scale when the quiz total equals maxPoints', () => {
+    const grades = buildQuizClassroomGradeEntries(
+      [resp('u1', 'completed', 17)],
+      [q(20)],
+      null,
+      20
+    );
+    expect(grades).toEqual([{ pseudonymUid: 'u1', pointsEarned: 17 }]);
+  });
+
+  it('rescales onto maxPoints when the quiz total drifts (edited after attach)', () => {
+    // earned 5 of total 10, scaled onto a frozen maxPoints of 20 → 10.
+    const grades = buildQuizClassroomGradeEntries(
+      [resp('u1', 'completed', 5)],
+      [q(10)],
+      null,
+      20
+    );
+    expect(grades[0].pointsEarned).toBe(10);
+  });
+
+  it('rounds, and clamps to [0, maxPoints]', () => {
+    // 1 of 3 onto 10 → 3.33 → round 3.
+    expect(
+      buildQuizClassroomGradeEntries(
+        [resp('u', 'completed', 1)],
+        [q(3)],
+        null,
+        10
+      )[0].pointsEarned
+    ).toBe(3);
+    // earned beyond the total clamps to maxPoints.
+    expect(
+      buildQuizClassroomGradeEntries(
+        [resp('u', 'completed', 99)],
+        [q(10)],
+        null,
+        10
+      )[0].pointsEarned
+    ).toBe(10);
+  });
+
+  it('treats a non-finite earned score as 0 (never propagates NaN)', () => {
+    const grades = buildQuizClassroomGradeEntries(
+      [resp('u', 'completed', Number.NaN)],
+      [q(10)],
+      null,
+      10
+    );
+    expect(grades[0].pointsEarned).toBe(0);
+    expect(Number.isNaN(grades[0].pointsEarned)).toBe(false);
+  });
+
+  it('returns 0 when the quiz total is 0 (no divide-by-zero)', () => {
+    const grades = buildQuizClassroomGradeEntries(
+      [resp('u', 'completed', 5)],
+      [q(0)],
+      null,
+      10
+    );
+    expect(grades[0].pointsEarned).toBe(0);
+  });
+
+  it('includes only completed responses with a resolvable pseudonym', () => {
+    const grades = buildQuizClassroomGradeEntries(
+      [
+        resp('u1', 'completed', 5),
+        resp('u2', 'in-progress', 5),
+        resp('', 'completed', 5),
+      ],
+      [q(10)],
+      null,
+      10
+    );
+    expect(grades).toEqual([{ pseudonymUid: 'u1', pointsEarned: 5 }]);
+  });
+});

--- a/utils/classroomGradePush.ts
+++ b/utils/classroomGradePush.ts
@@ -19,11 +19,48 @@
  */
 
 import { httpsCallable, type Functions } from 'firebase/functions';
+import { getEarnedPoints } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+import type { QuizQuestion, QuizResponse, QuizSession } from '@/types';
 
 /** A single PII-free grade entry: ClassLink pseudonym → earned points. */
 export interface ClassroomGradeEntry {
   pseudonymUid: string;
   pointsEarned: number;
+}
+
+/**
+ * Build the quiz grade payload for a Classroom push — the single source of truth
+ * shared by the dashboard monitor (QuizResults) and the in-iframe grader
+ * (TeacherReviewRoute) so their scaling can't drift.
+ *
+ * One entry per COMPLETED response with a resolvable pseudonym. The current quiz
+ * total can drift from the Classroom denominator (`maxPoints`, frozen at attach
+ * time) if the quiz was edited after attaching, so each student's raw earned
+ * points are scaled onto `maxPoints`, then rounded and clamped to [0, maxPoints].
+ * A non-finite earned score (e.g. a malformed question) is treated as 0 so NaN
+ * can never propagate into the payload (the CF would otherwise reject it).
+ *
+ * Callers must still validate `maxPoints` (finite & > 0) and surface an
+ * actionable message — this helper assumes a valid denominator.
+ */
+export function buildQuizClassroomGradeEntries(
+  responses: QuizResponse[],
+  questions: QuizQuestion[],
+  session: QuizSession | null | undefined,
+  maxPoints: number
+): ClassroomGradeEntry[] {
+  const currentTotal = questions.reduce((s, q) => s + (q.points ?? 1), 0);
+  return responses
+    .filter((r) => r.status === 'completed' && !!r.studentUid)
+    .map((r) => {
+      const rawPoints = getEarnedPoints(r, questions, session ?? undefined);
+      const earned = Number.isFinite(rawPoints) ? rawPoints : 0;
+      const scaled = currentTotal > 0 ? (earned / currentTotal) * maxPoints : 0;
+      return {
+        pseudonymUid: r.studentUid,
+        pointsEarned: Math.max(0, Math.min(maxPoints, Math.round(scaled))),
+      };
+    });
 }
 
 /** Arguments the `pushClassroomGradesForAssignment` callable accepts. */


### PR DESCRIPTION
Polishes the Google Classroom add-on from its de-risk **spike** state into a shippable teacher/student experience, and closes the gaps surfaced after live-verifying assignment creation, student access, quiz completion, and grade passback.

Branch is off `dev-paul`; each workstream is its own commit (plus a couple of follow-up fixes from review).

## What changed

**A — Brand redesign of both iframes** (`feat: redesign…`, `fix: AddonSelect…`, `refactor: light theme`)
- Rebuilt the attachment-setup and student-view routes on a shared, brand-aligned UI kit (`AddonShell`): scrollable shell (works inside Classroom's fixed iframe), glass-free **light** cards, brand-blue accents, status line + error banner.
- Removed **all** spike debug surfaces (courseId/itemId/addOnToken table, "current session" dump, scrolling log) — nothing developer-facing is shown to teachers or students.
- New custom **`DueDatePicker`** (popover calendar + 12-hour time + presets) replacing the generic native `datetime-local`.
- New custom **`AddonSelect`** replacing native `<select>`s, whose OS-rendered option lists overflowed the control.
- Switched the surfaces to a **light theme** (Classroom's chrome is white; matches SpartBoard's student-facing/login family).

**B — Due date now syncs to the real Classroom assignment** (`feat: sync the add-on due date…`)
- The attach flow PATCHes the parent courseWork's `dueDate`/`dueTime` (UTC) so the date the teacher picks here becomes **the** Classroom assignment due date — entered once.
- New `classroomAddonNet.patchCourseWorkDueDate` seam; `createClassroomAttachment` accepts `dueAtMs`. Best-effort: a patch failure never fails the attach.
- Teacher token gains `classroom.coursework.students` (sensitive, but Orono's OAuth consent is Internal → exempt from verification).
- +4 CF tests (UTC extraction, absent, non-fatal failure, real-seam URL/body).

**C — Completed students can see their published results** (`fix(quiz): show published results…`)
- A Classroom attachment is self-paced, so the session never "ends" — a completed student was stranded on "waiting for the teacher to end the quiz" and could only see the grade in Classroom's gradebook.
- Now, when the teacher has published (`scoreVisibility != none`), a completed student sees `PublishedScoreReview` even on an active session (mirrors the post-end screen + the video-activity completion screen, which already did this). Student CTA relabeled Start → Open.

**D — In-iframe teacher grading** (`feat: carry the session ref…`, `feat: in-iframe teacher quiz grading`)
- The teacher-view URI now carries the session ref; opening the attachment as a teacher mounts a **lean** grader (`ClassroomAddonTeacherReview`) instead of round-tripping to the dashboard.
- **No DashboardProvider** (no dashboard Firestore listeners) — runs on the session + quiz-library hooks only. Reuses the real `WrittenResponseGrader`. Lists each student (SSO names via the pseudonym map, no rosters), grades written responses, **publishes scores to students**, and **pushes grades to Classroom**.

## Known limitations / follow-ups
- **Grade passback is draft-only** (Google constraint): the add-on pushes a *draft* grade; the final **Return** still happens in Classroom's grading tool. Surfaced in the UI.
- **VA grading-in-iframe** is out of scope (its own runner) — the teacher view shows a "review in SpartBoard" note for video activities.
- **Needs live verification** for D specifically (and the C reopen flow): the auth-bypass dev env can't simulate a real Classroom teacher launch + a graded session. Routing/mount/empty states are verified locally; type-check, lint, format, and the affected quiz + CF tests are green.

## Validation
`type-check:all`, `lint` (--max-warnings 0), `format:check` all pass. Functions tests 39/39, quiz tests 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
