### PR TITLE
fix(a11y): give shared ToggleRow switches an accessible name

### DIFF
--- a/components/common/library/AssignmentSettingsToggleGroup.tsx
+++ b/components/common/library/AssignmentSettingsToggleGroup.tsx
@@ -127,7 +127,19 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
       >
         {label}
       </span>
-      <Toggle checked={checked} onChange={onChange} size="sm" showLabels />
+      {/*
+        Forward `label` so the switch gets an accessible name (Toggle maps
+        `label` to `aria-label`). Without it, screen readers announce the
+        switch as just "switch, off". The visible "ON"/"OFF" text is driven
+        by `showLabels`, not `label`, so this does not double up the label.
+      */}
+      <Toggle
+        checked={checked}
+        onChange={onChange}
+        size="sm"
+        showLabels
+        label={label}
+      />
     </div>
     {hint && <p className="text-xxs text-slate-500 mt-0.5">{hint}</p>}
   </div>

--- a/components/common/library/AssignmentSettingsToggleGroup.tsx
+++ b/components/common/library/AssignmentSettingsToggleGroup.tsx
@@ -116,7 +116,7 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
   disabled,
   compact = false,
 }) => (
-  <div className={disabled ? 'opacity-40 pointer-events-none' : ''}>
+  <div className={disabled ? 'opacity-40' : ''}>
     <div className="flex items-center justify-between">
       <span
         className={
@@ -132,6 +132,12 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
         `label` to `aria-label`). Without it, screen readers announce the
         switch as just "switch, off". The visible "ON"/"OFF" text is driven
         by `showLabels`, not `label`, so this does not double up the label.
+
+        Forward `disabled` to the switch itself (not just the wrapper). The
+        old `pointer-events-none` wrapper blocked the mouse but left the
+        button keyboard-focusable/activatable and gave assistive tech no
+        disabled state. The `disabled` attribute removes it from the tab
+        order and announces it correctly.
       */}
       <Toggle
         checked={checked}
@@ -139,6 +145,7 @@ export const ToggleRow: React.FC<ToggleRowProps> = ({
         size="sm"
         showLabels
         label={label}
+        disabled={disabled}
       />
     </div>
     {hint && <p className="text-xxs text-slate-500 mt-0.5">{hint}</p>}

--- a/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
+++ b/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
@@ -35,6 +35,21 @@ describe('QuizBehaviorSettingsPanel', () => {
     expect(screen.getByText('Block Copy & Paste')).toBeInTheDocument();
   });
 
+  it('gives each toggle-row switch an accessible name (a11y)', () => {
+    render(
+      <QuizBehaviorSettingsPanel value={defaultValue} onChange={vi.fn()} />
+    );
+    // ToggleRow forwards its visible label to the switch's aria-label, so the
+    // switch is discoverable by name instead of being announced as just
+    // "switch, off". Regression guard for the missing accessible name.
+    expect(
+      screen.getByRole('switch', { name: /Block Copy & Paste/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: /Tab Switch Detection/i })
+    ).toBeInTheDocument();
+  });
+
   it('reflects an existing blockCopyPaste: true value as a checked switch', () => {
     const value: QuizBehaviorSettings = {
       ...DEFAULT_QUIZ_BEHAVIOR,

--- a/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
+++ b/tests/components/common/library/QuizBehaviorSettingsPanel.test.tsx
@@ -50,6 +50,23 @@ describe('QuizBehaviorSettingsPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('forwards disabled to the switch so disabled rows are truly disabled (a11y)', () => {
+    // sessionMode 'teacher' (the default) makes "Shuffle Questions" unavailable,
+    // so ToggleRow renders it disabled. The switch must expose a real disabled
+    // state — not just a pointer-events-none wrapper — so keyboard and AT users
+    // cannot focus or activate it.
+    render(
+      <QuizBehaviorSettingsPanel value={defaultValue} onChange={vi.fn()} />
+    );
+    // Expand the "Question Randomization" disclosure to reveal its rows.
+    fireEvent.click(
+      screen.getByRole('button', { name: /Question Randomization/i })
+    );
+    expect(
+      screen.getByRole('switch', { name: /Shuffle Questions/i })
+    ).toBeDisabled();
+  });
+
   it('reflects an existing blockCopyPaste: true value as a checked switch', () => {
     const value: QuizBehaviorSettings = {
       ...DEFAULT_QUIZ_BEHAVIOR,


### PR DESCRIPTION
## Problem

The shared `ToggleRow` in `components/common/library/AssignmentSettingsToggleGroup.tsx` rendered its visible label as a sibling `<span>` but passed nothing down to `<Toggle>`. `Toggle` maps its `label` prop to `aria-label` on the `role="switch"` element, so with no label every `ToggleRow` switch — "Tab Switch Detection", "Block Copy & Paste", "Shuffle Questions", the feedback toggles, etc. — was announced by screen readers as just **"switch, off"** with no accessible name. This violates the WCAG AA / screen-reader-label baseline in `CLAUDE.md`.

## Fix

Forward `label={label}` from `ToggleRow` to `<Toggle>`.

Verified safe before choosing this approach (per the review note's condition): `Toggle` uses `label` **solely** for `aria-label` (`Toggle.tsx:73`) and never renders it visibly — the on-screen "ON"/"OFF" text is driven by the separate `showLabels` prop. So there is no double-labeling and **no visual change** to any panel; `aria-label` is a non-visual attribute. This reuses the prop the codebase already documents as the intended screen-reader mechanism for `Toggle`, rather than adding `aria-labelledby` plumbing to the shared component.

## Scope / regression check

`ToggleRow` is shared across the Quiz, Video Activity, and PLC assignment settings panels. All their existing suites pass unchanged:

- `QuizBehaviorSettingsPanel.test.tsx`
- `VideoActivityBehaviorSettingsPanel.test.tsx`
- `QuizAssignmentSettingsModal.test.tsx`
- `PlcAssignmentConfigModal.test.tsx`
- `Toggle.test.tsx`

`type-check`, `lint` (`--max-warnings 0`), and `prettier --check` all clean.

## Test

Added a regression test in `QuizBehaviorSettingsPanel.test.tsx` asserting the switches are discoverable by accessible name:

```ts
expect(screen.getByRole('switch', { name: /Block Copy & Paste/i })).toBeInTheDocument();
expect(screen.getByRole('switch', { name: /Tab Switch Detection/i })).toBeInTheDocument();
```

## Context

Surfaced during review of #1796 (Block Copy & Paste toggle); intentionally left out of that PR's scope because it touches the shared component and unrelated rows.

https://claude.ai/code/session_01ULbZzbHhC7oyApBRu14gbf

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULbZzbHhC7oyApBRu14gbf)_