### PR TITLE
fix(quiz): publishAssignmentScores inflates pointsMax on duplicate question ids

### DIFF
--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -2013,10 +2013,18 @@ export const useQuizAssignments = (
         // — the inner `.some` would otherwise become a noticeable stall on
         // PLC-shared assignments with hundreds of submissions × dozens of
         // questions.
+        //
+        // Iterate questionsById (already deduped) rather than the raw
+        // quizData.questions array. A duplicate question id in the raw array
+        // (possible when a Drive export writes the same question twice via an
+        // arrayUnion-style race) would cause pointsMax to count the same
+        // question's points more than once, inflating the denominator and
+        // deflating every student's published score. Mirrors the identical
+        // fix in publishAssignmentScores for Video Activity (#1728, #1787).
         const answeredQuestionIds = new Set<string>();
         for (const a of answers) answeredQuestionIds.add(a.questionId);
-        for (const q of quizData.questions) {
-          if (!answeredQuestionIds.has(q.id)) {
+        for (const [qId, q] of questionsById) {
+          if (!answeredQuestionIds.has(qId)) {
             pointsMax += q.points ?? 1;
           }
         }

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1567,7 +1567,8 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
     const studentCall = batchUpdate.mock.calls.find(
       ([ref]) => ref === refStudent
     );
-    if (!studentCall) throw new Error('expected update on student response ref');
+    if (!studentCall)
+      throw new Error('expected update on student response ref');
 
     // Correct: 1pt earned / 3pt total (q0=1 + q1=2; q1 dup must not be
     // counted) = 33%. The bug would produce 1/5 = 20%.

--- a/tests/hooks/useQuizAssignments.test.ts
+++ b/tests/hooks/useQuizAssignments.test.ts
@@ -1487,6 +1487,92 @@ describe('useQuizAssignments - publishAssignmentScores', () => {
     // First batch + at least one continuation batch.
     expect(batchCommit.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('does not inflate pointsMax when quizData.questions contains a duplicate question id (dedup guard)', async () => {
+    // Regression test for the unanswered-questions denominator-inflation bug.
+    //
+    // If `quizData.questions` contains a duplicate question id (possible when
+    // a Drive export writes the same question twice via an arrayUnion-style
+    // race), iterating the raw array for unanswered questions adds that
+    // question's points to `pointsMax` twice. This inflates the denominator
+    // and silently deflates the student's published score.
+    //
+    // Fix: iterate `questionsById` (the deduped Map) instead of the raw array,
+    // mirroring the identical fix in useVideoActivityAssignments (#1728, #1787).
+    //
+    // Scenario: 2 distinct questions (q0 = 1pt, q1 = 2pt) but q1 appears
+    // twice in the raw questions array. A student answers q0 correctly (1/1pt)
+    // and skips q1. Correct denominator = 1 + 2 = 3 → score = 33%.
+    // Buggy denominator = 1 + 2 + 2 = 5 → score = 20% (wrong — deflated).
+    const dupQuizData = {
+      id: 'quiz-dup',
+      title: 'Dup Quiz',
+      questions: [
+        {
+          id: 'q0',
+          text: 'Q0',
+          type: 'MC' as const,
+          correctAnswer: 'a',
+          incorrectAnswers: ['b'],
+          timeLimit: 30,
+          points: 1,
+        },
+        {
+          id: 'q1',
+          text: 'Q1',
+          type: 'MC' as const,
+          correctAnswer: 'b',
+          incorrectAnswers: ['a'],
+          timeLimit: 30,
+          points: 2,
+        },
+        // Duplicate of q1 — same id, simulates a Drive arrayUnion race.
+        {
+          id: 'q1',
+          text: 'Q1 (dup)',
+          type: 'MC' as const,
+          correctAnswer: 'b',
+          incorrectAnswers: ['a'],
+          timeLimit: 30,
+          points: 2,
+        },
+      ],
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    const refStudent = { id: 'r-student' };
+    // Student answers q0 correctly and leaves q1 unanswered.
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        {
+          ref: refStudent,
+          data: () => ({
+            studentUid: 's1',
+            answers: [{ questionId: 'q0', answer: 'a', answeredAt: 1 }],
+          }),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useQuizAssignments(TEACHER_UID));
+    await act(async () => {
+      await result.current.publishAssignmentScores(
+        ASSIGNMENT_ID,
+        dupQuizData,
+        'score-only'
+      );
+    });
+
+    const studentCall = batchUpdate.mock.calls.find(
+      ([ref]) => ref === refStudent
+    );
+    if (!studentCall) throw new Error('expected update on student response ref');
+
+    // Correct: 1pt earned / 3pt total (q0=1 + q1=2; q1 dup must not be
+    // counted) = 33%. The bug would produce 1/5 = 20%.
+    expect((studentCall[1] as { score: number }).score).toBe(33);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`publishAssignmentScores` in `hooks/useQuizAssignments.ts` (line 2018 pre-fix) iterated the raw `quizData.questions` array in the unanswered-questions denominator loop, but `questionsById` — a `Map<string, QuizQuestion>` built a few lines earlier specifically to deduplicate the raw array — was only used for grading lookups. If `quizData.questions` contained a duplicate question ID (possible when a Drive export uses an `arrayUnion`-style write that races to append the same question twice), the loop added that question's `points` to `pointsMax` once per occurrence, inflating the denominator and silently deflating every student's published score.

**Example:** Quiz with q0 (1 pt) and q1 (2 pt) where q1 appears twice. Student answers q0 correctly, skips q1.
- **Buggy:** `pointsMax` = 1 + 2 + 2 = 5 → published score = **20%** ✗
- **Fixed:** `pointsMax` = 1 + 2 = 3 → published score = **33%** ✓

Same root cause as #1728 (`computeVideoActivityScorePct`), #1777 (`buildContributionDoc`), and #1787 (`useVideoActivityAssignments.publishAssignmentScores`).

## Rejected band-aid

Adding a `seen: Set<string>` inside the existing raw-array loop. This would work but duplicates deduplication logic that `questionsById` already provides, and obscures the architectural inconsistency.

## Fix

Changed the unanswered-questions loop from iterating `quizData.questions` to iterating `questionsById.entries()` — reusing the Map that already exists and that already deduplicates by last-write. One-line change, mirrors the identical fix applied to the Video Activity path in #1787.

## Regression test

**`tests/hooks/useQuizAssignments.test.ts`**
— `"does not inflate pointsMax when quizData.questions contains a duplicate question id (dedup guard)"`

Constructs a quiz with q0 (1 pt) and q1 (2 pt) where q1 appears twice. A student who answers q0 correctly and skips q1 should score 33%. Before fix: `AssertionError: expected 20 to be 33`. After fix: passes (score = 33).

Verified: **FAILS** on `dev-paul`, **PASSES** on this branch.

## Risk

**Contained** — one-line change in `useQuizAssignments.ts`. No schema changes, no new state. Consistent with the dedup pattern already established across the codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PP8BBgbB654KUqPxyMY3d)_