### PR TITLE
fix(classroom-addon): verify teacher via single courses.teachers.get

### DIFF
--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -713,11 +713,13 @@ describe('createClassroomAttachment (spike)', () => {
 });
 
 // linkClassroomCourse — server-gated creator of classroom_course_links/{courseId}.
-// The trust anchor is listTeacherCourseIds (the caller's OWN teacher course
-// list): the chosen courseId MUST appear there, or the link is refused. These
-// tests pin the squatting fix — a non-teacher can't claim a course, teacherUid
-// is always the authenticated caller (never the client payload), and an existing
-// link owned by a different teacher is never overwritten.
+// The trust anchor is verifyTeacherOfCourse (a single courses.teachers.get call
+// for the EXACT courseId): 200 → the caller teaches it (link allowed), 404 → not
+// a teacher (permission-denied), any other outcome → UNVERIFIABLE (fail closed,
+// unauthenticated). These tests pin the squatting fix — a non-teacher can't claim
+// a course, teacherUid is always the authenticated caller (never the client
+// payload), and an existing link owned by a different teacher is never
+// overwritten.
 const callLink = linkClassroomCourse as unknown as (req: {
   data: unknown;
   auth?: { uid: string } | null;
@@ -737,9 +739,9 @@ function findLinkWrite() {
 
 describe('linkClassroomCourse (course-squatting fix)', () => {
   it('writes the link for a verified teacher of the course', async () => {
-    const listSpy = vi
-      .spyOn(classroomAddonNet, 'listTeacherCourseIds')
-      .mockResolvedValue({ ok: true, status: 200, courseIds: ['C0', 'C1'] });
+    const verifySpy = vi
+      .spyOn(classroomAddonNet, 'verifyTeacherOfCourse')
+      .mockResolvedValue({ ok: true, status: 200, isTeacher: true });
 
     const res = await callLink({
       data: linkData,
@@ -747,7 +749,8 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
     });
 
     expect(res).toMatchObject({ ok: true, courseId: 'C1' });
-    expect(listSpy).toHaveBeenCalledWith('teacher-courses-token');
+    // Verified against the EXACT courseId with the caller's token (one call).
+    expect(verifySpy).toHaveBeenCalledWith('teacher-courses-token', 'C1');
     const write = findLinkWrite();
     expect(write?.data).toMatchObject({
       classlinkClassId: 'CL-SECTION-1',
@@ -760,12 +763,13 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
     expect(typeof write?.data.updatedAt).toBe('number');
   });
 
-  it('refuses to link a course the caller does not teach (squat attempt)', async () => {
-    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+  it('refuses to link a course the caller does not teach (squat attempt → 404)', async () => {
+    // courses.teachers.get returns 404 when the caller is not a teacher of the
+    // claimed course (or it doesn't exist) — a DEFINITIVE "not a teacher".
+    vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse').mockResolvedValue({
       ok: true,
-      status: 200,
-      // The caller teaches OTHER courses, but NOT the courseId they're claiming.
-      courseIds: ['SOME-OTHER-COURSE'],
+      status: 404,
+      isTeacher: false,
     });
 
     await expect(
@@ -775,10 +779,10 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
   });
 
   it('always records teacherUid from the authenticated caller, never the client payload', async () => {
-    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+    vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse').mockResolvedValue({
       ok: true,
       status: 200,
-      courseIds: ['C1'],
+      isTeacher: true,
     });
 
     await callLink({
@@ -796,10 +800,10 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
       teacherUid: 'original-teacher',
     };
     // Even a genuine co-teacher (passes the teacher check) can't steal it.
-    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+    vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse').mockResolvedValue({
       ok: true,
       status: 200,
-      courseIds: ['C1'],
+      isTeacher: true,
     });
 
     await expect(
@@ -814,10 +818,10 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
       teacherUid: 'teacher-1',
       createdAt: 111,
     } as Record<string, unknown>;
-    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+    vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse').mockResolvedValue({
       ok: true,
       status: 200,
-      courseIds: ['C1'],
+      isTeacher: true,
     });
 
     await callLink({ data: linkData, auth: { uid: 'teacher-1' } });
@@ -831,11 +835,11 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
     expect(typeof write?.data.updatedAt).toBe('number');
   });
 
-  it('fails closed when the teacher course-list check errors (never links on an unverifiable token)', async () => {
-    vi.spyOn(classroomAddonNet, 'listTeacherCourseIds').mockResolvedValue({
+  it('fails closed when the teacher check is unverifiable (never links on an unverifiable token)', async () => {
+    vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse').mockResolvedValue({
       ok: false,
       status: 401,
-      courseIds: [],
+      isTeacher: false,
     });
 
     await expect(
@@ -844,13 +848,61 @@ describe('linkClassroomCourse (course-squatting fix)', () => {
     expect(findLinkWrite()).toBeUndefined();
   });
 
+  it('distinguishes a 404 (not a teacher → permission-denied) from an unverifiable non-404 (→ fail closed)', async () => {
+    // 404 is the ONLY non-2xx that means "definitively not a teacher" — it maps
+    // to permission-denied. Every other non-2xx (403 insufficient scope, 5xx,
+    // network 0) is UNVERIFIABLE and must fail closed as `unauthenticated`,
+    // never be misread as a clean "not a teacher" deny. Both paths write
+    // nothing.
+    const verifySpy = vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse');
+
+    // 404 → permission-denied.
+    verifySpy.mockResolvedValueOnce({
+      ok: true,
+      status: 404,
+      isTeacher: false,
+    });
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+
+    // 403 (insufficient scope) → fail closed, NOT permission-denied.
+    verifySpy.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      isTeacher: false,
+    });
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+
+    // 5xx → fail closed.
+    verifySpy.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      isTeacher: false,
+    });
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+
+    // Network failure (status 0) → fail closed.
+    verifySpy.mockResolvedValueOnce({ ok: false, status: 0, isTeacher: false });
+    await expect(
+      callLink({ data: linkData, auth: { uid: 'teacher-1' } })
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+
+    // Not one of these four attempts wrote a link doc.
+    expect(findLinkWrite()).toBeUndefined();
+  });
+
   it('rejects an unauthenticated caller before any Classroom call', async () => {
-    const listSpy = vi.spyOn(classroomAddonNet, 'listTeacherCourseIds');
+    const verifySpy = vi.spyOn(classroomAddonNet, 'verifyTeacherOfCourse');
 
     await expect(
       callLink({ data: linkData, auth: null })
     ).rejects.toMatchObject({ code: 'unauthenticated' });
-    expect(listSpy).not.toHaveBeenCalled();
+    expect(verifySpy).not.toHaveBeenCalled();
     expect(findLinkWrite()).toBeUndefined();
   });
 
@@ -983,77 +1035,76 @@ describe('classroomAddonNet.patchStudentSubmissionGrade URL construction', () =>
   });
 });
 
-// The teacher course-list seam — the trust anchor for linkClassroomCourse. The
-// linkClassroomCourse tests stub it, so these pin the real URL/pagination it
-// builds and that it degrades safely on a weird upstream body (the parse guard).
-describe('classroomAddonNet.listTeacherCourseIds (real seam)', () => {
+// The single-course teacher-verification seam — the trust anchor for
+// linkClassroomCourse. The linkClassroomCourse tests stub it, so these pin the
+// real URL it builds (courses.teachers.get, one call — NOT a teacherId=me
+// enumeration) and the 200 / 404 / other-status mapping that drives the
+// fail-closed semantics.
+describe('classroomAddonNet.verifyTeacherOfCourse (real seam)', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('GETs courses?teacherId=me&courseStates=ACTIVE and paginates, collecting ids', async () => {
-    const urls: string[] = [];
+  it('GETs /courses/{courseId}/teachers/me once and maps 200 → isTeacher:true', async () => {
+    let calledUrl = '';
     const fetchMock = vi.fn(async (url: unknown) => {
-      const u = url as string;
-      urls.push(u);
-      // The second page (token present) is the last — no nextPageToken.
-      if (u.includes('pageToken=PAGE2')) {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ courses: [{ id: 'C3' }] }),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
-          courses: [{ id: 'C1' }, { id: 'C2' }],
-          nextPageToken: 'PAGE2',
-        }),
-      };
+      calledUrl = url as string;
+      return { ok: true, status: 200, json: async () => ({ userId: 'me' }) };
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+    const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
 
-    expect(res).toEqual({
-      ok: true,
-      status: 200,
-      courseIds: ['C1', 'C2', 'C3'],
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(urls[0]).toContain('https://classroom.googleapis.com/v1/courses?');
-    expect(urls[0]).toContain('teacherId=me');
-    expect(urls[0]).toContain('courseStates=ACTIVE');
-    expect(urls[1]).toContain('pageToken=PAGE2');
-  });
-
-  it('treats a null/non-object 200 body as an empty final page (no crash)', async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => null,
-    }));
-    vi.stubGlobal('fetch', fetchMock);
-
-    const res = await classroomAddonNet.listTeacherCourseIds('tok');
-
-    expect(res).toEqual({ ok: true, status: 200, courseIds: [] });
+    expect(res).toEqual({ ok: true, status: 200, isTeacher: true });
+    // Exactly one call — no enumeration / pagination of the teacher's catalog.
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(calledUrl).toBe(
+      'https://classroom.googleapis.com/v1/courses/C1/teachers/me'
+    );
+    // State-agnostic: there is no courseStates filter on this endpoint.
+    expect(calledUrl).not.toContain('courseStates');
+    expect(calledUrl).not.toContain('teacherId=me');
   });
 
-  it('fails closed (ok:false) on a non-2xx response', async () => {
+  it('maps a 404 to a DEFINITIVE not-a-teacher answer (ok:true, isTeacher:false)', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: false,
-      status: 401,
+      status: 404,
       json: async () => ({}),
     }));
     vi.stubGlobal('fetch', fetchMock);
 
-    const res = await classroomAddonNet.listTeacherCourseIds('tok');
+    const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
 
-    expect(res).toEqual({ ok: false, status: 401, courseIds: [] });
+    // ok:true (definitive) but isTeacher:false — the caller turns this into
+    // permission-denied.
+    expect(res).toEqual({ ok: true, status: 404, isTeacher: false });
+  });
+
+  it('fails closed (ok:false) on a non-404 non-2xx response', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
+
+    // 403/5xx are UNVERIFIABLE → ok:false (the caller fails closed), never
+    // misread as a clean "not a teacher".
+    expect(res).toEqual({ ok: false, status: 403, isTeacher: false });
+  });
+
+  it('fails closed (ok:false, status 0) on a network failure', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down');
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
+
+    expect(res).toEqual({ ok: false, status: 0, isTeacher: false });
   });
 });
 

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -283,78 +283,62 @@ export const classroomAddonNet = {
   },
 
   /**
-   * List the Google Classroom course ids the access token's owner TEACHES
-   * (`courses.list?teacherId=me`). This is the trust anchor for
-   * `linkClassroomCourse`: Classroom only returns a course here if the
-   * authenticated user is a teacher of it, so membership in this list proves
-   * teaching authority that Firestore rules can't verify. Paginated with a
-   * generous cap so a teacher with many courses is fully covered without an
-   * unbounded loop. Any upstream/network failure returns `ok: false` so the
-   * caller fails CLOSED (never links on an unverifiable token). Seam so tests
+   * Verify the access token's owner TEACHES a specific Google Classroom course
+   * with a SINGLE `courses.teachers.get` call
+   * (`GET /v1/courses/{courseId}/teachers/me`). This is the trust anchor for
+   * `linkClassroomCourse`: Classroom returns 200 here ONLY when the
+   * authenticated token owner is a teacher of `courseId`, proving teaching
+   * authority that Firestore rules can't verify. Unlike a
+   * `courses.list?courseStates=ACTIVE` enumeration, this is STATE-AGNOSTIC — a
+   * teacher of an ACTIVE, ARCHIVED, or PROVISIONED course is verified the same
+   * way — and costs exactly one API call instead of paging the teacher's whole
+   * catalog.
+   *
+   * Return contract (the caller maps it to fail-closed semantics):
+   *   - 200            → { ok: true,  status: 200, isTeacher: true }  (write allowed)
+   *   - 404            → { ok: true,  status: 404, isTeacher: false } (definitively NOT a teacher)
+   *   - other non-2xx / network / timeout
+   *                    → { ok: false, status,      isTeacher: false } (UNVERIFIABLE → fail closed)
+   *
+   * `ok` means Classroom gave a DEFINITIVE teacher / not-a-teacher answer; only
+   * 200 and 404 are definitive. A 401/403 (bad/expired/insufficient-scope
+   * token), a 5xx, or a network failure is UNVERIFIABLE — never treat it as
+   * "not a teacher" (the caller fails closed on it, never links). Seam so tests
    * can stub it without a live Classroom call.
    */
-  async listTeacherCourseIds(
-    accessToken: string
-  ): Promise<{ ok: boolean; status: number; courseIds: string[] }> {
-    const courseIds: string[] = [];
-    let pageToken: string | undefined;
-    let pages = 0;
-    // A single teacher having >2500 active courses is implausible; the cap is a
-    // runaway guard, not an expected limit.
-    const MAX_PAGES = 25;
+  async verifyTeacherOfCourse(
+    accessToken: string,
+    courseId: string
+  ): Promise<{ ok: boolean; status: number; isTeacher: boolean }> {
+    const url = `${CLASSROOM_API}/courses/${encodeURIComponent(
+      courseId
+    )}/teachers/me`;
     try {
-      do {
-        const qs = new URLSearchParams({
-          teacherId: 'me',
-          courseStates: 'ACTIVE',
-          pageSize: '100',
-        });
-        if (pageToken) qs.set('pageToken', pageToken);
-        const res = await fetch(`${CLASSROOM_API}/courses?${qs.toString()}`, {
-          headers: bearer(accessToken),
-          signal: AbortSignal.timeout(API_TIMEOUT_MS),
-        });
-        if (!res.ok) {
-          console.warn(`[classroomAddon] listTeacherCourseIds ${res.status}`);
-          return { ok: false, status: res.status, courseIds: [] };
-        }
-        const body = (await res.json()) as {
-          courses?: { id?: string }[];
-          nextPageToken?: string;
-        } | null;
-        // A 200 with a null / non-object body shouldn't happen for
-        // courses.list, but guard rather than deref it (and treat it as an
-        // empty final page rather than throwing into the catch, which would
-        // discard course ids already collected from earlier pages).
-        if (body && typeof body === 'object') {
-          for (const c of body.courses ?? []) {
-            if (typeof c.id === 'string') courseIds.push(c.id);
-          }
-          pageToken = body.nextPageToken;
-        } else {
-          pageToken = undefined;
-        }
-        pages += 1;
-      } while (pageToken && pages < MAX_PAGES);
-      // If we stopped because of the page cap while more pages remained, the
-      // enumeration is INCOMPLETE — fail closed rather than treat the truncated
-      // list as authoritative, which could wrongly deny a teacher whose course
-      // sits beyond the cap. (Practically unreachable — a teacher with >2500
-      // active courses doesn't exist — but it keeps the trust anchor honest.)
-      if (pageToken) {
-        console.warn(
-          '[classroomAddon] listTeacherCourseIds hit the page cap with more ' +
-            'pages remaining; treating the enumeration as unverifiable.'
-        );
-        return { ok: false, status: 0, courseIds: [] };
+      const res = await fetch(url, {
+        headers: bearer(accessToken),
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      });
+      // 2xx → the token owner is a teacher of this course.
+      if (res.ok) {
+        return { ok: true, status: res.status, isTeacher: true };
       }
-      return { ok: true, status: 200, courseIds };
+      // 404 → the token owner is NOT a teacher of this course (or it doesn't
+      // exist). Either way the caller must deny the link; this is a DEFINITIVE
+      // answer, so `ok: true`.
+      if (res.status === 404) {
+        return { ok: true, status: 404, isTeacher: false };
+      }
+      // Everything else (401/403/5xx/…) is UNVERIFIABLE — the caller fails
+      // closed on it rather than reading it as "not a teacher".
+      console.warn(`[classroomAddon] verifyTeacherOfCourse ${res.status}`);
+      return { ok: false, status: res.status, isTeacher: false };
     } catch (err) {
+      // Network failure / timeout / abort → unverifiable; caller fails closed.
       console.warn(
-        '[classroomAddon] listTeacherCourseIds fetch failed (network/timeout):',
+        '[classroomAddon] verifyTeacherOfCourse fetch failed (network/timeout):',
         err
       );
-      return { ok: false, status: 0, courseIds: [] };
+      return { ok: false, status: 0, isTeacher: false };
     }
   },
 
@@ -903,14 +887,16 @@ export const createClassroomAttachment = onCall(
  * teacher out, since `update` requires the existing teacherUid). The rules now
  * block client writes; this CF is the only writer.
  *
- * TRUST ANCHOR: re-run the caller's OWN `courses?teacherId=me` query
- * server-side with their `classroom.courses.readonly` token (the same token
- * that listed the courses they picked from). Classroom only returns a course in
- * that list if the user is a teacher of it, so the chosen courseId must appear
- * there — a forged/borrowed courseId won't. `teacherUid` is taken from
- * `request.auth.uid` (never the client). An existing link owned by a DIFFERENT
- * teacher is never overwritten (`already-exists`), preserving the no-hijack
- * invariant.
+ * TRUST ANCHOR: a single server-side `courses.teachers.get` call
+ * (`GET /courses/{courseId}/teachers/me`) with the caller's
+ * `classroom.courses.readonly` token. Classroom returns 200 ONLY when the token
+ * owner is a teacher of that exact course, so a forged/borrowed courseId yields
+ * 404 → denied; this is state-agnostic (ACTIVE/ARCHIVED/PROVISIONED) and one
+ * call rather than enumerating the teacher's whole catalog. Any non-200/404
+ * outcome (401/403/5xx/network) is UNVERIFIABLE → fail closed (never link).
+ * `teacherUid` is taken from `request.auth.uid` (never the client). An existing
+ * link owned by a DIFFERENT teacher is never overwritten (`already-exists`),
+ * preserving the no-hijack invariant.
  */
 export const linkClassroomCourse = onCall(
   {
@@ -955,19 +941,24 @@ export const linkClassroomCourse = onCall(
       typeof data.classlinkOrgId === 'string' ? data.classlinkOrgId : null;
     const rosterId = typeof data.rosterId === 'string' ? data.rosterId : null;
 
-    // TRUST ANCHOR: prove the caller teaches this Google course. Fail CLOSED on
-    // any upstream error (never link on an unverifiable token).
-    const teacherCourses =
-      await classroomAddonNet.listTeacherCourseIds(accessToken);
-    if (!teacherCourses.ok) {
+    // TRUST ANCHOR: prove the caller teaches this Google course with a single
+    // courses.teachers.get call. Fail CLOSED on any UNVERIFIABLE outcome
+    // (network/timeout/401/403/5xx) — never link on a token we couldn't get a
+    // definitive answer for.
+    const verification = await classroomAddonNet.verifyTeacherOfCourse(
+      accessToken,
+      courseId
+    );
+    if (!verification.ok) {
       throw new HttpsError(
         'unauthenticated',
-        `Could not verify your Google Classroom courses (status ${teacherCourses.status}).`
+        `Could not verify that you teach this Google Classroom course (status ${verification.status}).`
       );
     }
-    if (!teacherCourses.courseIds.includes(courseId)) {
-      // Opaque on purpose: don't reveal whether the course exists to someone who
-      // doesn't teach it.
+    if (!verification.isTeacher) {
+      // 404 → the caller is DEFINITIVELY not a teacher of this course. Opaque on
+      // purpose: don't reveal whether the course exists to someone who doesn't
+      // teach it.
       console.warn(
         `[linkClassroomCourse] uid=${callerUid} is not a teacher of course ${courseId}.`
       );

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -318,6 +318,14 @@ export const classroomAddonNet = {
         headers: bearer(accessToken),
         signal: AbortSignal.timeout(API_TIMEOUT_MS),
       });
+      // This is the one outbound call here that never reads its body (it
+      // decides purely on the status code), so under Node's fetch (undici) the
+      // socket would be held open until GC instead of returning to the pool.
+      // Drain it on every path. Guarded for the unit-test fetch mocks, which
+      // return a bare `{ ok, status }` with no `text`.
+      if (typeof res.text === 'function') {
+        await res.text();
+      }
       // 2xx → the token owner is a teacher of this course.
       if (res.ok) {
         return { ok: true, status: res.status, isTeacher: true };


### PR DESCRIPTION
## Summary

Simplifies and hardens the Google Classroom teacher-verification used by the `linkClassroomCourse` Cloud Function (the security trust anchor for the course-squatting fix in #1810).

The old `classroomAddonNet.listTeacherCourseIds(accessToken)` enumerated **all** of the teacher's courses (`courses.list?teacherId=me&courseStates=ACTIVE`, paginated, up to 25 API calls) just to answer "does this teacher teach course X?". This is replaced with a single `courses.teachers.get` call: `GET /v1/courses/{courseId}/teachers/me`.

### Problems fixed
1. **`courseStates=ACTIVE` rejected legitimate teachers.** A teacher of a PROVISIONED (brand-new) or ARCHIVED (end-of-year) course was wrongly treated as a squatter (`permission-denied`). It failed closed (no security hole), but blocked real workflows. `courses.teachers.get` is **state-agnostic** (ACTIVE / ARCHIVED / PROVISIONED all verify the same way).
2. **Enumeration cost.** Up to 25 API calls collapse to **one**.

### Verification mapping (drives fail-closed semantics)
| Upstream | Result | Callable outcome |
| --- | --- | --- |
| `200` | `{ ok: true, isTeacher: true }` | link written |
| `404` | `{ ok: true, isTeacher: false }` | `permission-denied` (definitively not a teacher) |
| other non-2xx / network / timeout | `{ ok: false, isTeacher: false }` | `unauthenticated` — **never writes** |

`ok` means Classroom gave a *definitive* teacher / not-a-teacher answer (only `200`/`404`). A `401`/`403`/`5xx`/network failure is UNVERIFIABLE and is **never** misread as a clean "not a teacher" — it fails closed.

### Preserved invariants (the #1810 trust anchor)
- `teacherUid` is derived from `request.auth.uid`, never the client payload.
- A different teacher's existing link is never overwritten (`already-exists`).
- Any unverifiable verification result fails closed without writing.

### Tests
- Kept the squat-rejection, fail-closed, `teacherUid`-from-auth, and no-hijack tests (updated to the new seam).
- **Added** an explicit 404-vs-other-error distinction test: `404 → permission-denied`, while `403` / `5xx` / network(`0`) all fail closed as `unauthenticated`, none writing a link doc.
- Rewrote the real-seam tests to pin the single `GET /courses/{courseId}/teachers/me` URL (no `courseStates` / `teacherId=me`) and the `200` / `404` / other-status / network mapping.

### Scope
Only `functions/src/classroomAddonAuth.ts` and its test file. `firestore.rules` and the client (the course-picker UI in `SidebarClasses.tsx`, which lists courses for UX only) are untouched.

Deferred from the #1813 release review (deliberately not rewritten minutes before a prod deploy).

### Validation
- `pnpm run type-check:all` ✅
- `pnpm run lint` (root, covers `functions/**/*.ts`) ✅ (exit 0)
- functions vitest suite ✅ (361 passed; `classroomAddonAuth.test.ts` 49 passed)
- `prettier --check` on changed files ✅

https://claude.ai/code/session_01GNvfDoFwhkbpfZ3rz9Rdzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNvfDoFwhkbpfZ3rz9Rdzq)_