### PR TITLE
fix(classroom-addon): address review feedback on PR #1798

### DIFF
--- a/components/classroomAddon/AddonShell.tsx
+++ b/components/classroomAddon/AddonShell.tsx
@@ -201,7 +201,18 @@ export const AddonSelect: React.FC<{
   const selected = options.find((o) => o.value === value) ?? null;
 
   return (
-    <div className="relative" ref={ref}>
+    <div
+      className="relative"
+      ref={ref}
+      onBlur={(e) => {
+        // useClickOutside only handles pointer dismissals; close on keyboard
+        // tab-out too, so the popover doesn't linger when focus leaves the
+        // control entirely (relatedTarget outside this subtree).
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+          setOpen(false);
+        }
+      }}
+    >
       <button
         type="button"
         id={id}

--- a/components/classroomAddon/AddonShell.tsx
+++ b/components/classroomAddon/AddonShell.tsx
@@ -207,8 +207,14 @@ export const AddonSelect: React.FC<{
       onBlur={(e) => {
         // useClickOutside only handles pointer dismissals; close on keyboard
         // tab-out too, so the popover doesn't linger when focus leaves the
-        // control entirely (relatedTarget outside this subtree).
-        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+        // control entirely (relatedTarget outside this subtree). Guard against a
+        // null relatedTarget (focus lost to a non-focusable element such as the
+        // dropdown's own scrollbar) so those don't prematurely close the popover —
+        // useClickOutside handles real outside clicks instead.
+        if (
+          e.relatedTarget &&
+          !e.currentTarget.contains(e.relatedTarget as Node)
+        ) {
           setOpen(false);
         }
       }}

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -23,7 +23,7 @@
  *        - Quiz → `/classroom-addon/student?code=<code>`
  *        - VA   → `/classroom-addon/student?kind=va&sessionId=<sessionId>`
  */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useId, useMemo, useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { doc, getDoc, updateDoc } from 'firebase/firestore';
 import { db, functions } from '@/config/firebase';
@@ -164,6 +164,11 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+
+  // Stable, instance-unique ids for label/control pairing so two mounts of
+  // this route on the same page can't collide on a hardcoded string id.
+  const librarySelectId = useId();
+  const teacherNameId = useId();
   const [kind, setKind] = useState<ContentKind>('quiz');
   const [selectedQuizId, setSelectedQuizId] = useState('');
   const [selectedActivityId, setSelectedActivityId] = useState('');
@@ -792,16 +797,14 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
           {/* Library picker */}
           <AddonCard className="p-4">
             <label
-              htmlFor={
-                kind === 'quiz' ? 'addon-quiz-select' : 'addon-va-select'
-              }
+              htmlFor={librarySelectId}
               className="mb-1.5 block text-sm font-medium text-slate-700"
             >
               {kind === 'quiz' ? 'Quiz' : 'Video Activity'}
             </label>
             {kind === 'quiz' ? (
               <AddonSelect
-                id="addon-quiz-select"
+                id={librarySelectId}
                 ariaLabel="Quiz"
                 value={selectedQuizId}
                 onChange={setSelectedQuizId}
@@ -817,7 +820,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
               />
             ) : (
               <AddonSelect
-                id="addon-va-select"
+                id={librarySelectId}
                 ariaLabel="Video Activity"
                 value={selectedActivityId}
                 onChange={setSelectedActivityId}
@@ -859,7 +862,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
 
               <div>
                 <label
-                  htmlFor="addon-teacher-name"
+                  htmlFor={teacherNameId}
                   className="mb-1.5 block text-sm font-medium text-slate-700"
                 >
                   Your name{' '}
@@ -868,7 +871,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
                   </span>
                 </label>
                 <input
-                  id="addon-teacher-name"
+                  id={teacherNameId}
                   type="text"
                   value={teacherName}
                   onChange={(e) => setTeacherName(e.target.value)}

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -117,6 +117,9 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const [resolvingSession, setResolvingSession] = useState(true);
   useEffect(() => {
     if (kind !== 'quiz' || !code || !user) {
+      // Clear any stale session from a prior code/user so a sign-out or
+      // code change can't leak the previous session's id into state.
+      setSessionId(null);
       setResolvingSession(false);
       return;
     }
@@ -156,10 +159,17 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const [quizData, setQuizData] = useState<QuizData | null>(null);
   useEffect(() => {
     const quizId = session?.quizId;
+    // Drop any previously-loaded quiz when the session loses its quizId (or
+    // switches to a different one) so stale questions/answers can't bleed into
+    // the grader or score math while the new quiz resolves.
+    if (!quizId) {
+      setQuizData(null);
+      return;
+    }
     // Wait for the library to finish loading (quizzesLoading) rather than for a
     // non-empty list — an empty library is a legitimate "not found" signal, not
     // "still loading".
-    if (!quizId || quizzesLoading || !googleAccessToken) return;
+    if (quizzesLoading || !googleAccessToken) return;
     const meta = quizzes.find((q) => q.id === quizId);
     if (!meta) {
       // The session's quiz isn't in this teacher's library (e.g. a co-teacher
@@ -440,10 +450,20 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
                       </span>
                       <span className="flex shrink-0 items-center gap-2">
                         <span className="font-semibold text-slate-900">
-                          {Math.round(
-                            getDisplayScore(r, questions, session ?? undefined)
+                          {quizData ? (
+                            <>
+                              {Math.round(
+                                getDisplayScore(
+                                  r,
+                                  questions,
+                                  session ?? undefined
+                                )
+                              )}
+                              {scoreSuffix}
+                            </>
+                          ) : (
+                            '—'
                           )}
-                          {scoreSuffix}
                         </span>
                         <span
                           className={`rounded-full px-2 py-0.5 text-xs font-medium ${


### PR DESCRIPTION
Addresses the unresolved gemini-code-assist review comments on #1798. Targets `dev-paul` so the fixes land on that PR's branch (this environment can't push to `dev-paul` directly).

## Changes

- **TeacherReviewRoute** — reset `sessionId` to `null` on the session-resolver early return so a sign-out or code change can't leak the prior session id into state.
- **TeacherReviewRoute** — reset `quizData` to `null` when the session loses or changes its `quizId`, so stale questions/answers can't bleed into the grader or score math.
- **TeacherReviewRoute** — guard the per-student score with a `—` placeholder until `quizData` loads. (Note: `getDisplayScore` already returns `0`, never `NaN`, because both score helpers guard the empty-questions case — but the guard avoids a transient, misleading `0%` row while the quiz Drive file loads.)
- **AddonShell / AddonSelect** — close the custom dropdown on keyboard tab-out via an `onBlur` handler (`useClickOutside` only handled pointer dismissals).
- **TeacherDiscoveryRoute** — use `useId()` for label/control pairing instead of hardcoded string ids, avoiding collisions if the route mounts twice.

`pnpm run type-check`, ESLint, and Prettier all pass on the touched files.

https://claude.ai/code/session_01P8a4ZLaPQxwwVRcS7ZMguC

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8a4ZLaPQxwwVRcS7ZMguC)_