### PR TITLE
Release: classroom-addon squatting fix + shared-helpers dedup + quiz false-0/SSO-gate hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ verification/
 # Local data / Drive-sync artifacts — never commit (may contain student PII)
 Data/
 .tmp.driveupload/
+# Local in-app quiz exports (".quiz.json" downloads) — quiz content, not repo source
+Quizzes/

--- a/components/classroomAddon/StudentSpikeRoute.tsx
+++ b/components/classroomAddon/StudentSpikeRoute.tsx
@@ -35,6 +35,7 @@ import {
 } from 'firebase/firestore';
 import { ClipboardList, ClipboardCheck, Video, ArrowRight } from 'lucide-react';
 import { auth, db, functions } from '@/config/firebase';
+import { normalizeQuizCode } from '@/utils/quizCode';
 import { ensureGis, requestAccessToken } from './gisOAuth';
 import {
   AddonShell,
@@ -99,14 +100,6 @@ interface SessionInfo {
   isAnonymous: boolean;
   studentRole: boolean;
   classIds: unknown;
-}
-
-/** Normalize a quiz join code to the stored form (uppercase alphanumerics). */
-function normalizeCode(code: string): string {
-  return code
-    .trim()
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .toUpperCase();
 }
 
 export const ClassroomAddonStudentSpike: React.FC = () => {
@@ -210,7 +203,7 @@ export const ClassroomAddonStudentSpike: React.FC = () => {
         const sessSnap = await getDocs(
           query(
             collection(db, 'quiz_sessions'),
-            where('code', '==', normalizeCode(code))
+            where('code', '==', normalizeQuizCode(code))
           )
         );
         if (!active || sessSnap.empty) return;

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -44,6 +44,7 @@ import {
   QUIZ_SESSIONS_COLLECTION,
   RESPONSES_COLLECTION,
 } from '@/hooks/useQuizSession';
+import { normalizeQuizCode } from '@/utils/quizCode';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { resolveResponseDisplayName } from '@/components/widgets/QuizWidget/utils/resolveDisplayName';
 import {
@@ -53,9 +54,14 @@ import {
 import { WrittenResponseGrader } from '@/components/widgets/QuizWidget/components/WrittenResponseGrader';
 import {
   buildQuizClassroomGradeEntries,
-  pushClassroomGradesForAssignment,
   formatGradePushToast,
 } from '@/utils/classroomGradePush';
+import {
+  runClassroomGradePush,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  PUSH_PERMISSION_DENIED_MESSAGE,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from './gisOAuth';
 import { logError } from '@/utils/logError';
 import {
@@ -85,14 +91,6 @@ const PUBLISH_OPTIONS: {
     label: 'Score + answers + correct answers',
   },
 ];
-
-/** Resolve the quiz_sessions doc id from a join code (mirrors the student lookup). */
-function normalizeCode(code: string): string {
-  return code
-    .trim()
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .toUpperCase();
-}
 
 export const ClassroomAddonTeacherReview: React.FC = () => {
   const params =
@@ -130,7 +128,7 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
         const snap = await getDocs(
           query(
             collection(db, QUIZ_SESSIONS_COLLECTION),
-            where('code', '==', normalizeCode(code))
+            where('code', '==', normalizeQuizCode(code))
           )
         );
         if (!active) return;
@@ -283,72 +281,80 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const pushGrades = useCallback(async () => {
     const attachment = session?.classroomAttachment;
     if (!attachment || !quizData) return;
-    // Check for gradeable work BEFORE the OAuth popup — don't prompt the teacher
-    // for Classroom permission only to tell them there's nothing to push. Require
-    // a RESOLVABLE pseudonym too (the grade builder also needs studentUid), so a
-    // quiz completed only by non-SSO/PIN students doesn't pop a consent dialog
-    // that then no-ops on an empty payload.
+    // Pre-flight guards (iframe order): check for gradeable work BEFORE the
+    // OAuth popup — don't prompt for Classroom permission only to report there's
+    // nothing to push. Require a RESOLVABLE pseudonym too (the grade builder
+    // needs studentUid), so a quiz completed only by non-SSO/PIN students
+    // doesn't pop a consent dialog that then no-ops on an empty payload.
     if (!responses.some((r) => r.status === 'completed' && !!r.studentUid)) {
       setStatusMsg('No completed responses to push yet.');
       return;
     }
-    // Guard the grade scale BEFORE the OAuth popup: a malformed/stale attachment
-    // could carry 0/NaN maxPoints, which would scale every grade to 0 (or NaN).
-    if (!Number.isFinite(attachment.maxPoints) || attachment.maxPoints <= 0) {
-      setErrorMsg(
-        'This assignment is missing its Classroom point total — re-attach it ' +
-          'to push grades.'
-      );
+    if (!hasValidMaxPoints(attachment.maxPoints)) {
+      setErrorMsg(MISSING_MAX_POINTS_MESSAGE);
       return;
     }
-    setBusy(true);
-    setErrorMsg(null);
-    try {
-      setStatusMsg('Granting Classroom permission…');
-      const accessToken = await requestClassroomTeacherToken(
-        user?.email ?? loginHint
-      );
-
-      // Scale each completed student's earned points onto the attachment's grade
-      // scale (== the quiz's total points) via the shared builder — same scaling
-      // the dashboard monitor (QuizResults) uses, so they can't drift.
-      const grades = buildQuizClassroomGradeEntries(
-        responses,
-        questions,
-        attachment.maxPoints
-      );
-      if (grades.length === 0) {
-        setStatusMsg('No completed responses to push yet.');
-        return;
-      }
-
-      setStatusMsg('Pushing grades to Google Classroom…');
-      const data = await pushClassroomGradesForAssignment(functions, {
+    // Shared push flow. The iframe renders progress/result on an inline status
+    // line (no toasts) and pushes WITHOUT a confirm dialog; a token failure is
+    // NOT given the distinct cancelled-consent message (it folds into the
+    // generic error line). The grade builder is the shared quiz scaler — same
+    // scaling the dashboard monitor (QuizResults) uses, so they can't drift.
+    await runClassroomGradePush({
+      functions,
+      attachment: {
         courseId: attachment.courseId,
         itemId: attachment.itemId,
         attachmentId: attachment.attachmentId,
-        accessToken,
-        grades,
         maxPoints: attachment.maxPoints,
-      });
-      setStatusMsg(`${formatGradePushToast(data)} Return them in Classroom.`);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logError('ClassroomAddonTeacherReview.pushGrades', err, {
-        sessionId,
-      });
-      // permission-denied → the course isn't linked to ClassLink under this
-      // teacher (the CF gates push on the link doc); give an actionable hint
-      // instead of the raw error.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      setErrorMsg(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : `Couldn't push grades: ${message}`
-      );
-    } finally {
-      setBusy(false);
-    }
+      },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? loginHint),
+      buildGrades: () =>
+        buildQuizClassroomGradeEntries(
+          responses,
+          questions,
+          attachment.maxPoints
+        ),
+      logTag: 'ClassroomAddonTeacherReview.pushGrades',
+      logContext: { sessionId },
+      onStatus: (status) => {
+        switch (status.phase) {
+          case 'start':
+            setBusy(true);
+            setErrorMsg(null);
+            break;
+          case 'settled':
+            setBusy(false);
+            break;
+          case 'requesting-token':
+            setStatusMsg('Granting Classroom permission…');
+            break;
+          case 'pushing':
+            setStatusMsg('Pushing grades to Google Classroom…');
+            break;
+          case 'nothing-to-push':
+            setStatusMsg('No completed responses to push yet.');
+            break;
+          case 'pushed':
+            setStatusMsg(
+              `${formatGradePushToast(status.data)} Return them in Classroom.`
+            );
+            break;
+          case 'token-cancelled':
+            // Unused: the iframe omits distinctTokenCancel, so a token failure
+            // falls through to onError instead of emitting this beat.
+            break;
+        }
+      },
+      onError: ({ permissionDenied, error }) => {
+        const message = error instanceof Error ? error.message : String(error);
+        setErrorMsg(
+          permissionDenied
+            ? PUSH_PERMISSION_DENIED_MESSAGE
+            : `Couldn't push grades: ${message}`
+        );
+      },
+    });
   }, [
     session,
     quizData,

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -48,6 +48,7 @@ import { normalizeQuizCode } from '@/utils/quizCode';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { resolveResponseDisplayName } from '@/components/widgets/QuizWidget/utils/resolveDisplayName';
 import {
+  canScoreResponse,
   getDisplayScore,
   getScoreSuffix,
 } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
@@ -283,10 +284,20 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     if (!attachment || !quizData) return;
     // Pre-flight guards (iframe order): check for gradeable work BEFORE the
     // OAuth popup — don't prompt for Classroom permission only to report there's
-    // nothing to push. Require a RESOLVABLE pseudonym too (the grade builder
-    // needs studentUid), so a quiz completed only by non-SSO/PIN students
-    // doesn't pop a consent dialog that then no-ops on an empty payload.
-    if (!responses.some((r) => r.status === 'completed' && !!r.studentUid)) {
+    // nothing to push. Require a RESOLVABLE pseudonym (the grade builder needs
+    // studentUid) AND a response that can actually be scored — mirroring
+    // buildQuizClassroomGradeEntries, which also drops unscoreable responses
+    // (answer key not loaded / question-id drift). Otherwise a quiz whose only
+    // completed responses are unscoreable would pop a consent dialog that then
+    // no-ops on an empty payload.
+    if (
+      !responses.some(
+        (r) =>
+          r.status === 'completed' &&
+          !!r.studentUid &&
+          canScoreResponse(r, questions)
+      )
+    ) {
       setStatusMsg('No completed responses to push yet.');
       return;
     }

--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Users,
@@ -13,14 +13,14 @@ import {
   Loader2,
   AlertTriangle,
 } from 'lucide-react';
-import { doc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { httpsCallable } from 'firebase/functions';
 
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { useClassLinkEnabled } from '@/hooks/useClassLinkEnabled';
 import { ClassRoster, Student } from '@/types';
-import { auth, db } from '@/config/firebase';
+import { auth, functions } from '@/config/firebase';
 import { RosterEditorModal } from '@/components/classes/RosterEditorModal';
 import { Modal } from '@/components/common/Modal';
 import {
@@ -41,6 +41,26 @@ interface GoogleClassroomCourse {
   id: string;
   name: string;
   section?: string;
+}
+
+/**
+ * Args for the `linkClassroomCourse` Cloud Function. The link doc is written
+ * server-side (not via `setDoc`) so the CF can verify — with the teacher's own
+ * courses token — that the caller actually teaches the Google course before
+ * recording the link. `teacherUid` is intentionally omitted: the CF derives it
+ * from the authenticated caller, so a client can't claim to be another teacher.
+ */
+interface LinkClassroomCourseParams {
+  accessToken: string;
+  courseId: string;
+  classlinkClassId: string | null;
+  classlinkOrgId: string | null;
+  rosterId: string;
+}
+
+interface LinkClassroomCourseResult {
+  ok: boolean;
+  courseId: string;
 }
 
 interface SidebarClassesProps {
@@ -85,6 +105,11 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
   const [courseLoadError, setCourseLoadError] = useState<string | null>(null);
   const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  // The `classroom.courses.readonly` token used to LIST the teacher's courses is
+  // the same one the link CF needs to RE-VERIFY teaching authority server-side.
+  // Captured here so confirming the link reuses it (no second OAuth popup);
+  // cleared when the modal closes.
+  const coursesAccessTokenRef = useRef<string | null>(null);
 
   const loadCourses = useCallback(async () => {
     setCourseLoadState('loading');
@@ -97,6 +122,8 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
         CLASSROOM_COURSES_READONLY_SCOPE,
         user?.email ?? undefined
       );
+      // Reused at confirm time to verify teaching authority server-side.
+      coursesAccessTokenRef.current = token;
       const res = await fetch(
         'https://classroom.googleapis.com/v1/courses?teacherId=me&courseStates=ACTIVE',
         { headers: { Authorization: `Bearer ${token}` } }
@@ -127,6 +154,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     setSelectedCourseId(null);
     setCourseLoadError(null);
     setIsSaving(false);
+    coursesAccessTokenRef.current = null;
   }, []);
 
   const handleConfirmLink = useCallback(async () => {
@@ -143,12 +171,33 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     }
     setIsSaving(true);
     try {
-      await setDoc(doc(db, 'classroom_course_links', selectedCourseId), {
+      // The link doc is written by the `linkClassroomCourse` Cloud Function, NOT
+      // a direct setDoc: Firestore rules can't verify Google-course teaching, so
+      // client writes to classroom_course_links are blocked. The CF re-verifies
+      // — with the teacher's own courses token — that the caller actually teaches
+      // this course before recording the link, closing the course-squatting hole.
+      let accessToken = coursesAccessTokenRef.current;
+      if (!accessToken) {
+        // The list token expired or was cleared; re-acquire (silent if already
+        // consented this session) and cache it so a retry after a failed link
+        // doesn't pop another token request.
+        await ensureGis();
+        accessToken = await requestAccessToken(
+          CLASSROOM_COURSES_READONLY_SCOPE,
+          user?.email ?? undefined
+        );
+        coursesAccessTokenRef.current = accessToken;
+      }
+      const linkCourse = httpsCallable<
+        LinkClassroomCourseParams,
+        LinkClassroomCourseResult
+      >(functions, 'linkClassroomCourse');
+      await linkCourse({
+        accessToken,
+        courseId: selectedCourseId,
         classlinkClassId: linkingRoster.classlinkClassId ?? null,
         classlinkOrgId: linkingRoster.classlinkOrgId ?? null,
-        teacherUid: uid,
         rosterId: linkingRoster.id,
-        createdAt: serverTimestamp(),
       });
       await updateRoster(linkingRoster.id, {
         googleClassroomCourseId: selectedCourseId,
@@ -167,6 +216,8 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
         }),
         'error'
       );
+      // The CF surfaces an actionable message (e.g. "you can only link a course
+      // you teach", "already linked by another teacher") — show it in the modal.
       setCourseLoadError(
         err instanceof Error ? err.message : 'Failed to link to Classroom.'
       );
@@ -179,6 +230,7 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
     t,
     updateRoster,
     closeLinkModal,
+    user?.email,
   ]);
 
   const editingRoster: ClassRoster | null =

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -45,6 +45,8 @@ import {
 import { signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
 import { auth, db } from '@/config/firebase';
+import { QUIZ_SSO_REDIRECT_ENABLED } from '@/config/constants';
+import { shouldGateToSso } from '@/utils/studentJoinRouting';
 import { logError } from '@/utils/logError';
 import {
   useQuizSessionStudent,
@@ -287,6 +289,16 @@ const QuizJoinFlow: React.FC<{
   // the student would sit on the "Joining quiz…" loader forever.
   const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
 
+  // SSO gate (feature-flagged). Anonymous joiners on a ClassLink-rostered
+  // session are offered Google sign-in by default — which keys their response
+  // by their own stable auth.uid and sidesteps the wrong-period fork — with a
+  // "use a PIN instead" escape. 'pending' means we still need to look up the
+  // session to learn whether it's ClassLink-gated; when the flag is off (the
+  // default) we start at 'pin' so there is zero extra work and zero extra read.
+  const [ssoGate, setSsoGate] = useState<'pending' | 'gate' | 'pin'>(() =>
+    QUIZ_SSO_REDIRECT_ENABLED && !!urlCode && !embedded ? 'pending' : 'pin'
+  );
+
   const {
     session,
     myResponse,
@@ -408,6 +420,51 @@ const QuizJoinFlow: React.FC<{
     };
     void run();
   }, [isStudentRole, urlCode, joined, joinQuizSession, subscribeForReview]);
+
+  // Resolve the SSO gate. SSO students skip it (the auto-join effect handles
+  // them). Otherwise look up the session to learn whether it's ClassLink-
+  // rostered; any failure falls back to the PIN path (fail-open) so a flaky
+  // lookup never blocks a student from joining. This is the only added read,
+  // and it runs solely when the flag is on (otherwise ssoGate starts at 'pin'
+  // and this effect returns immediately).
+  useEffect(() => {
+    if (ssoGate !== 'pending') return;
+    // SSO students are handled by the auto-join effect, and the render branch
+    // above returns for them before the gate is ever shown — so just skip the
+    // lookup. We deliberately don't setState here: forcing ssoGate to 'pin'
+    // would be a synchronous derived-state reset inside an effect (the
+    // remaining 'pending' value is simply never rendered for SSO students).
+    if (isStudentRole) return;
+    // No run-once ref here: the `ssoGate !== 'pending'` guard already stops a
+    // re-run once the gate resolves, and `cancelled` makes StrictMode's
+    // double-invoke safe (run #1 is cancelled, run #2 resolves). A ref set
+    // before the await would instead DEADLOCK under StrictMode — run #2 would
+    // early-return on the ref while run #1's setState is suppressed by
+    // `cancelled`, stranding the student on the 'pending' loader forever.
+    let cancelled = false;
+    void (async () => {
+      try {
+        const info = await lookupSession(urlCode);
+        if (cancelled) return;
+        setSsoGate(
+          shouldGateToSso({
+            flagEnabled: QUIZ_SSO_REDIRECT_ENABLED,
+            isStudentRole,
+            embedded,
+            hasCode: !!urlCode,
+            classIds: info?.classIds,
+          })
+            ? 'gate'
+            : 'pin'
+        );
+      } catch {
+        if (!cancelled) setSsoGate('pin');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [ssoGate, isStudentRole, embedded, urlCode, lookupSession]);
 
   const isViewOnly = session?.mode === 'view-only';
 
@@ -583,6 +640,55 @@ const QuizJoinFlow: React.FC<{
         );
       }
       return <FullPageLoader message="Joining quiz…" light />;
+    }
+    // SSO gate is still deciding whether this is a ClassLink session.
+    if (ssoGate === 'pending') {
+      return <FullPageLoader message="Loading…" />;
+    }
+    // ClassLink-rostered session: offer Google sign-in by default (keys the
+    // response by the student's own stable auth.uid — no PIN/period fork),
+    // with a PIN escape hatch for students who can't sign in.
+    if (ssoGate === 'gate') {
+      const nextTarget = `${window.location.pathname}?code=${encodeURIComponent(
+        urlCode
+      )}`;
+      return (
+        <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">
+          <div className="w-full max-w-sm">
+            <div className="flex items-center justify-center mb-8">
+              <ClipboardList className="w-5 h-5 text-violet-400 mr-2" />
+              <span className="text-sm text-slate-300 font-semibold">
+                Student Quiz
+              </span>
+            </div>
+
+            <h1 className="text-2xl font-black text-white mb-2 text-center">
+              Sign in to join
+            </h1>
+            <p className="text-slate-400 text-sm text-center mb-6">
+              Use your school Google account so your quiz is saved to you.
+            </p>
+
+            <button
+              onClick={() =>
+                window.location.assign(
+                  `/student/login?next=${encodeURIComponent(nextTarget)}`
+                )
+              }
+              className="w-full py-4 bg-violet-600 hover:bg-violet-500 text-white font-bold text-lg rounded-xl flex items-center justify-center gap-2 transition-colors"
+            >
+              Sign in with Google <ArrowRight className="w-5 h-5" />
+            </button>
+
+            <button
+              onClick={() => setSsoGate('pin')}
+              className="w-full mt-3 py-2 text-slate-500 hover:text-slate-300 text-sm font-medium transition-colors"
+            >
+              Can&rsquo;t sign in? Use a PIN instead
+            </button>
+          </div>
+        </div>
+      );
     }
     return (
       <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center p-6">

--- a/components/student/StudentLoginPage.tsx
+++ b/components/student/StudentLoginPage.tsx
@@ -5,6 +5,7 @@ import { Loader2, GraduationCap, AlertCircle, Inbox } from 'lucide-react';
 import { auth, functions } from '@/config/firebase';
 import { APP_NAME } from '@/config/constants';
 import { STUDENT_FIRST_NAME_KEY } from '@/context/StudentAuthContextValue';
+import { resolveNextTarget } from '@/utils/studentJoinRouting';
 
 /**
  * Student login page (Phase 2A of the ClassLink-via-Google auth flow).
@@ -238,6 +239,18 @@ function readInitialBounceReason(): ErrorKind | null {
   }
 }
 
+/** Pull the validated `?next=` redirect target from the current URL. */
+function readNextTarget(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return resolveNextTarget(
+      new URLSearchParams(window.location.search).get('next')
+    );
+  } catch {
+    return null;
+  }
+}
+
 const StudentLoginPage: React.FC = () => {
   const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
 
@@ -283,12 +296,17 @@ const StudentLoginPage: React.FC = () => {
         await signInWithCustomToken(auth, customToken);
         setStatus({ kind: 'success' });
 
-        // Forward a hint about emptiness if the function told us — the
-        // assignments page will render its own empty state either way.
+        // If we were sent here to authenticate before joining a quiz/activity
+        // (validated `?next=` → e.g. `/quiz?code=ABC`), return there so the
+        // student lands back on their join with a stable SSO identity instead
+        // of the fork-prone anonymous PIN path. Otherwise fall back to the
+        // assignments page, forwarding the emptiness hint when we have one.
+        const next = readNextTarget();
         const target =
-          hasAssignments === false
+          next ??
+          (hasAssignments === false
             ? '/my-assignments?empty=1'
-            : '/my-assignments';
+            : '/my-assignments');
         window.location.assign(target);
       } catch (err) {
         // IMPORTANT: never log the id_token or the raw error object — either

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -57,12 +57,17 @@ import {
 import {
   buildLiveLeaderboard,
   buildPinToNameMap,
+  canScoreResponse,
   getDisplayScore,
   getResponseScore,
   getScoreSuffix,
   isGamificationActive,
 } from '../utils/quizScoreboard';
-import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
+import {
+  resolveResponseDisplayName,
+  responseTeamId,
+  findDuplicateResponseIds,
+} from '../utils/resolveDisplayName';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { db } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
@@ -460,6 +465,17 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     filterActive,
     session.classPeriodByClassId,
   ]);
+
+  // Detect likely forked / duplicate identities across the FULL response set
+  // (not the period-filtered view): a single physical student who ended up
+  // with two response docs — e.g. an SSO "joined" stub plus a separately-keyed
+  // completed doc from the wrong-period PIN bridge — resolves to one real
+  // roster/ClassLink name spread across multiple rows. Flag those rows so the
+  // teacher can reconcile instead of silently mis-grading one as "not done".
+  const duplicateIds = useMemo(
+    () => findDuplicateResponseIds(responses, pinToName, byStudentUid),
+    [responses, pinToName, byStudentUid]
+  );
 
   const { addToast } = useDashboard();
 
@@ -1768,6 +1784,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               }
                               pinToName={pinToName}
                               byStudentUid={byStudentUid}
+                              isPossibleDuplicate={duplicateIds.has(
+                                responseTeamId(r)
+                              )}
                             />
                           );
                         })}
@@ -2216,6 +2235,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                               }
                               pinToName={pinToName}
                               byStudentUid={byStudentUid}
+                              isPossibleDuplicate={duplicateIds.has(
+                                responseTeamId(r)
+                              )}
                             />
                           );
                         })}
@@ -2665,6 +2687,12 @@ const StudentRow: React.FC<{
     string,
     import('@/hooks/useAssignmentPseudonyms').StudentName
   >;
+  /**
+   * True when this row shares a resolved roster/ClassLink name with another
+   * response — a likely forked/duplicate identity. Drives a "duplicate?" badge
+   * so the teacher reconciles instead of mis-reading one copy as "not done".
+   */
+  isPossibleDuplicate?: boolean;
 }> = ({
   response,
   totalQuestions,
@@ -2682,6 +2710,7 @@ const StudentRow: React.FC<{
   resultsTabWarningThreshold,
   pinToName,
   byStudentUid,
+  isPossibleDuplicate,
 }) => {
   const warnings = response.tabSwitchWarnings ?? 0;
 
@@ -2689,14 +2718,19 @@ const StudentRow: React.FC<{
   // gamification bonuses don't distort the proficiency tier), and the
   // gamification-aware display score drives the pill text (so it agrees
   // with the live scoreboard).
-  const bandScore =
-    response.status === 'completed'
-      ? getResponseScore(response, questions)
-      : null;
-  const displayScore =
-    response.status === 'completed'
-      ? getDisplayScore(response, questions, scoringConfig)
-      : null;
+  //
+  // Both are gated on `canScoreResponse`: a completed response can only be
+  // scored once the answer key has loaded (the teacher view fetches the full
+  // quiz from Drive asynchronously) AND at least one of its answers maps to a
+  // loaded question. Otherwise grading silently yields 0, which would render
+  // as a real "0%"/red row for a student who actually finished. When we can't
+  // score yet we leave both null and the pill shows a neutral placeholder.
+  const scoreable =
+    response.status === 'completed' && canScoreResponse(response, questions);
+  const bandScore = scoreable ? getResponseScore(response, questions) : null;
+  const displayScore = scoreable
+    ? getDisplayScore(response, questions, scoringConfig)
+    : null;
   const scoreSuffix = getScoreSuffix(scoringConfig);
 
   // Row background. When colors are enabled AND the student has finished,
@@ -2785,6 +2819,12 @@ const StudentRow: React.FC<{
     pillText = `${response.answers.length}/${totalQuestions}`;
   } else if (response.status === 'completed' && displayScore != null) {
     pillText = `${displayScore}${scoreSuffix}`;
+  } else if (response.status === 'completed') {
+    // Completed but not scoreable yet — the answer key is still loading, or
+    // this response's answers don't match the loaded quiz (e.g. synced-quiz
+    // id drift). Show a neutral placeholder rather than a misleading 0% or an
+    // "answered/total" count that could be misread as a perfect score.
+    pillText = '—';
   } else {
     // No completed score yet — fall back to progress so teachers always see
     // *something* about in-progress students even when "percent" is selected.
@@ -2835,6 +2875,22 @@ const StudentRow: React.FC<{
         >
           {displayName}
         </span>
+
+        {isPossibleDuplicate && (
+          <span
+            className="flex items-center gap-0.5 bg-amber-100 text-amber-800 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
+            style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+            title="This name appears on more than one submission — a student may have joined twice (e.g. via Google sign-in and a PIN, or under the wrong class period). Review and remove the extra copy before grading."
+          >
+            <Users
+              style={{
+                width: 'min(12px, 3cqmin)',
+                height: 'min(12px, 3cqmin)',
+              }}
+            />
+            Dup?
+          </span>
+        )}
 
         {showTabWarnings && warnings > 0 && (
           <span

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -54,6 +54,7 @@ import {
   buildPinToNameMap,
   buildPinToExportNameMap,
   buildScoreboardTeams,
+  canScoreResponse,
   getResponseScore,
   getDisplayScore,
   getScoreSuffix,
@@ -513,13 +514,21 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     () => filteredResponses.filter((r) => r.status === 'completed'),
     [filteredResponses]
   );
+  // Only average responses we can actually score. A completed response that
+  // can't be graded yet (answer key not loaded, or question-id drift) would
+  // otherwise contribute a phantom 0 and drag the class average down — see
+  // `canScoreResponse`.
+  const filteredScoreable = useMemo(
+    () => filteredCompleted.filter((r) => canScoreResponse(r, quiz.questions)),
+    [filteredCompleted, quiz.questions]
+  );
   const filteredAvgScore =
-    filteredCompleted.length > 0
+    filteredScoreable.length > 0
       ? Math.round(
-          filteredCompleted.reduce(
+          filteredScoreable.reduce(
             (sum, r) => sum + getDisplayScore(r, quiz.questions, session),
             0
-          ) / filteredCompleted.length
+          ) / filteredScoreable.length
         )
       : null;
 
@@ -540,6 +549,19 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         session,
         byStudentUid
       );
+
+      // buildScoreboardTeams drops responses that can't be scored yet (answer
+      // key still loading / id drift), so `completed` can be non-empty while
+      // `newTeams` is empty. Bail before touching the widget — otherwise we'd
+      // overwrite an already-populated scoreboard with an empty roster and toast
+      // a misleading "0 students" success.
+      if (newTeams.length === 0) {
+        addToast(
+          'No scoreable students yet — the answer key may still be loading.',
+          'info'
+        );
+        return;
+      }
 
       const existingScoreboard = activeDashboard?.widgets.find(
         (w) => w.type === 'scoreboard'
@@ -1646,7 +1668,9 @@ const OverviewTab: React.FC<{
   // Distribution chart always uses percentage scores for meaningful bucketing,
   // even when gamification is active (points would not fit 0-100% buckets).
   const completedScores = React.useMemo(() => {
-    return completed.map((r) => getResponseScore(r, questions, session));
+    return completed
+      .filter((r) => canScoreResponse(r, questions))
+      .map((r) => getResponseScore(r, questions, session));
   }, [completed, questions, session]);
 
   return (
@@ -1709,9 +1733,14 @@ const OverviewTab: React.FC<{
             const count = completedScores.filter(
               (s) => s >= b.min && s <= b.max
             ).length;
+            // Denominator is the SCOREABLE population (what completedScores
+            // counts), not all completed responses — otherwise unscoreable
+            // responses (answer key still loading / id drift) inflate the
+            // denominator so the buckets under-sum and read as all-0% next to a
+            // non-zero "Finished" tile. See canScoreResponse / completedScores.
             const pct =
-              completed.length > 0
-                ? Math.round((count / completed.length) * 100)
+              completedScores.length > 0
+                ? Math.round((count / completedScores.length) * 100)
                 : 0;
 
             return (
@@ -1990,19 +2019,27 @@ const StudentsTab: React.FC<{
         responses
           .slice()
           .sort((a, b) => {
-            const scoreA =
-              a.status === 'completed' || a.status === 'in-progress'
-                ? getDisplayScore(a, questions, session)
+            // Match the row's display gate (below): an unscoreable response
+            // renders "—", so rank it with not-started (-1) rather than letting
+            // its phantom 0 sort it in among genuine low scores.
+            const rankScore = (r: QuizResponse) =>
+              (r.status === 'completed' || r.status === 'in-progress') &&
+              canScoreResponse(r, questions)
+                ? getDisplayScore(r, questions, session)
                 : -1;
-            const scoreB =
-              b.status === 'completed' || b.status === 'in-progress'
-                ? getDisplayScore(b, questions, session)
-                : -1;
-            return scoreB - scoreA;
+            return rankScore(b) - rankScore(a);
           })
           .map((r) => {
             const score = getDisplayScore(r, questions, session);
             const earned = getEarnedPoints(r, questions, session);
+            // A finished/in-progress response is only shown with a numeric
+            // score once it can actually be graded — answer key loaded AND at
+            // least one answer maps to a loaded question. Otherwise we render a
+            // neutral placeholder instead of a misleading 0 (see
+            // `canScoreResponse`).
+            const scoreable =
+              (r.status === 'completed' || r.status === 'in-progress') &&
+              canScoreResponse(r, questions);
             const warnings = r.tabSwitchWarnings ?? 0;
             const resultsLockedOut = r.resultsLockedOut === true;
             const resultsTabWarnings = r.resultsTabWarnings ?? 0;
@@ -2135,7 +2172,7 @@ const StudentsTab: React.FC<{
                 </div>
 
                 <div className="text-right shrink-0 ml-4 pl-4 border-l border-brand-blue-primary/5">
-                  {r.status === 'completed' || r.status === 'in-progress' ? (
+                  {scoreable ? (
                     <>
                       <p
                         className={`font-black ${gamified ? 'text-brand-blue-dark' : score >= 80 ? 'text-emerald-600' : score >= 60 ? 'text-amber-600' : 'text-brand-red-primary'}`}
@@ -2168,6 +2205,14 @@ const StudentsTab: React.FC<{
                           </span>
                         )}
                     </>
+                  ) : r.status === 'completed' || r.status === 'in-progress' ? (
+                    <p
+                      className="font-black text-brand-gray-primary"
+                      style={{ fontSize: 'min(15px, 5cqmin)' }}
+                      title="Scoring unavailable — the quiz answer key hasn't loaded yet, or this submission doesn't match the current quiz version."
+                    >
+                      &mdash;
+                    </p>
                   ) : (
                     <div
                       className="bg-brand-gray-lightest text-brand-gray-primary font-black uppercase rounded px-2 py-1 tracking-tighter"

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1067,15 +1067,21 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 
     // Guard the grade scale FIRST (a malformed/stale attachment could carry
     // NaN/0 maxPoints, scaling every grade to 0/NaN), then the eligible list —
-    // completed responses with a resolvable pseudonym — so we never pop a
-    // consent dialog when there's nothing to push. The eligible list and the
-    // grade payload both reflect the responses/quiz captured when the teacher
-    // clicked (this closure); a brief mid-dialog Firestore update isn't re-read.
+    // completed responses with a resolvable pseudonym THAT CAN BE SCORED — so we
+    // never pop a consent dialog when there's nothing to push. The eligible
+    // filter mirrors buildQuizClassroomGradeEntries (which also drops
+    // unscoreable responses), so the confirm-dialog count matches what actually
+    // gets pushed and we don't confirm only to toast "nothing to push". The
+    // eligible list and the grade payload both reflect the responses/quiz
+    // captured when the teacher clicked (this closure); a brief mid-dialog
+    // Firestore update isn't re-read.
     if (!hasValidMaxPoints(maxPoints)) {
       addToast(MISSING_MAX_POINTS_MESSAGE, 'error');
       return;
     }
-    const eligible = completed.filter((r) => !!r.studentUid);
+    const eligible = completed.filter(
+      (r) => !!r.studentUid && canScoreResponse(r, quiz.questions)
+    );
     if (eligible.length === 0) {
       addToast(NOTHING_TO_PUSH_TOAST, 'info');
       return;
@@ -2021,13 +2027,19 @@ const StudentsTab: React.FC<{
           .sort((a, b) => {
             // Match the row's display gate (below): an unscoreable response
             // renders "—", so rank it with not-started (-1) rather than letting
-            // its phantom 0 sort it in among genuine low scores.
-            const rankScore = (r: QuizResponse) =>
-              (r.status === 'completed' || r.status === 'in-progress') &&
-              canScoreResponse(r, questions)
-                ? getDisplayScore(r, questions, session)
+            // its phantom 0 sort it in among genuine low scores. Computed inline
+            // (no nested helper) so a closure isn't re-allocated per comparison.
+            const scoreA =
+              (a.status === 'completed' || a.status === 'in-progress') &&
+              canScoreResponse(a, questions)
+                ? getDisplayScore(a, questions, session)
                 : -1;
-            return rankScore(b) - rankScore(a);
+            const scoreB =
+              (b.status === 'completed' || b.status === 'in-progress') &&
+              canScoreResponse(b, questions)
+                ? getDisplayScore(b, questions, session)
+                : -1;
+            return scoreB - scoreA;
           })
           .map((r) => {
             const score = getDisplayScore(r, questions, session);

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -67,11 +67,14 @@ import { PlcTab } from '@/components/common/library/PlcTab';
 import { WrittenResponseGrader } from './WrittenResponseGrader';
 import { doc, updateDoc } from 'firebase/firestore';
 import { db, functions } from '@/config/firebase';
+import { buildQuizClassroomGradeEntries } from '@/utils/classroomGradePush';
 import {
-  buildQuizClassroomGradeEntries,
-  pushClassroomGradesForAssignment,
-  formatGradePushToast,
-} from '@/utils/classroomGradePush';
+  runClassroomGradePush,
+  createToastGradePushHandlers,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  NOTHING_TO_PUSH_TOAST,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from '@/components/classroomAddon/gisOAuth';
 import {
   QUIZ_SESSIONS_COLLECTION,
@@ -1040,104 +1043,49 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     if (!classroomAttachment) return;
     const { attachmentId, courseId, itemId, maxPoints } = classroomAttachment;
 
-    // Defensive guard: `maxPoints` is typed required, but a malformed/stale
-    // attachment doc could carry NaN/0 — which would scale every grade to 0 (or
-    // NaN). Bail with an actionable message rather than push garbage grades.
-    if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
-      addToast(
-        'This assignment is missing its Classroom point total — re-attach it to push grades.',
-        'error'
-      );
+    // Guard the grade scale FIRST (a malformed/stale attachment could carry
+    // NaN/0 maxPoints, scaling every grade to 0/NaN), then the eligible list —
+    // completed responses with a resolvable pseudonym — so we never pop a
+    // consent dialog when there's nothing to push. The eligible list and the
+    // grade payload both reflect the responses/quiz captured when the teacher
+    // clicked (this closure); a brief mid-dialog Firestore update isn't re-read.
+    if (!hasValidMaxPoints(maxPoints)) {
+      addToast(MISSING_MAX_POINTS_MESSAGE, 'error');
       return;
     }
-
-    // Compute the eligible list — completed responses with a resolvable
-    // pseudonym — and gate on it BEFORE confirming, so we never pop a consent
-    // dialog when there's nothing to push. Both the eligible list and the grade
-    // payload below reflect the responses/quiz captured when the teacher
-    // initiated the push (this handler's closure); a brief mid-dialog Firestore
-    // update is intentionally not re-read — the teacher pushes what they were
-    // looking at when they clicked.
     const eligible = completed.filter((r) => !!r.studentUid);
-
     if (eligible.length === 0) {
-      addToast('No completed submissions to push yet', 'info');
+      addToast(NOTHING_TO_PUSH_TOAST, 'info');
       return;
     }
 
-    const confirmed = await showConfirm(
-      `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
-        'Classroom? This writes draft grades to the assignment gradebook — ' +
-        'you still review and return them in Classroom.',
-      {
-        title: 'Push grades to Google Classroom',
-        confirmLabel: 'Push grades',
-        cancelLabel: 'Cancel',
-      }
-    );
-    if (!confirmed) return;
-
-    // Build the PII-free grade payload via the shared scaler (the single source
-    // of truth also used by the in-iframe grader, TeacherReviewRoute, so the two
-    // can't drift): each completed student's correctness points are scaled onto
-    // the frozen Classroom denominator (`maxPoints`), then rounded + clamped to
-    // [0, maxPoints], with a non-finite score treated as 0.
-    const grades = buildQuizClassroomGradeEntries(
-      completed,
-      quiz.questions,
-      maxPoints
-    );
-
-    setPushingGrades(true);
-    try {
-      // Mint a fresh add-on teacher token via the GIS popup (the teacher is
-      // present), then hand it to the CF to PATCH the DRAFT grades. A cancelled
-      // or failed consent rejects here — surface it distinctly from a CF failure
-      // so the teacher knows nothing was pushed.
-      let accessToken: string;
-      try {
-        accessToken = await requestClassroomTeacherToken(
-          user?.email ?? undefined
-        );
-      } catch (tokenErr) {
-        logError('QuizResults.pushClassroomGrades.token', tokenErr, {
-          sessionId: session?.id,
-          attachmentId,
-        });
-        addToast(
-          'Google sign-in was cancelled — no grades were pushed.',
-          'error'
-        );
-        return;
-      }
-
-      const data = await pushClassroomGradesForAssignment(functions, {
-        courseId,
-        itemId,
-        attachmentId,
-        accessToken,
-        grades,
-        maxPoints,
-      });
-      addToast(formatGradePushToast(data), 'success');
-    } catch (err) {
-      logError('QuizResults.pushClassroomGrades', err, {
-        sessionId: session?.id,
-        attachmentId,
-      });
-      // A permission-denied means this course isn't linked to ClassLink under
-      // the current teacher (the CF gates push on the link doc). Tell the
-      // teacher how to fix it instead of a dead-end generic error.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      addToast(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : 'Could not push grades to Google Classroom.',
-        'error'
-      );
-    } finally {
-      setPushingGrades(false);
-    }
+    // Shared push flow (token mint → CF → result toast); QuizResults supplies
+    // only its grade builder (correctness points scaled onto the frozen
+    // denominator via the single-source-of-truth scaler the in-iframe grader
+    // also uses) and the toast reporter.
+    await runClassroomGradePush({
+      functions,
+      attachment: { courseId, itemId, attachmentId, maxPoints },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? undefined),
+      buildGrades: () =>
+        buildQuizClassroomGradeEntries(completed, quiz.questions, maxPoints),
+      confirm: () =>
+        showConfirm(
+          `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
+            'Classroom? This writes draft grades to the assignment gradebook — ' +
+            'you still review and return them in Classroom.',
+          {
+            title: 'Push grades to Google Classroom',
+            confirmLabel: 'Push grades',
+            cancelLabel: 'Cancel',
+          }
+        ),
+      distinctTokenCancel: true,
+      logTag: 'QuizResults.pushClassroomGrades',
+      logContext: { sessionId: session?.id, attachmentId },
+      ...createToastGradePushHandlers(addToast, setPushingGrades),
+    });
   };
 
   return (

--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -34,6 +34,7 @@ import {
   getDisplayScore,
   getScoreSuffix,
   isGamificationActive,
+  canScoreResponse,
   buildPinToNameMap,
   buildPinToExportNameMap,
   buildScoreboardTeams,
@@ -127,6 +128,64 @@ function makeRoster(
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('quizScoreboard', () => {
+  describe('canScoreResponse', () => {
+    const qs = [makeQuestion('q1', 'a'), makeQuestion('q2', 'b')];
+
+    it('returns false when the answer key has not loaded (empty questions)', () => {
+      const r = makeResponse('1', [{ questionId: 'q1', answer: 'a' }]);
+      expect(canScoreResponse(r, [])).toBe(false);
+    });
+
+    it('returns true for a completed response whose answers match loaded questions', () => {
+      const r = makeResponse('1', [{ questionId: 'q1', answer: 'a' }]);
+      expect(canScoreResponse(r, qs)).toBe(true);
+    });
+
+    it('treats a zero-answer response as scoreable (genuine 0, not a missing key)', () => {
+      const r = makeResponse('1', [], 'completed');
+      expect(canScoreResponse(r, qs)).toBe(true);
+    });
+
+    it('returns false when no answer matches a loaded question id (synced ID drift)', () => {
+      const r = makeResponse('1', [
+        { questionId: 'old-q1', answer: 'a' },
+        { questionId: 'old-q2', answer: 'b' },
+      ]);
+      expect(canScoreResponse(r, qs)).toBe(false);
+    });
+
+    it('returns true when at least one answer matches (partial drift still gradable)', () => {
+      const r = makeResponse('1', [
+        { questionId: 'q1', answer: 'a' },
+        { questionId: 'old-q2', answer: 'b' },
+      ]);
+      expect(canScoreResponse(r, qs)).toBe(true);
+    });
+  });
+
+  describe('ranking builders exclude unscoreable responses', () => {
+    const qs = [makeQuestion('q1', 'a'), makeQuestion('q2', 'b')];
+
+    it('buildScoreboardTeams drops a completed response whose answers match no loaded question', () => {
+      const matched = makeResponse('1', [{ questionId: 'q1', answer: 'a' }]);
+      const drifted = makeResponse('2', [{ questionId: 'old-q', answer: 'a' }]);
+      const teams = buildScoreboardTeams([matched, drifted], qs, 'pin', {});
+      expect(teams.map((t) => t.name)).toEqual(['PIN 1']);
+    });
+
+    it('buildScoreboardTeams returns empty when the answer key has not loaded', () => {
+      const r = makeResponse('1', [{ questionId: 'q1', answer: 'a' }]);
+      expect(buildScoreboardTeams([r], [], 'pin', {})).toEqual([]);
+    });
+
+    it('buildLiveLeaderboard drops a completed response with no matching question ids', () => {
+      const matched = makeResponse('1', [{ questionId: 'q1', answer: 'a' }]);
+      const drifted = makeResponse('2', [{ questionId: 'old-q', answer: 'a' }]);
+      const entries = buildLiveLeaderboard([matched, drifted], qs, null, {});
+      expect(entries.map((e) => e.pin)).toEqual(['1']);
+    });
+  });
+
   describe('getEarnedPoints', () => {
     it('returns points for correct answers', () => {
       const questions = [makeQuestion('q1', 'A'), makeQuestion('q2', 'B')];

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -152,6 +152,48 @@ export function getScoreSuffix(session?: QuizScoringSession): string {
 }
 
 /**
+ * Whether a response can be meaningfully scored against the given question set.
+ *
+ * Guards the "false 0" failure mode. Scores are computed on read by grading
+ * each answer against `questions[].correctAnswer` — so if the question set is
+ * the wrong one, `getEarnedPoints` silently yields 0 (every `qMap.get` misses
+ * and the answer is skipped). That 0 then renders as a real "0%"/"0 pts",
+ * which reads as a student who failed rather than a scoring artifact. Two
+ * cases produce it:
+ *
+ *   1. **Answer key not loaded** — `questions` is empty. The teacher's view
+ *      loads the full quiz (with `correctAnswer`) from Drive asynchronously;
+ *      before it resolves (or if the Drive fetch fails / the Google token
+ *      lapsed) the array is empty and EVERY completed response scores 0.
+ *   2. **Question-id drift** — a completed response's answers reference no
+ *      question in the loaded set (e.g. a PLC-synced quiz whose question IDs
+ *      were regenerated after the student submitted). Grading skips all of
+ *      them and the response scores 0 despite real answers.
+ *
+ * Callers should render a pending / "—" indicator (not a score) when this
+ * returns false, and ranking helpers should keep these out of the numeric
+ * leaderboard rather than seating them at 0.
+ *
+ * A response with zero answers is treated as gradable: its 0 is a genuine
+ * "didn't answer", not a missing-key artifact, so the caller can still show 0.
+ */
+export function canScoreResponse(
+  r: QuizResponse,
+  questions: QuizQuestion[]
+): boolean {
+  // Case 1: the answer key hasn't loaded — nothing can be graded yet.
+  if (questions.length === 0) return false;
+  const answers = r.answers ?? [];
+  // A genuine empty submission is scoreable (it's a real 0, not a missing key).
+  if (answers.length === 0) return true;
+  // Case 2: at least one answer must map to a loaded question. Partial drift
+  // (some ids match, some don't) is still gradable — the matched answers score
+  // and the unmatched ones are skipped, same as today.
+  const ids = new Set(questions.map((q) => q.id));
+  return answers.some((a) => ids.has(a.questionId));
+}
+
+/**
  * Composite-key separator used by `buildPinToNameMap` /
  * `buildPinToExportNameMap`. Map keys are `${classPeriod}${PIN_KEY_SEP}${pin}`
  * so that the same PIN in two different rosters resolves to two different
@@ -342,29 +384,35 @@ export function buildScoreboardTeams(
   session?: QuizSession | null,
   byStudentUid?: Map<string, StudentName>
 ): ScoreboardTeam[] {
-  return completedResponses
-    .map((r) => ({
-      response: r,
-      score: getDisplayScore(r, questions, session),
-    }))
-    .sort((a, b) => b.score - a.score)
-    .map(({ response, score }) => {
-      const resolvedName = resolveResponseDisplayName(
-        response,
-        pinToName,
-        byStudentUid
-      );
-      const pinModeName = response.pin ? `PIN ${response.pin}` : resolvedName;
-      return {
-        id: responseTeamId(response),
-        name: mode === 'name' ? resolvedName : pinModeName,
-        score,
-        color:
-          SCOREBOARD_COLORS[
-            responseColorIndex(response, SCOREBOARD_COLORS.length)
-          ],
-      };
-    });
+  return (
+    completedResponses
+      // Keep responses that can't be scored yet (answer key not loaded, or
+      // question-id drift) off the board entirely rather than seating them at a
+      // phantom 0 — see `canScoreResponse`.
+      .filter((r) => canScoreResponse(r, questions))
+      .map((r) => ({
+        response: r,
+        score: getDisplayScore(r, questions, session),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .map(({ response, score }) => {
+        const resolvedName = resolveResponseDisplayName(
+          response,
+          pinToName,
+          byStudentUid
+        );
+        const pinModeName = response.pin ? `PIN ${response.pin}` : resolvedName;
+        return {
+          id: responseTeamId(response),
+          name: mode === 'name' ? resolvedName : pinModeName,
+          score,
+          color:
+            SCOREBOARD_COLORS[
+              responseColorIndex(response, SCOREBOARD_COLORS.length)
+            ],
+        };
+      })
+  );
 }
 
 /**
@@ -381,20 +429,26 @@ export function buildLiveLeaderboard(
   pinToName: Record<string, string>,
   byStudentUid?: Map<string, StudentName>
 ): QuizLeaderboardEntry[] {
-  return responses
-    .filter((response) => response.status !== 'joined')
-    .map((response) => ({
-      // `pin` is set only for anonymous joiners; SSO joiners use `studentUid`
-      // for self-identification on the student-side leaderboard view.
-      ...(response.pin ? { pin: response.pin } : {}),
-      studentUid: response.studentUid,
-      name: resolveResponseDisplayName(response, pinToName, byStudentUid),
-      score: getDisplayScore(response, questions, session),
-    }))
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 10)
-    .map((entry, index) => ({
-      ...entry,
-      rank: index + 1,
-    }));
+  return (
+    responses
+      .filter((response) => response.status !== 'joined')
+      // Drop responses we can't score yet (answer key not loaded, or question-id
+      // drift) so the leaderboard never ranks a real submission at a phantom 0.
+      // Legitimately-empty in-progress responses still score 0 as before.
+      .filter((response) => canScoreResponse(response, questions))
+      .map((response) => ({
+        // `pin` is set only for anonymous joiners; SSO joiners use `studentUid`
+        // for self-identification on the student-side leaderboard view.
+        ...(response.pin ? { pin: response.pin } : {}),
+        studentUid: response.studentUid,
+        name: resolveResponseDisplayName(response, pinToName, byStudentUid),
+        score: getDisplayScore(response, questions, session),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 10)
+      .map((entry, index) => ({
+        ...entry,
+        rank: index + 1,
+      }))
+  );
 }

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.test.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { findDuplicateResponseIds, responseTeamId } from './resolveDisplayName';
+import { buildPinToNameMap } from './quizScoreboard';
+import type { QuizResponse, ClassRoster } from '@/types';
+import type { StudentName } from '@/hooks/useAssignmentPseudonyms';
+
+function resp(overrides: Partial<QuizResponse>): QuizResponse {
+  return {
+    studentUid: 'uid-x',
+    joinedAt: 0,
+    status: 'completed',
+    answers: [],
+    score: null,
+    submittedAt: 0,
+    ...overrides,
+  } as QuizResponse;
+}
+
+const sso = (uid: string): QuizResponse => resp({ studentUid: uid });
+const pinResp = (pin: string, classPeriod?: string): QuizResponse =>
+  resp({ studentUid: `anon-${pin}`, pin, classPeriod });
+
+const byUid = (entries: Record<string, StudentName>) =>
+  new Map(Object.entries(entries));
+
+describe('findDuplicateResponseIds', () => {
+  it('flags two SSO docs that resolve to the same ClassLink name (the fork signature)', () => {
+    const a = sso('uidA');
+    const b = sso('uidB');
+    const dup = findDuplicateResponseIds(
+      [a, b],
+      {},
+      byUid({
+        uidA: { givenName: 'Kya', familyName: 'Newell' },
+        uidB: { givenName: 'Kya', familyName: 'Newell' },
+      })
+    );
+    expect(dup).toEqual(new Set([responseTeamId(a), responseTeamId(b)]));
+  });
+
+  it('flags an SSO stub + a PIN doc that resolve to the same roster student', () => {
+    const stub = sso('uidA');
+    const pinDoc = pinResp('21', 'Hour 1');
+    const roster: ClassRoster = {
+      id: 'r1',
+      name: 'Hour 1',
+      driveFileId: null,
+      studentCount: 1,
+      createdAt: 0,
+      students: [{ id: 's1', firstName: 'Kya', lastName: 'Newell', pin: '21' }],
+    };
+    const pinToName = buildPinToNameMap([roster], ['Hour 1']);
+    const dup = findDuplicateResponseIds(
+      [stub, pinDoc],
+      pinToName,
+      byUid({ uidA: { givenName: 'Kya', familyName: 'Newell' } })
+    );
+    expect(dup.has(responseTeamId(stub))).toBe(true);
+    expect(dup.has(responseTeamId(pinDoc))).toBe(true);
+  });
+
+  it('does not flag a real name that appears only once', () => {
+    const a = sso('uidA');
+    const b = sso('uidB');
+    const dup = findDuplicateResponseIds(
+      [a, b],
+      {},
+      byUid({
+        uidA: { givenName: 'Kya', familyName: 'Newell' },
+        uidB: { givenName: 'Sam', familyName: 'Jones' },
+      })
+    );
+    expect(dup.size).toBe(0);
+  });
+
+  it('ignores the generic "Student" fallback (unresolved SSO joiners)', () => {
+    // Two SSO docs with no pseudonym match → both resolve to "Student".
+    const dup = findDuplicateResponseIds(
+      [sso('uidA'), sso('uidB')],
+      {},
+      byUid({})
+    );
+    expect(dup.size).toBe(0);
+  });
+
+  it('ignores the "PIN <n>" fallback (no roster name)', () => {
+    // Two distinct PIN docs with no roster entry → "PIN 5" / "PIN 6", and even
+    // two with the same unresolved PIN must not be treated as a real name.
+    const dup = findDuplicateResponseIds(
+      [pinResp('5', 'Hour 1'), pinResp('5', 'Hour 3')],
+      {},
+      undefined
+    );
+    expect(dup.size).toBe(0);
+  });
+});

--- a/components/widgets/QuizWidget/utils/resolveDisplayName.ts
+++ b/components/widgets/QuizWidget/utils/resolveDisplayName.ts
@@ -71,6 +71,45 @@ export function hasPinIdentity(response: QuizResponse): boolean {
 }
 
 /**
+ * Detect likely duplicate / forked identities within a response set.
+ *
+ * A single physical student can end up with two response docs — e.g. a
+ * ClassLink/SSO "joined" stub plus a separate completed doc written under a
+ * different identity by the wrong-period PIN-bridge fork. Both resolve to the
+ * SAME real roster/ClassLink name, so we flag any *resolved* name that maps to
+ * more than one distinct response.
+ *
+ * Only real names are considered. The generic `Student` and `PIN <n>`
+ * fallbacks recur across many unrelated rows (every unresolved SSO joiner is
+ * "Student"), so counting them would flood the teacher with false positives —
+ * they're skipped here.
+ *
+ * Returns the set of `responseTeamId(response)` values that share a real name
+ * with at least one other response; callers badge those rows for review.
+ */
+export function findDuplicateResponseIds(
+  responses: QuizResponse[],
+  pinToName: Record<string, string>,
+  byStudentUid: Map<string, StudentName> | undefined
+): Set<string> {
+  const idsByName = new Map<string, Set<string>>();
+  for (const r of responses) {
+    const name = resolveResponseDisplayName(r, pinToName, byStudentUid);
+    // Skip the generic fallbacks — only a real resolved name is reliable.
+    if (name === UNKNOWN_STUDENT_LABEL) continue;
+    if (r.pin && name === `PIN ${r.pin}`) continue;
+    const ids = idsByName.get(name) ?? new Set<string>();
+    ids.add(responseTeamId(r));
+    idsByName.set(name, ids);
+  }
+  const duplicates = new Set<string>();
+  for (const ids of idsByName.values()) {
+    if (ids.size > 1) ids.forEach((id) => duplicates.add(id));
+  }
+  return duplicates;
+}
+
+/**
  * Stable, unique team id for scoreboard rows. PIN joiners keep their
  * historical `pin-{pin}` shape so existing scoreboard widgets that reference
  * those ids (via `parseInt(response.pin, 10)`) keep working. SSO students

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -31,11 +31,13 @@ import {
   computeVideoActivityScorePct,
 } from '@/utils/videoActivityGrading';
 import {
-  pushClassroomGradesForAssignment,
-  formatGradePushToast,
-} from '@/utils/classroomGradePush';
+  runClassroomGradePush,
+  createToastGradePushHandlers,
+  hasValidMaxPoints,
+  MISSING_MAX_POINTS_MESSAGE,
+  NOTHING_TO_PUSH_TOAST,
+} from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from '@/components/classroomAddon/gisOAuth';
-import { logError } from '@/utils/logError';
 import { functions } from '@/config/firebase';
 import {
   useAssignmentPseudonymsMulti,
@@ -237,108 +239,59 @@ export const Results: React.FC<ResultsProps> = ({
     if (!classroomAttachment) return;
     const { attachmentId, courseId, itemId, maxPoints } = classroomAttachment;
 
-    // Defensive guard: `maxPoints` is typed required, but a malformed/stale
-    // attachment doc could carry NaN/0 — which would scale every grade to 0 (or
-    // NaN). Bail with an actionable message rather than push garbage grades.
-    if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
-      addToast(
-        'This assignment is missing its Classroom point total — re-attach it to push grades.',
-        'error'
-      );
+    // Guard the grade scale FIRST (a malformed/stale attachment could carry
+    // NaN/0 maxPoints, scaling every grade to 0/NaN), then the eligible list —
+    // completed responses with a resolvable pseudonym — so we never pop a
+    // consent dialog when there's nothing to push.
+    if (!hasValidMaxPoints(maxPoints)) {
+      addToast(MISSING_MAX_POINTS_MESSAGE, 'error');
       return;
     }
-
-    // The eligible list — completed responses with a resolvable pseudonym —
-    // is cheap to compute and stable across the confirm dialog, so we derive
-    // it (and gate on it) BEFORE confirming. The per-student SCORING, however,
-    // is built AFTER the confirm against the latest props, so an edit pushed by
-    // the Firestore listener while the dialog is open can't bake stale scores
-    // into the payload (TOCTOU).
     const eligible = responses.filter(
       (r) => r.completedAt !== null && !!r.studentUid
     );
-
     if (eligible.length === 0) {
-      addToast('No completed submissions to push yet', 'info');
+      addToast(NOTHING_TO_PUSH_TOAST, 'info');
       return;
     }
 
-    const confirmed = await showConfirm(
-      `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
-        'Classroom? This writes draft grades to the assignment gradebook — ' +
-        'you still review and return them in Classroom.',
-      {
-        title: 'Push grades to Google Classroom',
-        confirmLabel: 'Push grades',
-        cancelLabel: 'Cancel',
-      }
-    );
-    if (!confirmed) return;
-
-    // Build the PII-free grade payload: one entry per completed response with a
-    // resolvable pseudonym. `getStudentScore` returns the SAME 0–100 percentage
-    // the Students tab displays; scale it onto the frozen Classroom denominator,
-    // then round + clamp to [0, maxPoints]. Built from the responses captured
-    // when the teacher initiated the push (this handler's closure).
-    const grades = eligible.map((r) => {
-      const pct = getStudentScore(r);
-      const safePct = Number.isFinite(pct) ? pct : 0;
-      const pointsEarned = Math.max(
-        0,
-        Math.min(maxPoints, Math.round((safePct / 100) * maxPoints))
-      );
-      return { pseudonymUid: r.studentUid, pointsEarned };
+    // Shared push flow (token mint → CF → result toast); the VA monitor supplies
+    // only its grade builder. `getStudentScore` returns the SAME 0–100
+    // percentage the Students tab shows; scale it onto the frozen denominator,
+    // then round + clamp to [0, maxPoints]. The payload is built inside the flow
+    // (AFTER the confirm) from the responses captured when the teacher clicked
+    // (this closure), so a mid-dialog Firestore edit can't bake in stale scores.
+    await runClassroomGradePush({
+      functions,
+      attachment: { courseId, itemId, attachmentId, maxPoints },
+      requestToken: () =>
+        requestClassroomTeacherToken(user?.email ?? undefined),
+      buildGrades: () =>
+        eligible.map((r) => {
+          const pct = getStudentScore(r);
+          const safePct = Number.isFinite(pct) ? pct : 0;
+          const pointsEarned = Math.max(
+            0,
+            Math.min(maxPoints, Math.round((safePct / 100) * maxPoints))
+          );
+          return { pseudonymUid: r.studentUid, pointsEarned };
+        }),
+      confirm: () =>
+        showConfirm(
+          `Push ${eligible.length} grade${eligible.length === 1 ? '' : 's'} to Google ` +
+            'Classroom? This writes draft grades to the assignment gradebook — ' +
+            'you still review and return them in Classroom.',
+          {
+            title: 'Push grades to Google Classroom',
+            confirmLabel: 'Push grades',
+            cancelLabel: 'Cancel',
+          }
+        ),
+      distinctTokenCancel: true,
+      logTag: 'VideoActivityResults.pushClassroomGrades',
+      logContext: { sessionId: session?.id, attachmentId },
+      ...createToastGradePushHandlers(addToast, setPushingGrades),
     });
-
-    setPushingGrades(true);
-    try {
-      // Mint a fresh add-on teacher token via the GIS popup (the teacher is
-      // present), then hand it to the CF to PATCH the DRAFT grades. A cancelled
-      // or failed consent rejects here — surface it distinctly from a CF failure
-      // so the teacher knows nothing was pushed.
-      let accessToken: string;
-      try {
-        accessToken = await requestClassroomTeacherToken(
-          user?.email ?? undefined
-        );
-      } catch (tokenErr) {
-        logError('VideoActivityResults.pushClassroomGrades.token', tokenErr, {
-          sessionId: session?.id,
-          attachmentId,
-        });
-        addToast(
-          'Google sign-in was cancelled — no grades were pushed.',
-          'error'
-        );
-        return;
-      }
-
-      const data = await pushClassroomGradesForAssignment(functions, {
-        courseId,
-        itemId,
-        attachmentId,
-        accessToken,
-        grades,
-        maxPoints,
-      });
-      addToast(formatGradePushToast(data), 'success');
-    } catch (err) {
-      logError('VideoActivityResults.pushClassroomGrades', err, {
-        sessionId: session?.id,
-        attachmentId,
-      });
-      // permission-denied → this course isn't linked to ClassLink under the
-      // current teacher (the CF gates push on the link doc); tell them how to fix.
-      const code = (err as { code?: string } | null)?.code ?? '';
-      addToast(
-        code.includes('permission-denied')
-          ? 'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.'
-          : 'Could not push grades to Google Classroom.',
-        'error'
-      );
-    } finally {
-      setPushingGrades(false);
-    }
   };
 
   return (

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,1 +1,16 @@
 export const APP_NAME = 'SpartBoard';
+
+/**
+ * When true, anonymous students opening a ClassLink-rostered quiz session
+ * (the session carries `classIds`) are steered to Google SSO sign-in by
+ * default — with a "use a PIN instead" escape — rather than the PIN+period
+ * join path. SSO keys the response by the student's own stable `auth.uid`,
+ * which eliminates the "wrong period → forked onto another roster slot"
+ * failure mode that the PIN+period path is prone to.
+ *
+ * Ships OFF. Flip to `true` to enable the redirect — do this only AFTER any
+ * in-progress quiz session has ended, since it changes the join flow for
+ * rostered sessions. PIN-only sessions (no `classIds`) are unaffected either
+ * way.
+ */
+export const QUIZ_SSO_REDIRECT_ENABLED = false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -651,18 +651,23 @@ service cloud.firestore {
     // ClassLink class (section) sourcedId, so the add-on can resolve students
     // against the existing OneRoster roster + name pipeline. Keyed by the
     // Google courseId; the doc records the claiming teacher. The student-login
-    // CF reads it via the Admin SDK (bypasses rules). Low-sensitivity (an
-    // id→id map, no PII), but writes are constrained to the claiming teacher
-    // and an existing link can't be hijacked by a different teacher.
+    // CF reads it via the Admin SDK (bypasses rules).
+    //
+    // READ is open to any authed user (the teacher discovery iframe reads the
+    // link to resolve class targeting). WRITES are SERVER-ONLY: the
+    // `linkClassroomCourse` CF first verifies — with the teacher's own
+    // `classroom.courses.readonly` token — that the caller genuinely teaches the
+    // Google course, then writes via the Admin SDK. Rules cannot verify
+    // Google-course teaching, so a client `create` (checking only
+    // teacherUid == auth.uid) let ANY authed user squat ANY courseId: the
+    // student-login CF mints every student's class-gate `classIds` from whatever
+    // class this doc names, so a squatter could mis-route a victim course's
+    // students AND permanently lock the real teacher out (first-write-wins; an
+    // update requires the existing teacherUid). Blocking client writes closes
+    // that hole.
     match /classroom_course_links/{courseId} {
       allow read: if request.auth != null;
-      allow create: if request.auth != null
-        && request.resource.data.teacherUid == request.auth.uid;
-      allow update: if request.auth != null
-        && request.resource.data.teacherUid == request.auth.uid
-        && resource.data.teacherUid == request.auth.uid;
-      allow delete: if request.auth != null
-        && resource.data.teacherUid == request.auth.uid;
+      allow write: if false;
     }
 
     // Global permissions - all authenticated users can read, only admins can write

--- a/functions/src/classlinkShared.ts
+++ b/functions/src/classlinkShared.ts
@@ -1,0 +1,112 @@
+/**
+ * classlinkShared — single source of truth for the ClassLink / OneRoster + CORS
+ * primitives that `index.ts` and `classroomAddonAuth.ts` both depend on.
+ *
+ * These were previously copy-pasted into each file with "keep in sync" / "MUST
+ * match index.ts" comments. The riskiest of them is `computeStudentUid`: it is
+ * the HMAC pseudonym CONTRACT. A Classroom add-on student and that same student's
+ * ClassLink SSO login must mint the IDENTICAL Firebase uid, or the monitor's name
+ * resolution and grade passback silently target the wrong (or no) student — with
+ * NO compile error to catch the drift. Centralizing the formula here makes that
+ * contract un-driftable.
+ *
+ * No Firebase Admin app is initialized in this module (only `index.ts` calls
+ * `admin.initializeApp()`); `resolveOrgIdForDomain` receives the Firestore handle
+ * from its caller so this stays a pure, import-anywhere helper module.
+ */
+import * as admin from 'firebase-admin';
+import * as CryptoJS from 'crypto-js';
+import OAuth from 'oauth-1.0a';
+
+/**
+ * CORS allowlist + per-callable `cors` config shared by every onCall in both
+ * files. Production host, Firebase default host, the dev-channel preview pattern,
+ * and localhost. (Previously duplicated as `ALLOWED_ORIGINS` in each file with a
+ * "Keep in sync" comment.)
+ */
+export const ALLOWED_ORIGINS: (string | RegExp)[] = [
+  'https://spartboard.web.app',
+  'https://spartboard.firebaseapp.com',
+  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
+  /^http:\/\/localhost(:\d+)?$/,
+];
+
+/** OneRoster v1.1 API base path segment (appended to a tenant URL). */
+export const ONEROSTER_BASE = '/ims/oneroster/v1p1';
+
+/**
+ * OneRoster student shape (subset). Fields are optional because a OneRoster
+ * `users`/`students` payload can omit any of them — every consumer guards
+ * (`if (!s.sourcedId) continue`, `s.email ?? ''`) before use.
+ */
+export interface ClassLinkStudent {
+  sourcedId?: string;
+  givenName?: string;
+  familyName?: string;
+  email?: string;
+}
+
+/**
+ * Stable per-student pseudonym: `HMAC-SHA256("sid:"+sourcedId, secret)` in hex.
+ * THE pseudonym contract — see the module header. Must produce the byte-identical
+ * uid for a given (sourcedId, secret) across every caller.
+ */
+export function computeStudentUid(
+  sourcedId: string,
+  hmacSecret: string
+): string {
+  return CryptoJS.HmacSHA256(`sid:${sourcedId}`, hmacSecret).toString(
+    CryptoJS.enc.Hex
+  );
+}
+
+/**
+ * Normalize an email to its `@domain` form (lowercased, leading '@'), or null
+ * when the address is malformed. Matches the domain-doc storage format.
+ */
+export function normalizeEmailDomain(email: string): string | null {
+  const at = email.lastIndexOf('@');
+  if (at < 0 || at === email.length - 1) return null;
+  return '@' + email.slice(at + 1).toLowerCase();
+}
+
+/**
+ * Look up the organization that owns an email domain. Matches the
+ * `/organizations/{orgId}/domains/{doc}` subcollection, requiring
+ * `status === 'verified'`. Domain values are stored with a leading '@'. Returns
+ * null when no verified match exists.
+ */
+export async function resolveOrgIdForDomain(
+  db: admin.firestore.Firestore,
+  domainWithAt: string
+): Promise<string | null> {
+  const snap = await db
+    .collectionGroup('domains')
+    .where('domain', '==', domainWithAt)
+    .where('status', '==', 'verified')
+    .limit(1)
+    .get();
+  if (snap.empty) return null;
+  const orgRef = snap.docs[0].ref.parent.parent;
+  return orgRef ? orgRef.id : null;
+}
+
+/** Generate OAuth 1.0 (HMAC-SHA1) headers for a ClassLink OneRoster request. */
+export function getOAuthHeaders(
+  baseUrl: string,
+  params: Record<string, string>,
+  method: string,
+  clientId: string,
+  clientSecret: string
+): Record<string, string> {
+  const oauth = new OAuth({
+    consumer: { key: clientId, secret: clientSecret },
+    signature_method: 'HMAC-SHA1',
+    hash_function(base_string: string, key: string) {
+      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
+    },
+  });
+  return oauth.toHeader(
+    oauth.authorize({ url: baseUrl, method, data: params })
+  ) as unknown as Record<string, string>;
+}

--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -145,6 +145,7 @@ vi.mock('firebase-functions/params', () => ({
 import {
   classroomAddonLoginV1,
   createClassroomAttachment,
+  linkClassroomCourse,
   pushClassroomGradesForAssignment,
   classroomAddonNet,
 } from './classroomAddonAuth';
@@ -711,6 +712,164 @@ describe('createClassroomAttachment (spike)', () => {
   });
 });
 
+// linkClassroomCourse — server-gated creator of classroom_course_links/{courseId}.
+// The trust anchor is listTeacherCourseIds (the caller's OWN teacher course
+// list): the chosen courseId MUST appear there, or the link is refused. These
+// tests pin the squatting fix — a non-teacher can't claim a course, teacherUid
+// is always the authenticated caller (never the client payload), and an existing
+// link owned by a different teacher is never overwritten.
+const callLink = linkClassroomCourse as unknown as (req: {
+  data: unknown;
+  auth?: { uid: string } | null;
+}) => Promise<{ ok: boolean; courseId: string }>;
+
+const linkData = {
+  accessToken: 'teacher-courses-token',
+  courseId: 'C1',
+  classlinkClassId: 'CL-SECTION-1',
+  classlinkOrgId: 'orono',
+  rosterId: 'roster-1',
+};
+
+function findLinkWrite() {
+  return firestoreWrites.find((w) => w.path === 'classroom_course_links/C1');
+}
+
+describe('linkClassroomCourse (course-squatting fix)', () => {
+  it('writes the link for a verified teacher of the course', async () => {
+    const listSpy = vi
+      .spyOn(classroomAddonNet, 'listTeacherCourseIds')
+      .mockResolvedValue({ ok: true, status: 200, courseIds: ['C0', 'C1'] });
+
+    const res = await callLink({
+      data: linkData,
+      auth: { uid: 'teacher-1' },
+    });
+
+    expect(res).toMatchObject({ ok: true, courseId: 'C1' });
+    expect(listSpy).toHaveBeenCalledWith('teacher-courses-token');
+    const write = findLinkWrite();
+    expect(write?.data).toMatchObject({
+      classlinkClassId: 'CL-SECTION-1',
+      classlinkOrgId: 'orono',
+      teacherUid: 'teacher-1',
+      rosterId: 'roster-1',
+    });
+    // First create stamps both timestamps.
+    expect(typeof write?.data.createdAt).toBe('number');
+    expect(typeof write?.data.updatedAt).toBe('number');
+  });
+
+  it('refuses to link a course the caller does not teach (squat attempt)', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      // The caller teaches OTHER courses, but NOT the courseId they're claiming.
+      courseIds: ['SOME-OTHER-COURSE'],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'squatter' } })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('always records teacherUid from the authenticated caller, never the client payload', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await callLink({
+      // A malicious client tries to set someone else as the owner.
+      data: { ...linkData, teacherUid: 'victim-teacher' },
+      auth: { uid: 'real-caller' },
+    });
+
+    expect(findLinkWrite()?.data.teacherUid).toBe('real-caller');
+  });
+
+  it('refuses to overwrite a link owned by a different teacher (no hijack)', async () => {
+    courseLinkDoc = {
+      classlinkClassId: 'CL-OTHER',
+      teacherUid: 'original-teacher',
+    };
+    // Even a genuine co-teacher (passes the teacher check) can't steal it.
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'co-teacher' } })
+    ).rejects.toMatchObject({ code: 'already-exists' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('lets the SAME teacher re-link (update) without resetting createdAt', async () => {
+    courseLinkDoc = {
+      classlinkClassId: 'CL-OLD',
+      teacherUid: 'teacher-1',
+      createdAt: 111,
+    } as Record<string, unknown>;
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: true,
+      status: 200,
+      courseIds: ['C1'],
+    });
+
+    await callLink({ data: linkData, auth: { uid: 'teacher-1' } });
+
+    const write = findLinkWrite();
+    expect(write?.data.teacherUid).toBe('teacher-1');
+    expect(write?.data.classlinkClassId).toBe('CL-SECTION-1');
+    // createdAt is only set on first create; a re-link must not stamp it (merge
+    // preserves the original).
+    expect(write?.data.createdAt).toBeUndefined();
+    expect(typeof write?.data.updatedAt).toBe('number');
+  });
+
+  it('fails closed when the teacher course-list check errors (never links on an unverifiable token)', async () => {
+    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+      ok: false,
+      status: 401,
+      courseIds: [],
+    });
+
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('rejects an unauthenticated caller before any Classroom call', async () => {
+    const listSpy = vi.spyOn(classroomAddonNet, 'listTeacherCourseIds');
+
+    await expect(
+      callLink({ data: linkData, auth: null })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+    expect(listSpy).not.toHaveBeenCalled();
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
+  it('requires accessToken and courseId', async () => {
+    await expect(
+      callLink({
+        data: { ...linkData, accessToken: '' },
+        auth: { uid: 'teacher-1' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    await expect(
+      callLink({
+        data: { ...linkData, courseId: '' },
+        auth: { uid: 'teacher-1' },
+      })
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
 // Regression: every other test stubs fetchAddOnContext wholesale, so the real
 // URL it builds was never exercised — which is exactly how a wrong REST path
 // shipped. The method is named getAddOnContext, but the REST path segment is
@@ -821,6 +980,80 @@ describe('classroomAddonNet.patchStudentSubmissionGrade URL construction', () =>
     expect(calledInit.method).toBe('PATCH');
     expect(JSON.parse(calledInit.body ?? '{}')).toEqual({ pointsEarned: 8 });
     vi.unstubAllGlobals();
+  });
+});
+
+// The teacher course-list seam — the trust anchor for linkClassroomCourse. The
+// linkClassroomCourse tests stub it, so these pin the real URL/pagination it
+// builds and that it degrades safely on a weird upstream body (the parse guard).
+describe('classroomAddonNet.listTeacherCourseIds (real seam)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs courses?teacherId=me&courseStates=ACTIVE and paginates, collecting ids', async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const u = url as string;
+      urls.push(u);
+      // The second page (token present) is the last — no nextPageToken.
+      if (u.includes('pageToken=PAGE2')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ courses: [{ id: 'C3' }] }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          courses: [{ id: 'C1' }, { id: 'C2' }],
+          nextPageToken: 'PAGE2',
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({
+      ok: true,
+      status: 200,
+      courseIds: ['C1', 'C2', 'C3'],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(urls[0]).toContain('https://classroom.googleapis.com/v1/courses?');
+    expect(urls[0]).toContain('teacherId=me');
+    expect(urls[0]).toContain('courseStates=ACTIVE');
+    expect(urls[1]).toContain('pageToken=PAGE2');
+  });
+
+  it('treats a null/non-object 200 body as an empty final page (no crash)', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => null,
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({ ok: true, status: 200, courseIds: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed (ok:false) on a non-2xx response', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+
+    expect(res).toEqual({ ok: false, status: 401, courseIds: [] });
   });
 });
 

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -22,8 +22,9 @@
  *   - No rate limiting (neither studentLoginV1 nor pinLoginV1 has one to copy).
  *   - Teacher launches are out of scope here: returns `{ role: 'teacher' }`
  *     with no token.
- *   - Helpers (hmac, email-domain→org) are inlined to keep the spike
- *     self-contained; production should share them with `index.ts`.
+ *   - Shared ClassLink helpers (hmac pseudonym, email-domain→org, OAuth
+ *     headers, CORS allowlist, OneRoster base path) now live in
+ *     `./classlinkShared` and are imported by both this file and `index.ts`.
  *   - Outbound Google calls go through `classroomAddonNet` so unit tests can
  *     stub them without a live Classroom install. Uses raw `fetch` + Bearer
  *     (mirrors `getDriveHeaders` in index.ts) — no `googleapis` dependency.
@@ -33,7 +34,15 @@ import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
 import * as CryptoJS from 'crypto-js';
 import axios from 'axios';
-import OAuth from 'oauth-1.0a';
+import {
+  ALLOWED_ORIGINS,
+  ONEROSTER_BASE,
+  computeStudentUid,
+  getOAuthHeaders,
+  normalizeEmailDomain,
+  resolveOrgIdForDomain,
+  type ClassLinkStudent,
+} from './classlinkShared';
 
 // Same named secrets as index.ts; Firebase params dedupes by name. The
 // CLASSLINK_* secrets power the ClassLink identity bridge: a Classroom student
@@ -46,15 +55,6 @@ const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
 const CLASSLINK_CLIENT_ID = defineSecret('CLASSLINK_CLIENT_ID');
 const CLASSLINK_CLIENT_SECRET = defineSecret('CLASSLINK_CLIENT_SECRET');
 const CLASSLINK_TENANT_URL = defineSecret('CLASSLINK_TENANT_URL');
-
-// Keep in sync with ALLOWED_ORIGINS in index.ts (spike duplication; production
-// should import a shared constant).
-const ALLOWED_ORIGINS: (string | RegExp)[] = [
-  'https://spartboard.web.app',
-  'https://spartboard.firebaseapp.com',
-  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
-  /^http:\/\/localhost(:\d+)?$/,
-];
 
 const CLASSROOM_API = 'https://classroom.googleapis.com/v1';
 const USERINFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo';
@@ -95,14 +95,6 @@ interface GoogleUserInfo {
   // the student view requests it). Used ONLY as a transient watermark label,
   // returned to the student's own client; never persisted (PII gate).
   name?: string;
-}
-
-/** OneRoster student shape (subset) — mirrors index.ts's ClassLinkStudent. */
-interface ClassLinkStudent {
-  sourcedId?: string;
-  givenName?: string;
-  familyName?: string;
-  email?: string;
 }
 
 /**
@@ -192,66 +184,6 @@ interface AddOnAttachmentBody {
 
 function bearer(accessToken: string): Record<string, string> {
   return { Authorization: `Bearer ${accessToken}` };
-}
-
-function normalizeEmailDomain(email: string): string | null {
-  const at = email.lastIndexOf('@');
-  if (at < 0 || at === email.length - 1) return null;
-  return '@' + email.slice(at + 1).toLowerCase();
-}
-
-const ONEROSTER_BASE = '/ims/oneroster/v1p1';
-
-/**
- * Stable per-student pseudonym — MUST match index.ts `computeStudentUid`
- * (`HMAC("sid:"+sourcedId)`) so a Classroom student mints the SAME Firebase uid
- * as their ClassLink SSO login, and the existing `getPseudonymsForAssignmentV1`
- * monitor resolves their name. (Spike duplication; production should share it.)
- */
-function computeStudentUid(sourcedId: string, hmacSecret: string): string {
-  return CryptoJS.HmacSHA256(`sid:${sourcedId}`, hmacSecret).toString(
-    CryptoJS.enc.Hex
-  );
-}
-
-/** OAuth 1.0 headers for the ClassLink OneRoster API — mirrors index.ts. */
-function getOAuthHeaders(
-  baseUrl: string,
-  params: Record<string, string>,
-  method: string,
-  clientId: string,
-  clientSecret: string
-): Record<string, string> {
-  const oauth = new OAuth({
-    consumer: { key: clientId, secret: clientSecret },
-    signature_method: 'HMAC-SHA1',
-    hash_function(base_string: string, key: string) {
-      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
-    },
-  });
-  return oauth.toHeader(
-    oauth.authorize({ url: baseUrl, method, data: params })
-  ) as unknown as Record<string, string>;
-}
-
-/**
- * Looks up the org that owns an email domain — same query as index.ts's
- * `resolveOrgIdForDomain`. Domains are stored with a leading '@' and must be
- * `status === 'verified'`.
- */
-async function resolveOrgIdForDomain(
-  db: admin.firestore.Firestore,
-  domainWithAt: string
-): Promise<string | null> {
-  const snap = await db
-    .collectionGroup('domains')
-    .where('domain', '==', domainWithAt)
-    .where('status', '==', 'verified')
-    .limit(1)
-    .get();
-  if (snap.empty) return null;
-  const orgRef = snap.docs[0].ref.parent.parent;
-  return orgRef ? orgRef.id : null;
 }
 
 function isItemType(v: unknown): v is ItemType {

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -159,6 +159,22 @@ interface CreateAttachmentData {
 }
 
 /**
+ * Input to `linkClassroomCourse` (the SpartBoard dashboard "Link to Google
+ * Classroom" flow). `accessToken` is the teacher's own
+ * `classroom.courses.readonly` token — the SAME token that listed their courses
+ * client-side — used here to RE-VERIFY teaching authority server-side.
+ * `teacherUid` is intentionally absent: it's taken from `request.auth.uid`, not
+ * the client, so a caller can never claim to be a different teacher.
+ */
+interface LinkClassroomCourseData {
+  accessToken?: unknown;
+  courseId?: unknown;
+  classlinkClassId?: unknown;
+  classlinkOrgId?: unknown;
+  rosterId?: unknown;
+}
+
+/**
  * `EmbedUri` view-URI objects + title, per addOnAttachments.create.
  *
  * Grade-sync fields (`studentWorkReviewUri` + `maxPoints`) are added together:
@@ -331,6 +347,82 @@ export const classroomAddonNet = {
     } catch (err) {
       console.warn('[classroomAddonLoginV1] userinfo fetch failed:', err);
       return null;
+    }
+  },
+
+  /**
+   * List the Google Classroom course ids the access token's owner TEACHES
+   * (`courses.list?teacherId=me`). This is the trust anchor for
+   * `linkClassroomCourse`: Classroom only returns a course here if the
+   * authenticated user is a teacher of it, so membership in this list proves
+   * teaching authority that Firestore rules can't verify. Paginated with a
+   * generous cap so a teacher with many courses is fully covered without an
+   * unbounded loop. Any upstream/network failure returns `ok: false` so the
+   * caller fails CLOSED (never links on an unverifiable token). Seam so tests
+   * can stub it without a live Classroom call.
+   */
+  async listTeacherCourseIds(
+    accessToken: string
+  ): Promise<{ ok: boolean; status: number; courseIds: string[] }> {
+    const courseIds: string[] = [];
+    let pageToken: string | undefined;
+    let pages = 0;
+    // A single teacher having >2500 active courses is implausible; the cap is a
+    // runaway guard, not an expected limit.
+    const MAX_PAGES = 25;
+    try {
+      do {
+        const qs = new URLSearchParams({
+          teacherId: 'me',
+          courseStates: 'ACTIVE',
+          pageSize: '100',
+        });
+        if (pageToken) qs.set('pageToken', pageToken);
+        const res = await fetch(`${CLASSROOM_API}/courses?${qs.toString()}`, {
+          headers: bearer(accessToken),
+          signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          console.warn(`[classroomAddon] listTeacherCourseIds ${res.status}`);
+          return { ok: false, status: res.status, courseIds: [] };
+        }
+        const body = (await res.json()) as {
+          courses?: { id?: string }[];
+          nextPageToken?: string;
+        } | null;
+        // A 200 with a null / non-object body shouldn't happen for
+        // courses.list, but guard rather than deref it (and treat it as an
+        // empty final page rather than throwing into the catch, which would
+        // discard course ids already collected from earlier pages).
+        if (body && typeof body === 'object') {
+          for (const c of body.courses ?? []) {
+            if (typeof c.id === 'string') courseIds.push(c.id);
+          }
+          pageToken = body.nextPageToken;
+        } else {
+          pageToken = undefined;
+        }
+        pages += 1;
+      } while (pageToken && pages < MAX_PAGES);
+      // If we stopped because of the page cap while more pages remained, the
+      // enumeration is INCOMPLETE — fail closed rather than treat the truncated
+      // list as authoritative, which could wrongly deny a teacher whose course
+      // sits beyond the cap. (Practically unreachable — a teacher with >2500
+      // active courses doesn't exist — but it keeps the trust anchor honest.)
+      if (pageToken) {
+        console.warn(
+          '[classroomAddon] listTeacherCourseIds hit the page cap with more ' +
+            'pages remaining; treating the enumeration as unverifiable.'
+        );
+        return { ok: false, status: 0, courseIds: [] };
+      }
+      return { ok: true, status: 200, courseIds };
+    } catch (err) {
+      console.warn(
+        '[classroomAddon] listTeacherCourseIds fetch failed (network/timeout):',
+        err
+      );
+      return { ok: false, status: 0, courseIds: [] };
     }
   },
 
@@ -860,6 +952,137 @@ export const createClassroomAttachment = onCall(
     // composer (→ PERMISSION_DENIED). The teacher sets the due date once, in
     // that composer (the screen this add-on iframe is embedded in).
     return { attachmentId: createResult.id };
+  }
+);
+
+/**
+ * linkClassroomCourse — server-gated creator of
+ * `classroom_course_links/{courseId}`, called from the SpartBoard dashboard's
+ * "Link to Google Classroom" flow (NOT inside a Classroom iframe, so there's no
+ * getAddOnContext launch to lean on — the trust anchor is a server-side
+ * Classroom course-list check instead).
+ *
+ * WHY THIS EXISTS: the link doc maps a Google courseId → a ClassLink section,
+ * and `classroomAddonLoginV1` mints every student's class-gate `classIds` from
+ * whatever class this doc names. Firestore rules can only check
+ * `teacherUid == auth.uid`; they CANNOT verify the caller actually teaches the
+ * Google course. So a client `create` let any authed user squat ANY courseId
+ * (first-write-wins → mis-route a victim course's students AND lock the real
+ * teacher out, since `update` requires the existing teacherUid). The rules now
+ * block client writes; this CF is the only writer.
+ *
+ * TRUST ANCHOR: re-run the caller's OWN `courses?teacherId=me` query
+ * server-side with their `classroom.courses.readonly` token (the same token
+ * that listed the courses they picked from). Classroom only returns a course in
+ * that list if the user is a teacher of it, so the chosen courseId must appear
+ * there — a forged/borrowed courseId won't. `teacherUid` is taken from
+ * `request.auth.uid` (never the client). An existing link owned by a DIFFERENT
+ * teacher is never overwritten (`already-exists`), preserving the no-hijack
+ * invariant.
+ */
+export const linkClassroomCourse = onCall(
+  {
+    memory: '256MiB',
+    // Public IAM invoker like the other add-on callables: the Firebase Auth
+    // check happens IN the callable framework (the ID token is in the request),
+    // not at the IAM layer, so the endpoint must be reachable. Auth is still
+    // enforced below — an unauthenticated caller is rejected before any work.
+    invoker: 'public',
+    cors: ALLOWED_ORIGINS,
+  },
+  async (request) => {
+    const data = (request.data ?? {}) as LinkClassroomCourseData;
+
+    // teacherUid comes from the authenticated caller, never the client payload.
+    const callerUid = request.auth?.uid ?? '';
+    if (!callerUid) {
+      throw new HttpsError(
+        'unauthenticated',
+        'You must be signed in to link a class.'
+      );
+    }
+
+    const accessToken =
+      typeof data.accessToken === 'string' ? data.accessToken : '';
+    const courseId = typeof data.courseId === 'string' ? data.courseId : '';
+    if (!accessToken) {
+      throw new HttpsError(
+        'invalid-argument',
+        'accessToken is required (your Google Classroom courses token).'
+      );
+    }
+    if (!courseId) {
+      throw new HttpsError('invalid-argument', 'courseId is required.');
+    }
+    // Link payload. classlinkClassId/OrgId are null for a roster with no
+    // ClassLink linkage (it still links to the Google course by id); rosterId
+    // ties the link back to the SpartBoard roster the teacher chose.
+    const classlinkClassId =
+      typeof data.classlinkClassId === 'string' ? data.classlinkClassId : null;
+    const classlinkOrgId =
+      typeof data.classlinkOrgId === 'string' ? data.classlinkOrgId : null;
+    const rosterId = typeof data.rosterId === 'string' ? data.rosterId : null;
+
+    // TRUST ANCHOR: prove the caller teaches this Google course. Fail CLOSED on
+    // any upstream error (never link on an unverifiable token).
+    const teacherCourses =
+      await classroomAddonNet.listTeacherCourseIds(accessToken);
+    if (!teacherCourses.ok) {
+      throw new HttpsError(
+        'unauthenticated',
+        `Could not verify your Google Classroom courses (status ${teacherCourses.status}).`
+      );
+    }
+    if (!teacherCourses.courseIds.includes(courseId)) {
+      // Opaque on purpose: don't reveal whether the course exists to someone who
+      // doesn't teach it.
+      console.warn(
+        `[linkClassroomCourse] uid=${callerUid} is not a teacher of course ${courseId}.`
+      );
+      throw new HttpsError(
+        'permission-denied',
+        'You can only link a Google Classroom course that you teach.'
+      );
+    }
+
+    const db = admin.firestore();
+    const ref = db.doc(`classroom_course_links/${courseId}`);
+    const existing = await ref.get();
+    if (existing.exists) {
+      const prior = existing.data() as CourseLink;
+      if (
+        typeof prior?.teacherUid === 'string' &&
+        prior.teacherUid &&
+        prior.teacherUid !== callerUid
+      ) {
+        // A co-teacher may also genuinely teach this course, but silently
+        // re-pointing an existing link would re-route the original teacher's
+        // students. Preserve the existing no-hijack invariant.
+        console.warn(
+          `[linkClassroomCourse] course ${courseId} already linked by a ` +
+            `different teacher; refusing to overwrite.`
+        );
+        throw new HttpsError(
+          'already-exists',
+          'This Google Classroom course is already linked by another teacher.'
+        );
+      }
+    }
+
+    // Admin SDK write — bypasses the now read-only client rules. createdAt is set
+    // only on first create; merge:true preserves it (and any other fields) on a
+    // same-teacher re-link.
+    const payload: Record<string, unknown> = {
+      classlinkClassId,
+      classlinkOrgId,
+      teacherUid: callerUid,
+      rosterId,
+      updatedAt: Date.now(),
+    };
+    if (!existing.exists) payload.createdAt = Date.now();
+    await ref.set(payload, { merge: true });
+
+    return { ok: true, courseId };
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4371,5 +4371,6 @@ export const pinLoginV1 = onCall(
 export {
   classroomAddonLoginV1,
   createClassroomAttachment,
+  linkClassroomCourse,
   pushClassroomGradesForAssignment,
 } from './classroomAddonAuth';

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,7 +3,6 @@ import { setGlobalOptions } from 'firebase-functions/v2';
 import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
 import axios, { AxiosError } from 'axios';
-import OAuth from 'oauth-1.0a';
 import * as CryptoJS from 'crypto-js';
 import { GoogleGenAI, Content, Type, Schema } from '@google/genai';
 import { randomUUID } from 'node:crypto';
@@ -12,6 +11,16 @@ import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
 import { BoundedLruMap } from './utils/boundedLruMap';
 import { readAnalyticsSnapshot } from './adminAnalyticsSnapshot';
+import {
+  ALLOWED_ORIGINS,
+  ONEROSTER_BASE,
+  computeStudentUid,
+  getOAuthHeaders,
+  normalizeEmailDomain,
+  resolveOrgIdForDomain,
+  type ClassLinkStudent,
+} from './classlinkShared';
+import { normalizeQuizCode } from './quizCode';
 
 // Phase 4 — organization invitations + membership write-through.
 // These modules initialize their own `admin.initializeApp()` guarded by
@@ -61,13 +70,6 @@ const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
 );
 const GOOGLE_OAUTH_CLIENT_ID = defineSecret('GOOGLE_OAUTH_CLIENT_ID');
 
-const ALLOWED_ORIGINS: (string | RegExp)[] = [
-  'https://spartboard.web.app',
-  'https://spartboard.firebaseapp.com',
-  /^https:\/\/spartboard--[\w-]+\.web\.app$/,
-  /^http:\/\/localhost(:\d+)?$/,
-];
-
 admin.initializeApp();
 
 interface ClassLinkUser {
@@ -81,13 +83,6 @@ interface ClassLinkClass {
   sourcedId: string;
   title: string;
   classCode?: string;
-}
-
-interface ClassLinkStudent {
-  sourcedId: string;
-  givenName: string;
-  familyName: string;
-  email: string;
 }
 
 interface AIData {
@@ -456,36 +451,6 @@ const makeDriveFilePublic = async (
   }
 };
 
-/**
- * Generates OAuth 1.0 Headers for ClassLink
- */
-function getOAuthHeaders(
-  baseUrl: string,
-  params: Record<string, string>,
-  method: string,
-  clientId: string,
-  clientSecret: string
-) {
-  const oauth = new OAuth({
-    consumer: {
-      key: clientId,
-      secret: clientSecret,
-    },
-    signature_method: 'HMAC-SHA1',
-    hash_function(base_string: string, key: string) {
-      return CryptoJS.HmacSHA1(base_string, key).toString(CryptoJS.enc.Base64);
-    },
-  });
-
-  const request_data = {
-    url: baseUrl,
-    method: method,
-    data: params,
-  };
-
-  return oauth.toHeader(oauth.authorize(request_data));
-}
-
 export const getClassLinkRosterV1 = onCall(
   {
     memory: '256MiB',
@@ -530,7 +495,7 @@ export const getClassLinkRosterV1 = onCall(
       if (!isSafeEmailForOneRosterFilter(userEmail)) {
         return { classes: [], studentsByClass: {} };
       }
-      const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const usersBaseUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const userParams = { filter: `email='${userEmail}'` };
 
       const userHeaders = getOAuthHeaders(
@@ -557,7 +522,7 @@ export const getClassLinkRosterV1 = onCall(
 
       const teacherSourcedId = users[0].sourcedId;
 
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${teacherSourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${teacherSourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -581,7 +546,7 @@ export const getClassLinkRosterV1 = onCall(
       for (const classBatch of chunk(classes, CLASSLINK_FANOUT_CHUNK)) {
         await Promise.all(
           classBatch.map(async (cls: ClassLinkClass) => {
-            const studentsUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/classes/${cls.sourcedId}/students`;
+            const studentsUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/classes/${cls.sourcedId}/students`;
             const studentsHeaders = getOAuthHeaders(
               studentsUrl,
               {},
@@ -3071,22 +3036,12 @@ function hmacSha256Hex(secret: string, message: string): string {
   return CryptoJS.HmacSHA256(message, secret).toString(CryptoJS.enc.Hex);
 }
 
-function computeStudentUid(sourcedId: string, hmacSecret: string): string {
-  return hmacSha256Hex(hmacSecret, `sid:${sourcedId}`);
-}
-
 function computeAssignmentPseudonym(
   uid: string,
   assignmentId: string,
   hmacSecret: string
 ): string {
   return hmacSha256Hex(hmacSecret, `asn:${uid}:${assignmentId}`);
-}
-
-function normalizeEmailDomain(email: string): string | null {
-  const at = email.lastIndexOf('@');
-  if (at < 0 || at === email.length - 1) return null;
-  return '@' + email.slice(at + 1).toLowerCase();
 }
 
 /**
@@ -3097,27 +3052,6 @@ function normalizeEmailDomain(email: string): string | null {
  */
 function isSafeEmailForOneRosterFilter(email: string): boolean {
   return !/['\\]/.test(email);
-}
-
-/**
- * Looks up the organization that owns the given email domain. Matches against
- * the existing /organizations/{orgId}/domains/{doc} subcollection, requiring
- * `status === 'verified'`. Domain values in that collection are stored with a
- * leading '@' (e.g. '@orono.k12.mn.us'). Returns null if no match.
- */
-async function resolveOrgIdForDomain(
-  db: admin.firestore.Firestore,
-  domainWithAt: string
-): Promise<string | null> {
-  const snap = await db
-    .collectionGroup('domains')
-    .where('domain', '==', domainWithAt)
-    .where('status', '==', 'verified')
-    .limit(1)
-    .get();
-  if (snap.empty) return null;
-  const orgRef = snap.docs[0].ref.parent.parent;
-  return orgRef ? orgRef.id : null;
 }
 
 function isOneRosterStudent(user: OneRosterUserWithRole): boolean {
@@ -3282,7 +3216,7 @@ export const studentLoginV1 = onCall(
           'No student record found in ClassLink roster.'
         );
       }
-      const usersBaseUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const usersBaseUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const userParams = { filter: `email='${email}'` };
       const userHeaders = getOAuthHeaders(
         usersBaseUrl,
@@ -3306,7 +3240,7 @@ export const studentLoginV1 = onCall(
       }
       sourcedId = studentUser.sourcedId;
 
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${sourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${sourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -3801,7 +3735,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
           'Teacher not found in ClassLink roster.'
         );
       }
-      const teacherUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users`;
+      const teacherUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users`;
       const teacherParams = { filter: `email='${teacherEmail}'` };
       const teacherHeaders = getOAuthHeaders(
         teacherUrl,
@@ -3821,7 +3755,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
           'Teacher not found in ClassLink roster.'
         );
       }
-      const classesUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/users/${teacherUser.sourcedId}/classes`;
+      const classesUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/users/${teacherUser.sourcedId}/classes`;
       const classesHeaders = getOAuthHeaders(
         classesUrl,
         {},
@@ -3844,7 +3778,7 @@ export const getPseudonymsForAssignmentV1 = onCall(
       }
 
       // Now fetch the class's students and compute the pseudonym map.
-      const studentsUrl = `${cleanTenantUrl}/ims/oneroster/v1p1/classes/${classId}/students`;
+      const studentsUrl = `${cleanTenantUrl}${ONEROSTER_BASE}/classes/${classId}/students`;
       const studentsHeaders = getOAuthHeaders(
         studentsUrl,
         {},
@@ -4198,12 +4132,7 @@ export const pinLoginV1 = onCall(
     let sessionRef: admin.firestore.DocumentReference;
     if (kind === 'quiz') {
       const code =
-        typeof data.code === 'string'
-          ? data.code
-              .trim()
-              .replace(/[^a-zA-Z0-9]/g, '')
-              .toUpperCase()
-          : '';
+        typeof data.code === 'string' ? normalizeQuizCode(data.code) : '';
       if (!code) {
         throw new HttpsError('invalid-argument', 'code is required for quiz.');
       }

--- a/functions/src/quizCode.test.ts
+++ b/functions/src/quizCode.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Pins the FUNCTIONS-SIDE quiz-code canonicalization. These cases are kept
+ * IDENTICAL to the client suite (`tests/utils/quizCode.test.ts`) on purpose: the
+ * two `normalizeQuizCode` copies (client + functions) must agree byte-for-byte
+ * or `pinLoginV1` would resolve a different `quiz_sessions` doc than the teacher
+ * created. A change to either normalizer that breaks parity fails one suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeQuizCode } from './quizCode';
+
+describe('normalizeQuizCode (functions)', () => {
+  it('uppercases', () => {
+    expect(normalizeQuizCode('abc123')).toBe('ABC123');
+  });
+
+  it('strips whitespace and non-alphanumerics', () => {
+    expect(normalizeQuizCode('  a-b c1!2  ')).toBe('ABC12');
+    expect(normalizeQuizCode('ab_cd')).toBe('ABCD');
+  });
+
+  it('is stable on an already-canonical code', () => {
+    expect(normalizeQuizCode('ABC123')).toBe('ABC123');
+  });
+
+  it('returns empty when nothing alphanumeric survives', () => {
+    expect(normalizeQuizCode('   ')).toBe('');
+    expect(normalizeQuizCode('!!!')).toBe('');
+  });
+});

--- a/functions/src/quizCode.ts
+++ b/functions/src/quizCode.ts
@@ -1,0 +1,23 @@
+/**
+ * Quiz join-code canonicalization — FUNCTIONS-SIDE copy.
+ *
+ * This MUST stay byte-for-byte identical to the client's `utils/quizCode.ts`
+ * `normalizeQuizCode`. The teacher creates a session and students join from the
+ * CLIENT (which normalizes there), while `pinLoginV1` resolves that same
+ * `quiz_sessions` doc by `code` HERE on the server — so if the two normalizers
+ * drift, a student's PIN login would query a differently-cased/-stripped code
+ * than the one stored and silently resolve a different session (or none).
+ *
+ * It can't be a single shared module: `functions/` is a separate TypeScript
+ * project that bundles/deploys on its own and can't import the repo-root
+ * `utils/`. The drift guard is instead a test (`quizCode.test.ts`) that pins the
+ * SAME cases as the client's, so a change on either side fails its suite.
+ */
+
+/** Trim, strip every non-alphanumeric character, and uppercase a quiz join code. */
+export function normalizeQuizCode(code: string): string {
+  return code
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+}

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -47,6 +47,7 @@ import {
   GradeResult,
 } from '@/types';
 import { resolvePeriodNames } from '@/utils/periodCompat';
+import { normalizeQuizCode } from '@/utils/quizCode';
 
 // Re-export for backward compatibility with callers that imported
 // QuizSessionOptions from this module before it was moved into types.ts.
@@ -1356,10 +1357,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // Without this a network/Firestore failure during code lookup silently
       // strands the student on the join form with no spinner and no error.
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) return null;
         setError(null);
         const snap = await getDocs(
@@ -1411,10 +1409,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       // legitimate snapshots in the new one.
       lastHistorySnapshotAtRef.current.clear();
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) throw new Error('Invalid code');
 
         // Ensure we have an anonymous Firebase Auth session so Firestore
@@ -2350,10 +2345,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       setLoading(true);
       setError(null);
       try {
-        const normCode = code
-          .trim()
-          .replace(/[^a-zA-Z0-9]/g, '')
-          .toUpperCase();
+        const normCode = normalizeQuizCode(code);
         if (!normCode) throw new Error('Invalid code');
 
         const currentUser = auth.currentUser;

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -1170,7 +1170,9 @@ export interface UseQuizSessionStudentResult {
    * Returns the session's periodNames so the UI can show a period picker
    * before the student commits to joining.
    */
-  lookupSession: (code: string) => Promise<{ periodNames: string[] } | null>;
+  lookupSession: (
+    code: string
+  ) => Promise<{ periodNames: string[]; classIds: string[] } | null>;
   /**
    * Join a quiz session.
    *
@@ -1351,7 +1353,9 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
   }, [sessionIdState, responseKeyState]);
 
   const lookupSession = useCallback(
-    async (code: string): Promise<{ periodNames: string[] } | null> => {
+    async (
+      code: string
+    ): Promise<{ periodNames: string[]; classIds: string[] } | null> => {
       // Populate the hook's `error` state on failure so callers' .catch
       // handlers (which only console.warn) still produce visible UI feedback.
       // Without this a network/Firestore failure during code lookup silently
@@ -1382,7 +1386,16 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // resolvePeriodNames normalises legacy periodName + new periodNames
         // into a typed string[], avoiding the `any[]` from Firestore's
         // DocumentData bleed-through.
-        return { periodNames: resolvePeriodNames(sessionData) };
+        return {
+          periodNames: resolvePeriodNames(sessionData),
+          // ClassLink-rostered sessions carry `classIds`; the join screen uses
+          // this to steer anonymous joiners to SSO (where identity = their own
+          // auth.uid) instead of the PIN+period path, which can fork a
+          // submission onto the wrong roster slot when the period is wrong.
+          classIds: Array.isArray(sessionData.classIds)
+            ? sessionData.classIds
+            : [],
+        };
       } catch (err) {
         const msg =
           err instanceof Error

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,43 @@
 {
   "entries": [
     {
+      "version": "2026.06.02.2",
+      "date": "2026-06-02",
+      "title": "Quiz grading accuracy fixes",
+      "overview": [
+        {
+          "type": "fix",
+          "subtitle": "Quiz grading accuracy",
+          "items": [
+            {
+              "text": "A student who actually finished a quiz no longer shows a misleading 0% before their real score is ready:",
+              "items": [
+                {
+                  "text": "Your results, live monitor, scoreboard, and leaderboard now show a neutral dash instead, and that response stays out of class averages and rankings until it can be scored accurately."
+                },
+                {
+                  "text": "A phantom 0 can no longer be pushed to your Google Classroom gradebook."
+                }
+              ]
+            },
+            {
+              "text": "When the same student lands on two submissions — say, a Google sign-in and a PIN — the live monitor now flags both rows with a \"Dup?\" badge so you can clear the extra copy before grading."
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "type": "fix",
+          "text": "Quiz scoring — a student who actually finished a quiz no longer shows up as a real 0% while their score is still being worked out. This could happen when the answer key was still loading or when a student's submission got mixed up across class periods (for example, joining once with Google sign-in and again with a PIN). Those finished-but-not-yet-scoreable submissions now show a neutral \"—\" placeholder in your results, the live monitor, the scoreboard, and the live leaderboard, and they're kept out of your class averages and rankings until they can be scored accurately — rather than sitting at a false 0 and dragging the average down. A genuinely blank submission still counts as a real 0."
+        },
+        {
+          "type": "fix",
+          "text": "Quiz monitor — when the same student turns up on two submissions (for example, they joined once with Google sign-in and again with a PIN, or under the wrong class period), the live monitor now flags both rows with a \"Dup?\" badge. Hovering it explains that a student may have joined twice and to review and remove the extra copy before grading, so you no longer mistake one copy for a student who hasn't finished."
+        }
+      ]
+    },
+    {
       "version": "2026.06.02",
       "date": "2026-06-02",
       "title": "Quiz scoring, guided learning, and display fixes",

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -766,7 +766,33 @@ describe('useQuizSessionStudent — lookupSession', () => {
 
     const { result } = renderHook(() => useQuizSessionStudent());
     const out = await result.current.lookupSession('abc-123');
-    expect(out).toEqual({ periodNames: ['Period 1', 'Period 2'] });
+    expect(out).toEqual({
+      periodNames: ['Period 1', 'Period 2'],
+      classIds: [],
+    });
+  });
+
+  it('surfaces the session classIds (drives the SSO-redirect gate) and defaults to [] when absent', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [
+        buildSessionDoc('classlink', {
+          status: 'active',
+          startedAt: 1,
+          periodNames: ['Hour 1'],
+          classIds: ['F33EC569', 'FB8737C8'],
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useQuizSessionStudent());
+    const out = await result.current.lookupSession('abc-123');
+    expect(out).toEqual({
+      periodNames: ['Hour 1'],
+      classIds: ['F33EC569', 'FB8737C8'],
+    });
   });
 });
 

--- a/tests/utils/classroomGradePush.test.ts
+++ b/tests/utils/classroomGradePush.test.ts
@@ -20,6 +20,12 @@ const { getEarnedPointsMock } = vi.hoisted(() => ({
 }));
 vi.mock('@/components/widgets/QuizWidget/utils/quizScoreboard', () => ({
   getEarnedPoints: getEarnedPointsMock,
+  // The builder now drops responses canScoreResponse rejects (answer key not
+  // loaded / question-id drift → a phantom 0). Stub it off a per-response flag
+  // so a test can mark one unscoreable; default true keeps the scaling tests
+  // focused on scaling rather than the (separately tested) scoreability rule.
+  canScoreResponse: (r: unknown) =>
+    (r as { __scoreable?: boolean }).__scoreable !== false,
 }));
 
 import { buildQuizClassroomGradeEntries } from '@/utils/classroomGradePush';
@@ -28,13 +34,23 @@ import { buildQuizClassroomGradeEntries } from '@/utils/classroomGradePush';
 const q = (points: number): QuizQuestion =>
   ({ id: `q${points}`, type: 'MC', points }) as unknown as QuizQuestion;
 
-/** Minimal response carrying status/studentUid + a stubbed earned score. */
+/**
+ * Minimal response carrying status/studentUid + a stubbed earned score.
+ * `scoreable` defaults true; pass false to simulate an unscoreable response
+ * (the mocked canScoreResponse reads `__scoreable`).
+ */
 const resp = (
   studentUid: string,
   status: QuizResponse['status'],
-  earned: number
+  earned: number,
+  scoreable = true
 ): QuizResponse =>
-  ({ studentUid, status, __earned: earned }) as unknown as QuizResponse;
+  ({
+    studentUid,
+    status,
+    __earned: earned,
+    __scoreable: scoreable,
+  }) as unknown as QuizResponse;
 
 describe('buildQuizClassroomGradeEntries', () => {
   it('is an identity scale when the quiz total equals maxPoints', () => {
@@ -102,6 +118,22 @@ describe('buildQuizClassroomGradeEntries', () => {
       10
     );
     expect(grades).toEqual([{ pseudonymUid: 'u1', pointsEarned: 5 }]);
+  });
+
+  it('excludes a completed response that cannot be scored (no phantom 0 to the gradebook)', () => {
+    // A completed response whose answers map to no loaded question (synced-quiz
+    // id drift, or answer key not loaded) scores a phantom 0 via getEarnedPoints.
+    // It must be OMITTED from the push — not written as 0/maxPoints to the real
+    // Classroom gradebook, where it is persistent and hard to notice/undo.
+    const grades = buildQuizClassroomGradeEntries(
+      [
+        resp('u1', 'completed', 8),
+        resp('drift', 'completed', 0, /* scoreable */ false),
+      ],
+      [q(10)],
+      10
+    );
+    expect(grades).toEqual([{ pseudonymUid: 'u1', pointsEarned: 8 }]);
   });
 
   it('scales on correctness points only — getEarnedPoints is called with NO session (excludes speed/streak bonuses)', () => {

--- a/tests/utils/quizCode.test.ts
+++ b/tests/utils/quizCode.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pins the CLIENT quiz-code canonicalization. These cases are kept IDENTICAL to
+ * the functions suite (`functions/src/quizCode.test.ts`) on purpose: the two
+ * `normalizeQuizCode` copies (client `utils/quizCode.ts` + functions
+ * `functions/src/quizCode.ts`) must agree byte-for-byte, or `pinLoginV1` would
+ * resolve a different `quiz_sessions` doc than the client stored. A change to
+ * either normalizer that breaks parity fails one suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { normalizeQuizCode } from '@/utils/quizCode';
+
+describe('normalizeQuizCode (client)', () => {
+  it('uppercases', () => {
+    expect(normalizeQuizCode('abc123')).toBe('ABC123');
+  });
+
+  it('strips whitespace and non-alphanumerics', () => {
+    expect(normalizeQuizCode('  a-b c1!2  ')).toBe('ABC12');
+    expect(normalizeQuizCode('ab_cd')).toBe('ABCD');
+  });
+
+  it('is stable on an already-canonical code', () => {
+    expect(normalizeQuizCode('ABC123')).toBe('ABC123');
+  });
+
+  it('returns empty when nothing alphanumeric survives', () => {
+    expect(normalizeQuizCode('   ')).toBe('');
+    expect(normalizeQuizCode('!!!')).toBe('');
+  });
+});

--- a/tests/utils/runClassroomGradePush.test.ts
+++ b/tests/utils/runClassroomGradePush.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPushPermissionDenied,
+  hasValidMaxPoints,
+} from '@/utils/runClassroomGradePush';
+
+describe('isPushPermissionDenied', () => {
+  it('is true for a Firebase callable permission-denied code', () => {
+    expect(
+      isPushPermissionDenied({ code: 'functions/permission-denied' })
+    ).toBe(true);
+    expect(isPushPermissionDenied({ code: 'permission-denied' })).toBe(true);
+  });
+
+  it('is false for a different string code', () => {
+    expect(isPushPermissionDenied({ code: 'functions/unavailable' })).toBe(
+      false
+    );
+  });
+
+  it('is false (and does NOT throw) when code is a number', () => {
+    // Regression: a non-Firebase error can carry a numeric code (e.g. 403 from
+    // a raw Google API error). `.includes()` on a number would throw and turn a
+    // handled error into an unhandled one if the type isn't guarded.
+    expect(() => isPushPermissionDenied({ code: 403 })).not.toThrow();
+    expect(isPushPermissionDenied({ code: 403 })).toBe(false);
+  });
+
+  it('is false for null, undefined, and non-objects', () => {
+    expect(isPushPermissionDenied(null)).toBe(false);
+    expect(isPushPermissionDenied(undefined)).toBe(false);
+    // A bare string isn't a callable error — we only inspect `.code`.
+    expect(isPushPermissionDenied('permission-denied')).toBe(false);
+    // A plain Error has no `.code`; its message is intentionally not consulted.
+    expect(isPushPermissionDenied(new Error('permission-denied'))).toBe(false);
+  });
+});
+
+describe('hasValidMaxPoints', () => {
+  it('is true only for a positive, finite number', () => {
+    expect(hasValidMaxPoints(20)).toBe(true);
+    expect(hasValidMaxPoints(0)).toBe(false);
+    expect(hasValidMaxPoints(-5)).toBe(false);
+    expect(hasValidMaxPoints(Number.NaN)).toBe(false);
+    expect(hasValidMaxPoints(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});

--- a/utils/classroomGradePush.ts
+++ b/utils/classroomGradePush.ts
@@ -19,7 +19,10 @@
  */
 
 import { httpsCallable, type Functions } from 'firebase/functions';
-import { getEarnedPoints } from '@/components/widgets/QuizWidget/utils/quizScoreboard';
+import {
+  getEarnedPoints,
+  canScoreResponse,
+} from '@/components/widgets/QuizWidget/utils/quizScoreboard';
 import type { QuizQuestion, QuizResponse } from '@/types';
 
 /** A single PII-free grade entry: ClassLink pseudonym → earned points. */
@@ -33,12 +36,20 @@ export interface ClassroomGradeEntry {
  * shared by the dashboard monitor (QuizResults) and the in-iframe grader
  * (TeacherReviewRoute) so their scaling can't drift.
  *
- * One entry per COMPLETED response with a resolvable pseudonym. The current quiz
- * total can drift from the Classroom denominator (`maxPoints`, frozen at attach
- * time) if the quiz was edited after attaching, so each student's CORRECTNESS
- * points are scaled onto `maxPoints`, then rounded and clamped to [0, maxPoints].
- * A non-finite earned score (e.g. a malformed question) is treated as 0 so NaN
- * can never propagate into the payload (the CF would otherwise reject it).
+ * One entry per COMPLETED response with a resolvable pseudonym THAT CAN ACTUALLY
+ * BE SCORED. The current quiz total can drift from the Classroom denominator
+ * (`maxPoints`, frozen at attach time) if the quiz was edited after attaching, so
+ * each student's CORRECTNESS points are scaled onto `maxPoints`, then rounded and
+ * clamped to [0, maxPoints]. A non-finite earned score (e.g. a malformed
+ * question) is treated as 0 so NaN can never propagate into the payload (the CF
+ * would otherwise reject it).
+ *
+ * Responses `canScoreResponse` rejects (the answer key hasn't loaded, or a
+ * synced-quiz id drift means no answer maps to a loaded question) are EXCLUDED
+ * rather than pushed: `getEarnedPoints` would silently return 0 for them, and
+ * unlike the "—" placeholder the teacher views render, a phantom 0 written to the
+ * real Classroom gradebook is persistent and hard to notice/undo. Omitting a
+ * student is the safe default — better no grade than a wrong 0.
  *
  * Grades are intentionally correctness-based: `getEarnedPoints` is called with NO
  * session, so speed/streak bonuses are excluded. A Classroom gradebook grade
@@ -57,7 +68,14 @@ export function buildQuizClassroomGradeEntries(
 ): ClassroomGradeEntry[] {
   const currentTotal = questions.reduce((s, q) => s + (q.points ?? 1), 0);
   return responses
-    .filter((r) => r.status === 'completed' && !!r.studentUid)
+    .filter(
+      (r) =>
+        r.status === 'completed' &&
+        !!r.studentUid &&
+        // Skip responses we can't actually score (answer key not loaded /
+        // question-id drift) so a phantom 0 never reaches the gradebook.
+        canScoreResponse(r, questions)
+    )
     .map((r) => {
       // No session arg → correctness points only (no speed/streak bonus); see
       // the function doc for why the gradebook grade excludes gamification.

--- a/utils/quizCode.ts
+++ b/utils/quizCode.ts
@@ -1,0 +1,20 @@
+/**
+ * Quiz join-code canonicalization.
+ *
+ * Teacher session creation, student join, in-session review, and the Google
+ * Classroom add-on routes (teacher + student) all run a raw code through THIS
+ * one function before querying `quiz_sessions` by `code`. Funneling every path
+ * through the same normalization guarantees a given code resolves to the SAME
+ * session everywhere — a lowercase, spaced, or hyphenated entry still matches the
+ * stored uppercase-alphanumeric code. Drift between any two of these call sites
+ * would let a teacher and a student (or the dashboard monitor and the in-iframe
+ * grader) silently resolve different sessions for the same code.
+ */
+
+/** Trim, strip every non-alphanumeric character, and uppercase a quiz join code. */
+export function normalizeQuizCode(code: string): string {
+  return code
+    .trim()
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .toUpperCase();
+}

--- a/utils/runClassroomGradePush.ts
+++ b/utils/runClassroomGradePush.ts
@@ -1,0 +1,246 @@
+/**
+ * runClassroomGradePush — the one shared "Push grades to Google Classroom" flow
+ * behind the three teacher surfaces that expose it:
+ *   - the dashboard quiz monitor (QuizResults),
+ *   - the dashboard video-activity monitor (VideoActivityWidget Results), and
+ *   - the in-iframe quiz grader (TeacherReviewRoute).
+ *
+ * Each surface differs ONLY in how it builds its grade payload (quiz scaling vs
+ * video-activity percentage) and how it reports progress (toasts vs an inline
+ * status line). The orchestration in between — minting a fresh add-on teacher
+ * token, calling the Cloud Function, and discriminating a "course not linked"
+ * permission-denied from a generic failure — is identical, and was previously
+ * copy-pasted into all three. Centralizing it here keeps the wording and the
+ * failure handling from drifting between surfaces.
+ *
+ * The CF wrapper (`pushClassroomGradesForAssignment`) lives in
+ * `@/utils/classroomGradePush`; this module imports it across that module
+ * boundary ON PURPOSE so a test can mock the CF at the
+ * `@/utils/classroomGradePush` seam while exercising the real orchestration here
+ * (an intra-module call could not be intercepted that way).
+ *
+ * Pre-flight guards (maxPoints validity + an eligible-empty check) stay at the
+ * CALL SITE because their ORDER and reporting channel differ per surface; the
+ * shared helpers/constants below let those guards stay byte-identical without
+ * living here. This function begins at the optional confirm.
+ */
+import type { Functions } from 'firebase/functions';
+import type { Toast } from '@/types';
+import { logError } from '@/utils/logError';
+import {
+  pushClassroomGradesForAssignment,
+  formatGradePushToast,
+  type ClassroomGradeEntry,
+  type PushClassroomGradesData,
+} from '@/utils/classroomGradePush';
+
+/** Shared copy: the attachment carries no usable Classroom point total. */
+export const MISSING_MAX_POINTS_MESSAGE =
+  'This assignment is missing its Classroom point total — re-attach it to push grades.';
+
+/** Shared copy: the benign "nothing eligible to push" toast (info, not error). */
+export const NOTHING_TO_PUSH_TOAST = 'No completed submissions to push yet';
+
+/** Shared copy: the GIS consent popup was dismissed / failed. */
+export const TOKEN_CANCELLED_MESSAGE =
+  'Google sign-in was cancelled — no grades were pushed.';
+
+/** Shared copy: the push failed because the course isn't ClassLink-linked. */
+export const PUSH_PERMISSION_DENIED_MESSAGE =
+  'Only the teacher who linked this course to ClassLink can push grades. Link it from your Classes list first.';
+
+/** Shared copy: a generic (non-permission) push failure. */
+export const GRADE_PUSH_GENERIC_ERROR_MESSAGE =
+  'Could not push grades to Google Classroom.';
+
+/** True when a Classroom attachment's frozen denominator is usable for scaling. */
+export function hasValidMaxPoints(maxPoints: number): boolean {
+  return Number.isFinite(maxPoints) && maxPoints > 0;
+}
+
+/**
+ * True when a thrown CF error is the batch endpoint's `permission-denied` —
+ * raised when the course isn't linked to ClassLink under the calling teacher.
+ */
+export function isPushPermissionDenied(err: unknown): boolean {
+  // `code` is a string for Firebase callable errors, but guard the type: a
+  // non-Firebase error can carry a numeric `code` (e.g. 403), and `??` wouldn't
+  // catch it — `.includes()` on a number would throw and turn a handled error
+  // into an unhandled one.
+  const code = (err as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && code.includes('permission-denied');
+}
+
+/** The Classroom-attachment identifiers + frozen scale a push targets. */
+export interface ClassroomGradePushAttachment {
+  courseId: string;
+  itemId: string;
+  attachmentId: string;
+  maxPoints: number;
+}
+
+/**
+ * Progress / terminal beats `runClassroomGradePush` emits, in order. A run goes
+ * `start` → `requesting-token` → (`token-cancelled` | `nothing-to-push` |
+ * (`pushing` → `pushed`)) and always ends on `settled`. Each surface maps these
+ * to its own UI (a toast monitor ignores the progress beats; the iframe shows
+ * them as an inline status line).
+ */
+export type ClassroomGradePushStatus =
+  | { phase: 'start' }
+  | { phase: 'requesting-token' }
+  | { phase: 'pushing' }
+  | { phase: 'token-cancelled'; error: unknown }
+  | { phase: 'nothing-to-push' }
+  | { phase: 'pushed'; data: PushClassroomGradesData }
+  | { phase: 'settled' };
+
+/** A failed push, with the permission-denied case pre-discriminated. */
+export interface ClassroomGradePushError {
+  permissionDenied: boolean;
+  error: unknown;
+}
+
+export interface RunClassroomGradePushOptions {
+  functions: Functions;
+  attachment: ClassroomGradePushAttachment;
+  /** Builds the PII-free grade payload — the only genuinely per-surface logic. */
+  buildGrades: () => ClassroomGradeEntry[];
+  /** Mints a fresh `classroom.addons.teacher` token (a GIS popup). */
+  requestToken: () => Promise<string>;
+  /** Maps each emitted status beat to the surface's UI. */
+  onStatus: (status: ClassroomGradePushStatus) => void;
+  /** Renders a push failure (permission-denied vs generic) in the surface's UI. */
+  onError: (err: ClassroomGradePushError) => void;
+  /**
+   * Optional confirm gate run BEFORE any token mint. Resolve false to abort
+   * silently (no status emitted). The dashboard monitors confirm; the in-iframe
+   * grader pushes without a dialog (omit).
+   */
+  confirm?: () => Promise<boolean>;
+  /**
+   * When true, a token/consent failure is reported as a distinct
+   * `token-cancelled` status (and logged under `${logTag}.token`) instead of
+   * falling through to `onError` as a generic failure. The dashboard monitors
+   * set this; the iframe folds a token failure into its generic error line.
+   */
+  distinctTokenCancel?: boolean;
+  /** logError tag for a push failure (the token catch logs `${logTag}.token`). */
+  logTag: string;
+  /**
+   * Extra logError context (e.g. sessionId / attachmentId). Matches logError's
+   * own `LogErrorContext` value shape (scalars only — it isn't exported).
+   */
+  logContext?: Record<string, string | number | boolean | null | undefined>;
+}
+
+/**
+ * Run the shared push flow. Owns everything from the (optional) confirm through
+ * the token mint, the CF call, and its success / failure reporting; the caller's
+ * pre-flight guards run before this.
+ */
+export async function runClassroomGradePush({
+  functions,
+  attachment,
+  buildGrades,
+  requestToken,
+  onStatus,
+  onError,
+  confirm,
+  distinctTokenCancel,
+  logTag,
+  logContext,
+}: RunClassroomGradePushOptions): Promise<void> {
+  if (confirm) {
+    const confirmed = await confirm();
+    if (!confirmed) return;
+  }
+
+  onStatus({ phase: 'start' });
+  try {
+    onStatus({ phase: 'requesting-token' });
+    let accessToken: string;
+    if (distinctTokenCancel) {
+      // The teacher is present; a cancelled/failed consent is a distinct, benign
+      // outcome (nothing was pushed) — surfaced apart from a CF failure.
+      try {
+        accessToken = await requestToken();
+      } catch (tokenErr) {
+        logError(`${logTag}.token`, tokenErr, logContext);
+        onStatus({ phase: 'token-cancelled', error: tokenErr });
+        return;
+      }
+    } else {
+      // No distinct handling: a token failure falls through to the catch below
+      // and renders as a generic push error (the iframe's behavior).
+      accessToken = await requestToken();
+    }
+
+    const grades = buildGrades();
+    if (grades.length === 0) {
+      onStatus({ phase: 'nothing-to-push' });
+      return;
+    }
+
+    onStatus({ phase: 'pushing' });
+    const data = await pushClassroomGradesForAssignment(functions, {
+      courseId: attachment.courseId,
+      itemId: attachment.itemId,
+      attachmentId: attachment.attachmentId,
+      accessToken,
+      grades,
+      maxPoints: attachment.maxPoints,
+    });
+    onStatus({ phase: 'pushed', data });
+  } catch (err) {
+    logError(logTag, err, logContext);
+    onError({ permissionDenied: isPushPermissionDenied(err), error: err });
+  } finally {
+    onStatus({ phase: 'settled' });
+  }
+}
+
+/**
+ * Build the `{ onStatus, onError }` reporter the two dashboard monitors share —
+ * they are byte-identical: progress beats are silent, a completed push is a
+ * success toast, a cancelled consent / failed push is an error toast, and the
+ * pushing flag toggles on `start` / `settled`. The in-iframe grader does NOT use
+ * this (it renders an inline status line instead).
+ */
+export function createToastGradePushHandlers(
+  addToast: (message: string, type: Toast['type']) => void,
+  setPushing: (pushing: boolean) => void
+): Pick<RunClassroomGradePushOptions, 'onStatus' | 'onError'> {
+  return {
+    onStatus: (status) => {
+      switch (status.phase) {
+        case 'start':
+          setPushing(true);
+          break;
+        case 'settled':
+          setPushing(false);
+          break;
+        case 'token-cancelled':
+          addToast(TOKEN_CANCELLED_MESSAGE, 'error');
+          break;
+        case 'nothing-to-push':
+          addToast(NOTHING_TO_PUSH_TOAST, 'info');
+          break;
+        case 'pushed':
+          addToast(formatGradePushToast(status.data), 'success');
+          break;
+        case 'requesting-token':
+        case 'pushing':
+          // The dashboard monitors show no inline progress — these are silent.
+          break;
+      }
+    },
+    onError: ({ permissionDenied }) =>
+      addToast(
+        permissionDenied
+          ? PUSH_PERMISSION_DENIED_MESSAGE
+          : GRADE_PUSH_GENERIC_ERROR_MESSAGE,
+        'error'
+      ),
+  };
+}

--- a/utils/studentJoinRouting.test.ts
+++ b/utils/studentJoinRouting.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNextTarget, shouldGateToSso } from './studentJoinRouting';
+
+describe('resolveNextTarget', () => {
+  it('returns null for empty / missing input', () => {
+    expect(resolveNextTarget(null)).toBeNull();
+    expect(resolveNextTarget('')).toBeNull();
+  });
+
+  it('allows the whitelisted /quiz and /join routes (with query preserved)', () => {
+    expect(resolveNextTarget('/quiz?code=ABC123')).toBe('/quiz?code=ABC123');
+    expect(resolveNextTarget('/join?code=XYZ')).toBe('/join?code=XYZ');
+    expect(resolveNextTarget('/quiz')).toBe('/quiz');
+  });
+
+  it('rejects protocol-relative URLs (open-redirect vector)', () => {
+    expect(resolveNextTarget('//evil.com')).toBeNull();
+    expect(resolveNextTarget('//evil.com/quiz')).toBeNull();
+  });
+
+  it('rejects absolute URLs to another origin', () => {
+    expect(resolveNextTarget('https://evil.com/quiz')).toBeNull();
+    expect(resolveNextTarget('http://evil.com')).toBeNull();
+  });
+
+  it('rejects backslash tricks some engines normalise to /', () => {
+    expect(resolveNextTarget('/\\evil.com')).toBeNull();
+    expect(resolveNextTarget('/quiz\\@evil.com')).toBeNull();
+  });
+
+  it('rejects non-whitelisted internal paths', () => {
+    expect(resolveNextTarget('/my-assignments')).toBeNull();
+    expect(resolveNextTarget('/admin')).toBeNull();
+    // Prefix look-alikes must not slip through — the path must match exactly.
+    expect(resolveNextTarget('/quizzes')).toBeNull();
+    expect(resolveNextTarget('/quiz/../admin')).toBeNull();
+  });
+});
+
+describe('shouldGateToSso', () => {
+  const base = {
+    flagEnabled: true,
+    isStudentRole: false,
+    embedded: false,
+    hasCode: true,
+    classIds: ['F33EC569'],
+  };
+
+  it('gates when every condition is met', () => {
+    expect(shouldGateToSso(base)).toBe(true);
+  });
+
+  it('does not gate when the flag is off', () => {
+    expect(shouldGateToSso({ ...base, flagEnabled: false })).toBe(false);
+  });
+
+  it('does not gate an already-SSO student (they auto-join)', () => {
+    expect(shouldGateToSso({ ...base, isStudentRole: true })).toBe(false);
+  });
+
+  it('does not gate inside the Classroom add-on iframe', () => {
+    expect(shouldGateToSso({ ...base, embedded: true })).toBe(false);
+  });
+
+  it('does not gate without a join code', () => {
+    expect(shouldGateToSso({ ...base, hasCode: false })).toBe(false);
+  });
+
+  it('does not gate a PIN-only session (no classIds)', () => {
+    expect(shouldGateToSso({ ...base, classIds: [] })).toBe(false);
+    expect(shouldGateToSso({ ...base, classIds: undefined })).toBe(false);
+  });
+});

--- a/utils/studentJoinRouting.ts
+++ b/utils/studentJoinRouting.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure routing helpers for the student quiz-join flow.
+ *
+ * Deliberately free of Firebase / DOM / React imports so they can be unit
+ * tested in isolation and reused by both the login page and the join flow.
+ */
+
+/**
+ * Validate a post-login redirect target read from a `?next=` query param.
+ *
+ * SECURITY: the returned value is handed to `window.location.assign`, so an
+ * unvalidated value is an open-redirect (phishing) vector. We accept ONLY a
+ * root-relative path to a known student-join route:
+ *   - must start with a single `/` (reject `//host` protocol-relative URLs),
+ *   - must contain no backslash (some engines normalise `\` to `/`),
+ *   - its path (sans query/hash) must be exactly `/quiz` or `/join`.
+ *
+ * Anything else returns `null` and the caller should fall back to its default
+ * destination.
+ */
+export function resolveNextTarget(rawNext: string | null): string | null {
+  if (!rawNext) return null;
+  if (
+    !rawNext.startsWith('/') ||
+    rawNext.startsWith('//') ||
+    rawNext.includes('\\')
+  ) {
+    return null;
+  }
+  // Compare on the path alone so `/quiz?code=ABC` (with its query) is allowed.
+  const path = rawNext.split(/[?#]/)[0];
+  return path === '/quiz' || path === '/join' ? rawNext : null;
+}
+
+/**
+ * Decide whether an anonymous quiz joiner should be steered to Google SSO
+ * instead of the PIN+period path. True only when:
+ *   - the feature flag is on,
+ *   - the visitor isn't already an SSO `studentRole` user (they auto-join),
+ *   - we're not embedded in the Classroom add-on iframe (own auth handshake),
+ *   - a join code is present, and
+ *   - the session is ClassLink-rostered (`classIds` non-empty).
+ *
+ * The last condition is the key one: only ClassLink sessions can fork a
+ * submission onto the wrong roster slot via a wrong PIN-period, and only they
+ * have an SSO identity to fall back to. PIN-only sessions stay on the PIN path.
+ */
+export function shouldGateToSso(args: {
+  flagEnabled: boolean;
+  isStudentRole: boolean;
+  embedded: boolean;
+  hasCode: boolean;
+  classIds: string[] | undefined;
+}): boolean {
+  return (
+    args.flagEnabled &&
+    !args.isStudentRole &&
+    !args.embedded &&
+    args.hasCode &&
+    Array.isArray(args.classIds) &&
+    args.classIds.length > 0
+  );
+}


### PR DESCRIPTION
Promotes dev-paul to production. The `main..dev-paul` delta is **exactly three reviewed PRs** (everything else is already on main):

- **[#1810](https://github.com/OPS-PIvers/SpartBoard/pull/1810)** — CF-gate `classroom_course_links` to close course squatting.
- **[#1811](https://github.com/OPS-PIvers/SpartBoard/pull/1811)** — extract shared ClassLink/CORS, quiz-code & grade-push helpers (pure refactor).
- **[#1812](https://github.com/OPS-PIvers/SpartBoard/pull/1812)** — guard "false 0" quiz scoring + duplicate-identity badge + flag-gated SSO join redirect (incl. the grade-passback guard).

## ⚠️ Merge method
**Use a regular merge commit — NOT squash** (dev-paul → main flow rule).

## Deploy notes
- **Watch the `deploy` job.** This delta touches `functions/src` (#1810, #1811), the commit shape that historically triggered the Cloud Build buildpack pnpm-skew failure. `functions/package.json` still pins `packageManager: pnpm@10.30.2`, so it should hold — but if deploy fails with "Update your lockfile" / all functions fail, that's the latent buildpack issue, not this code (re-run; don't revert).
- **Ordering is favorable:** prod deploys `functions,firestore,storage` then hosting, so the new `linkClassroomCourse` CF + the tightened rules go live *before* the new client bundle.

## Back-compat
- **`classroom_course_links` rules now block client writes** (server-only via `linkClassroomCourse`). One self-healing transient: a teacher with the **old bundle still open** who links a course post-deploy gets a permission error until they refresh. Existing link docs unaffected (read stays open); no migration. No new OAuth scope (the CF reuses the `classroom.courses.readonly` token already used to list courses).
- **#1811** is a pure refactor — byte-identical contracts, `computeStudentUid` unchanged → SSO + add-on uids and grade passback are stable.
- **#1812** is display + push-payload only — no stored-schema change. For a healthy quiz (answer key loads, no id drift) it is **zero behavior change**. The one visible difference: pushing grades while the key is still loading / for id-drifted responses now **omits** those students instead of writing a phantom 0 to the gradebook (the intended fix). Active/assigned quizzes are safe.

## Flags — nothing to flip on merge
`QUIZ_SSO_REDIRECT_ENABLED` ships **OFF** and stays off. Flipping it is a separate, deliberate later step (one-line constant + deploy), and only **after any in-progress quiz session ends** (it changes the rostered-session join flow).

## Still outstanding (not a blocker)
Live Classroom end-to-end smoke test (attach → student submits → publish → push → student views results) remains pending — the auth-bypass dev env can't simulate a real teacher launch. Worth running on prod after this lands, especially given the grade-push guard change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)