### PR TITLE
fix(video-activity): guard teacher monitor against phantom 0% scores

### DIFF
--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -29,6 +29,7 @@ import { QuizDriveService } from '@/utils/quizDriveService';
 import {
   gradeVideoActivityAnswer,
   computeVideoActivityScorePct,
+  canScoreVideoActivityResponse,
 } from '@/utils/videoActivityGrading';
 import {
   runClassroomGradePush,
@@ -118,17 +119,31 @@ export const Results: React.FC<ResultsProps> = ({
 
     let completedCount = 0;
     let scoreSum = 0;
+    // Average only over responses we can actually score. A completed response
+    // whose questions haven't loaded yet (or whose answers map to no loaded
+    // question) would score a phantom 0 and drag the class average down as if
+    // everyone failed — exclude it from the mean rather than seating it at 0.
+    // See `canScoreVideoActivityResponse`. `completedCount` still counts every
+    // completion (that's a real headcount), so only the denominator narrows.
+    let scoredCount = 0;
 
     for (const r of responses) {
       if (r.completedAt !== null) {
         completedCount++;
-        scoreSum += computeVideoActivityScorePct(questions, r.answers);
+        if (canScoreVideoActivityResponse(questions, r.answers)) {
+          scoreSum += computeVideoActivityScorePct(questions, r.answers);
+          scoredCount++;
+        }
       }
     }
 
     return {
       completed: completedCount,
-      avgScore: completedCount > 0 ? Math.round(scoreSum / completedCount) : 0,
+      // `null` when nothing is scoreable yet (question set not loaded, or every
+      // completed response drifted) — the tile renders "—" rather than a
+      // phantom "0%" that reads as a class that failed. A genuine empty
+      // submission still counts as a real 0, so it keeps the average defined.
+      avgScore: scoredCount > 0 ? Math.round(scoreSum / scoredCount) : null,
     };
   }, [responses, questions]);
 
@@ -248,7 +263,16 @@ export const Results: React.FC<ResultsProps> = ({
       return;
     }
     const eligible = responses.filter(
-      (r) => r.completedAt !== null && !!r.studentUid
+      (r) =>
+        r.completedAt !== null &&
+        !!r.studentUid &&
+        // Skip responses we can't actually score (question set not loaded /
+        // question-id drift). `getStudentScore` would silently return 0 for
+        // them, and unlike the "—" placeholder the teacher views render, a
+        // phantom 0 PATCHed into the real Classroom gradebook is persistent and
+        // easy to miss. Omitting the student is the safe default — better no
+        // grade than a wrong 0. Mirrors `buildQuizClassroomGradeEntries`.
+        canScoreVideoActivityResponse(questions, r.answers)
     );
     if (eligible.length === 0) {
       addToast(NOTHING_TO_PUSH_TOAST, 'info');
@@ -506,7 +530,7 @@ export const Results: React.FC<ResultsProps> = ({
                 },
                 {
                   label: 'Avg Score',
-                  value: `${avgScore}%`,
+                  value: avgScore === null ? '—' : `${avgScore}%`,
                   color: 'text-violet-600',
                 },
               ].map((stat) => (
@@ -639,6 +663,14 @@ export const Results: React.FC<ResultsProps> = ({
                 .sort((a, b) => getStudentScore(b) - getStudentScore(a))
                 .map((r) => {
                   const score = getStudentScore(r);
+                  // When the question set hasn't loaded (or the response's
+                  // answers map to no loaded question), the score is a phantom
+                  // 0 rather than a real result — show a neutral "—" instead of
+                  // "0%". See `canScoreVideoActivityResponse`.
+                  const scoreable = canScoreVideoActivityResponse(
+                    questions,
+                    r.answers
+                  );
                   const correct = r.answers.filter((a) =>
                     isAnswerCorrect(a.questionId, a.answer)
                   ).length;
@@ -697,10 +729,18 @@ export const Results: React.FC<ResultsProps> = ({
                           )
                         )}
                         <span
-                          className={`font-black ml-1 ${score >= 70 ? 'text-emerald-600' : score >= 40 ? 'text-amber-600' : 'text-brand-red-primary'}`}
+                          className={`font-black ml-1 ${
+                            !scoreable
+                              ? 'text-slate-400'
+                              : score >= 70
+                                ? 'text-emerald-600'
+                                : score >= 40
+                                  ? 'text-amber-600'
+                                  : 'text-brand-red-primary'
+                          }`}
                           style={{ fontSize: 'min(14px, 4.5cqmin)' }}
                         >
-                          {score}%
+                          {scoreable ? `${score}%` : '—'}
                         </span>
                       </div>
                     </div>

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -114,7 +114,11 @@ export const Results: React.FC<ResultsProps> = ({
   // Calculate completed count and average score in a single loop
   const { completed, avgScore } = React.useMemo(() => {
     if (responses.length === 0) {
-      return { completed: 0, avgScore: 0 };
+      // No responses → nothing is scoreable, so the average is undefined, not a
+      // real 0. Return `null` (not `0`) so the Avg Score tile renders "—",
+      // matching the no-scoreable-responses path below — otherwise an empty
+      // session would show a phantom "0%" that reads as a class that failed.
+      return { completed: 0, avgScore: null };
     }
 
     let completedCount = 0;

--- a/tests/utils/videoActivityGrading.test.ts
+++ b/tests/utils/videoActivityGrading.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   gradeVideoActivityAnswer,
   computeVideoActivityScorePct,
+  canScoreVideoActivityResponse,
 } from '@/utils/videoActivityGrading';
 import type { VideoActivityQuestion } from '@/types';
 
@@ -365,5 +366,94 @@ describe('computeVideoActivityScorePct', () => {
     // Without the fix: max = 4 (counted twice), earned = 2, score = 50.
     // With the fix:    max = 2 (counted once),  earned = 2, score = 100.
     expect(score).toBe(100);
+  });
+});
+
+describe('canScoreVideoActivityResponse', () => {
+  const qs = [
+    q({ id: 'q1', type: 'MC', correctAnswer: 'a' }),
+    q({ id: 'q2', type: 'MC', correctAnswer: 'b' }),
+  ];
+
+  it('returns false when the question set has not loaded (empty questions)', () => {
+    // The teacher Results view scores against `session.questions`; before that
+    // hydrates from Firestore every completed response would score a phantom 0.
+    expect(
+      canScoreVideoActivityResponse([], [{ questionId: 'q1', answer: 'a' }])
+    ).toBe(false);
+  });
+
+  it('returns true for a response whose answers match loaded questions', () => {
+    expect(
+      canScoreVideoActivityResponse(qs, [{ questionId: 'q1', answer: 'a' }])
+    ).toBe(true);
+  });
+
+  it('treats a zero-answer response as scoreable (genuine 0, not a missing key)', () => {
+    expect(canScoreVideoActivityResponse(qs, [])).toBe(true);
+  });
+
+  it('returns false when no answer maps to a loaded question id (synced ID drift)', () => {
+    expect(
+      canScoreVideoActivityResponse(qs, [
+        { questionId: 'old-q1', answer: 'a' },
+        { questionId: 'old-q2', answer: 'b' },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns true when at least one answer maps to a loaded question (partial drift)', () => {
+    expect(
+      canScoreVideoActivityResponse(qs, [
+        { questionId: 'q1', answer: 'a' },
+        { questionId: 'old-q2', answer: 'b' },
+      ])
+    ).toBe(true);
+  });
+});
+
+describe('class-average / gradebook exclusion (phantom-0 guard)', () => {
+  const qs = [q({ id: 'q1', type: 'MC', correctAnswer: 'a', points: 1 })];
+
+  // Mirrors the Results.tsx aggregate loop: a completed response is only folded
+  // into the class average when `canScoreVideoActivityResponse` says it can be
+  // scored. This is the behavior the monitor relies on so an unscoreable
+  // response can't drag the average toward a phantom 0. Returns `null` when
+  // nothing is scoreable, which the tile renders as "—" rather than "0%".
+  function classAverage(
+    questions: VideoActivityQuestion[],
+    completed: { answers: { questionId: string; answer: string }[] }[]
+  ): number | null {
+    let sum = 0;
+    let scored = 0;
+    for (const r of completed) {
+      if (canScoreVideoActivityResponse(questions, r.answers)) {
+        sum += computeVideoActivityScorePct(questions, r.answers);
+        scored++;
+      }
+    }
+    return scored > 0 ? Math.round(sum / scored) : null;
+  }
+
+  it('excludes a drifted (unscoreable) response from the average', () => {
+    const scored = { answers: [{ questionId: 'q1', answer: 'a' }] }; // 100%
+    const drifted = { answers: [{ questionId: 'gone', answer: 'a' }] }; // phantom 0
+    // Without the guard: (100 + 0) / 2 = 50. With it: 100 / 1 = 100.
+    expect(classAverage(qs, [scored, drifted])).toBe(100);
+  });
+
+  it('yields null (rendered as "—") when the question set has not loaded', () => {
+    const r = { answers: [{ questionId: 'q1', answer: 'a' }] };
+    // Every response is unscoreable, so the average has no scored members and
+    // is null — the tile shows "—" instead of a misleading 0% "everyone failed".
+    expect(classAverage([], [r])).toBeNull();
+  });
+
+  it('still counts a genuine empty submission as a real 0 in the average', () => {
+    const perfect = { answers: [{ questionId: 'q1', answer: 'a' }] }; // 100%
+    const empty = { answers: [] as { questionId: string; answer: string }[] }; // real 0
+    // A no-answer submission is a true 0, not a missing-key artifact — it stays
+    // in the mean: (100 + 0) / 2 = 50.
+    expect(classAverage(qs, [perfect, empty])).toBe(50);
   });
 });

--- a/utils/videoActivityGrading.ts
+++ b/utils/videoActivityGrading.ts
@@ -150,3 +150,46 @@ export function computeVideoActivityScorePct(
   if (max === 0) return 0;
   return Math.round((earned / max) * 100);
 }
+
+/**
+ * Whether a Video Activity response can be meaningfully scored against the
+ * given question set — the VA mirror of `quizScoreboard.canScoreResponse`.
+ *
+ * Guards the same "false 0" failure mode. `computeVideoActivityScorePct`
+ * grades each answer against `questions[].correctAnswer`, so when the question
+ * set is the wrong one (or absent) it silently yields 0: every `answers.find`
+ * misses a loaded question and contributes nothing. That 0 then renders as a
+ * real "0%", which reads as a student who failed rather than a scoring
+ * artifact. Two cases produce it:
+ *
+ *   1. **Question set not loaded** — `questions` is empty. The teacher Results
+ *      view scores against `session.questions`; before that hydrates from
+ *      Firestore (or if it arrives empty) EVERY completed response scores 0,
+ *      so the monitor shows a "0%" class average as if everyone failed.
+ *   2. **Question-id drift** — a completed response's answers reference no
+ *      question in the loaded set (e.g. a PLC-synced activity whose question
+ *      IDs were regenerated after the student submitted). Grading skips all of
+ *      them and the response scores 0 despite real answers.
+ *
+ * Callers should render a pending / "—" indicator (not a score) when this
+ * returns false, exclude these responses from the class average / aggregate,
+ * and keep them out of any Google Classroom gradebook push rather than seating
+ * them at a phantom 0.
+ *
+ * A response with zero answers is treated as scoreable: its 0 is a genuine
+ * "didn't answer", not a missing-key artifact, so the caller can still show 0.
+ */
+export function canScoreVideoActivityResponse(
+  questions: VideoActivityQuestion[],
+  answers: { questionId: string; answer: string }[]
+): boolean {
+  // Case 1: the question set hasn't loaded — nothing can be graded yet.
+  if (questions.length === 0) return false;
+  // A genuine empty submission is scoreable (a real 0, not a missing key).
+  if (answers.length === 0) return true;
+  // Case 2: at least one answer must map to a loaded question. Partial drift
+  // (some ids match, some don't) is still gradable — the matched answers score
+  // and the unmatched ones are skipped, same as computeVideoActivityScorePct.
+  const ids = new Set(questions.map((q) => q.id));
+  return answers.some((a) => ids.has(a.questionId));
+}


### PR DESCRIPTION
## Summary

Guards the **Video Activity teacher monitor** against phantom `0%` scores — the same class of bug the quiz monitor already fixes via `canScoreResponse` (PR #1812). Deferred from the PR #1813 release review as the out-of-scope-but-worth-doing sequel to the quiz fix.

### The bug

`components/widgets/VideoActivityWidget/components/Results.tsx` scored every completed response with `computeVideoActivityScorePct(questions, answers)`, which returns `0` when:

1. **`session.questions` hasn't hydrated** from Firestore yet (empty array → every answer lookup misses), or
2. **question-id drift** — a response's answers map to no loaded question (e.g. a PLC-synced activity whose question IDs were regenerated after the student submitted).

That phantom `0` surfaced as a real **"0%" class-average tile and per-student score**, reading as a class that failed when nothing is actually scored yet — and could be PATCHed into the real Google Classroom gradebook on a grade push.

### The fix (mirrors the quiz path)

1. **New predicate** `canScoreVideoActivityResponse(questions, answers)` in `utils/videoActivityGrading.ts`, next to the VA scoring util — mirrors `quizScoreboard.canScoreResponse`. Scoreable iff the question set is loaded **and** at least one answer maps to a loaded question; a genuinely empty submission stays a real `0`.
2. **Overview tile** — average only over scoreable responses; render Avg Score as **"—"** when nothing is scoreable instead of `0%`. (`completedCount` still counts every completion — only the average's denominator narrows.)
3. **Students tab** — render a neutral slate **"—"** for an unscoreable completed response instead of a red `0%`.
4. **Grade push** — exclude unscoreable responses from the `eligible` set so a phantom `0` is never PATCHed to the real Classroom gradebook. Mirrors `utils/classroomGradePush.ts buildQuizClassroomGradeEntries`.

### Tests

`tests/utils/videoActivityGrading.test.ts` adds coverage for the predicate (empty question set, matching answers, zero-answer genuine 0, full drift, partial drift) and the exclusion behavior (drifted response excluded from average; null/"—" when the question set hasn't loaded; genuine empty submission still counts as a real 0).

### Verification

- `pnpm run type-check` ✅
- `pnpm run lint` ✅ (clean, `--max-warnings 0`)
- `pnpm run format:check` ✅
- `pnpm exec vitest run tests/utils/videoActivityGrading.test.ts` ✅ (37 passed)

https://claude.ai/code/session_01UdjvE9cuobnN6FR4DJk2Ku

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdjvE9cuobnN6FR4DJk2Ku)_