### PR TITLE
fix(analytics): blooms-ai usage silently dropped from admin analytics

### DIFF
--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -443,6 +443,7 @@ export async function computeAnalyticsForOrg(
     'quiz',
     'ocr',
     'guided-learning',
+    'blooms-ai',
   ];
 
   const aiUsageStream = db

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -874,6 +874,39 @@ describe('adminAnalytics', () => {
     expect(capturedData.api.totalCalls).toBe(10);
   });
 
+  it('counts blooms-ai usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: blooms-ai was missing from GEMINI_SPECIFIC_FEATURES in
+    // adminAnalyticsCompute.ts. A doc like `uid1_blooms-ai_2026-06-02` was
+    // treated as an "overall" doc with uid = `uid1_blooms-ai`, which never
+    // matched any org member, so the call was silently dropped from totalCalls
+    // and byFeature['blooms-ai'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-02', data: { count: 5 } },
+      // Per-feature blooms-ai doc — should count toward byFeature['blooms-ai']
+      // but NOT toward totalCalls (to avoid double-counting)
+      { id: 'uid1_blooms-ai_2026-06-02', data: { count: 3 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(5);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['blooms-ai']).toBe(3);
+  });
+
   it('returns topUsers with resolved email and unknown fallback', async () => {
     mockFirestoreState.users = [
       {


### PR DESCRIPTION
## Root cause

`adminAnalyticsCompute.ts` uses `GEMINI_SPECIFIC_FEATURES` to decide whether the second-to-last segment of an `ai_usage` doc ID is a feature name or part of the UID. `functions/src/index.ts` writes per-feature Blooms AI docs with ID pattern `{uid}_blooms-ai_{date}` (line 676: `if (genType === 'blooms-ai') specificFeatureId = 'blooms-ai'`), but `'blooms-ai'` was absent from `GEMINI_SPECIFIC_FEATURES`.

Result: a doc like `uid123_blooms-ai_2026-06-02` was misidentified as an "overall" usage doc with UID `uid123_blooms-ai` — a string that never matches any real Firebase Auth UID in the org member set. Every Blooms AI usage call was silently:
1. Dropped from `api.totalCalls`
2. Not counted in `api.byFeature['blooms-ai']` (key never populated)
3. Not attributed to any user in `topUsers`

## Rejected band-aid

Changing the doc ID format written by `index.ts` (e.g. using a different separator). That would lose all historical data stored under the existing format.

## Fix

Added `'blooms-ai'` to the `GEMINI_SPECIFIC_FEATURES` array in `adminAnalyticsCompute.ts`. One-line change; the parsing logic correctly handles the feature once it knows to look for it.

## Regression test

**`functions/src/index.test.ts`**
— `"adminAnalytics > counts blooms-ai usage docs toward byFeature without corrupting uid parsing"`

Creates mock `ai_usage` docs: one overall doc (`uid1_2026-06-02`, count=5) and one per-feature doc (`uid1_blooms-ai_2026-06-02`, count=3). Asserts `totalCalls=5` and `byFeature['blooms-ai']=3`. Before fix: `byFeature['blooms-ai']` is `undefined`. After fix: test passes.

Verified: **FAILS** on `dev-paul`, **PASSES** on this branch.

## Risk

**Contained** — single one-line addition to the feature constant list in `adminAnalyticsCompute.ts`. No schema changes, no impact on other features.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PP8BBgbB654KUqPxyMY3d)_