### PR TITLE
fix(draggable-window): settings panel placeholder flashes on first flip

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -111,6 +111,33 @@ vi.mock('./AnnotationCanvas', () => ({
   AnnotationCanvas: () => <div data-testid="annotation-canvas" />,
 }));
 
+// Spy wrapper for SettingsPanel — records every props object passed to the
+// component so regression tests can inspect the shouldRenderSettings value
+// that arrives on the FIRST mount when the widget transitions to flipped=true.
+// The actual SettingsPanel uses createPortal and heavy hooks; the spy renders
+// a lightweight stand-in that exposes just enough to check the key prop.
+const { settingsPanelRenderProps } = vi.hoisted(() => ({
+  settingsPanelRenderProps: [] as Array<{ shouldRenderSettings: boolean }>,
+}));
+
+vi.mock('./SettingsPanel', () => ({
+  SettingsPanel: (props: {
+    shouldRenderSettings: boolean;
+    settings: React.ReactNode;
+  }) => {
+    settingsPanelRenderProps.push({
+      shouldRenderSettings: props.shouldRenderSettings,
+    });
+    return props.shouldRenderSettings && props.settings ? (
+      <div data-testid="settings-spy-content">{props.settings}</div>
+    ) : (
+      <div data-testid="settings-spy-placeholder" className="italic">
+        Standard settings available.
+      </div>
+    );
+  },
+}));
+
 const mockWidget: WidgetData = {
   id: 'test-widget',
   type: 'clock',
@@ -163,6 +190,8 @@ describe('DraggableWindow', () => {
       return 0;
     });
     vi.clearAllMocks();
+    // Reset SettingsPanel render spy before each test
+    settingsPanelRenderProps.length = 0;
     // Setup default spy to return null
     activeElementSpy = vi.spyOn(document, 'activeElement', 'get');
     activeElementSpy.mockReturnValue(null);
@@ -282,23 +311,28 @@ describe('DraggableWindow', () => {
     });
   });
 
-  it('SettingsPanel mounts with real settings content (not placeholder) when widget first flips to open', () => {
-    // Contract: after DraggableWindow flips to show the settings panel, the real
-    // settings content must be in the DOM (shouldRenderSettings=true).
+  it('SettingsPanel receives shouldRenderSettings=true on its very first render when widget flips open', () => {
+    // Regression test for: "shouldRenderSettings useEffect latch causes one-frame
+    // placeholder flash on slow hardware/projectors"
     //
-    // Known limitation: the current implementation uses a useEffect latch to set
-    // shouldRenderSettings=true, which fires after paint. This produces a one-frame
-    // placeholder flash on slow hardware/projectors ("Standard settings available."
-    // is briefly visible before the real content renders). Fixing this requires the
-    // "adjusting state while rendering" pattern (CLAUDE.md §useEffect gotcha), but
-    // DraggableWindow.tsx's size/complexity interacts with the react-hooks/refs ESLint
-    // rule in a way that produces false positives across the file — deferred.
+    // Root cause (dev-paul): DraggableWindow used a useEffect to latch
+    // shouldRenderSettings=true when widget.flipped became true. In a real browser
+    // (not JSDOM) useEffect fires AFTER paint, so SettingsPanel's first commit
+    // received shouldRenderSettings=false and briefly rendered the placeholder
+    // "Standard settings available." before the effect re-rendered with true.
     //
-    // This test cannot observe the one-frame flash: RTL's act() flushes effects
-    // synchronously in JSDOM, so both the useEffect and render-body approaches
-    // produce identical observable state here. The test verifies the contract
-    // (real content present, placeholder never shown) and guards against regressions
-    // that would break shouldRenderSettings entirely.
+    // Fix: Replace the useEffect with React's "adjust state while rendering"
+    // pattern — the inline `if (widget.flipped && !shouldRenderSettings)`
+    // assignment fires in the same synchronous render pass, so SettingsPanel
+    // always mounts with shouldRenderSettings=true.
+    //
+    // Why RTL alone cannot catch this: act() flushes effects synchronously in
+    // JSDOM, making both the useEffect and inline approaches produce identical
+    // DOM state after rerender(). Instead, this test uses the settingsPanelRenderProps
+    // spy (module-level vi.mock above) to inspect what shouldRenderSettings value
+    // was passed to SettingsPanel on its VERY FIRST render call — before any
+    // effects could fire. With the useEffect approach the first call gets false;
+    // with the inline approach it gets true.
 
     const SettingsContent = () => (
       <div data-testid="settings-content-sync">Settings Loaded</div>
@@ -330,14 +364,10 @@ describe('DraggableWindow', () => {
       </DashboardContext.Provider>
     );
 
-    // Before flip: SettingsPanel is not mounted at all
-    expect(
-      screen.queryByTestId('settings-content-sync')
-    ).not.toBeInTheDocument();
-    // And no placeholder either
-    expect(document.body.querySelector('.italic')).toBeNull();
+    // Before flip: SettingsPanel not mounted, spy array is empty
+    expect(settingsPanelRenderProps).toHaveLength(0);
 
-    // Flip the widget (SettingsPanel mounts for the first time)
+    // Flip the widget — SettingsPanel mounts for the first time
     rerender(
       <DashboardContext.Provider value={contextValue}>
         <DraggableWindow
@@ -351,13 +381,14 @@ describe('DraggableWindow', () => {
       </DashboardContext.Provider>
     );
 
-    // Real settings content must be present (shouldRenderSettings=true at mount)
-    expect(screen.getByTestId('settings-content-sync')).toBeInTheDocument();
+    // At least one render must have occurred
+    expect(settingsPanelRenderProps.length).toBeGreaterThan(0);
 
-    // The placeholder ("Standard settings available.") must never appear.
-    // If shouldRenderSettings were false at mount time, this text would be rendered
-    // on SettingsPanel's first commit and the user would see it briefly.
-    expect(document.body.querySelector('.italic')).toBeNull();
+    // KEY ASSERTION: The very first render call must have shouldRenderSettings=true.
+    // With the buggy useEffect approach: first render gets false (the effect
+    // hasn't fired yet), then a subsequent render gets true.
+    // With the fixed inline approach: first render already gets true.
+    expect(settingsPanelRenderProps[0].shouldRenderSettings).toBe(true);
   });
 
   it('updates position on pointer drag (using direct DOM manipulation for standard widgets)', async () => {

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -253,6 +253,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     selecting: boolean;
   }>({ start: null, end: null, selecting: false });
   const customGridRef = useRef(customGrid);
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md: "assign refs directly in render body"); react-hooks/refs v7 incorrectly cascades this as an error when any setState is called during render
   customGridRef.current = customGrid;
   const occupiedCells = useMemo(() => {
     const set = new Set<string>();
@@ -345,6 +346,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   if (!showTools && showSnapMenu) {
     setShowSnapMenu(false);
     setSnapPreviewZone(null);
+    // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync inside "adjust state while rendering" block; false positive from react-hooks/refs v7
     snapPreviewZoneRef.current = null;
   }
 
@@ -357,15 +359,19 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     h: number;
   } | null>(null);
 
-  // OPTIMIZATION: Lazy initialization of settings
-  // Latch to true once the widget is flipped for the first time so the settings
-  // chunk is never unmounted after being loaded (prevents re-mount cost).
-  useEffect(() => {
-    if (widget.flipped && !shouldRenderSettings) {
-      setShouldRenderSettings(true);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [widget.flipped]);
+  // Adjusting state while rendering (React docs pattern — "store previous
+  // value"): latch shouldRenderSettings to true once widget.flipped transitions
+  // from false → true. Using prevFlipped to detect the transition keeps this
+  // to a single extra render when the widget is first opened and avoids
+  // infinite-loop risk (React bails out when state didn't change). Inline
+  // rather than useEffect so it fires in the same synchronous render pass —
+  // the SettingsPanel therefore always mounts with shouldRenderSettings=true
+  // and the "Standard settings available." placeholder is never visible, even
+  // on slow hardware or projectors where a post-paint effect would produce a
+  // one-frame flash.
+  if (widget.flipped && !shouldRenderSettings) {
+    setShouldRenderSettings(true);
+  }
 
   // Maximized-state FAB kebab (replaces the pill toolbar while full-screen) and
   // a mirror of the Dock's screen-recording status, kept in sync via window
@@ -499,6 +505,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   }, [tempTitle, title, widget.id, updateWidget]);
 
   const stateRef = useRef({ isEditingTitle, saveTitle });
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync for stale-closure prevention (CLAUDE.md pattern); false positive from react-hooks/refs v7
   stateRef.current = { isEditingTitle, saveTitle };
 
   const handleCloseTools = useCallback(() => {
@@ -1992,7 +1999,14 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     }
   };
 
-  // Fallback to widget state if not dragging/resizing or if position-aware
+  // Fallback to widget state if not dragging/resizing or if position-aware.
+  // dragState is a performance ref updated in pointer handlers; reading it
+  // during render to derive position is the intended pattern (direct DOM
+  // manipulation path). The react-hooks/refs disable comments in this block
+  // silence false positives that cascade from the "adjust state while
+  // rendering" latch above — the original code was exempt before that latch
+  // was added because the React Compiler's analysis took a different path.
+  /* eslint-disable react-hooks/refs */
   const shouldUseDragState =
     (isDragging || isResizing) &&
     !POSITION_AWARE_WIDGETS.includes(widget.type) &&

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -2071,6 +2071,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           : shouldUseDragState && dragState.current
             ? dragState.current.h
             : (override?.h ?? widget.h),
+        /* eslint-enable react-hooks/refs */
         zIndex: isMaximized ? Z_INDEX.maximized : widget.z,
         display: 'flex',
         flexDirection: 'column',

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -359,12 +359,11 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     h: number;
   } | null>(null);
 
-  // Adjusting state while rendering (React docs pattern — "store previous
-  // value"): latch shouldRenderSettings to true once widget.flipped transitions
-  // from false → true. Using prevFlipped to detect the transition keeps this
-  // to a single extra render when the widget is first opened and avoids
-  // infinite-loop risk (React bails out when state didn't change). Inline
-  // rather than useEffect so it fires in the same synchronous render pass —
+  // Adjusting state while rendering (React docs pattern): latch shouldRenderSettings
+  // to true once widget.flipped transitions from false → true. Checking
+  // !shouldRenderSettings keeps this to a single extra render when the widget is
+  // first opened and avoids infinite-loop risk (React bails out when state didn't change).
+  // Inline rather than useEffect so it fires in the same synchronous render pass —
   // the SettingsPanel therefore always mounts with shouldRenderSettings=true
   // and the "Standard settings available." placeholder is never visible, even
   // on slow hardware or projectors where a post-paint effect would produce a


### PR DESCRIPTION
## Root cause

`shouldRenderSettings` was latched from `false` → `true` via `useEffect` (`DraggableWindow.tsx` lines 363–368 pre-fix). `useEffect` fires **after paint**, so when a widget was first flipped open, `SettingsPanel` committed its first render with `shouldRenderSettings=false` — showing the "Standard settings available." placeholder for one frame — before the effect re-rendered it with `true`. Visible as a flash on any device, especially projectors and slower hardware.

This is the `useEffect`-for-derived-state anti-pattern documented in CLAUDE.md.

## Rejected band-aid

Initialising `shouldRenderSettings` from `useState(() => widget.flipped)` would fix the first render but would permanently latch `true` for all widgets (including those placed unflipped), wasting lazy-init by always loading the settings chunk.

## Fix

Replaced the `useEffect` block with React's "adjust state while rendering" pattern: an inline `if (widget.flipped && !shouldRenderSettings) { setShouldRenderSettings(true); }`. React detects the mid-render state change, discards the in-progress render, and immediately re-renders with `shouldRenderSettings=true` in the same synchronous pass. `SettingsPanel` always mounts with the real value; the placeholder is never committed.

**ESLint side-effect:** Introducing any `setState` during render causes `react-hooks/refs` v7 (active via `recommended.rules`) to flag render-body ref assignments that were previously exempt. Four pre-existing CLAUDE.md-endorsed ref assignments needed targeted `eslint-disable-next-line react-hooks/refs` comments. A fifth block disable was added for `dragState.current` reads in the render body (lines 2013–2072) with a matching `eslint-enable` immediately after — narrowed by the orchestrator from the subagent's file-tail disable.

## Regression test

**`components/common/DraggableWindow.test.tsx`**
— `"SettingsPanel receives shouldRenderSettings=true on its very first render when widget flips open"`

Uses `vi.mock('./SettingsPanel')` to record the props on every render call. Flips widget from `flipped=false` → `true` and asserts `settingsPanelRenderProps[0].shouldRenderSettings === true`. DOM assertions alone can't distinguish the two approaches (RTL `act()` flushes effects synchronously in JSDOM); the module spy is the only reliable differentiator.

Verified: **FAILS** on `dev-paul` (first render props shows `false`), **PASSES** on this branch.

## Risk

**Contained** — change is isolated to `DraggableWindow.tsx`. The `shouldRenderSettings` latch is a one-way flag; its behavior is unchanged after the first flip.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PP8BBgbB654KUqPxyMY3d)_