### PR TITLE
fix(deps): pin path-to-regexp to patched versions to close HIGH ReDoS advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
       "lodash": "^4.17.23",
       "lodash-es": "^4.18.1",
       "rollup": "^4.59.0",
-      "protobufjs": "^7.5.6"
+      "protobufjs": "^7.5.6",
+      "path-to-regexp@0.1": "^0.1.13",
+      "path-to-regexp@8": "^8.4.0"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,8 @@ overrides:
   lodash-es: ^4.18.1
   rollup: ^4.59.0
   protobufjs: ^7.5.6
+  path-to-regexp@0.1: ^0.1.13
+  path-to-regexp@8: ^8.4.0
 
 importers:
 
@@ -4922,14 +4924,14 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -9714,7 +9716,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
@@ -11891,13 +11893,13 @@ snapshots:
       minipass: 7.1.2
     optional: true
 
-  path-to-regexp@0.1.12: {}
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@1.9.0:
     dependencies:
       isarray: 0.0.1
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -12408,7 +12410,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Root `pnpm audit` reported **two HIGH `path-to-regexp` advisories**:

| Advisory | Affected range | Chain | Resolved (before) |
| --- | --- | --- | --- |
| GHSA-37ch-88jc-xwx2 — ReDoS via multiple route parameters | `<0.1.13` | `firebase-functions@7.2.5 > express@4 > path-to-regexp` | `0.1.12` |
| GHSA-j3q9-mxjg-w52f — DoS via sequential optional groups | `>=8.0.0 <8.4.0` | `@google/genai > @modelcontextprotocol/sdk > express@5 > router > path-to-regexp` | `8.3.0` |

## Root cause

`express@4.22.1` declares `path-to-regexp: ~0.1.12` (permits `0.1.13`) and `router@2.2.0` declares `path-to-regexp: ^8.x` (permits `8.4.x`), so **both ranges already allow the patched versions** — the root lockfile was simply stale. The `functions/` workspace (more recently regenerated lockfile, no override) already resolved `0.1.13` and `8.4.2` cleanly, confirming compatibility.

## Fix

Added two **version-scoped** entries to root `package.json` `pnpm.overrides`:

```jsonc
"path-to-regexp@0.1": "^0.1.13",  // express@4 chain -> 0.1.13
"path-to-regexp@8":   "^8.4.0"    // express@5/router chain -> 8.4.2
```

A blanket `"path-to-regexp"` override was deliberately **not** used: the `0.1.x` (express@4) and `8.x` (express@5/router) lines have incompatible APIs, so pinning all resolutions to one version would break express@4. The unrelated `1.9.0` resolution (via `superstatic > firebase-tools`, not flagged) is left untouched. `functions/` needed no change.

## Verification

- `pnpm why path-to-regexp` → `0.1.13`, `1.9.0`, `8.4.2`
- `pnpm audit | grep -c path-to-regexp` → `0` (both HIGH advisories cleared)
- `pnpm type-check` → 0 errors
- `pnpm lint --max-warnings 0` → 0 errors / 0 warnings
- `pnpm format:check` → clean
- `pnpm build` → succeeded (~32s)

Dependency-only change (package.json overrides + lockfile refresh); no source files touched.

https://claude.ai/code/session_01Ee8VaDbirgBenY1fMjm4hA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee8VaDbirgBenY1fMjm4hA)_