### PR TITLE
fix(classroom-addon): CF-gate classroom_course_links to close course squatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ verification/
 # Local data / Drive-sync artifacts — never commit (may contain student PII)
 Data/
 .tmp.driveupload/
+# Local in-app quiz exports (".quiz.json" downloads) — quiz content, not repo source
+Quizzes/

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Users,
@@ -13,14 +13,14 @@ import {
   Loader2,
   AlertTriangle,
 } from 'lucide-react';
-import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { useClassLinkEnabled } from '@/hooks/useClassLinkEnabled';
 import { ClassRoster, Student } from '@/types';
-import { auth, db } from '@/config/firebase';
+import { auth, functions } from '@/config/firebase';
 import { RosterEditorModal } from '@/components/classes/RosterEditorModal';
 import { Modal } from '@/components/common/Modal';
 import {
@@ -41,6 +41,26 @@ interface GoogleClassroomCourse {
   id: string;
   name: string;
   section?: string;
+}
+
+/**
+ * Args for the `linkClassroomCourse` Cloud Function. The link doc is written
+ * server-side (not via `setDoc`) so the CF can verify — with the teacher's own
+ * courses token — that the caller actually teaches the Google course before
+ * recording the link. `teacherUid` is intentionally omitted: the CF derives it
+ * from the authenticated caller, so a client can't claim to be another teacher.
+ */
+interface LinkClassroomCourseParams {
+  accessToken: string;
+  courseId: string;
+  classlinkClassId: string | null;
+  classlinkOrgId: string | null;
+  rosterId: string;
+}
+
+interface LinkClassroomCourseResult {
+  ok: boolean;
+  courseId: string;
 }
 
 interface SidebarClassesProps {
@@ -85,6 +105,11 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
   const [courseLoadError, setCourseLoadError] = useState<string | null>(null);
   const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  // The `classroom.courses.readonly` token used to LIST the teacher's courses is
+  // the same one the link CF needs to RE-VERIFY teaching authority server-side.
+  // Captured here so confirming the link reuses it (no second OAuth popup);
+  // cleared when the modal closes.
+  const coursesAccessTokenRef = useRef<string | null>(null);
 
   const loadCourses = useCallback(async () => {
     setCourseLoadState('loading');
@@ -97,6 +122,8 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
         CLASSROOM_COURSES_READONLY_SCOPE,
         user?.email ?? undefined
       );
+      // Reused at confirm time to verify teaching authority server-side.
+      coursesAccessTokenRef.current = token;
       const res = await fetch(
         'https://classroom.googleapis.com/v1/courses?teacherId=me&courseStates=ACTIVE',
         { headers: { Authorization: `Bearer ${token}` } }
@@ -127,6 +154,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     setSelectedCourseId(null);
     setCourseLoadError(null);
     setIsSaving(false);
+    coursesAccessTokenRef.current = null;
   }, []);
 
   const handleConfirmLink = useCallback(async () => {
@@ -143,12 +171,31 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     }
     setIsSaving(true);
     try {
-      await setDoc(doc(db, 'classroom_course_links', selectedCourseId), {
+      // The link doc is written by the `linkClassroomCourse` Cloud Function, NOT
+      // a direct setDoc: Firestore rules can't verify Google-course teaching, so
+      // client writes to classroom_course_links are blocked. The CF re-verifies
+      // — with the teacher's own courses token — that the caller actually teaches
+      // this course before recording the link, closing the course-squatting hole.
+      let accessToken = coursesAccessTokenRef.current;
+      if (!accessToken) {
+        // The list token expired or was cleared; re-acquire (silent if already
+        // consented this session).
+        await ensureGis();
+        accessToken = await requestAccessToken(
+          CLASSROOM_COURSES_READONLY_SCOPE,
+          user?.email ?? undefined
+        );
+      }
+      const linkCourse = httpsCallable<
+        LinkClassroomCourseParams,
+        LinkClassroomCourseResult
+      >(functions, 'linkClassroomCourse');
+      await linkCourse({
+        accessToken,
+        courseId: selectedCourseId,
         classlinkClassId: linkingRoster.classlinkClassId ?? null,
         classlinkOrgId: linkingRoster.classlinkOrgId ?? null,
-        teacherUid: uid,
         rosterId: linkingRoster.id,
-        createdAt: serverTimestamp(),
       });
       await updateRoster(linkingRoster.id, {
         googleClassroomCourseId: selectedCourseId,
@@ -167,6 +214,8 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
         }),
         'error'
       );
+      // The CF surfaces an actionable message (e.g. "you can only link a course
+      // you teach", "already linked by another teacher") — show it in the modal.
       setCourseLoadError(
         err instanceof Error ? err.message : 'Failed to link to Classroom.'
       );
@@ -179,6 +228,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     t,
     updateRoster,
     closeLinkModal,
+    user?.email,
   ]);
 
   const editingRoster: ClassRoster | null =

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -179,12 +179,14 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
       let accessToken = coursesAccessTokenRef.current;
       if (!accessToken) {
         // The list token expired or was cleared; re-acquire (silent if already
-        // consented this session).
+        // consented this session) and cache it so a retry after a failed link
+        // doesn't pop another token request.
         await ensureGis();
         accessToken = await requestAccessToken(
           CLASSROOM_COURSES_READONLY_SCOPE,
           user?.email ?? undefined
         );
+        coursesAccessTokenRef.current = accessToken;
       }
       const linkCourse = httpsCallable<
         LinkClassroomCourseParams,

--- a/firestore.rules
+++ b/firestore.rules
@@ -651,18 +651,23 @@ service cloud.firestore {
     // ClassLink class (section) sourcedId, so the add-on can resolve students
     // against the existing OneRoster roster + name pipeline. Keyed by the
     // Google courseId; the doc records the claiming teacher. The student-login
-    // CF reads it via the Admin SDK (bypasses rules). Low-sensitivity (an
-    // id→id map, no PII), but writes are constrained to the claiming teacher
-    // and an existing link can't be hijacked by a different teacher.
+    // CF reads it via the Admin SDK (bypasses rules).
+    //
+    // READ is open to any authed user (the teacher discovery iframe reads the
+    // link to resolve class targeting). WRITES are SERVER-ONLY: the
+    // `linkClassroomCourse` CF first verifies — with the teacher's own
+    // `classroom.courses.readonly` token — that the caller genuinely teaches the
+    // Google course, then writes via the Admin SDK. Rules cannot verify
+    // Google-course teaching, so a client `create` (checking only
+    // teacherUid == auth.uid) let ANY authed user squat ANY courseId: the
+    // student-login CF mints every student's class-gate `classIds` from whatever
+    // class this doc names, so a squatter could mis-route a victim course's
+    // students AND permanently lock the real teacher out (first-write-wins; an
+    // update requires the existing teacherUid). Blocking client writes closes
+    // that hole.
     match /classroom_course_links/{courseId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null
-        && request.resource.data.teacherUid == request.auth.uid;
-      allow update: if request.auth != null
-        && request.resource.data.teacherUid == request.auth.uid
-        && resource.data.teacherUid == request.auth.uid;
-      allow delete: if request.auth != null
-        && resource.data.teacherUid == request.auth.uid;
+      allow write: if false;
     }
 
     // Global permissions - all authenticated users can read, only admins can write

--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -983,6 +983,80 @@ describe('classroomAddonNet.patchStudentSubmissionGrade URL construction', () =>
   });
 });
 
+// The teacher course-list seam — the trust anchor for linkClassroomCourse. The
+// linkClassroomCourse tests stub it, so these pin the real URL/pagination it
+// builds and that it degrades safely on a weird upstream body (the parse guard).
+describe('classroomAddonNet.listTeacherCourseIds (real seam)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs courses?teacherId=me&courseStates=ACTIVE and paginates, collecting ids', async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const u = url as string;
+      urls.push(u);
+      // The second page (token present) is the last — no nextPageToken.
+      if (u.includes('pageToken=PAGE2')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ courses: [{ id: 'C3' }] }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          courses: [{ id: 'C1' }, { id: 'C2' }],
+          nextPageToken: 'PAGE2',
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({
+      ok: true,
+      status: 200,
+      courseIds: ['C1', 'C2', 'C3'],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(urls[0]).toContain('https://classroom.googleapis.com/v1/courses?');
+    expect(urls[0]).toContain('teacherId=me');
+    expect(urls[0]).toContain('courseStates=ACTIVE');
+    expect(urls[1]).toContain('pageToken=PAGE2');
+  });
+
+  it('treats a null/non-object 200 body as an empty final page (no crash)', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => null,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({ ok: true, status: 200, courseIds: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed (ok:false) on a non-2xx response', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({ ok: false, status: 401, courseIds: [] });
+  });
+});
+
 // The courseWork due-date PATCH seam used to sync the add-on picker's date onto
 // the parent assignment. The createClassroomAttachment tests stub this seam, so
 // this standalone test pins the real URL/updateMask/body it builds against a

--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -145,6 +145,7 @@ vi.mock('firebase-functions/params', () => ({
 import {
   classroomAddonLoginV1,
   createClassroomAttachment,
+  linkClassroomCourse,
   pushClassroomGradesForAssignment,
   classroomAddonNet,
 } from './classroomAddonAuth';
@@ -708,6 +709,164 @@ describe('createClassroomAttachment (spike)', () => {
     await expect(callAttach({ data: attachData })).rejects.toMatchObject({
       code: 'internal',
     });
+  });
+});
+
+// linkClassroomCourse — server-gated creator of classroom_course_links/{courseId}.
+// The trust anchor is listTeacherCourseIds (the caller's OWN teacher course
+// list): the chosen courseId MUST appear there, or the link is refused. These
+// tests pin the squatting fix — a non-teacher can't claim a course, teacherUid
+// is always the authenticated caller (never the client payload), and an existing
+// link owned by a different teacher is never overwritten.
+const callLink = linkClassroomCourse as unknown as (req: {
+  data: unknown;
+  auth?: { uid: string } | null;
+}) => Promise<{ ok: boolean; courseId: string }>;
+
+const linkData = {
+  accessToken: 'teacher-courses-token',
+  courseId: 'C1',
+  classlinkClassId: 'CL-SECTION-1',
+  classlinkOrgId: 'orono',
+  rosterId: 'roster-1',
+};
+
+function findLinkWrite() {
+  return firestoreWrites.find((w) => w.path === 'classroom_course_links/C1');
+}
+
+describe('linkClassroomCourse (course-squatting fix)', () => {
+  it('writes the link for a verified teacher of the course', async () => {
+    const listSpy = vi
+      .spyOn(classroomAddonNet, 'listTeacherCourseIds')
+      .mockResolvedValue({ ok: true, status: 200, courseIds: ['C0', 'C1'] });
+
+    const res = await callLink({
+      data: linkData,
+      auth: { uid: 'teacher-1' },
+    });
+
+    expect(res).toMatchObject({ ok: true, courseId: 'C1' });
+    expect(listSpy).toHaveBeenCalledWith('teacher-courses-token');
+    const write = findLinkWrite();
+    expect(write?.data).toMatchObject({
+      classlinkClassId: 'CL-SECTION-1',
+      classlinkOrgId: 'orono',
+      teacherUid: 'teacher-1',
+      rosterId: 'roster-1',
+    });
+    // First create stamps both timestamps.
+    expect(typeof write?.data.createdAt).toBe('number');
+    expect(typeof write?.data.updatedAt).toBe('number');
+  });
+
+  it('refuses to link a course the caller does not teach (squat attempt)', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      // The caller teaches OTHER courses, but NOT the courseId they're claiming.
+      courseIds: ['SOME-OTHER-COURSE'],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'squatter' } })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('always records teacherUid from the authenticated caller, never the client payload', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await callLink({
+      // A malicious client tries to set someone else as the owner.
+      data: { ...linkData, teacherUid: 'victim-teacher' },
+      auth: { uid: 'real-caller' },
+    });
+
+    expect(findLinkWrite()?.data.teacherUid).toBe('real-caller');
+  });
+
+  it('refuses to overwrite a link owned by a different teacher (no hijack)', async () => {
+    courseLinkDoc = {
+      classlinkClassId: 'CL-OTHER',
+      teacherUid: 'original-teacher',
+    };
+    // Even a genuine co-teacher (passes the teacher check) can't steal it.
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'co-teacher' } })
+    ).rejects.toMatchObject({ code: 'already-exists' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('lets the SAME teacher re-link (update) without resetting createdAt', async () => {
+    courseLinkDoc = {
+      classlinkClassId: 'CL-OLD',
+      teacherUid: 'teacher-1',
+      createdAt: 111,
+    } as Record<string, unknown>;
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await callLink({ data: linkData, auth: { uid: 'teacher-1' } });
+
+    const write = findLinkWrite();
+    expect(write?.data.teacherUid).toBe('teacher-1');
+    expect(write?.data.classlinkClassId).toBe('CL-SECTION-1');
+    // createdAt is only set on first create; a re-link must not stamp it (merge
+    // preserves the original).
+    expect(write?.data.createdAt).toBeUndefined();
+    expect(typeof write?.data.updatedAt).toBe('number');
+  });
+
+  it('fails closed when the teacher course-list check errors (never links on an unverifiable token)', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: false,
+      status: 401,
+      courseIds: [],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('rejects an unauthenticated caller before any Classroom call', async () => {
+    const listSpy = vi.spyOn(classroomAddonNet, 'listTeacherCourseIds');
+
+    await expect(
+      callLink({ data: linkData, auth: null })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+    expect(listSpy).not.toHaveBeenCalled();
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('requires accessToken and courseId', async () => {
+    await expect(
+      callLink({
+        data: { ...linkData, accessToken: '' },
+        auth: { uid: 'teacher-1' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    await expect(
+      callLink({
+        data: { ...linkData, courseId: '' },
+        auth: { uid: 'teacher-1' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
   });
 });
 

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -389,11 +389,19 @@ export const classroomAddonNet = {
         const body = (await res.json()) as {
           courses?: { id?: string }[];
           nextPageToken?: string;
-        };
-        for (const c of body.courses ?? []) {
-          if (typeof c.id === 'string') courseIds.push(c.id);
+        } | null;
+        // A 200 with a null / non-object body shouldn't happen for
+        // courses.list, but guard rather than deref it (and treat it as an
+        // empty final page rather than throwing into the catch, which would
+        // discard course ids already collected from earlier pages).
+        if (body && typeof body === 'object') {
+          for (const c of body.courses ?? []) {
+            if (typeof c.id === 'string') courseIds.push(c.id);
+          }
+          pageToken = body.nextPageToken;
+        } else {
+          pageToken = undefined;
         }
-        pageToken = body.nextPageToken;
         pages += 1;
       } while (pageToken && pages < MAX_PAGES);
       return { ok: true, status: 200, courseIds };

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -404,6 +404,18 @@ export const classroomAddonNet = {
         }
         pages += 1;
       } while (pageToken && pages < MAX_PAGES);
+      // If we stopped because of the page cap while more pages remained, the
+      // enumeration is INCOMPLETE — fail closed rather than treat the truncated
+      // list as authoritative, which could wrongly deny a teacher whose course
+      // sits beyond the cap. (Practically unreachable — a teacher with >2500
+      // active courses doesn't exist — but it keeps the trust anchor honest.)
+      if (pageToken) {
+        console.warn(
+          '[classroomAddon] listTeacherCourseIds hit the page cap with more ' +
+            'pages remaining; treating the enumeration as unverifiable.'
+        );
+        return { ok: false, status: 0, courseIds: [] };
+      }
       return { ok: true, status: 200, courseIds };
     } catch (err) {
       console.warn(
@@ -971,6 +983,11 @@ export const createClassroomAttachment = onCall(
 export const linkClassroomCourse = onCall(
   {
     memory: '256MiB',
+    // Public IAM invoker like the other add-on callables: the Firebase Auth
+    // check happens IN the callable framework (the ID token is in the request),
+    // not at the IAM layer, so the endpoint must be reachable. Auth is still
+    // enforced below — an unauthenticated caller is rejected before any work.
+    invoker: 'public',
     cors: ALLOWED_ORIGINS,
   },
   async (request) => {

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -159,6 +159,22 @@ interface CreateAttachmentData {
 }
 
 /**
+ * Input to `linkClassroomCourse` (the SpartBoard dashboard "Link to Google
+ * Classroom" flow). `accessToken` is the teacher's own
+ * `classroom.courses.readonly` token — the SAME token that listed their courses
+ * client-side — used here to RE-VERIFY teaching authority server-side.
+ * `teacherUid` is intentionally absent: it's taken from `request.auth.uid`, not
+ * the client, so a caller can never claim to be a different teacher.
+ */
+interface LinkClassroomCourseData {
+  accessToken?: unknown;
+  courseId?: unknown;
+  classlinkClassId?: unknown;
+  classlinkOrgId?: unknown;
+  rosterId?: unknown;
+}
+
+/**
  * `EmbedUri` view-URI objects + title, per addOnAttachments.create.
  *
  * Grade-sync fields (`studentWorkReviewUri` + `maxPoints`) are added together:
@@ -331,6 +347,62 @@ export const classroomAddonNet = {
     } catch (err) {
       console.warn('[classroomAddonLoginV1] userinfo fetch failed:', err);
       return null;
+    }
+  },
+
+  /**
+   * List the Google Classroom course ids the access token's owner TEACHES
+   * (`courses.list?teacherId=me`). This is the trust anchor for
+   * `linkClassroomCourse`: Classroom only returns a course here if the
+   * authenticated user is a teacher of it, so membership in this list proves
+   * teaching authority that Firestore rules can't verify. Paginated with a
+   * generous cap so a teacher with many courses is fully covered without an
+   * unbounded loop. Any upstream/network failure returns `ok: false` so the
+   * caller fails CLOSED (never links on an unverifiable token). Seam so tests
+   * can stub it without a live Classroom call.
+   */
+  async listTeacherCourseIds(
+    accessToken: string
+  ): Promise<{ ok: boolean; status: number; courseIds: string[] }> {
+    const courseIds: string[] = [];
+    let pageToken: string | undefined;
+    let pages = 0;
+    // A single teacher having >2500 active courses is implausible; the cap is a
+    // runaway guard, not an expected limit.
+    const MAX_PAGES = 25;
+    try {
+      do {
+        const qs = new URLSearchParams({
+          teacherId: 'me',
+          courseStates: 'ACTIVE',
+          pageSize: '100',
+        });
+        if (pageToken) qs.set('pageToken', pageToken);
+        const res = await fetch(`${CLASSROOM_API}/courses?${qs.toString()}`, {
+          headers: bearer(accessToken),
+          signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          console.warn(`[classroomAddon] listTeacherCourseIds ${res.status}`);
+          return { ok: false, status: res.status, courseIds: [] };
+        }
+        const body = (await res.json()) as {
+          courses?: { id?: string }[];
+          nextPageToken?: string;
+        };
+        for (const c of body.courses ?? []) {
+          if (typeof c.id === 'string') courseIds.push(c.id);
+        }
+        pageToken = body.nextPageToken;
+        pages += 1;
+      } while (pageToken && pages < MAX_PAGES);
+      return { ok: true, status: 200, courseIds };
+    } catch (err) {
+      console.warn(
+        '[classroomAddon] listTeacherCourseIds fetch failed (network/timeout):',
+        err
+      );
+      return { ok: false, status: 0, courseIds: [] };
     }
   },
 
@@ -860,6 +932,132 @@ export const createClassroomAttachment = onCall(
     // composer (→ PERMISSION_DENIED). The teacher sets the due date once, in
     // that composer (the screen this add-on iframe is embedded in).
     return { attachmentId: createResult.id };
+  }
+);
+
+/**
+ * linkClassroomCourse — server-gated creator of
+ * `classroom_course_links/{courseId}`, called from the SpartBoard dashboard's
+ * "Link to Google Classroom" flow (NOT inside a Classroom iframe, so there's no
+ * getAddOnContext launch to lean on — the trust anchor is a server-side
+ * Classroom course-list check instead).
+ *
+ * WHY THIS EXISTS: the link doc maps a Google courseId → a ClassLink section,
+ * and `classroomAddonLoginV1` mints every student's class-gate `classIds` from
+ * whatever class this doc names. Firestore rules can only check
+ * `teacherUid == auth.uid`; they CANNOT verify the caller actually teaches the
+ * Google course. So a client `create` let any authed user squat ANY courseId
+ * (first-write-wins → mis-route a victim course's students AND lock the real
+ * teacher out, since `update` requires the existing teacherUid). The rules now
+ * block client writes; this CF is the only writer.
+ *
+ * TRUST ANCHOR: re-run the caller's OWN `courses?teacherId=me` query
+ * server-side with their `classroom.courses.readonly` token (the same token
+ * that listed the courses they picked from). Classroom only returns a course in
+ * that list if the user is a teacher of it, so the chosen courseId must appear
+ * there — a forged/borrowed courseId won't. `teacherUid` is taken from
+ * `request.auth.uid` (never the client). An existing link owned by a DIFFERENT
+ * teacher is never overwritten (`already-exists`), preserving the no-hijack
+ * invariant.
+ */
+export const linkClassroomCourse = onCall(
+  {
+    memory: '256MiB',
+    cors: ALLOWED_ORIGINS,
+  },
+  async (request) => {
+    const data = (request.data ?? {}) as LinkClassroomCourseData;
+
+    // teacherUid comes from the authenticated caller, never the client payload.
+    const callerUid = request.auth?.uid ?? '';
+    if (!callerUid) {
+      throw new HttpsError(
+        'unauthenticated',
+        'You must be signed in to link a class.'
+      );
+    }
+
+    const accessToken =
+      typeof data.accessToken === 'string' ? data.accessToken : '';
+    const courseId = typeof data.courseId === 'string' ? data.courseId : '';
+    if (!accessToken) {
+      throw new HttpsError(
+        'invalid-argument',
+        'accessToken is required (your Google Classroom courses token).'
+      );
+    }
+    if (!courseId) {
+      throw new HttpsError('invalid-argument', 'courseId is required.');
+    }
+    // Link payload. classlinkClassId/OrgId are null for a roster with no
+    // ClassLink linkage (it still links to the Google course by id); rosterId
+    // ties the link back to the SpartBoard roster the teacher chose.
+    const classlinkClassId =
+      typeof data.classlinkClassId === 'string' ? data.classlinkClassId : null;
+    const classlinkOrgId =
+      typeof data.classlinkOrgId === 'string' ? data.classlinkOrgId : null;
+    const rosterId = typeof data.rosterId === 'string' ? data.rosterId : null;
+
+    // TRUST ANCHOR: prove the caller teaches this Google course. Fail CLOSED on
+    // any upstream error (never link on an unverifiable token).
+    const teacherCourses =
+      await classroomAddonNet.listTeacherCourseIds(accessToken);
+    if (!teacherCourses.ok) {
+      throw new HttpsError(
+        'unauthenticated',
+        `Could not verify your Google Classroom courses (status ${teacherCourses.status}).`
+      );
+    }
+    if (!teacherCourses.courseIds.includes(courseId)) {
+      // Opaque on purpose: don't reveal whether the course exists to someone who
+      // doesn't teach it.
+      console.warn(
+        `[linkClassroomCourse] uid=${callerUid} is not a teacher of course ${courseId}.`
+      );
+      throw new HttpsError(
+        'permission-denied',
+        'You can only link a Google Classroom course that you teach.'
+      );
+    }
+
+    const db = admin.firestore();
+    const ref = db.doc(`classroom_course_links/${courseId}`);
+    const existing = await ref.get();
+    if (existing.exists) {
+      const prior = existing.data() as CourseLink;
+      if (
+        typeof prior?.teacherUid === 'string' &&
+        prior.teacherUid &&
+        prior.teacherUid !== callerUid
+      ) {
+        // A co-teacher may also genuinely teach this course, but silently
+        // re-pointing an existing link would re-route the original teacher's
+        // students. Preserve the existing no-hijack invariant.
+        console.warn(
+          `[linkClassroomCourse] course ${courseId} already linked by a ` +
+            `different teacher; refusing to overwrite.`
+        );
+        throw new HttpsError(
+          'already-exists',
+          'This Google Classroom course is already linked by another teacher.'
+        );
+      }
+    }
+
+    // Admin SDK write — bypasses the now read-only client rules. createdAt is set
+    // only on first create; merge:true preserves it (and any other fields) on a
+    // same-teacher re-link.
+    const payload: Record<string, unknown> = {
+      classlinkClassId,
+      classlinkOrgId,
+      teacherUid: callerUid,
+      rosterId,
+      updatedAt: Date.now(),
+    };
+    if (!existing.exists) payload.createdAt = Date.now();
+    await ref.set(payload, { merge: true });
+
+    return { ok: true, courseId };
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4371,5 +4371,6 @@ export const pinLoginV1 = onCall(
 export {
   classroomAddonLoginV1,
   createClassroomAttachment,
+  linkClassroomCourse,
   pushClassroomGradesForAssignment,
 } from './classroomAddonAuth';


### PR DESCRIPTION
## Problem (authorization gap from code review)

`firestore.rules` let **any authenticated user** `create` a `classroom_course_links/{courseId}` doc for **any** Google courseId (it could only check `teacherUid == auth.uid`, never that the caller actually teaches the course). Keyed by courseId with first-write-wins, a squatter could:

- **Mis-route a victim course's students** — `classroomAddonLoginV1` mints every student's class-gate `classIds` from whatever ClassLink class the link names.
- **Permanently lock the real teacher out** — `create` fails (doc exists), `update` fails (teacherUid mismatch).

Severity is moderate (insider DoS / mis-targeting, Orono-only, attacker needs the victim's courseId, grade tampering still blocked by Google's per-course token) — not a public exploit.

## Fix

Rules can't verify Google-course teaching, so move writes server-side:

- **`firestore.rules`** — `classroom_course_links` is now `allow read … ; allow write: if false;`. All writes go through the Admin SDK.
- **New CF `linkClassroomCourse`** — trust anchor is a new `classroomAddonNet.listTeacherCourseIds()` seam that re-runs the caller's own `courses?teacherId=me` query with their `classroom.courses.readonly` token; the chosen `courseId` must appear there. `teacherUid` is taken from `request.auth.uid` (never the client). An existing link owned by a *different* teacher is never overwritten (`already-exists`). **Fails closed** on any upstream error.
- **`SidebarClasses.tsx`** — calls the CF instead of `setDoc`, reusing the course-list token (no second OAuth popup) and surfacing the CF's actionable message.

## Backwards compatibility — none broken

Purely additive on the link-**create** path. Existing link docs, active sessions, assigned quizzes, token minting, the class-gate, and grade push are all unchanged — every read path is untouched and the Admin SDK bypasses rules. No consumer reads the `createdAt`/`updatedAt` fields whose shape differs. The only changed behavior (a new link now requires teaching the course + can't hijack) matches the old *effective* rules behavior, with clearer errors.

Prod deploy order is favorable: `firebase deploy --only functions,firestore,storage` (backend together) runs **before** hosting, so the CF is live alongside the rules and before the new client that calls it.

## Tests & validation

- 8 new CF tests (verified-teacher write, squat rejection, teacherUid-from-auth, no-hijack, same-teacher re-link, fail-closed, unauthenticated, arg validation).
- `type-check:all` ✅ · `lint` ✅ · `format:check` ✅ · functions suite **351 passed** (was 343).

Also gitignores `Quizzes/` (local in-app `.quiz.json` exports — separate commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)