### PR TITLE
feat(quiz): add Block Copy & Paste test-integrity toggle

### DIFF
--- a/components/common/library/AssignmentSettingsToggleGroup.tsx
+++ b/components/common/library/AssignmentSettingsToggleGroup.tsx
@@ -176,6 +176,13 @@ export interface AssignmentSettingsToggleGroupProps {
    */
   excludeSections?: AssignmentSettingsSection[];
   /**
+   * Show the "Block Copy & Paste" toggle directly under Tab Switch Detection
+   * in the integrity section. Quiz opts in (it has free-text answer fields a
+   * student could paste into); Video Activity has no text inputs and leaves
+   * this off. Defaults to false.
+   */
+  showCopyPasteToggle?: boolean;
+  /**
    * Optional content rendered after the standard sections. Quiz uses this
    * for the gamification block; VA uses this for rewind/penalty/score
    * visibility. The trailing block can use the exported `SectionHeader`
@@ -197,6 +204,7 @@ export const AssignmentSettingsToggleGroup: React.FC<
   excludeSections,
   trailingSlot,
   integritySectionLabel,
+  showCopyPasteToggle = false,
 }) => {
   const update = <K extends keyof BaseSessionOptions>(
     key: K,
@@ -237,6 +245,14 @@ export const AssignmentSettingsToggleGroup: React.FC<
             onChange={(v) => update('tabWarningsEnabled', v)}
             hint="Warn students who leave the assignment tab"
           />
+          {showCopyPasteToggle && (
+            <ToggleRow
+              label="Block Copy & Paste"
+              checked={options.blockCopyPaste ?? false}
+              onChange={(v) => update('blockCopyPaste', v)}
+              hint="Stops students pasting answers from other tabs"
+            />
+          )}
         </>
       )}
 

--- a/components/common/library/QuizBehaviorSettingsPanel.tsx
+++ b/components/common/library/QuizBehaviorSettingsPanel.tsx
@@ -116,8 +116,10 @@ export const QuizBehaviorSettingsPanel: React.FC<
       {/* Toggle group: integrity / feedback / randomization + gamification */}
       <AssignmentSettingsToggleGroup
         modeLocked={modeLocked}
+        showCopyPasteToggle
         options={{
           tabWarningsEnabled: value.sessionOptions.tabWarningsEnabled,
+          blockCopyPaste: value.sessionOptions.blockCopyPaste,
           showResultToStudent: value.sessionOptions.showResultToStudent,
           showCorrectAnswerToStudent:
             value.sessionOptions.showCorrectAnswerToStudent,

--- a/components/plc/assignments/PlcAssignmentConfigModal.tsx
+++ b/components/plc/assignments/PlcAssignmentConfigModal.tsx
@@ -108,6 +108,7 @@ type PlcAssignmentConfigModalProps = {
 
 const DEFAULT_QUIZ_SESSION_OPTIONS: QuizSessionOptions = {
   tabWarningsEnabled: true,
+  blockCopyPaste: false,
   showResultToStudent: false,
   showCorrectAnswerToStudent: false,
   showCorrectOnBoard: false,
@@ -573,6 +574,7 @@ export const PlcAssignmentConfigModal: React.FC<
                 attemptLimit={attemptLimit}
                 onAttemptLimitChange={setAttemptLimit}
                 shuffleQuestionsAvailable={false}
+                showCopyPasteToggle
               />
             </>
           ) : vaBehavior ? (

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -897,16 +897,22 @@ const ActiveQuiz: React.FC<{
   const tabWarningsEnabled = session.tabWarningsEnabled !== false;
 
   // Test integrity: when the teacher enabled "Block Copy & Paste", suppress
-  // copy/cut/paste across the question + answer area so a student can't paste
-  // a block of text composed in another tab. Default off (clipboard allowed).
+  // copy/cut/paste — and drag-and-drop, the other channel for importing text
+  // composed elsewhere — across the question + answer area. Default off
+  // (clipboard allowed). The drop guard is safe alongside the Matching/
+  // Ordering inputs because those use dnd-kit's pointer sensors, not native
+  // HTML5 drag events.
   const blockCopyPaste = session.blockCopyPaste === true;
   const handleBlockedClipboard = (e: React.ClipboardEvent<HTMLDivElement>) =>
+    e.preventDefault();
+  const handleBlockedDrop = (e: React.DragEvent<HTMLDivElement>) =>
     e.preventDefault();
   const clipboardGuards = blockCopyPaste
     ? {
         onCopy: handleBlockedClipboard,
         onCut: handleBlockedClipboard,
         onPaste: handleBlockedClipboard,
+        onDrop: handleBlockedDrop,
       }
     : undefined;
 

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -896,6 +896,20 @@ const ActiveQuiz: React.FC<{
   // The Visibility Tracker — only active when tabWarningsEnabled
   const tabWarningsEnabled = session.tabWarningsEnabled !== false;
 
+  // Test integrity: when the teacher enabled "Block Copy & Paste", suppress
+  // copy/cut/paste across the question + answer area so a student can't paste
+  // a block of text composed in another tab. Default off (clipboard allowed).
+  const blockCopyPaste = session.blockCopyPaste === true;
+  const handleBlockedClipboard = (e: React.ClipboardEvent<HTMLDivElement>) =>
+    e.preventDefault();
+  const clipboardGuards = blockCopyPaste
+    ? {
+        onCopy: handleBlockedClipboard,
+        onCut: handleBlockedClipboard,
+        onPaste: handleBlockedClipboard,
+      }
+    : undefined;
+
   useEffect(() => {
     if (!tabWarningsEnabled) return; // Skip entirely when disabled
 
@@ -1963,6 +1977,7 @@ const ActiveQuiz: React.FC<{
       </div>
 
       <div
+        {...clipboardGuards}
         className={`flex flex-col p-6 mx-auto w-full ${
           // Per-type width caps. Tuned for the personal-device viewport
           // a student actually uses (laptop / Chromebook / tablet), not
@@ -2340,6 +2355,7 @@ const ActiveQuiz: React.FC<{
                 maxWords={currentQuestion.maxWords}
                 disabled={submitted && !isStudentPaced}
                 isEssay={currentQuestion.type === 'essay'}
+                blockClipboard={blockCopyPaste}
               />
             </React.Suspense>
 

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -45,6 +45,12 @@ interface WrittenResponseEditorProps {
   /** Disable editing (e.g. when the quiz is paused or submitted). */
   disabled?: boolean;
   /**
+   * When true, copy / cut / paste are blocked inside the editor (test
+   * integrity). Paste is fully suppressed rather than stripped-to-plain-text,
+   * and copy/cut from the editor are prevented. Default false.
+   */
+  blockClipboard?: boolean;
+  /**
    * When true, the toolbar exposes list controls and the editor grows to a
    * multi-paragraph height. Short-answer questions stay single-paragraph.
    */
@@ -88,7 +94,15 @@ const KEYBOARD_RESIZE_STEP_PX = 32;
 
 const WrittenResponseEditorInner: React.FC<
   Omit<WrittenResponseEditorProps, 'questionKey'>
-> = ({ value, onChange, placeholder, maxWords, disabled, isEssay }) => {
+> = ({
+  value,
+  onChange,
+  placeholder,
+  maxWords,
+  disabled,
+  isEssay,
+  blockClipboard,
+}) => {
   const editorRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [wordCount, setWordCount] = useState(() => countWords(value));
@@ -237,12 +251,22 @@ const WrittenResponseEditorInner: React.FC<
   // Strip formatting from pasted content so students can't inject styled
   // HTML by copy/pasting from rich sources. We only allow plain text on
   // paste; the toolbar buttons are the only path to formatting.
+  //
+  // When `blockClipboard` is on (teacher enabled "Block Copy & Paste"),
+  // paste is suppressed entirely — preventDefault and bail before inserting.
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
+    if (blockClipboard) return;
     const text = e.clipboardData.getData('text/plain');
     if (!text) return;
     // Insert as plain text at the current selection.
     document.execCommand('insertText', false, text);
+  };
+
+  // Block copy/cut from inside the editor when clipboard is locked. (Paste is
+  // handled above.) A no-op handler otherwise so the native clipboard works.
+  const handleClipboardCopyCut = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    if (blockClipboard) e.preventDefault();
   };
 
   const exec = (command: string) => {
@@ -342,6 +366,8 @@ const WrittenResponseEditorInner: React.FC<
           suppressContentEditableWarning
           onInput={handleInput}
           onPaste={handlePaste}
+          onCopy={handleClipboardCopyCut}
+          onCut={handleClipboardCopyCut}
           spellCheck
           className={`w-full px-5 py-4 bg-slate-800 border-2 border-t-0 ${
             disabled

--- a/components/quiz/WrittenResponseEditor.tsx
+++ b/components/quiz/WrittenResponseEditor.tsx
@@ -269,6 +269,14 @@ const WrittenResponseEditorInner: React.FC<
     if (blockClipboard) e.preventDefault();
   };
 
+  // Drag-and-drop is the other channel for importing externally-composed text,
+  // so block native drops when clipboard is locked. In-app this also bubbles
+  // to QuizStudentApp's container guard, but keeping it here makes the editor
+  // self-contained for any other caller.
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (blockClipboard) e.preventDefault();
+  };
+
   const exec = (command: string) => {
     if (disabled) return;
     editorRef.current?.focus();
@@ -368,6 +376,7 @@ const WrittenResponseEditorInner: React.FC<
           onPaste={handlePaste}
           onCopy={handleClipboardCopyCut}
           onCut={handleClipboardCopyCut}
+          onDrop={handleDrop}
           spellCheck
           className={`w-full px-5 py-4 bg-slate-800 border-2 border-t-0 ${
             disabled

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -77,6 +77,7 @@ import { getQuizBehavior } from '@/utils/quizBehavior';
  */
 const VIEW_ONLY_SESSION_OPTIONS: Required<QuizSessionOptions> = {
   tabWarningsEnabled: false,
+  blockCopyPaste: false,
   showResultToStudent: false,
   showCorrectAnswerToStudent: false,
   showCorrectOnBoard: false,

--- a/hooks/usePlcQuizzes.ts
+++ b/hooks/usePlcQuizzes.ts
@@ -25,6 +25,7 @@ const QUIZZES_SUBCOLLECTION = 'quizzes';
  */
 const SESSION_OPTION_KEYS: readonly (keyof QuizSessionOptions)[] = [
   'tabWarningsEnabled',
+  'blockCopyPaste',
   'showResultToStudent',
   'showCorrectAnswerToStudent',
   'showCorrectOnBoard',

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -739,6 +739,7 @@ export const useQuizAssignments = (
         publicQuestions: quiz.questions.map(toPublicQuestion),
         // Phase 1 toggles
         tabWarningsEnabled: opts.tabWarningsEnabled ?? true,
+        blockCopyPaste: opts.blockCopyPaste ?? false,
         showResultToStudent: opts.showResultToStudent ?? false,
         showCorrectAnswerToStudent: opts.showCorrectAnswerToStudent ?? false,
         showCorrectOnBoard: opts.showCorrectOnBoard ?? false,
@@ -1167,6 +1168,8 @@ export const useQuizAssignments = (
         const o = patch.sessionOptions;
         if (o.tabWarningsEnabled !== undefined)
           sessionPatch.tabWarningsEnabled = o.tabWarningsEnabled;
+        if (o.blockCopyPaste !== undefined)
+          sessionPatch.blockCopyPaste = o.blockCopyPaste;
         if (o.showResultToStudent !== undefined)
           sessionPatch.showResultToStudent = o.showResultToStudent;
         if (o.showCorrectAnswerToStudent !== undefined)

--- a/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
+++ b/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
@@ -35,6 +35,24 @@ describe('QuizBehaviorSettingsPanel', () => {
     expect(screen.getByText('Block Copy & Paste')).toBeInTheDocument();
   });
 
+  it('reflects an existing blockCopyPaste: true value as a checked switch', () => {
+    const value: QuizBehaviorSettings = {
+      ...DEFAULT_QUIZ_BEHAVIOR,
+      sessionOptions: {
+        ...DEFAULT_QUIZ_BEHAVIOR.sessionOptions,
+        blockCopyPaste: true,
+      },
+      attemptLimit: null,
+    };
+    render(<QuizBehaviorSettingsPanel value={value} onChange={vi.fn()} />);
+
+    const row = screen.getByText('Block Copy & Paste').closest('div');
+    const switchEl = row?.querySelector('[role="switch"]');
+    expect(switchEl).not.toBeNull();
+    // Not a dead control — the front-face reflects the stored value.
+    expect(switchEl).toHaveAttribute('aria-checked', 'true');
+  });
+
   it('toggling Block Copy & Paste calls onChange with blockCopyPaste: true', () => {
     const onChange = vi.fn();
     render(

--- a/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
+++ b/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
@@ -28,6 +28,31 @@ describe('QuizBehaviorSettingsPanel', () => {
     expect(screen.getByText('Tab Switch Detection')).toBeInTheDocument();
   });
 
+  it('renders the Block Copy & Paste toggle under Tab Switch Detection', () => {
+    render(
+      <QuizBehaviorSettingsPanel value={defaultValue} onChange={vi.fn()} />
+    );
+    expect(screen.getByText('Block Copy & Paste')).toBeInTheDocument();
+  });
+
+  it('toggling Block Copy & Paste calls onChange with blockCopyPaste: true', () => {
+    const onChange = vi.fn();
+    render(
+      <QuizBehaviorSettingsPanel value={defaultValue} onChange={onChange} />
+    );
+
+    const label = screen.getByText('Block Copy & Paste');
+    const row = label.closest('div');
+    const switchEl = row?.querySelector('[role="switch"]');
+    expect(switchEl).not.toBeNull();
+    fireEvent.click(switchEl as HTMLElement);
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange.mock.calls[0][0]).toMatchObject({
+      sessionOptions: expect.objectContaining({ blockCopyPaste: true }),
+    });
+  });
+
   it('renders the gamification section', () => {
     render(
       <QuizBehaviorSettingsPanel value={defaultValue} onChange={vi.fn()} />

--- a/tests/components/common/library/VideoActivityBehaviorSettingsPanel.test.tsx
+++ b/tests/components/common/library/VideoActivityBehaviorSettingsPanel.test.tsx
@@ -34,6 +34,16 @@ describe('VideoActivityBehaviorSettingsPanel', () => {
     expect(screen.getByText('Tab Switch Detection')).toBeInTheDocument();
   });
 
+  it('does NOT render the Block Copy & Paste toggle (Quiz-only feature)', () => {
+    render(
+      <VideoActivityBehaviorSettingsPanel
+        value={defaultValue}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('Block Copy & Paste')).not.toBeInTheDocument();
+  });
+
   it('renders the VA-specific Scoring section', () => {
     render(
       <VideoActivityBehaviorSettingsPanel

--- a/tests/components/quiz/QuizStudentApp.copyPaste.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.copyPaste.test.tsx
@@ -83,6 +83,30 @@ const FIB_QUESTION: QuizPublicQuestion = {
   timeLimit: 0,
 };
 
+const SHORT_QUESTION: QuizPublicQuestion = {
+  id: 'q1',
+  type: 'short',
+  text: 'Explain why the sky is blue.',
+  timeLimit: 0,
+};
+
+// jsdom does not implement document.execCommand; install a stub the editor's
+// paste handler can call (and we can assert against) to distinguish "blocked"
+// (no insert) from "allowed" (plain-text insert).
+type ExecHost = { execCommand?: unknown };
+const withExecStub = async (
+  run: (exec: ReturnType<typeof vi.fn>) => Promise<void>
+): Promise<void> => {
+  const exec = vi.fn();
+  const prev = (document as ExecHost).execCommand;
+  (document as ExecHost).execCommand = exec;
+  try {
+    await run(exec);
+  } finally {
+    (document as ExecHost).execCommand = prev;
+  }
+};
+
 function buildSession(overrides: Partial<QuizSession> = {}): QuizSession {
   return {
     id: 'session-1',
@@ -132,15 +156,54 @@ const getFibInput = async (): Promise<HTMLElement> => {
 };
 
 describe('QuizStudentApp — Block Copy & Paste', () => {
-  it('blocks paste into the answer field when blockCopyPaste is on', async () => {
+  it('blocks paste, cut, and drop on the answer field when blockCopyPaste is on', async () => {
     hookState.session = buildSession({ blockCopyPaste: true });
     render(<QuizStudentApp />);
     const input = await getFibInput();
     // fireEvent returns false when the event's default action was prevented.
-    const notPrevented = fireEvent.paste(input, {
-      clipboardData: { getData: () => 'Paris' },
+    expect(
+      fireEvent.paste(input, { clipboardData: { getData: () => 'Paris' } })
+    ).toBe(false);
+    expect(fireEvent.cut(input)).toBe(false);
+    // Drag-and-drop is the other channel for importing externally-composed
+    // text — the container guard blocks it too.
+    expect(
+      fireEvent.drop(input, { dataTransfer: { getData: () => 'Paris' } })
+    ).toBe(false);
+  });
+
+  it('blocks paste into the short/essay editor when blockCopyPaste is on (prop wiring)', async () => {
+    await withExecStub(async (exec) => {
+      hookState.session = buildSession({
+        blockCopyPaste: true,
+        publicQuestions: [SHORT_QUESTION],
+      });
+      render(<QuizStudentApp />);
+      // The editor is lazy-loaded; wait for the contenteditable to mount.
+      const editor = await screen.findByRole('textbox', {
+        name: /your response/i,
+      });
+      fireEvent.paste(editor, {
+        clipboardData: { getData: () => 'pasted essay' },
+      });
+      // If `blockClipboard` weren't threaded to the editor, its handler would
+      // insert the plain text via execCommand — assert it never does.
+      expect(exec).not.toHaveBeenCalled();
     });
-    expect(notPrevented).toBe(false);
+  });
+
+  it('still inserts pasted text into the short/essay editor when blockCopyPaste is off', async () => {
+    await withExecStub(async (exec) => {
+      hookState.session = buildSession({ publicQuestions: [SHORT_QUESTION] });
+      render(<QuizStudentApp />);
+      const editor = await screen.findByRole('textbox', {
+        name: /your response/i,
+      });
+      fireEvent.paste(editor, {
+        clipboardData: { getData: () => 'pasted essay' },
+      });
+      expect(exec).toHaveBeenCalledWith('insertText', false, 'pasted essay');
+    });
   });
 
   it('blocks copy from the question prompt when blockCopyPaste is on', async () => {
@@ -158,6 +221,9 @@ describe('QuizStudentApp — Block Copy & Paste', () => {
       clipboardData: { getData: () => 'Paris' },
     });
     expect(pastePrevented).toBe(true);
+    expect(
+      fireEvent.drop(input, { dataTransfer: { getData: () => 'Paris' } })
+    ).toBe(true);
     const prompt = screen.getByText(/capital of france/i);
     expect(fireEvent.copy(prompt)).toBe(true);
   });

--- a/tests/components/quiz/QuizStudentApp.copyPaste.test.tsx
+++ b/tests/components/quiz/QuizStudentApp.copyPaste.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Coverage for the teacher-configurable "Block Copy & Paste" quiz setting
+ * (session.blockCopyPaste). When enabled, the student quiz-taking surface
+ * (question prompt + answer fields) suppresses copy / cut / paste so a
+ * student can't paste a block of text composed in another tab. When off
+ * (default), the clipboard works normally.
+ *
+ * The harness mirrors QuizStudentApp.selfPaced.test.tsx: a stateful
+ * `useQuizSessionStudent` mock drives the active-question render, and an
+ * SSO user auto-joins so the answer field mounts.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import type { QuizSession, QuizResponse, QuizPublicQuestion } from '@/types';
+
+const { mockAuth, mockJoinQuizSession, mockLookupSession, hookState } =
+  vi.hoisted(() => {
+    type MockUser = {
+      uid: string;
+      isAnonymous: boolean;
+      getIdTokenResult: () => Promise<{ claims: Record<string, unknown> }>;
+    };
+    const state: {
+      session: import('@/types').QuizSession | null;
+      myResponse: import('@/types').QuizResponse | null;
+    } = { session: null, myResponse: null };
+    return {
+      mockAuth: {
+        onAuthStateChanged: vi.fn(),
+        signInWithPopup: vi.fn(),
+        signOut: vi.fn(),
+        authStateReady: vi.fn().mockResolvedValue(undefined),
+        currentUser: null as MockUser | null,
+      },
+      mockJoinQuizSession: vi.fn(),
+      mockLookupSession: vi.fn(),
+      hookState: state,
+    };
+  });
+
+vi.mock('@/config/firebase', () => ({
+  isConfigured: false,
+  isAuthBypass: false,
+  app: {},
+  db: {},
+  auth: mockAuth,
+  storage: {},
+  functions: {},
+  GOOGLE_OAUTH_SCOPES: [] as string[],
+  googleProvider: {},
+}));
+
+vi.mock('firebase/auth', () => ({
+  signInAnonymously: vi.fn().mockResolvedValue(undefined),
+  onAuthStateChanged: vi.fn(() => () => undefined),
+}));
+
+vi.mock('@/hooks/useQuizSession', () => ({
+  useQuizSessionStudent: () => ({
+    session: hookState.session,
+    myResponse: hookState.myResponse,
+    loading: false,
+    error: null,
+    sessionIdRef: { current: 'session-1' },
+    lookupSession: mockLookupSession,
+    joinQuizSession: mockJoinQuizSession,
+    submitAnswer: vi.fn(),
+    completeQuiz: vi.fn(),
+    reportTabSwitch: vi.fn(),
+    warningCount: 0,
+  }),
+  normalizeAnswer: (s: string) => s,
+}));
+
+import { QuizStudentApp } from '@/components/quiz/QuizStudentApp';
+
+const FIB_QUESTION: QuizPublicQuestion = {
+  id: 'q1',
+  type: 'FIB',
+  text: 'The capital of France is ____',
+  timeLimit: 0,
+};
+
+function buildSession(overrides: Partial<QuizSession> = {}): QuizSession {
+  return {
+    id: 'session-1',
+    assignmentId: 'asn-1',
+    quizId: 'quiz-1',
+    quizTitle: 'Test quiz',
+    teacherUid: 'teacher-1',
+    status: 'active',
+    sessionMode: 'student',
+    currentQuestionIndex: 0,
+    startedAt: Date.now(),
+    endedAt: null,
+    code: 'ABC123',
+    totalQuestions: 1,
+    publicQuestions: [FIB_QUESTION],
+    ...overrides,
+  };
+}
+
+function buildResponse(): QuizResponse {
+  return {
+    studentUid: 'sso-uid-1',
+    joinedAt: Date.now(),
+    status: 'in-progress',
+    answers: [],
+    score: null,
+    submittedAt: null,
+    completedAttempts: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hookState.myResponse = buildResponse();
+  mockAuth.currentUser = {
+    uid: 'sso-uid-1',
+    isAnonymous: false,
+    getIdTokenResult: () => Promise.resolve({ claims: { studentRole: true } }),
+  };
+  mockJoinQuizSession.mockResolvedValue('session-1');
+  window.history.replaceState({}, '', '/quiz?code=ABC123');
+});
+
+const getFibInput = async (): Promise<HTMLElement> => {
+  await screen.findByText(/capital of france/i);
+  return screen.getByPlaceholderText(/type your answer/i);
+};
+
+describe('QuizStudentApp — Block Copy & Paste', () => {
+  it('blocks paste into the answer field when blockCopyPaste is on', async () => {
+    hookState.session = buildSession({ blockCopyPaste: true });
+    render(<QuizStudentApp />);
+    const input = await getFibInput();
+    // fireEvent returns false when the event's default action was prevented.
+    const notPrevented = fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Paris' },
+    });
+    expect(notPrevented).toBe(false);
+  });
+
+  it('blocks copy from the question prompt when blockCopyPaste is on', async () => {
+    hookState.session = buildSession({ blockCopyPaste: true });
+    render(<QuizStudentApp />);
+    const prompt = await screen.findByText(/capital of france/i);
+    expect(fireEvent.copy(prompt)).toBe(false);
+  });
+
+  it('allows paste and copy when blockCopyPaste is off (default)', async () => {
+    hookState.session = buildSession(); // blockCopyPaste undefined
+    render(<QuizStudentApp />);
+    const input = await getFibInput();
+    const pastePrevented = fireEvent.paste(input, {
+      clipboardData: { getData: () => 'Paris' },
+    });
+    expect(pastePrevented).toBe(true);
+    const prompt = screen.getByText(/capital of france/i);
+    expect(fireEvent.copy(prompt)).toBe(true);
+  });
+});

--- a/tests/components/quiz/WrittenResponseEditor.test.tsx
+++ b/tests/components/quiz/WrittenResponseEditor.test.tsx
@@ -135,6 +135,79 @@ describe('WrittenResponseEditor', () => {
     ).toBeInTheDocument();
   });
 
+  // jsdom does not implement document.execCommand, so install a stub the
+  // editor's paste handler can call (and we can assert against).
+  type ExecHost = { execCommand?: unknown };
+  const withExecStub = (run: (exec: ReturnType<typeof vi.fn>) => void) => {
+    const exec = vi.fn();
+    const prev = (document as ExecHost).execCommand;
+    (document as ExecHost).execCommand = exec;
+    try {
+      run(exec);
+    } finally {
+      (document as ExecHost).execCommand = prev;
+    }
+  };
+
+  it('inserts pasted plain text when clipboard is not blocked (default)', () => {
+    withExecStub((exec) => {
+      render(
+        <WrittenResponseEditor value="" onChange={vi.fn()} questionKey="q1" />
+      );
+      const notPrevented = fireEvent.paste(getEditor(), {
+        clipboardData: { getData: () => 'pasted text' },
+      });
+      // Default action is prevented (we always strip formatting), but the
+      // plain text IS inserted via execCommand.
+      expect(notPrevented).toBe(false);
+      expect(exec).toHaveBeenCalledWith('insertText', false, 'pasted text');
+    });
+  });
+
+  it('suppresses paste entirely when blockClipboard is set', () => {
+    withExecStub((exec) => {
+      render(
+        <WrittenResponseEditor
+          value=""
+          onChange={vi.fn()}
+          questionKey="q1"
+          blockClipboard
+        />
+      );
+      const prevented = fireEvent.paste(getEditor(), {
+        clipboardData: { getData: () => 'pasted text' },
+      });
+      expect(prevented).toBe(false); // default prevented
+      // Nothing inserted — the blocked path bails before execCommand.
+      expect(exec).not.toHaveBeenCalled();
+    });
+  });
+
+  it('blocks copy and cut when blockClipboard is set', () => {
+    render(
+      <WrittenResponseEditor
+        value="secret answer"
+        onChange={vi.fn()}
+        questionKey="q1"
+        blockClipboard
+      />
+    );
+    expect(fireEvent.copy(getEditor())).toBe(false);
+    expect(fireEvent.cut(getEditor())).toBe(false);
+  });
+
+  it('allows copy and cut when clipboard is not blocked (default)', () => {
+    render(
+      <WrittenResponseEditor
+        value="answer"
+        onChange={vi.fn()}
+        questionKey="q1"
+      />
+    );
+    expect(fireEvent.copy(getEditor())).toBe(true);
+    expect(fireEvent.cut(getEditor())).toBe(true);
+  });
+
   it('disables editing and tab focus when disabled', () => {
     render(
       <WrittenResponseEditor

--- a/tests/components/quiz/WrittenResponseEditor.test.tsx
+++ b/tests/components/quiz/WrittenResponseEditor.test.tsx
@@ -208,6 +208,27 @@ describe('WrittenResponseEditor', () => {
     expect(fireEvent.cut(getEditor())).toBe(true);
   });
 
+  it('blocks drag-and-drop when blockClipboard is set, allows it otherwise', () => {
+    const { rerender } = render(
+      <WrittenResponseEditor
+        value=""
+        onChange={vi.fn()}
+        questionKey="q1"
+        blockClipboard
+      />
+    );
+    expect(
+      fireEvent.drop(getEditor(), { dataTransfer: { getData: () => 'x' } })
+    ).toBe(false);
+
+    rerender(
+      <WrittenResponseEditor value="" onChange={vi.fn()} questionKey="q2" />
+    );
+    expect(
+      fireEvent.drop(getEditor(), { dataTransfer: { getData: () => 'x' } })
+    ).toBe(true);
+  });
+
   it('disables editing and tab focus when disabled', () => {
     render(
       <WrittenResponseEditor

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -910,6 +910,22 @@ describe('useQuizAssignments - updateAssignmentSettings', () => {
     return call[1] as Record<string, unknown>;
   }
 
+  it('mirrors a blockCopyPaste change onto the live session doc', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+
+    await act(async () => {
+      await result.current.updateAssignmentSettings(ASSIGNMENT_ID, {
+        sessionOptions: { blockCopyPaste: true },
+      });
+    });
+
+    const sessionCall = batchUpdate.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!sessionCall) throw new Error('expected batch.update on session doc');
+    expect(sessionCall[1]).toMatchObject({ blockCopyPaste: true });
+  });
+
   it('translates explicit-undefined plc into deleteField() so toggle-OFF actually clears the linkage', async () => {
     // Firestore is initialized with `ignoreUndefinedProperties: true`, so a
     // raw `{ plc: undefined }` patch would be silently dropped on the wire
@@ -1541,6 +1557,36 @@ describe('useQuizAssignments - createAssignment (PLC index side effect)', () => 
       },
     };
   }
+
+  function findSessionSet(): Record<string, unknown> {
+    const call = batchSet.mock.calls.find(
+      ([ref]) => typeof ref === 'string' && ref.startsWith('quiz_sessions/')
+    );
+    if (!call) throw new Error('expected batch.set on session doc');
+    return call[1] as Record<string, unknown>;
+  }
+
+  it('mints the session with blockCopyPaste:true when the option is set', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.createAssignment(QUIZ, {
+        sessionMode: 'teacher',
+        sessionOptions: { blockCopyPaste: true },
+      });
+    });
+    expect(findSessionSet()).toMatchObject({ blockCopyPaste: true });
+  });
+
+  it('defaults blockCopyPaste to false when the option is omitted', async () => {
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.createAssignment(QUIZ, {
+        sessionMode: 'teacher',
+        sessionOptions: {},
+      });
+    });
+    expect(findSessionSet()).toMatchObject({ blockCopyPaste: false });
+  });
 
   it('writes an index entry to the PLC subcollection when settings.plc is set', async () => {
     const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));

--- a/tests/utils/quizBehavior.test.ts
+++ b/tests/utils/quizBehavior.test.ts
@@ -38,4 +38,7 @@ describe('getQuizBehavior', () => {
       true
     );
   });
+  it('DEFAULT leaves copy/paste allowed (blockCopyPaste false)', () => {
+    expect(DEFAULT_QUIZ_BEHAVIOR.sessionOptions.blockCopyPaste).toBe(false);
+  });
 });

--- a/types.ts
+++ b/types.ts
@@ -2570,6 +2570,13 @@ export type QuizSessionMode = 'teacher' | 'auto' | 'student';
  */
 export interface BaseSessionOptions {
   tabWarningsEnabled?: boolean;
+  /**
+   * Block copy / cut / paste in the student answer UI. Adds a layer of test
+   * integrity alongside tab-switch detection — a student can't switch to
+   * another tab, compose an answer there, then paste a block of text back in.
+   * Default false (copy/paste allowed) preserves the pre-existing behavior.
+   */
+  blockCopyPaste?: boolean;
   showResultToStudent?: boolean;
   showCorrectAnswerToStudent?: boolean;
   showCorrectOnBoard?: boolean;
@@ -2689,6 +2696,12 @@ export interface QuizSession {
   // ─── Toggles (Phase 1) ─────────────────────────────────────────────────────
   /** Whether tab-switch detection is active on student devices (default true) */
   tabWarningsEnabled?: boolean;
+  /**
+   * Block copy / cut / paste in the student quiz UI (default false). Mirrored
+   * from the assignment's `sessionOptions.blockCopyPaste` so the student
+   * client doesn't need a second fetch.
+   */
+  blockCopyPaste?: boolean;
   /** Show right/wrong indicator to students after they submit (default false) */
   showResultToStudent?: boolean;
   /** Reveal the correct answer text to students after submit (default false) */

--- a/utils/quizBehavior.ts
+++ b/utils/quizBehavior.ts
@@ -29,6 +29,7 @@ export const DEFAULT_QUIZ_BEHAVIOR: QuizBehaviorSettings = deepFreeze({
   sessionMode: 'teacher',
   sessionOptions: {
     tabWarningsEnabled: true,
+    blockCopyPaste: false,
     showResultToStudent: false,
     showCorrectAnswerToStudent: false,
     showCorrectOnBoard: false,


### PR DESCRIPTION
## Summary

Adds a teacher-configurable **Block Copy & Paste** setting to quiz assignments, sitting directly under **Tab Switch Detection** in the quiz settings. When enabled, the student quiz-taking surface (question prompt + answer fields) suppresses copy / cut / paste — so a student can't switch to another tab, compose an answer (or use an AI), and paste a block of text back in. Adds a layer of test integrity alongside the existing tab-switch warnings.

Default is **off**, so existing assignments behave exactly as before.

## Changes

**Data + propagation** (mirrors the `tabWarningsEnabled` path):
- `blockCopyPaste?: boolean` added to `BaseSessionOptions` and the `QuizSession` doc.
- Default `false` in `DEFAULT_QUIZ_BEHAVIOR`.
- Stamped onto the session doc at create time, **and** mirrored to the live session doc on settings edit (so toggling it on a running/paused assignment reaches students).

**Settings UI:**
- New `ToggleRow` in the shared `AssignmentSettingsToggleGroup`, gated behind a `showCopyPasteToggle` prop.
- `QuizBehaviorSettingsPanel` opts in → the toggle appears for Quiz and the PLC-assign / quiz-editor modals that reuse the panel. Video Activity (which has no text answers) is intentionally excluded.

**Student enforcement:**
- Copy/cut/paste guard on the question + answer container in `QuizStudentApp` (covers the prompt, MC/matching/ordering, and the Fill-in-the-Blank input).
- `WrittenResponseEditor` gets a `blockClipboard` prop that fully suppresses paste (rather than stripping to plain text) and blocks copy/cut, since it owns its own paste handler.

## Scope note

Blocks clipboard events (Ctrl+C/V/X, right-click menu). Drag-and-drop of text is a separate `drop` event and is **not** blocked — can follow up if desired.

## Testing

- `type-check`, `lint` (`--max-warnings 0`), `format:check`: all clean.
- New test coverage at every layer: default value, settings-panel render + onChange, VA scope-leak guard, session-doc propagation (create + edit), `WrittenResponseEditor` paste/copy block, and a `QuizStudentApp` integration test firing real clipboard events to confirm blocked-when-on / allowed-when-off. 381 tests pass across the related suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)