### PR TITLE
fix(classes): paginate + time-box Google Classroom course-link dropdown

### DIFF
--- a/components/layout/sidebar/SidebarClasses.tsx
+++ b/components/layout/sidebar/SidebarClasses.tsx
@@ -36,6 +36,23 @@ import {
 const CLASSROOM_COURSES_READONLY_SCOPE =
   'https://www.googleapis.com/auth/classroom.courses.readonly';
 
+/** `courses.list` page size — matches the server-side `listTeacherCourseIds`. */
+const COURSES_PAGE_SIZE = 100;
+
+/**
+ * Runaway guard on pagination: a single teacher with >2500 active courses is
+ * implausible, so this is a cap to avoid an unbounded loop — not an expected
+ * limit. Mirrors the CF's `MAX_PAGES`.
+ */
+const MAX_COURSE_PAGES = 25;
+
+/**
+ * Per-request timeout for the Classroom course listing. Mirrors `API_TIMEOUT_MS`
+ * in the server-side add-on CF so a hung Classroom call can't pin the dropdown's
+ * loading spinner forever — it surfaces a retryable error instead.
+ */
+const COURSES_API_TIMEOUT_MS = 10000;
+
 /** Minimal shape of a Google Classroom course we care about. */
 interface GoogleClassroomCourse {
   id: string;
@@ -124,15 +141,56 @@ export const SidebarClasses: React.FC<SidebarClassesProps> = ({
       );
       // Reused at confirm time to verify teaching authority server-side.
       coursesAccessTokenRef.current = token;
-      const res = await fetch(
-        'https://classroom.googleapis.com/v1/courses?teacherId=me&courseStates=ACTIVE',
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      if (!res.ok) {
-        throw new Error(`Classroom API returned ${res.status}`);
-      }
-      const data = (await res.json()) as { courses?: GoogleClassroomCourse[] };
-      setCourses(data.courses ?? []);
+      // Page through ALL the teacher's active courses (a teacher with many
+      // courses would otherwise be truncated to the first page), following
+      // `nextPageToken` until exhausted, capped by MAX_COURSE_PAGES so a buggy
+      // token loop can't spin unbounded.
+      const all: GoogleClassroomCourse[] = [];
+      let pageToken: string | undefined;
+      let pages = 0;
+      do {
+        const qs = new URLSearchParams({
+          teacherId: 'me',
+          courseStates: 'ACTIVE',
+          pageSize: String(COURSES_PAGE_SIZE),
+        });
+        if (pageToken) qs.set('pageToken', pageToken);
+        // Time-box each request so a slow/hung Classroom call surfaces a
+        // retryable error instead of pinning the loading spinner forever.
+        let res: Response;
+        try {
+          res = await fetch(
+            `https://classroom.googleapis.com/v1/courses?${qs.toString()}`,
+            {
+              headers: { Authorization: `Bearer ${token}` },
+              signal: AbortSignal.timeout(COURSES_API_TIMEOUT_MS),
+            }
+          );
+        } catch (fetchErr) {
+          // AbortSignal.timeout rejects with a DOMException('TimeoutError') —
+          // which isn't an `Error` in every engine — so match either type.
+          if (
+            (fetchErr instanceof DOMException || fetchErr instanceof Error) &&
+            (fetchErr.name === 'TimeoutError' || fetchErr.name === 'AbortError')
+          ) {
+            throw new Error(
+              'Timed out loading your Google Classroom courses. Please try again.'
+            );
+          }
+          throw fetchErr;
+        }
+        if (!res.ok) {
+          throw new Error(`Classroom API returned ${res.status}`);
+        }
+        const data = (await res.json()) as {
+          courses?: GoogleClassroomCourse[];
+          nextPageToken?: string;
+        };
+        for (const c of data.courses ?? []) all.push(c);
+        pageToken = data.nextPageToken;
+        pages += 1;
+      } while (pageToken && pages < MAX_COURSE_PAGES);
+      setCourses(all);
       setCourseLoadState('loaded');
     } catch (err) {
       setCourseLoadError(

--- a/tests/components/layout/sidebar/SidebarClasses.test.tsx
+++ b/tests/components/layout/sidebar/SidebarClasses.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { SidebarClasses } from '@/components/layout/sidebar/SidebarClasses';
+
+// GIS OAuth popup is stubbed so the modal goes straight to the course fetch.
+const { ensureGis, requestAccessToken } = vi.hoisted(() => ({
+  ensureGis: vi.fn(() => Promise.resolve()),
+  requestAccessToken: vi.fn(() => Promise.resolve('test-token')),
+}));
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    rosters: [{ id: 'r1', name: 'Period 1', students: [] }],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    addToast: vi.fn(),
+  }),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { email: 'teacher@example.edu' },
+    selectedBuildings: [],
+  }),
+}));
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({ showConfirm: vi.fn() }),
+}));
+// Surface the "Link to Google Classroom" button regardless of permission state.
+vi.mock('@/hooks/useClassLinkEnabled', () => ({
+  useClassLinkEnabled: () => true,
+}));
+vi.mock('@/components/classroomAddon/gisOAuth', () => ({
+  ensureGis,
+  requestAccessToken,
+}));
+vi.mock('@/config/firebase', () => ({
+  auth: { currentUser: { uid: 'u1' } },
+  functions: {},
+}));
+// Child modals are irrelevant here; stub them so their dependency trees don't
+// need wiring.
+vi.mock('@/components/classes/RosterEditorModal', () => ({
+  RosterEditorModal: () => null,
+}));
+vi.mock('@/components/classes/ClassLinkImportDialog', () => ({
+  ClassLinkImportDialog: () => null,
+}));
+
+const openLinkModal = () => {
+  render(<SidebarClasses isVisible />);
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Link to Google Classroom' })
+  );
+};
+
+describe('SidebarClasses — Link to Google Classroom course list', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('paginates through every active course (not just the first page)', async () => {
+    const urls: string[] = [];
+    const fetchMock = vi.fn((url: string) => {
+      urls.push(url);
+      // The token-bearing page is the last — no nextPageToken.
+      if (url.includes('pageToken=PAGE2')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ courses: [{ id: 'c3', name: 'Chemistry' }] }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            courses: [
+              { id: 'c1', name: 'Algebra' },
+              { id: 'c2', name: 'Biology' },
+            ],
+            nextPageToken: 'PAGE2',
+          }),
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    openLinkModal();
+
+    // A second-page course rendering proves nextPageToken was followed.
+    expect(await screen.findByText('Chemistry')).toBeInTheDocument();
+    expect(screen.getByText('Algebra')).toBeInTheDocument();
+    expect(screen.getByText('Biology')).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(urls[0]).toContain('pageSize=100');
+    expect(urls[0]).toContain('teacherId=me');
+    expect(urls[0]).toContain('courseStates=ACTIVE');
+    expect(urls[1]).toContain('pageToken=PAGE2');
+  });
+
+  it('surfaces a retryable error when the Classroom call times out', async () => {
+    const fetchMock = vi.fn(() => {
+      // Mirror what AbortSignal.timeout(...) makes fetch reject with.
+      const err = new Error('The operation timed out.');
+      err.name = 'TimeoutError';
+      return Promise.reject(err);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    openLinkModal();
+
+    expect(
+      await screen.findByText('Could not load courses')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Timed out/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Try Again' })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the **"Link to Google Classroom"** course dropdown in `SidebarClasses` truncating for teachers with many courses.

`loadCourses` fetched the teacher's courses with a single `courses?teacherId=me&courseStates=ACTIVE` request that passed **no `pageSize`** and **did not follow `nextPageToken`**. The Classroom API returns only the first page, so a teacher with many active courses saw a truncated list — the course they wanted to link could be missing, with **no error shown**. The fetch was also **unguarded by any timeout**, so a slow/hung Classroom call left the loading spinner stuck forever.

Deferred from the PR #1813 release review (pre-existing usability gap).

## Changes

`components/layout/sidebar/SidebarClasses.tsx` — `loadCourses`:

1. **Pagination** — request `pageSize=100` and follow `nextPageToken` until exhausted, capped at `MAX_COURSE_PAGES` (25) to avoid an unbounded loop. This mirrors the server-side `listTeacherCourseIds` in `functions/src/classroomAddonAuth.ts`.
2. **Timeout** — time-box each request with `AbortSignal.timeout(COURSES_API_TIMEOUT_MS)` (10s, matching the CF's `API_TIMEOUT_MS`). A timeout/abort throws a clean, retryable error that flows into the existing error state (which already renders a **Try Again** button) instead of pinning the spinner. The `DOMException`/`Error` check covers engines where `AbortSignal.timeout`'s `DOMException` isn't an `instanceof Error`.
3. **OAuth token capture unchanged** — `coursesAccessTokenRef` is still set before paging, so the `linkClassroomCourse` confirm step reuses the same `classroom.courses.readonly` token (no second OAuth popup).

## Tests

Adds `tests/components/layout/sidebar/SidebarClasses.test.tsx`:
- Opens the link modal and asserts courses **across multiple pages** all render (proving `nextPageToken` is followed), and that the first request carries `pageSize=100`/`teacherId=me`/`courseStates=ACTIVE` while the second carries `pageToken`.
- Asserts a timed-out Classroom call surfaces the **"Could not load courses"** state with a **Try Again** button.

> Implementation note: the pagination/timeout logic was kept inline in the component rather than extracted to a helper, because routing the helper's return value through `setCourses` tripped the React Compiler's `preserve-manual-memoization` rule (whole-component compile bail). The inline form matches the original blessed pattern and is covered by the component test above.

## Validation

- `pnpm run type-check` ✅
- `pnpm run lint` ✅
- `pnpm run format:check` ✅
- Layout/sidebar test suites (81 tests) ✅

https://claude.ai/code/session_01XmK14TMJwfL9vBAj3QqdpM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmK14TMJwfL9vBAj3QqdpM)_