### PR TITLE
refactor(classroom-addon): extract shared ClassLink/CORS, quiz-code & grade-push helpers

### DIFF
--- a/components/classroomAddon/StudentSpikeRoute.tsx
+++ b/components/classroomAddon/StudentSpikeRoute.tsx
@@ -35,6 +35,7 @@ import {
 } from 'firebase/firestore';
 import { ClipboardList, ClipboardCheck, Video, ArrowRight } from 'lucide-react';
 import { auth, db, functions } from '@/config/firebase';
+import { normalizeQuizCode } from '@/utils/quizCode';
 import { ensureGis, requestAccessToken } from './gisOAuth';
 import {
   AddonShell,
@@ -99,14 +100,6 @@ interface SessionInfo {
   isAnonymous: boolean;
   studentRole: boolean;
   classIds: unknown;
-}
-
-/** Normalize a quiz join code to the stored form (uppercase alphanumerics). */
-function normalizeCode(code: string): string {
-  return code
-    .trim()
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .toUpperCase();
 }
 
 export const ClassroomAddonStudentSpike: React.FC = () => {
@@ -210,7 +203,7 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
         const sessSnap = await getDocs(
           query(
             collection(db, 'quiz_sessions'),
-            where('code', '==', normalizeCode(code))
+            where('code', '==', normalizeQuizCode(code))
           )
         );
         if (!active || sessSnap.empty) return;

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -44,6 +44,7 @@ import {
   QUIZ_SESSIONS_COLLECTION,
   RESPONSES_COLLECTION,
 } from '@/hooks/useQuizSession';
+import { normalizeQuizCode } from '@/utils/quizCode';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { resolveResponseDisplayName } from '@/components/widgets/QuizWidget/utils/resolveDisplayName';
 import {
@@ -53,9 +54,14 @@ import {
 import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
 import {
   buildQuizClassroomGradeEntries,
-  pushClassroomGradesForAssignment,
   formatGradePushToast,
 } from '@/utils/classroomGradePush';
+import {
+  runClassroomGradePush,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  PUSH_PERMISSION_DENIED_MESSAGE,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from './gisOAuth';
 import { logError } from '@/utils/logError';
 import {
@@ -85,14 +91,6 @@ const PUBLISH_OPTIONS: {
     label: 'Score + answers + correct answers',
   },
 ];
-
-/** Resolve the quiz_sessions doc id from a join code (mirrors the student lookup). */
-function normalizeCode(code: string): string {
-  return code
-    .trim()
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .toUpperCase();
-}
 
 export const ClassroomAddonTeacherReview: React.FC = () => {
   const params =
@@ -130,7 +128,7 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
         const snap = await getDocs(
           query(
             collection(db, QUIZ_SESSIONS_COLLECTION),
-            where('code', '==', normalizeCode(code))
+            where('code', '==', normalizeQuizCode(code))
           )
         );
         if (!active) return;
@@ -283,72 +281,80 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const pushGrades = useCallback(async () => {
     const attachment = session?.classroomAttachment;
     if (!attachment || !quizData) return;
-    // Check for gradeable work BEFORE the OAuth popup — don't prompt the teacher
-    // for Classroom permission only to tell them there's nothing to push. Require
-    // a RESOLVABLE pseudonym too (the grade builder also needs studentUid), so a
-    // quiz completed only by non-SSO/PIN students doesn't pop a consent dialog
-    // that then no-ops on an empty payload.
+    // Pre-flight guards (iframe order): check for gradeable work BEFORE the
+    // OAuth popup — don't prompt for Classroom permission only to report there's
+    // nothing to push. Require a RESOLVABLE pseudonym too (the grade builder
+    // needs studentUid), so a quiz completed only by non-SSO/PIN students
+    // doesn't pop a consent dialog that then no-ops on an empty payload.
     if (!responses.some((r) => r.status === 'completed' && !!r.studentUid)) {
       setStatusMsg('No completed responses to push yet.');
       return;
     }
-    // Guard the grade scale BEFORE the OAuth popup: a malformed/stale attachment
-    // could carry 0/NaN maxPoints, which would scale every grade to 0 (or NaN).
-    if (!Number.isFinite(attachment.maxPoints) || attachment.maxPoints <= 0) {
-      setErrorMsg(
-        'This assignment is missing its Classroom point total — re-attach it ' +
-          'to push grades.'
-      );
+    if (!hasValidMaxPoints(attachment.maxPoints)) {
+      setErrorMsg(MISSING_MAX_POINTS_MESSAGE);
       return;
     }
-    setBusy(true);
-    setErrorMsg(null);
-    try {
-      setStatusMsg('Granting Classroom permission…');
-      const accessToken = await requestClassroomTeacherToken(
-        user?.email ?? loginHint
-      );
-
-      // Scale each completed student's earned points onto the attachment's grade
-      // scale (== the quiz's total points) via the shared builder — same scaling
-      // the dashboard monitor (QuizResults) uses, so they can't drift.
-      const grades = buildQuizClassroomGradeEntries(
-        responses,
-        questions,
-        attachment.maxPoints
-      );
-      if (grades.length === 0) {
-        setStatusMsg('No completed responses to push yet.');
-        return;
-      }
-
-      setStatusMsg('Pushing grades to Google Classroom…');
-      const data = await pushClassroomGradesForAssignment(functions, {
+    // Shared push flow. The iframe renders progress/result on an inline status
+    // line (no toasts) and pushes WITHOUT a confirm dialog; a token failure is
+    // NOT given the distinct cancelled-consent message (it folds into the
+    // generic error line). The grade builder is the shared quiz scaler — same
+    // scaling the dashboard monitor (QuizResults) uses, so they can't drift.
+    await runClassroomGradePush({
+      functions,
+      attachment: {
         courseId: attachment.courseId,
         itemId: attachment.itemId,
         attachmentId: attachment.attachmentId,
-        accessToken,
-        grades,
         maxPoints: attachment.maxPoints,
-      });
-      setStatusMsg(`${formatGradePushToast(data)} Return them in Classroom.`);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logError('ClassroomAddonTeacherReview.pushGrades', err, {
-        sessionId,
-      });
-      // permission-denied → the course isn't linked to ClassLink under this
-      // teacher (the CF gates push on the link doc); give an actionable hint
-      // instead of the raw error.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      setErrorMsg(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : `Couldn't push grades: ${message}`
-      );
-    } finally {
-      setBusy(false);
-    }
+      },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? loginHint),
+      buildGrades: () =>
+        buildQuizClassroomGradeEntries(
+          responses,
+          questions,
+          attachment.maxPoints
+        ),
+      logTag: 'ClassroomAddonTeacherReview.pushGrades',
+      logContext: { sessionId },
+      onStatus: (status) => {
+        switch (status.phase) {
+          case 'start':
+            setBusy(true);
+            setErrorMsg(null);
+            break;
+          case 'settled':
+            setBusy(false);
+            break;
+          case 'requesting-token':
+            setStatusMsg('Granting Classroom permission…');
+            break;
+          case 'pushing':
+            setStatusMsg('Pushing grades to Google Classroom…');
+            break;
+          case 'nothing-to-push':
+            setStatusMsg('No completed responses to push yet.');
+            break;
+          case 'pushed':
+            setStatusMsg(
+              `${formatGradePushToast(status.data)} Return them in Classroom.`
+            );
+            break;
+          case 'token-cancelled':
+            // Unused: the iframe omits distinctTokenCancel, so a token failure
+            // falls through to onError instead of emitting this beat.
+            break;
+        }
+      },
+      onError: ({ permissionDenied, error }) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setErrorMsg(
+          permissionDenied
+            ? PUSH_PERMISSION_DENIED_MESSAGE
+            : `Couldn't push grades: ${message}`
+        );
+      },
+    });
   }, [
     session,
     quizData,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -67,11 +67,14 @@ import { PlcTab } from '@/components/common/library/PlcTab';
 import { WrittenResponseGrader } from './WrittenResponseGrader';
 import { doc, updateDoc } from 'firebase/firestore';
 import { db, functions } from '@/config/firebase';
+import { buildQuizClassroomGradeEntries } from '@/utils/classroomGradePush';
 import {
-  buildQuizClassroomGradeEntries,
-  pushClassroomGradesForAssignment,
-  formatGradePushToast,
-} from '@/utils/classroomGradePush';
+  runClassroomGradePush,
+  createToastGradePushHandlers,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  NOTHING_TO_PUSH_TOAST,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from '@/components/classroomAddon/gisOAuth';
 import {
   QUIZ_SESSIONS_COLLECTION,
@@ -1040,104 +1043,49 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     if (!classroomAttachment) return;
     const { attachmentId, courseId, itemId, maxPoints } = classroomAttachment;
 
-    // Defensive guard: `maxPoints` is typed required, but a malformed/stale
-    // attachment doc could carry NaN/0 — which would scale every grade to 0 (or
-    // NaN). Bail with an actionable message rather than push garbage grades.
-    if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
-      addToast(
-        'This assignment is missing its Classroom point total — re-attach it to push grades.',
-        'error'
-      );
+    // Guard the grade scale FIRST (a malformed/stale attachment could carry
+    // NaN/0 maxPoints, scaling every grade to 0/NaN), then the eligible list —
+    // completed responses with a resolvable pseudonym — so we never pop a
+    // consent dialog when there's nothing to push. The eligible list and the
+    // grade payload both reflect the responses/quiz captured when the teacher
+    // clicked (this closure); a brief mid-dialog Firestore update isn't re-read.
+    if (!hasValidMaxPoints(maxPoints)) {
+      addToast(MISSING_MAX_POINTS_MESSAGE, 'error');
       return;
     }
-
-    // Compute the eligible list — completed responses with a resolvable
-    // pseudonym — and gate on it BEFORE confirming, so we never pop a consent
-    // dialog when there's nothing to push. Both the eligible list and the grade
-    // payload below reflect the responses/quiz captured when the teacher
-    // initiated the push (this handler's closure); a brief mid-dialog Firestore
-    // update is intentionally not re-read — the teacher pushes what they were
-    // looking at when they clicked.
     const eligible = completed.filter((r) => !!r.studentUid);
-
     if (eligible.length === 0) {
-      addToast('No completed submissions to push yet', 'info');
+      addToast(NOTHING_TO_PUSH_TOAST, 'info');
       return;
     }
 
-    const confirmed = await showConfirm(
-      `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
-        'Classroom? This writes draft grades to the assignment gradebook — ' +
-        'you still review and return them in Classroom.',
-      {
-        title: 'Push grades to Google Classroom',
-        confirmLabel: 'Push grades',
-        cancelLabel: 'Cancel',
-      }
-    );
-    if (!confirmed) return;
-
-    // Build the PII-free grade payload via the shared scaler (the single source
-    // of truth also used by the in-iframe grader, TeacherReviewRoute, so the two
-    // can't drift): each completed student's correctness points are scaled onto
-    // the frozen Classroom denominator (`maxPoints`), then rounded + clamped to
-    // [0, maxPoints], with a non-finite score treated as 0.
-    const grades = buildQuizClassroomGradeEntries(
-      completed,
-      quiz.questions,
-      maxPoints
-    );
-
-    setPushingGrades(true);
-    try {
-      // Mint a fresh add-on teacher token via the GIS popup (the teacher is
-      // present), then hand it to the CF to PATCH the DRAFT grades. A cancelled
-      // or failed consent rejects here — surface it distinctly from a CF failure
-      // so the teacher knows nothing was pushed.
-      let accessToken: string;
-      try {
-        accessToken = await requestClassroomTeacherToken(
-          user?.email ?? undefined
-        );
-      } catch (tokenErr) {
-        logError('QuizResults.pushClassroomGrades.token', tokenErr, {
-          sessionId: session?.id,
-          attachmentId,
-        });
-        addToast(
-          'Google sign-in was cancelled — no grades were pushed.',
-          'error'
-        );
-        return;
-      }
-
-      const data = await pushClassroomGradesForAssignment(functions, {
-        courseId,
-        itemId,
-        attachmentId,
-        accessToken,
-        grades,
-        maxPoints,
-      });
-      addToast(formatGradePushToast(data), 'success');
-    } catch (err) {
-      logError('QuizResults.pushClassroomGrades', err, {
-        sessionId: session?.id,
-        attachmentId,
-      });
-      // A permission-denied means this course isn't linked to ClassLink under
-      // the current teacher (the CF gates push on the link doc). Tell the
-      // teacher how to fix it instead of a dead-end generic error.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      addToast(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : 'Could not push grades to Google Classroom.',
-        'error'
-      );
-    } finally {
-      setPushingGrades(false);
-    }
+    // Shared push flow (token mint → CF → result toast); QuizResults supplies
+    // only its grade builder (correctness points scaled onto the frozen
+    // denominator via the single-source-of-truth scaler the in-iframe grader
+    // also uses) and the toast reporter.
+    await runClassroomGradePush({
+      functions,
+      attachment: { courseId, itemId, attachmentId, maxPoints },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? undefined),
+      buildGrades: () =>
+        buildQuizClassroomGradeEntries(completed, quiz.questions, maxPoints),
+      confirm: () =>
+        showConfirm(
+          `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
+            'Classroom? This writes draft grades to the assignment gradebook — ' +
+            'you still review and return them in Classroom.',
+          {
+            title: 'Push grades to Google Classroom',
+            confirmLabel: 'Push grades',
+            cancelLabel: 'Cancel',
+          }
+        ),
+      distinctTokenCancel: true,
+      logTag: 'QuizResults.pushClassroomGrades',
+      logContext: { sessionId: session?.id, attachmentId },
+      ...createToastGradePushHandlers(addToast, setPushingGrades),
+    });
   };
 
   return (

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -31,11 +31,13 @@ import {
   computeVideoActivityScorePct,
 } from '@/utils/videoActivityGrading';
 import {
-  pushClassroomGradesForAssignment,
-  formatGradePushToast,
-} from '@/utils/classroomGradePush';
+  runClassroomGradePush,
+  createToastGradePushHandlers,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  NOTHING_TO_PUSH_TOAST,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from '@/components/classroomAddon/gisOAuth';
-import { logError } from '@/utils/logError';
 import { functions } from '@/config/firebase';
 import {
   useAssignmentPseudonymsMulti,
@@ -237,108 +239,59 @@ export const Results: React.FC<ResultsProps> = ({
     if (!classroomAttachment) return;
     const { attachmentId, courseId, itemId, maxPoints } = classroomAttachment;
 
-    // Defensive guard: `maxPoints` is typed required, but a malformed/stale
-    // attachment doc could carry NaN/0 — which would scale every grade to 0 (or
-    // NaN). Bail with an actionable message rather than push garbage grades.
-    if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
-      addToast(
-        'This assignment is missing its Classroom point total — re-attach it to push grades.',
-        'error'
-      );
+    // Guard the grade scale FIRST (a malformed/stale attachment could carry
+    // NaN/0 maxPoints, scaling every grade to 0/NaN), then the eligible list —
+    // completed responses with a resolvable pseudonym — so we never pop a
+    // consent dialog when there's nothing to push.
+    if (!hasValidMaxPoints(maxPoints)) {
+      addToast(MISSING_MAX_POINTS_MESSAGE, 'error');
       return;
     }
-
-    // The eligible list — completed responses with a resolvable pseudonym —
-    // is cheap to compute and stable across the confirm dialog, so we derive
-    // it (and gate on it) BEFORE confirming. The per-student SCORING, however,
-    // is built AFTER the confirm against the latest props, so an edit pushed by
-    // the Firestore listener while the dialog is open can't bake stale scores
-    // into the payload (TOCTOU).
     const eligible = responses.filter(
       (r) => r.completedAt !== null && !!r.studentUid
     );
-
     if (eligible.length === 0) {
-      addToast('No completed submissions to push yet', 'info');
+      addToast(NOTHING_TO_PUSH_TOAST, 'info');
       return;
     }
 
-    const confirmed = await showConfirm(
-      `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
-        'Classroom? This writes draft grades to the assignment gradebook — ' +
-        'you still review and return them in Classroom.',
-      {
-        title: 'Push grades to Google Classroom',
-        confirmLabel: 'Push grades',
-        cancelLabel: 'Cancel',
-      }
-    );
-    if (!confirmed) return;
-
-    // Build the PII-free grade payload: one entry per completed response with a
-    // resolvable pseudonym. `getStudentScore` returns the SAME 0–100 percentage
-    // the Students tab displays; scale it onto the frozen Classroom denominator,
-    // then round + clamp to [0, maxPoints]. Built from the responses captured
-    // when the teacher initiated the push (this handler's closure).
-    const grades = eligible.map((r) => {
-      const pct = getStudentScore(r);
-      const safePct = Number.isFinite(pct) ? pct : 0;
-      const pointsEarned = Math.max(
-        0,
-        Math.min(maxPoints, Math.round((safePct / 100) * maxPoints))
-      );
-      return { pseudonymUid: r.studentUid, pointsEarned };
+    // Shared push flow (token mint → CF → result toast); the VA monitor supplies
+    // only its grade builder. `getStudentScore` returns the SAME 0–100
+    // percentage the Students tab shows; scale it onto the frozen denominator,
+    // then round + clamp to [0, maxPoints]. The payload is built inside the flow
+    // (AFTER the confirm) from the responses captured when the teacher clicked
+    // (this closure), so a mid-dialog Firestore edit can't bake in stale scores.
+    await runClassroomGradePush({
+      functions,
+      attachment: { courseId, itemId, attachmentId, maxPoints },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? undefined),
+      buildGrades: () =>
+        eligible.map((r) => {
+          const pct = getStudentScore(r);
+          const safePct = Number.isFinite(pct) ? pct : 0;
+          const pointsEarned = Math.max(
+            0,
+            Math.min(maxPoints, Math.round((safePct / 100) * maxPoints))
+          );
+          return { pseudonymUid: r.studentUid, pointsEarned };
+        }),
+      confirm: () =>
+        showConfirm(
+          `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
+            'Classroom? This writes draft grades to the assignment gradebook — ' +
+            'you still review and return them in Classroom.',
+          {
+            title: 'Push grades to Google Classroom',
+            confirmLabel: 'Push grades',
+            cancelLabel: 'Cancel',
+          }
+        ),
+      distinctTokenCancel: true,
+      logTag: 'VideoActivityResults.pushClassroomGrades',
+      logContext: { sessionId: session?.id, attachmentId },
+      ...createToastGradePushHandlers(addToast, setPushingGrades),
     });
-
-    setPushingGrades(true);
-    try {
-      // Mint a fresh add-on teacher token via the GIS popup (the teacher is
-      // present), then hand it to the CF to PATCH the DRAFT grades. A cancelled
-      // or failed consent rejects here — surface it distinctly from a CF failure
-      // so the teacher knows nothing was pushed.
-      let accessToken: string;
-      try {
-        accessToken = await requestClassroomTeacherToken(
-          user?.email ?? undefined
-        );
-      } catch (tokenErr) {
-        logError('VideoActivityResults.pushClassroomGrades.token', tokenErr, {
-          sessionId: session?.id,
-          attachmentId,
-        });
-        addToast(
-          'Google sign-in was cancelled — no grades were pushed.',
-          'error'
-        );
-        return;
-      }
-
-      const data = await pushClassroomGradesForAssignment(functions, {
-        courseId,
-        itemId,
-        attachmentId,
-        accessToken,
-        grades,
-        maxPoints,
-      });
-      addToast(formatGradePushToast(data), 'success');
-    } catch (err) {
-      logError('VideoActivityResults.pushClassroomGrades', err, {
-        sessionId: session?.id,
-        attachmentId,
-      });
-      // permission-denied → this course isn't linked to ClassLink under the
-      // current teacher (the CF gates push on the link doc); tell them how to fix.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      addToast(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : 'Could not push grades to Google Classroom.',
-        'error'
-      );
-    } finally {
-      setPushingGrades(false);
-    }
   };
 
   return (

--- a/functions/src/classlinkShared.ts
+++ b/functions/src/classlinkShared.ts
@@ -1,0 +1,112 @@
+/**
+ * classlinkShared — single source of truth for the ClassLink / OneRoster + CORS
+ * primitives that `index.ts` and `classroomAddonAuth.ts` both depend on.
+ *
+ * These were previously copy-pasted into each file with "keep in sync" / "MUST
+ * match index.ts" comments. The riskiest of them is `computeStudentUid`: it is
+ * the HMAC pseudonym CONTRACT. A Classroom add-on student and that same student's
+ * ClassLink SSO login must mint the IDENTICAL Firebase uid, or the monitor's name
+ * resolution and grade passback silently target the wrong (or no) student — with
+ * NO compile error to catch the drift. Centralizing the formula here makes that
+ * contract un-driftable.
+ *
+ * No Firebase Admin app is initialized in this module (only `index.ts` calls
+ * `admin.initializeApp()`); `resolveOrgIdForDomain` receives the Firestore handle
+ * from its caller so this stays a pure, import-anywhere helper module.
+ */
+import * as admin from 'firebase-admin';
+import * as CryptoJS from 'crypto-js';
+import OAuth from 'oauth-1.0a';
+
+/**
+ * CORS allowlist + per-callable `cors` config shared by every onCall in both
+ * files. Production host, Firebase default host, the dev-channel preview pattern,
+ * and localhost. (Previously duplicated as `ALLOWED_ORIGINS` in each file with a
+ * "Keep in sync" comment.)
+ */
+export const ALLOWED_ORIGINS: (string | RegExp)[] = [
+  'https://spartboard.web.app',
+  'https://spartboard.firebaseapp.com',
+  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
+  /^http:\/\/localhost(:\d+)?$/,
+];
+
+/** OneRoster v1.1 API base path segment (appended to a tenant URL). */
+export const ONEROSTER_BASE = '/ims/oneroster/v1p1';
+
+/**
+ * OneRoster student shape (subset). Fields are optional because a OneRoster
+ * `users`/`students` payload can omit any of them — every consumer guards
+ * (`if (!s.sourcedId) continue`, `s.email ?? ''`) before use.
+ */
+export interface ClassLinkStudent {
+  sourcedId?: string;
+  givenName?: string;
+  familyName?: string;
+  email?: string;
+}
+
+/**
+ * Stable per-student pseudonym: `HMAC-SHA256("sid:"+sourcedId, secret)` in hex.
+ * THE pseudonym contract — see the module header. Must produce the byte-identical
+ * uid for a given (sourcedId, secret) across every caller.
+ */
+export function computeStudentUid(
+  sourcedId: string,
+  hmacSecret: string
+): string {
+  return CryptoJS.HmacSHA256(`sid:${sourcedId}`, hmacSecret).toString(
+    CryptoJS.enc.Hex
+  );
+}
+
+/**
+ * Normalize an email to its `@domain` form (lowercased, leading '@'), or null
+ * when the address is malformed. Matches the domain-doc storage format.
+ */
+export function normalizeEmailDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return null;
+  return '@' + email.slice(at + 1).toLowerCase();
+}
+
+/**
+ * Look up the organization that owns an email domain. Matches the
+ * `/organizations/{orgId}/domains/{doc}` subcollection, requiring
+ * `status === 'verified'`. Domain values are stored with a leading '@'. Returns
+ * null when no verified match exists.
+ */
+export async function resolveOrgIdForDomain(
+  db: admin.firestore.Firestore,
+  domainWithAt: string
+): Promise<string | null> {
+  const snap = await db
+    .collectionGroup('domains')
+    .where('domain', '==', domainWithAt)
+    .where('status', '==', 'verified')
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  const orgRef = snap.docs[0].ref.parent.parent;
+  return orgRef ? orgRef.id : null;
+}
+
+/** Generate OAuth 1.0 (HMAC-SHA1) headers for a ClassLink OneRoster request. */
+export function getOAuthHeaders(
+  baseUrl: string,
+  params: Record<string, string>,
+  method: string,
+  clientId: string,
+  clientSecret: string
+): Record<string, string> {
+  const oauth = new OAuth({
+    consumer: { key: clientId, secret: clientSecret },
+    signature_method: 'HMAC-SHA1',
+    hash_function(base_string: string, key: string) {
+      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
+    },
+  });
+  return oauth.toHeader(
+    oauth.authorize({ url: baseUrl, method, data: params })
+  ) as unknown as Record<string, string>;
+}

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -22,8 +22,9 @@
  *   - No rate limiting (neither studentLoginV1 nor pinLoginV1 has one to copy).
  *   - Teacher launches are out of scope here: returns `{ role: 'teacher' }`
  *     with no token.
- *   - Helpers (hmac, email-domain→org) are inlined to keep the spike
- *     self-contained; production should share them with `index.ts`.
+ *   - Shared ClassLink helpers (hmac pseudonym, email-domain→org, OAuth
+ *     headers, CORS allowlist, OneRoster base path) now live in
+ *     `./classlinkShared` and are imported by both this file and `index.ts`.
  *   - Outbound Google calls go through `classroomAddonNet` so unit tests can
  *     stub them without a live Classroom install. Uses raw `fetch` + Bearer
  *     (mirrors `getDriveHeaders` in index.ts) — no `googleapis` dependency.
@@ -33,7 +34,15 @@ import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
 import * as CryptoJS from 'crypto-js';
 import axios from 'axios';
-import OAuth from 'oauth-1.0a';
+import {
+  ALLOWED_ORIGINS,
+  ONEROSTER_BASE,
+  computeStudentUid,
+  getOAuthHeaders,
+  normalizeEmailDomain,
+  resolveOrgIdForDomain,
+  type ClassLinkStudent,
+} from './classlinkShared';
 
 // Same named secrets as index.ts; Firebase params dedupes by name. The
 // CLASSLINK_* secrets power the ClassLink identity bridge: a Classroom student
@@ -46,15 +55,6 @@ const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
 const CLASSLINK_CLIENT_ID = defineSecret('CLASSLINK_CLIENT_ID');
 const CLASSLINK_CLIENT_SECRET = defineSecret('CLASSLINK_CLIENT_SECRET');
 const CLASSLINK_TENANT_URL = defineSecret('CLASSLINK_TENANT_URL');
-
-// Keep in sync with ALLOWED_ORIGINS in index.ts (spike duplication; production
-// should import a shared constant).
-const ALLOWED_ORIGINS: (string | RegExp)[] = [
-  'https://spartboard.web.app',
-  'https://spartboard.firebaseapp.com',
-  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
-  /^http:\/\/localhost(:\d+)?$/,
-];
 
 const CLASSROOM_API = 'https://classroom.googleapis.com/v1';
 const USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
@@ -95,14 +95,6 @@ interface GoogleUserInfo {
   // the student view requests it). Used ONLY as a transient watermark label,
   // returned to the student's own client; never persisted (PII gate).
   name?: string;
-}
-
-/** OneRoster student shape (subset) — mirrors index.ts's ClassLinkStudent. */
-interface ClassLinkStudent {
-  sourcedId?: string;
-  givenName?: string;
-  familyName?: string;
-  email?: string;
 }
 
 /**
@@ -192,66 +184,6 @@ interface AddOnAttachmentBody {
 
 function bearer(accessToken: string): Record<string, string> {
   return { Authorization: `Bearer ${accessToken}` };
-}
-
-function normalizeEmailDomain(email: string): string | null {
-  const at = email.lastIndexOf('@');
-  if (at < 0 || at === email.length - 1) return null;
-  return '@' + email.slice(at + 1).toLowerCase();
-}
-
-const ONEROSTER_BASE = '/ims/oneroster/v1p1';
-
-/**
- * Stable per-student pseudonym — MUST match index.ts `computeStudentUid`
- * (`HMAC("sid:"+sourcedId)`) so a Classroom student mints the SAME Firebase uid
- * as their ClassLink SSO login, and the existing `getPseudonymsForAssignmentV1`
- * monitor resolves their name. (Spike duplication; production should share it.)
- */
-function computeStudentUid(sourcedId: string, hmacSecret: string): string {
-  return CryptoJS.HmacSHA256(`sid:${sourcedId}`, hmacSecret).toString(
-    CryptoJS.enc.Hex
-  );
-}
-
-/** OAuth 1.0 headers for the ClassLink OneRoster API — mirrors index.ts. */
-function getOAuthHeaders(
-  baseUrl: string,
-  params: Record<string, string>,
-  method: string,
-  clientId: string,
-  clientSecret: string
-): Record<string, string> {
-  const oauth = new OAuth({
-    consumer: { key: clientId, secret: clientSecret },
-    signature_method: 'HMAC-SHA1',
-    hash_function(base_string: string, key: string) {
-      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
-    },
-  });
-  return oauth.toHeader(
-    oauth.authorize({ url: baseUrl, method, data: params })
-  ) as unknown as Record<string, string>;
-}
-
-/**
- * Looks up the org that owns an email domain — same query as index.ts's
- * `resolveOrgIdForDomain`. Domains are stored with a leading '@' and must be
- * `status === 'verified'`.
- */
-async function resolveOrgIdForDomain(
-  db: admin.firestore.Firestore,
-  domainWithAt: string
-): Promise<string | null> {
-  const snap = await db
-    .collectionGroup('domains')
-    .where('domain', '==', domainWithAt)
-    .where('status', '==', 'verified')
-    .limit(1)
-    .get();
-  if (snap.empty) return null;
-  const orgRef = snap.docs[0].ref.parent.parent;
-  return orgRef ? orgRef.id : null;
 }
 
 function isItemType(v: unknown): v is ItemType {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,6 @@ import { setGlobalOptions } from 'firebase-functions/v2';
 import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
 import axios, { AxiosError } from 'axios';
-import OAuth from 'oauth-1.0a';
 import * as CryptoJS from 'crypto-js';
 import { GoogleGenAI, Content, Type, Schema } from '@google/genai';
 import { randomUUID } from 'node:crypto';
@@ -12,6 +11,16 @@ import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
 import { BoundedLruMap } from './utils/boundedLruMap';
 import { readAnalyticsSnapshot } from './adminAnalyticsSnapshot';
+import {
+  ALLOWED_ORIGINS,
+  ONEROSTER_BASE,
+  computeStudentUid,
+  getOAuthHeaders,
+  normalizeEmailDomain,
+  resolveOrgIdForDomain,
+  type ClassLinkStudent,
+} from './classlinkShared';
+import { normalizeQuizCode } from './quizCode';
 
 // Phase 4 — organization invitations + membership write-through.
 // These modules initialize their own `admin.initializeApp()` guarded by
@@ -61,13 +70,6 @@ const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
 );
 const GOOGLE_OAUTH_CLIENT_ID = defineSecret('GOOGLE_OAUTH_CLIENT_ID');
 
-const ALLOWED_ORIGINS: (string | RegExp)[] = [
-  'https://spartboard.web.app',
-  'https://spartboard.firebaseapp.com',
-  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
-  /^http:\/\/localhost(:\d+)?$/,
-];
-
 admin.initializeApp();
 
 interface ClassLinkUser {
@@ -81,13 +83,6 @@ interface ClassLinkClass {
   sourcedId: string;
   title: string;
   classCode?: string;
-}
-
-interface ClassLinkStudent {
-  sourcedId: string;
-  givenName: string;
-  familyName: string;
-  email: string;
 }
 
 interface AIData {
@@ -456,36 +451,6 @@ const makeDriveFilePublic = async (
   }
 };
 
-/**
- * Generates OAuth 1.0 Headers for ClassLink
- */
-function getOAuthHeaders(
-  baseUrl: string,
-  params: Record<string, string>,
-  method: string,
-  clientId: string,
-  clientSecret: string
-) {
-  const oauth = new OAuth({
-    consumer: {
-      key: clientId,
-      secret: clientSecret,
-    },
-    signature_method: 'HMAC-SHA1',
-    hash_function(base_string: string, key: string) {
-      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
-    },
-  });
-
-  const request_data = {
-    url: baseUrl,
-    method: method,
-    data: params,
-  };
-
-  return oauth.toHeader(oauth.authorize(request_data));
-}
-
 export const getClassLinkRosterV1 = onCall(
   {
     memory: '256MiB',
@@ -530,7 +495,7 @@ export const getClassLinkRosterV1 = onCall(
       if (!isSafeEmailForOneRosterFilter(userEmail)) {
         return { classes: [], studentsByClass: {} };
       }
-      const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const usersBaseUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const userParams = { filter: `email='${userEmail}'` };
 
       const userHeaders = getOAuthHeaders(
@@ -557,7 +522,7 @@ export const getClassLinkRosterV1 = onCall(
 
       const teacherSourcedId = users[0].sourcedId;
 
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${teacherSourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${teacherSourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -581,7 +546,7 @@ export const getClassLinkRosterV1 = onCall(
       for (const classBatch of chunk(classes, CLASSLINK_FANOUT_CHUNK)) {
         await Promise.all(
           classBatch.map(async (cls: ClassLinkClass) => {
-            const studentsUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/classes/${cls.sourcedId}/students`;
+            const studentsUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/classes/${cls.sourcedId}/students`;
             const studentsHeaders = getOAuthHeaders(
               studentsUrl,
               {},
@@ -3071,22 +3036,12 @@ function hmacSha256Hex(secret: string, message: string): string {
   return CryptoJS.HmacSHA256(message, secret).toString(CryptoJS.enc.Hex);
 }
 
-function computeStudentUid(sourcedId: string, hmacSecret: string): string {
-  return hmacSha256Hex(hmacSecret, `sid:${sourcedId}`);
-}
-
 function computeAssignmentPseudonym(
   uid: string,
   assignmentId: string,
   hmacSecret: string
 ): string {
   return hmacSha256Hex(hmacSecret, `asn:${uid}:${assignmentId}`);
-}
-
-function normalizeEmailDomain(email: string): string | null {
-  const at = email.lastIndexOf('@');
-  if (at < 0 || at === email.length - 1) return null;
-  return '@' + email.slice(at + 1).toLowerCase();
 }
 
 /**
@@ -3097,27 +3052,6 @@ function normalizeEmailDomain(email: string): string | null {
  */
 function isSafeEmailForOneRosterFilter(email: string): boolean {
   return !/['\\]/.test(email);
-}
-
-/**
- * Looks up the organization that owns the given email domain. Matches against
- * the existing /organizations/{orgId}/domains/{doc} subcollection, requiring
- * `status === 'verified'`. Domain values in that collection are stored with a
- * leading '@' (e.g. '@orono.k12.mn.us'). Returns null if no match.
- */
-async function resolveOrgIdForDomain(
-  db: admin.firestore.Firestore,
-  domainWithAt: string
-): Promise<string | null> {
-  const snap = await db
-    .collectionGroup('domains')
-    .where('domain', '==', domainWithAt)
-    .where('status', '==', 'verified')
-    .limit(1)
-    .get();
-  if (snap.empty) return null;
-  const orgRef = snap.docs[0].ref.parent.parent;
-  return orgRef ? orgRef.id : null;
 }
 
 function isOneRosterStudent(user: OneRosterUserWithRole): boolean {
@@ -3282,7 +3216,7 @@ export const studentLoginV1 = onCall(
           'No student record found in ClassLink roster.'
         );
       }
-      const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const usersBaseUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const userParams = { filter: `email='${email}'` };
       const userHeaders = getOAuthHeaders(
         usersBaseUrl,
@@ -3306,7 +3240,7 @@ export const studentLoginV1 = onCall(
       }
       sourcedId = studentUser.sourcedId;
 
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${sourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${sourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -3801,7 +3735,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
           'Teacher not found in ClassLink roster.'
         );
       }
-      const teacherUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const teacherUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const teacherParams = { filter: `email='${teacherEmail}'` };
       const teacherHeaders = getOAuthHeaders(
         teacherUrl,
@@ -3821,7 +3755,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
           'Teacher not found in ClassLink roster.'
         );
       }
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${teacherUser.sourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${teacherUser.sourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -3844,7 +3778,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
       }
 
       // Now fetch the class's students and compute the pseudonym map.
-      const studentsUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/classes/${classId}/students`;
+      const studentsUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/classes/${classId}/students`;
       const studentsHeaders = getOAuthHeaders(
         studentsUrl,
         {},
@@ -4198,12 +4132,7 @@ export const pinLoginV1 = onCall(
     let sessionRef: admin.firestore.DocumentReference;
     if (kind === 'quiz') {
       const code =
-        typeof data.code === 'string'
-          ? data.code
-              .trim()
-              .replace(/[^a-zA-Z0-9]/g, '')
-              .toUpperCase()
-          : '';
+        typeof data.code === 'string' ? normalizeQuizCode(data.code) : '';
       if (!code) {
         throw new HttpsError('invalid-argument', 'code is required for quiz.');
       }

--- a/functions/src/quizCode.test.ts
+++ b/functions/src/quizCode.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Pins the FUNCTIONS-SIDE quiz-code canonicalization. These cases are kept
+ * IDENTICAL to the client suite (`tests/utils/quizCode.test.ts`) on purpose: the
+ * two `normalizeQuizCode` copies (client + functions) must agree byte-for-byte
+ * or `pinLoginV1` would resolve a different `quiz_sessions` doc than the teacher
+ * created. A change to either normalizer that breaks parity fails one suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeQuizCode } from './quizCode';
+
+describe('normalizeQuizCode (functions)', () => {
+  it('uppercases', () => {
+    expect(normalizeQuizCode('abc123')).toBe('ABC123');
+  });
+
+  it('strips whitespace and non-alphanumerics', () => {
+    expect(normalizeQuizCode('  a-b c1!2  ')).toBe('ABC12');
+    expect(normalizeQuizCode('ab_cd')).toBe('ABCD');
+  });
+
+  it('is stable on an already-canonical code', () => {
+    expect(normalizeQuizCode('ABC123')).toBe('ABC123');
+  });
+
+  it('returns empty when nothing alphanumeric survives', () => {
+    expect(normalizeQuizCode('   ')).toBe('');
+    expect(normalizeQuizCode('!!!')).toBe('');
+  });
+});

--- a/functions/src/quizCode.ts
+++ b/functions/src/quizCode.ts
@@ -1,0 +1,23 @@
+/**
+ * Quiz join-code canonicalization — FUNCTIONS-SIDE copy.
+ *
+ * This MUST stay byte-for-byte identical to the client's `utils/quizCode.ts`
+ * `normalizeQuizCode`. The teacher creates a session and students join from the
+ * CLIENT (which normalizes there), while `pinLoginV1` resolves that same
+ * `quiz_sessions` doc by `code` HERE on the server — so if the two normalizers
+ * drift, a student's PIN login would query a differently-cased/-stripped code
+ * than the one stored and silently resolve a different session (or none).
+ *
+ * It can't be a single shared module: `functions/` is a separate TypeScript
+ * project that bundles/deploys on its own and can't import the repo-root
+ * `utils/`. The drift guard is instead a test (`quizCode.test.ts`) that pins the
+ * SAME cases as the client's, so a change on either side fails its suite.
+ */
+
+/** Trim, strip every non-alphanumeric character, and uppercase a quiz join code. */
+export function normalizeQuizCode(code: string): string {
+  return code
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+}

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -47,6 +47,7 @@ import {
   GradeResult,
 } from '@/types';
 import { resolvePeriodNames } from '@/utils/periodCompat';
+import { normalizeQuizCode } from '@/utils/quizCode';
 
 // Re-export for backward compatibility with callers that imported
 // QuizSessionOptions from this module before it was moved into types.ts.
@@ -1356,10 +1357,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // Without this a network/Firestore failure during code lookup silently
       // strands the student on the join form with no spinner and no error.
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) return null;
         setError(null);
         const snap = await getDocs(
@@ -1411,10 +1409,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // legitimate snapshots in the new one.
       lastHistorySnapshotAtRef.current.clear();
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) throw new Error('Invalid code');
 
         // Ensure we have an anonymous Firebase Auth session so Firestore
@@ -2350,10 +2345,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       setLoading(true);
       setError(null);
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) throw new Error('Invalid code');
 
         const currentUser = auth.currentUser;

--- a/tests/utils/quizCode.test.ts
+++ b/tests/utils/quizCode.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pins the CLIENT quiz-code canonicalization. These cases are kept IDENTICAL to
+ * the functions suite (`functions/src/quizCode.test.ts`) on purpose: the two
+ * `normalizeQuizCode` copies (client `utils/quizCode.ts` + functions
+ * `functions/src/quizCode.ts`) must agree byte-for-byte, or `pinLoginV1` would
+ * resolve a different `quiz_sessions` doc than the client stored. A change to
+ * either normalizer that breaks parity fails one suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeQuizCode } from '@/utils/quizCode';
+
+describe('normalizeQuizCode (client)', () => {
+  it('uppercases', () => {
+    expect(normalizeQuizCode('abc123')).toBe('ABC123');
+  });
+
+  it('strips whitespace and non-alphanumerics', () => {
+    expect(normalizeQuizCode('  a-b c1!2  ')).toBe('ABC12');
+    expect(normalizeQuizCode('ab_cd')).toBe('ABCD');
+  });
+
+  it('is stable on an already-canonical code', () => {
+    expect(normalizeQuizCode('ABC123')).toBe('ABC123');
+  });
+
+  it('returns empty when nothing alphanumeric survives', () => {
+    expect(normalizeQuizCode('   ')).toBe('');
+    expect(normalizeQuizCode('!!!')).toBe('');
+  });
+});

--- a/tests/utils/runClassroomGradePush.test.ts
+++ b/tests/utils/runClassroomGradePush.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPushPermissionDenied,
+  hasValidMaxPoints,
+} from '@/utils/runClassroomGradePush';
+
+describe('isPushPermissionDenied', () => {
+  it('is true for a Firebase callable permission-denied code', () => {
+    expect(
+      isPushPermissionDenied({ code: 'functions/permission-denied' })
+    ).toBe(true);
+    expect(isPushPermissionDenied({ code: 'permission-denied' })).toBe(true);
+  });
+
+  it('is false for a different string code', () => {
+    expect(isPushPermissionDenied({ code: 'functions/unavailable' })).toBe(
+      false
+    );
+  });
+
+  it('is false (and does NOT throw) when code is a number', () => {
+    // Regression: a non-Firebase error can carry a numeric code (e.g. 403 from
+    // a raw Google API error). `.includes()` on a number would throw and turn a
+    // handled error into an unhandled one if the type isn't guarded.
+    expect(() => isPushPermissionDenied({ code: 403 })).not.toThrow();
+    expect(isPushPermissionDenied({ code: 403 })).toBe(false);
+  });
+
+  it('is false for null, undefined, and non-objects', () => {
+    expect(isPushPermissionDenied(null)).toBe(false);
+    expect(isPushPermissionDenied(undefined)).toBe(false);
+    // A bare string isn't a callable error — we only inspect `.code`.
+    expect(isPushPermissionDenied('permission-denied')).toBe(false);
+    // A plain Error has no `.code`; its message is intentionally not consulted.
+    expect(isPushPermissionDenied(new Error('permission-denied'))).toBe(false);
+  });
+});
+
+describe('hasValidMaxPoints', () => {
+  it('is true only for a positive, finite number', () => {
+    expect(hasValidMaxPoints(20)).toBe(true);
+    expect(hasValidMaxPoints(0)).toBe(false);
+    expect(hasValidMaxPoints(-5)).toBe(false);
+    expect(hasValidMaxPoints(Number.NaN)).toBe(false);
+    expect(hasValidMaxPoints(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});

--- a/utils/quizCode.ts
+++ b/utils/quizCode.ts
@@ -1,0 +1,20 @@
+/**
+ * Quiz join-code canonicalization.
+ *
+ * Teacher session creation, student join, in-session review, and the Google
+ * Classroom add-on routes (teacher + student) all run a raw code through THIS
+ * one function before querying `quiz_sessions` by `code`. Funneling every path
+ * through the same normalization guarantees a given code resolves to the SAME
+ * session everywhere — a lowercase, spaced, or hyphenated entry still matches the
+ * stored uppercase-alphanumeric code. Drift between any two of these call sites
+ * would let a teacher and a student (or the dashboard monitor and the in-iframe
+ * grader) silently resolve different sessions for the same code.
+ */
+
+/** Trim, strip every non-alphanumeric character, and uppercase a quiz join code. */
+export function normalizeQuizCode(code: string): string {
+  return code
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+}

--- a/utils/runClassroomGradePush.ts
+++ b/utils/runClassroomGradePush.ts
@@ -1,0 +1,242 @@
+/**
+ * runClassroomGradePush — the one shared "Push grades to Google Classroom" flow
+ * behind the three teacher surfaces that expose it:
+ *   - the dashboard quiz monitor (QuizResults),
+ *   - the dashboard video-activity monitor (VideoActivityWidget Results), and
+ *   - the in-iframe quiz grader (TeacherReviewRoute).
+ *
+ * Each surface differs ONLY in how it builds its grade payload (quiz scaling vs
+ * video-activity percentage) and how it reports progress (toasts vs an inline
+ * status line). The orchestration in between — minting a fresh add-on teacher
+ * token, calling the Cloud Function, and discriminating a "course not linked"
+ * permission-denied from a generic failure — is identical, and was previously
+ * copy-pasted into all three. Centralizing it here keeps the wording and the
+ * failure handling from drifting between surfaces.
+ *
+ * The CF wrapper (`pushClassroomGradesForAssignment`) lives in
+ * `@/utils/classroomGradePush`; this module imports it across that module
+ * boundary ON PURPOSE so a test can mock the CF at the
+ * `@/utils/classroomGradePush` seam while exercising the real orchestration here
+ * (an intra-module call could not be intercepted that way).
+ *
+ * Pre-flight guards (maxPoints validity + an eligible-empty check) stay at the
+ * CALL SITE because their ORDER and reporting channel differ per surface; the
+ * shared helpers/constants below let those guards stay byte-identical without
+ * living here. This function begins at the optional confirm.
+ */
+import type { Functions } from 'firebase/functions';
+import type { Toast } from '@/types';
+import { logError } from '@/utils/logError';
+import {
+  pushClassroomGradesForAssignment,
+  formatGradePushToast,
+  type ClassroomGradeEntry,
+  type PushClassroomGradesData,
+} from '@/utils/classroomGradePush';
+
+/** Shared copy: the attachment carries no usable Classroom point total. */
+export const MISSING_MAX_POINTS_MESSAGE =
+  'This assignment is missing its Classroom point total — re-attach it to push grades.';
+
+/** Shared copy: the benign "nothing eligible to push" toast (info, not error). */
+export const NOTHING_TO_PUSH_TOAST = 'No completed submissions to push yet';
+
+/** Shared copy: the GIS consent popup was dismissed / failed. */
+export const TOKEN_CANCELLED_MESSAGE =
+  'Google sign-in was cancelled — no grades were pushed.';
+
+/** Shared copy: the push failed because the course isn't ClassLink-linked. */
+export const PUSH_PERMISSION_DENIED_MESSAGE =
+  'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.';
+
+/** Shared copy: a generic (non-permission) push failure. */
+export const GRADE_PUSH_GENERIC_ERROR_MESSAGE =
+  'Could not push grades to Google Classroom.';
+
+/** True when a Classroom attachment's frozen denominator is usable for scaling. */
+export function hasValidMaxPoints(maxPoints: number): boolean {
+  return Number.isFinite(maxPoints) && maxPoints > 0;
+}
+
+/**
+ * True when a thrown CF error is the batch endpoint's `permission-denied` —
+ * raised when the course isn't linked to ClassLink under the calling teacher.
+ */
+export function isPushPermissionDenied(err: unknown): boolean {
+  const code = (err as { code?: string } | null)?.code ?? '';
+  return code.includes('permission-denied');
+}
+
+/** The Classroom-attachment identifiers + frozen scale a push targets. */
+export interface ClassroomGradePushAttachment {
+  courseId: string;
+  itemId: string;
+  attachmentId: string;
+  maxPoints: number;
+}
+
+/**
+ * Progress / terminal beats `runClassroomGradePush` emits, in order. A run goes
+ * `start` → `requesting-token` → (`token-cancelled` | `nothing-to-push` |
+ * (`pushing` → `pushed`)) and always ends on `settled`. Each surface maps these
+ * to its own UI (a toast monitor ignores the progress beats; the iframe shows
+ * them as an inline status line).
+ */
+export type ClassroomGradePushStatus =
+  | { phase: 'start' }
+  | { phase: 'requesting-token' }
+  | { phase: 'pushing' }
+  | { phase: 'token-cancelled'; error: unknown }
+  | { phase: 'nothing-to-push' }
+  | { phase: 'pushed'; data: PushClassroomGradesData }
+  | { phase: 'settled' };
+
+/** A failed push, with the permission-denied case pre-discriminated. */
+export interface ClassroomGradePushError {
+  permissionDenied: boolean;
+  error: unknown;
+}
+
+export interface RunClassroomGradePushOptions {
+  functions: Functions;
+  attachment: ClassroomGradePushAttachment;
+  /** Builds the PII-free grade payload — the only genuinely per-surface logic. */
+  buildGrades: () => ClassroomGradeEntry[];
+  /** Mints a fresh `classroom.addons.teacher` token (a GIS popup). */
+  requestToken: () => Promise<string>;
+  /** Maps each emitted status beat to the surface's UI. */
+  onStatus: (status: ClassroomGradePushStatus) => void;
+  /** Renders a push failure (permission-denied vs generic) in the surface's UI. */
+  onError: (err: ClassroomGradePushError) => void;
+  /**
+   * Optional confirm gate run BEFORE any token mint. Resolve false to abort
+   * silently (no status emitted). The dashboard monitors confirm; the in-iframe
+   * grader pushes without a dialog (omit).
+   */
+  confirm?: () => Promise<boolean>;
+  /**
+   * When true, a token/consent failure is reported as a distinct
+   * `token-cancelled` status (and logged under `${logTag}.token`) instead of
+   * falling through to `onError` as a generic failure. The dashboard monitors
+   * set this; the iframe folds a token failure into its generic error line.
+   */
+  distinctTokenCancel?: boolean;
+  /** logError tag for a push failure (the token catch logs `${logTag}.token`). */
+  logTag: string;
+  /**
+   * Extra logError context (e.g. sessionId / attachmentId). Matches logError's
+   * own `LogErrorContext` value shape (scalars only — it isn't exported).
+   */
+  logContext?: Record<string, string | number | boolean | null | undefined>;
+}
+
+/**
+ * Run the shared push flow. Owns everything from the (optional) confirm through
+ * the token mint, the CF call, and its success / failure reporting; the caller's
+ * pre-flight guards run before this.
+ */
+export async function runClassroomGradePush({
+  functions,
+  attachment,
+  buildGrades,
+  requestToken,
+  onStatus,
+  onError,
+  confirm,
+  distinctTokenCancel,
+  logTag,
+  logContext,
+}: RunClassroomGradePushOptions): Promise<void> {
+  if (confirm) {
+    const confirmed = await confirm();
+    if (!confirmed) return;
+  }
+
+  onStatus({ phase: 'start' });
+  try {
+    onStatus({ phase: 'requesting-token' });
+    let accessToken: string;
+    if (distinctTokenCancel) {
+      // The teacher is present; a cancelled/failed consent is a distinct, benign
+      // outcome (nothing was pushed) — surfaced apart from a CF failure.
+      try {
+        accessToken = await requestToken();
+      } catch (tokenErr) {
+        logError(`${logTag}.token`, tokenErr, logContext);
+        onStatus({ phase: 'token-cancelled', error: tokenErr });
+        return;
+      }
+    } else {
+      // No distinct handling: a token failure falls through to the catch below
+      // and renders as a generic push error (the iframe's behavior).
+      accessToken = await requestToken();
+    }
+
+    const grades = buildGrades();
+    if (grades.length === 0) {
+      onStatus({ phase: 'nothing-to-push' });
+      return;
+    }
+
+    onStatus({ phase: 'pushing' });
+    const data = await pushClassroomGradesForAssignment(functions, {
+      courseId: attachment.courseId,
+      itemId: attachment.itemId,
+      attachmentId: attachment.attachmentId,
+      accessToken,
+      grades,
+      maxPoints: attachment.maxPoints,
+    });
+    onStatus({ phase: 'pushed', data });
+  } catch (err) {
+    logError(logTag, err, logContext);
+    onError({ permissionDenied: isPushPermissionDenied(err), error: err });
+  } finally {
+    onStatus({ phase: 'settled' });
+  }
+}
+
+/**
+ * Build the `{ onStatus, onError }` reporter the two dashboard monitors share —
+ * they are byte-identical: progress beats are silent, a completed push is a
+ * success toast, a cancelled consent / failed push is an error toast, and the
+ * pushing flag toggles on `start` / `settled`. The in-iframe grader does NOT use
+ * this (it renders an inline status line instead).
+ */
+export function createToastGradePushHandlers(
+  addToast: (message: string, type: Toast['type']) => void,
+  setPushing: (pushing: boolean) => void
+): Pick<RunClassroomGradePushOptions, 'onStatus' | 'onError'> {
+  return {
+    onStatus: (status) => {
+      switch (status.phase) {
+        case 'start':
+          setPushing(true);
+          break;
+        case 'settled':
+          setPushing(false);
+          break;
+        case 'token-cancelled':
+          addToast(TOKEN_CANCELLED_MESSAGE, 'error');
+          break;
+        case 'nothing-to-push':
+          addToast(NOTHING_TO_PUSH_TOAST, 'info');
+          break;
+        case 'pushed':
+          addToast(formatGradePushToast(status.data), 'success');
+          break;
+        case 'requesting-token':
+        case 'pushing':
+          // The dashboard monitors show no inline progress — these are silent.
+          break;
+      }
+    },
+    onError: ({ permissionDenied }) =>
+      addToast(
+        permissionDenied
+          ? PUSH_PERMISSION_DENIED_MESSAGE
+          : GRADE_PUSH_GENERIC_ERROR_MESSAGE,
+        'error'
+      ),
+  };
+}

--- a/utils/runClassroomGradePush.ts
+++ b/utils/runClassroomGradePush.ts
@@ -63,8 +63,12 @@ export function hasValidMaxPoints(maxPoints: number): boolean {
  * raised when the course isn't linked to ClassLink under the calling teacher.
  */
 export function isPushPermissionDenied(err: unknown): boolean {
-  const code = (err as { code?: string } | null)?.code ?? '';
-  return code.includes('permission-denied');
+  // `code` is a string for Firebase callable errors, but guard the type: a
+  // non-Firebase error can carry a numeric `code` (e.g. 403), and `??` wouldn't
+  // catch it — `.includes()` on a number would throw and turn a handled error
+  // into an unhandled one.
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && code.includes('permission-denied');
 }
 
 /** The Classroom-attachment identifiers + frozen scale a push targets. */


### PR DESCRIPTION
## Dedup follow-up to [#1810](https://github.com/OPS-PIvers/SpartBoard/pull/1810) (course-squatting fix)

The second queued follow-up: remove the copy-paste duplication across the Classroom add-on's client + Cloud Functions that the squatting review flagged as drift-prone.

### Shared modules
- **`functions/src/classlinkShared.ts`** — `ALLOWED_ORIGINS`, `computeStudentUid` (THE HMAC pseudonym contract), `normalizeEmailDomain`, `resolveOrgIdForDomain`, `getOAuthHeaders`. Previously duplicated in `index.ts` and `classroomAddonAuth.ts` with "keep in sync" comments — a silent uid / grade-passback drift with no compile error to catch it.
- **`utils/quizCode.ts` + `functions/src/quizCode.ts`** — `normalizeQuizCode`, previously inlined ~5× across client and functions. With tests on both sides.
- **`utils/runClassroomGradePush.ts`** — the teacher grade-push orchestration, previously triplicated across `QuizResults`, VA `Results`, and `TeacherReviewRoute`.

### Pure refactor — no behavior change
Rebased onto dev-paul **after #1810 merged**, so it sits on top of the new `linkClassroomCourse` CF + `listTeacherCourseIds` (both kept; `linkClassroomCourse` now consumes the shared `ALLOWED_ORIGINS`). `bearer`/`CLASSROOM_API` intentionally stay local to `classroomAddonAuth.ts` (Classroom-specific, not ClassLink/CORS).

### Validation
- `type-check:all` ✅ · `lint` ✅ · `format:check` ✅
- functions tests **359 passed** · root tests **3959 passed** (incl. new quiz-code tests on both client + functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)