### PR TITLE
Extract guarded grade-passback scaling into a shared, tested helper

### DIFF
--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -58,6 +58,7 @@ import {
   getDisplayScore,
   getScoreSuffix,
   getEarnedPoints,
+  scaleEarnedToMaxPoints,
   isGamificationActive,
 } from '../utils/quizScoreboard';
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
@@ -1090,19 +1091,19 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     );
 
     // Build the PII-free grade payload: one entry per completed, scored
-    // response. `getEarnedPoints` returns the raw points on the current scale;
-    // scale onto the Classroom denominator, then round + clamp to [0, maxPoints].
-    const grades = eligible.map((r) => {
-      // Guard against a non-finite score (e.g. missing answers) so it can't
-      // propagate NaN through the clamp and make the CF reject the entry.
-      const rawPoints = getEarnedPoints(r, quiz.questions, session);
-      const earned = Number.isFinite(rawPoints) ? rawPoints : 0;
-      const scaled = currentTotal > 0 ? (earned / currentTotal) * maxPoints : 0;
-      return {
-        pseudonymUid: r.studentUid,
-        pointsEarned: Math.max(0, Math.min(maxPoints, Math.round(scaled))),
-      };
-    });
+    // response. `scaleEarnedToMaxPoints` scales each student's raw earned
+    // points onto the frozen Classroom denominator, guards a non-finite score
+    // (e.g. missing answers) so it can't propagate NaN through the clamp and
+    // make the CF reject the entry, and rounds + clamps to [0, maxPoints].
+    const grades = eligible.map((r) =>
+      scaleEarnedToMaxPoints(
+        r,
+        quiz.questions,
+        session,
+        currentTotal,
+        maxPoints
+      )
+    );
 
     setPushingGrades(true);
     try {

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/config/scoreboard', () => ({
 import { gradeAnswer } from '@/hooks/useQuizSession';
 import {
   getEarnedPoints,
+  scaleEarnedToMaxPoints,
   getResponseScore,
   getDisplayScore,
   getScoreSuffix,
@@ -327,6 +328,102 @@ describe('quizScoreboard', () => {
         // answeredAt defaults from helper, should not throw
         expect(getEarnedPoints(response, questions)).toBe(1);
       });
+    });
+  });
+
+  describe('scaleEarnedToMaxPoints', () => {
+    it('maps earned == total onto the full maxPoints (exact-total)', () => {
+      // Two 10-point questions, both correct → earned 20. The quiz is
+      // unchanged from attach time, so total === maxPoints and the scale is a
+      // no-op: the student gets the full denominator.
+      const questions = [
+        makeQuestion('q1', 'A', 10),
+        makeQuestion('q2', 'B', 10),
+      ];
+      const response = makeResponse('01', [
+        { questionId: 'q1', answer: 'A' },
+        { questionId: 'q2', answer: 'B' },
+      ]);
+      const entry = scaleEarnedToMaxPoints(
+        response,
+        questions,
+        undefined,
+        20,
+        20
+      );
+      expect(entry).toEqual({ pseudonymUid: 'uid-01', pointsEarned: 20 });
+    });
+
+    it('scales a partial score onto a drifted denominator and rounds', () => {
+      // 1 correct of 3 one-point questions → earned 1, total 3. Pushed onto a
+      // frozen maxPoints of 10: (1/3)*10 = 3.33… → rounds to 3.
+      const questions = [
+        makeQuestion('q1', 'A'),
+        makeQuestion('q2', 'B'),
+        makeQuestion('q3', 'C'),
+      ];
+      const response = makeResponse('02', [
+        { questionId: 'q1', answer: 'A' },
+        { questionId: 'q2', answer: 'wrong' },
+        { questionId: 'q3', answer: 'wrong' },
+      ]);
+      const entry = scaleEarnedToMaxPoints(
+        response,
+        questions,
+        undefined,
+        3,
+        10
+      );
+      expect(entry).toEqual({ pseudonymUid: 'uid-02', pointsEarned: 3 });
+    });
+
+    it('clamps to maxPoints when the scaled value exceeds the denominator', () => {
+      // earned 2 but a stale/drifted total of 1 → (2/1)*10 = 20, which must be
+      // clamped down to the frozen maxPoints (10) rather than over-credited.
+      const questions = [makeQuestion('q1', 'A'), makeQuestion('q2', 'B')];
+      const response = makeResponse('03', [
+        { questionId: 'q1', answer: 'A' },
+        { questionId: 'q2', answer: 'B' },
+      ]);
+      const entry = scaleEarnedToMaxPoints(
+        response,
+        questions,
+        undefined,
+        1,
+        10
+      );
+      expect(entry).toEqual({ pseudonymUid: 'uid-03', pointsEarned: 10 });
+    });
+
+    it('scales to 0 when total is 0 (no scorable questions) instead of dividing by zero', () => {
+      const questions = [makeQuestion('q1', 'A')];
+      const response = makeResponse('04', [{ questionId: 'q1', answer: 'A' }]);
+      const entry = scaleEarnedToMaxPoints(
+        response,
+        questions,
+        undefined,
+        0,
+        10
+      );
+      expect(entry).toEqual({ pseudonymUid: 'uid-04', pointsEarned: 0 });
+    });
+
+    it('coerces a non-finite earned score to 0 so NaN cannot propagate to the CF', () => {
+      // A question with NaN points makes getEarnedPoints return NaN (the
+      // missing-answers / malformed-grade case the guard exists for). Without
+      // the Number.isFinite guard, Math.round(NaN) → NaN slips through the
+      // clamp and the Cloud Function rejects the grade entry.
+      const questions = [makeQuestion('q1', 'A', NaN)];
+      const response = makeResponse('05', [{ questionId: 'q1', answer: 'A' }]);
+      expect(getEarnedPoints(response, questions)).toBeNaN();
+      const entry = scaleEarnedToMaxPoints(
+        response,
+        questions,
+        undefined,
+        2,
+        10
+      );
+      expect(entry).toEqual({ pseudonymUid: 'uid-05', pointsEarned: 0 });
     });
   });
 

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -14,6 +14,7 @@ import {
 import { gradeAnswer } from '@/hooks/useQuizSession';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import type { StudentName } from '@/hooks/useAssignmentPseudonyms';
+import type { ClassroomGradeEntry } from '@/utils/classroomGradePush';
 import {
   resolveResponseDisplayName,
   responseColorIndex,
@@ -101,6 +102,45 @@ export function getEarnedPoints(
   }
 
   return Math.round(totalPoints);
+}
+
+/**
+ * Scale ONE quiz response's raw earned points onto a Google Classroom
+ * attachment's frozen `maxPoints` denominator, producing the PII-free grade
+ * entry the `pushClassroomGradesForAssignment` Cloud Function expects.
+ *
+ * `total` is the quiz's *current* point total. It can drift from `maxPoints`
+ * (frozen at attach time) when the quiz is edited after attaching, so scaling
+ * keeps the pushed ratio correct. When the quiz is unchanged
+ * (`total === maxPoints`) the scale is a no-op and the result equals the raw
+ * earned points (preserving the original "same number" behavior).
+ *
+ * Guards — so a single bad response can't make the CF reject the whole batch:
+ *   - A non-finite earned score (e.g. `getEarnedPoints` returning `NaN` for a
+ *     response with missing/un-gradeable answers) is coerced to 0 rather than
+ *     propagating `NaN` through the clamp.
+ *   - `total <= 0` (no scorable questions) scales to 0 instead of dividing by
+ *     zero.
+ *   - The scaled value is rounded and clamped to `[0, maxPoints]`.
+ *
+ * Pure and React-free so the passback math is testable without rendering a
+ * results view. Callers pass `total`/`maxPoints` because both denominators are
+ * caller-owned (the current quiz total vs. the frozen attachment total).
+ */
+export function scaleEarnedToMaxPoints(
+  response: QuizResponse,
+  questions: QuizQuestion[],
+  session: QuizScoringSession,
+  total: number,
+  maxPoints: number
+): ClassroomGradeEntry {
+  const rawPoints = getEarnedPoints(response, questions, session);
+  const earned = Number.isFinite(rawPoints) ? rawPoints : 0;
+  const scaled = total > 0 ? (earned / total) * maxPoints : 0;
+  return {
+    pseudonymUid: response.studentUid,
+    pointsEarned: Math.max(0, Math.min(maxPoints, Math.round(scaled))),
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Extracts the "scale a student's earned points onto the Google Classroom attachment's frozen `maxPoints`" grade-passback math out of `QuizResults` and into a single pure helper:

```ts
scaleEarnedToMaxPoints(response, questions, session, total, maxPoints)
  -> { pseudonymUid, pointsEarned }
```

It lives in `components/widgets/QuizWidget/utils/quizScoreboard.ts`, right next to `getEarnedPoints`, and carries all three guards:

- **`Number.isFinite` guard** — a non-finite earned score (e.g. `getEarnedPoints` returning `NaN` for a response with missing/un-gradeable answers) is coerced to `0` rather than propagating `NaN` through the clamp and making the Cloud Function reject the grade entry.
- **zero-total guard** — `total <= 0` scales to `0` instead of dividing by zero.
- **round + clamp** to `[0, maxPoints]`.

`QuizResults.pushClassroomGrades` now calls the helper instead of inlining the scale.

## Why

The earned→`maxPoints` scaling was inlined in `QuizResults` with a comment documenting the exact `NaN`-rejection risk the `Number.isFinite` guard protects against. Inlined math like this invites a second passback caller (e.g. a teacher review route) to copy it *without* the guard and silently diverge — `Math.round(NaN)` would slip through the clamp and the CF would reject the entry. Funneling all callers through one helper removes that divergence risk and makes the math testable without rendering a results view.

## Note on scope

The task referenced a second, unguarded copy in `components/classroomAddon/TeacherReviewRoute.tsx`. **That file does not exist in the current tree** — the only `getEarnedPoints`-based scaling site today is `QuizResults` (already guarded), and the Video Activity results view uses a different percentage-based formula (`getStudentScore`) that has its own guard. So there is no current divergence to repair; this PR is the preventative extraction so any future passback caller shares the guarded math. Happy to wire up the helper at a second call site if/when one lands.

## Tests

Added a `scaleEarnedToMaxPoints` suite to `quizScoreboard.test.ts` covering:

- exact-total (`earned == total` → `maxPoints`)
- partial (scales onto a drifted denominator and rounds)
- over-total clamp (scaled value exceeds `maxPoints` → clamped)
- zero-total guard (→ `0`)
- non-finite earned (`getEarnedPoints` → `NaN` → `0`)

`type-check`, `eslint`, `prettier --check`, and the full `quizScoreboard.test.ts` suite (61 tests) all pass locally.

https://claude.ai/code/session_016bxfSdZDysV5eFsXkFzbxk

---
_Generated by [Claude Code](https://claude.ai/code/session_016bxfSdZDysV5eFsXkFzbxk)_