### PR TITLE
Release: quiz removeStudent missing-ledger permission fix (#1818)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2499,9 +2499,21 @@ service cloud.firestore {
         isAdmin()
       );
       // Owning teacher (or admin) may delete the entry — used by the
-      // teacher monitor's "Reset student" action. The student cannot
-      // delete (they'd be able to wipe their own cap).
+      // teacher monitor's "Reset student" / "Remove student" actions. The
+      // student cannot delete (they'd be able to wipe their own cap).
+      //
+      // The `resource == null` short-circuit makes deleting a NON-EXISTENT
+      // ledger a harmless no-op. Without it the rule dereferences
+      // `resource.data.teacherUid` on a null resource and DENIES — which
+      // breaks `removeStudent`'s atomic archive+delete batch for any response
+      // that never wrote a ledger (anonymous PIN joiners, idle auto-submitted
+      // blanks, joined-only stubs, legacy pre-ledger responses), surfacing as
+      // a "Missing or insufficient permissions" toast. The read rule above
+      // already uses this same pattern; the delete rule must match it.
+      // Defense-in-depth alongside the client existence probe in
+      // `removeStudent`.
       allow delete: if request.auth != null && (
+        resource == null ||
         request.auth.uid == resource.data.teacherUid || isAdmin()
       );
     }
@@ -2545,7 +2557,13 @@ service cloud.firestore {
         ||
         isAdmin()
       );
+      // `resource == null` short-circuit mirrors quiz_attempt_ledger above:
+      // deleting a non-existent ledger is a safe no-op, and without it the
+      // rule null-derefs `resource.data.teacherUid` and denies. VA has no
+      // ledger-deleting remove path today, but the guard keeps the two
+      // ledgers' delete rules symmetric and forecloses the same footgun.
       allow delete: if request.auth != null && (
+        resource == null ||
         request.auth.uid == resource.data.teacherUid || isAdmin()
       );
     }

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -853,6 +853,31 @@ export const useQuizSessionTeacher = (
         await historyBatch.commit();
       }
 
+      // Probe the cross-launch ledger BEFORE opening the batch so we only
+      // enqueue its delete when it actually exists. A ledger doc is written
+      // ONLY for non-anonymous (SSO/studentRole) joiners that finalize via
+      // `completeQuiz` (see the `writeLedger` guard). Several common states
+      // therefore have NO ledger: anonymous PIN joiners, idle/force
+      // auto-submitted blanks (`autoSubmitted: true` — never ran the ledger
+      // transaction), joined-but-never-submitted stubs, and legacy
+      // pre-ledger responses. The ledger `delete` rule dereferences
+      // `resource.data.teacherUid` with no `resource == null` short-circuit,
+      // so a `batch.delete()` against a missing ledger is REJECTED and rolls
+      // back the entire archive+delete batch — which surfaces to the teacher
+      // as a "Missing or insufficient permissions" toast when removing such a
+      // student. Mirror `unlockStudentAttempt`'s probe-then-touch pattern.
+      //
+      // Skip the probe entirely for anonymous PIN joiners (`pin-…` keys):
+      // their uids rotate per device so they NEVER write a ledger, making the
+      // read a guaranteed miss — so we save the round-trip and just don't
+      // enqueue the delete. The other no-ledger cases (SSO idle auto-submit,
+      // joined-only, legacy) live in the SSO uid keyspace, so the existence
+      // probe still covers them.
+      const ledgerSnap =
+        ledgerRef && !responseKey.startsWith('pin-')
+          ? await getDoc(ledgerRef)
+          : null;
+
       // Archive the response before delete so partial answers survive
       // the teacher's "remove" action. The deterministic key model
       // means we can't soft-delete in place (the slot must be free for
@@ -890,7 +915,10 @@ export const useQuizSessionTeacher = (
         });
       }
       batch.delete(responseRef);
-      if (ledgerRef) batch.delete(ledgerRef);
+      // Only delete the ledger when it exists (see the probe above) — a
+      // delete against a non-existent ledger doc is rejected by the rules
+      // and would roll back the whole batch.
+      if (ledgerRef && ledgerSnap?.exists()) batch.delete(ledgerRef);
       await batch.commit();
     },
     [sessionId, responses, session?.quizId]

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -1746,6 +1746,7 @@ interface TeacherMockEnv {
   collectionCalls: unknown[][];
   /** Mock writeBatch instance the hook will use during finalize. */
   batch: {
+    set: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
     commit: ReturnType<typeof vi.fn>;
@@ -1767,6 +1768,7 @@ function setupTeacherMocks(): TeacherMockEnv {
     docCalls: [],
     collectionCalls: [],
     batch: {
+      set: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
       commit: vi.fn().mockResolvedValue(undefined),
@@ -1973,6 +1975,162 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
       'history',
       'h2',
     ]);
+  });
+
+  it('skips the ledger delete (and still commits) when the response has no attempt-ledger doc', async () => {
+    // Regression: removeStudent batch-deleted the cross-launch ledger
+    // UNCONDITIONALLY. SSO students who were idle auto-submitted, joined
+    // but never submitted, or anonymous PIN joiners have NO ledger doc —
+    // and the ledger delete rule null-derefs `resource.data.teacherUid` on
+    // a missing doc, rolling back the WHOLE batch ("Missing or insufficient
+    // permissions"). The hook must probe the ledger and only enqueue its
+    // delete when it exists.
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    // Drive the session snapshot so `session.quizId` is set — that's what
+    // makes removeStudent resolve a ledger ref at all. Sync state update, so
+    // no await (act returns a non-thenable for a synchronous callback).
+    act(() => {
+      env.sessionCallback?.({
+        exists: () => true,
+        data: () => buildSession({ status: 'active', quizId: 'quiz-1' }),
+      } as never);
+    });
+
+    // getDoc #1: fallback response fetch (snapshot list is empty, so the
+    // hook fetches the doc directly to build the archive).
+    // getDoc #2: the ledger existence probe → NOT FOUND.
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    getDocMock
+      .mockResolvedValueOnce({
+        exists: () => true,
+        id: 'sso-key',
+        data: () => ({
+          studentUid: 'sso-uid',
+          status: 'completed',
+          answers: [],
+        }),
+      })
+      .mockResolvedValueOnce({ exists: () => false });
+
+    await act(async () => {
+      await result.current.removeStudent('sso-key');
+    });
+
+    // Archive is written and the response is deleted, but the non-existent
+    // ledger delete is skipped — so delete fires exactly once and the batch
+    // still commits (no permission-denied rollback).
+    expect(env.batch.set).toHaveBeenCalledTimes(1);
+    expect(env.batch.delete).toHaveBeenCalledTimes(1);
+    expect(env.batch.commit).toHaveBeenCalledTimes(1);
+    const deletedPaths = env.batch.delete.mock.calls.map(
+      (c) => (c[0] as { path: string[] }).path
+    );
+    expect(deletedPaths.some((p) => p[0] === 'quiz_attempt_ledger')).toBe(
+      false
+    );
+  });
+
+  it('deletes the attempt-ledger atomically when one exists', async () => {
+    // The guard must not over-correct: when the ledger DOES exist it still
+    // has to be removed in the same batch (frees the cross-launch attempt
+    // slot so the student can rejoin under the cap).
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    // Sync state update, so no await (see the no-ledger test above).
+    act(() => {
+      env.sessionCallback?.({
+        exists: () => true,
+        data: () => buildSession({ status: 'active', quizId: 'quiz-1' }),
+      } as never);
+    });
+
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    getDocMock
+      .mockResolvedValueOnce({
+        exists: () => true,
+        id: 'sso-key',
+        data: () => ({
+          studentUid: 'sso-uid',
+          status: 'completed',
+          answers: [],
+        }),
+      })
+      // Ledger probe → EXISTS, so its delete must be enqueued.
+      .mockResolvedValueOnce({
+        exists: () => true,
+        data: () => ({ teacherUid: 'teacher-1' }),
+      });
+
+    await act(async () => {
+      await result.current.removeStudent('sso-key');
+    });
+
+    // Response + ledger both deleted in the one batch.
+    expect(env.batch.delete).toHaveBeenCalledTimes(2);
+    expect(env.batch.commit).toHaveBeenCalledTimes(1);
+    const deletedPaths = env.batch.delete.mock.calls.map(
+      (c) => (c[0] as { path: string[] }).path
+    );
+    expect(deletedPaths).toContainEqual([
+      'quiz_attempt_ledger',
+      'quiz-1__sso-uid',
+    ]);
+  });
+
+  it('skips the ledger probe entirely for anonymous PIN joiners (pin- keys never have a ledger)', async () => {
+    // A `pin-…` responseKey is an anonymous joiner whose uid rotates per
+    // device — they never write a cross-launch ledger, so probing it is a
+    // guaranteed miss. removeStudent must skip the getDoc round-trip (and the
+    // ledger delete) for them; only the fallback response fetch runs.
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    // Sync state update, so no await (see the no-ledger test above).
+    act(() => {
+      env.sessionCallback?.({
+        exists: () => true,
+        data: () => buildSession({ status: 'active', quizId: 'quiz-1' }),
+      } as never);
+    });
+
+    // Exactly ONE getDoc — the fallback response fetch. No ledger probe.
+    const getDocMock = firestore.getDoc as unknown as ReturnType<typeof vi.fn>;
+    getDocMock.mockResolvedValueOnce({
+      exists: () => true,
+      id: 'pin-period_1-07',
+      data: () => ({
+        studentUid: 'anon-rotating-uid',
+        status: 'completed',
+        answers: [],
+      }),
+    });
+
+    await act(async () => {
+      await result.current.removeStudent('pin-period_1-07');
+    });
+
+    expect(getDocMock).toHaveBeenCalledTimes(1);
+    // Response deleted, no ledger delete enqueued.
+    expect(env.batch.delete).toHaveBeenCalledTimes(1);
+    expect(env.batch.commit).toHaveBeenCalledTimes(1);
+    const deletedPaths = env.batch.delete.mock.calls.map(
+      (c) => (c[0] as { path: string[] }).path
+    );
+    expect(deletedPaths.some((p) => p[0] === 'quiz_attempt_ledger')).toBe(
+      false
+    );
   });
 
   it('revealAnswer writes a dotted-path map entry on the session doc', async () => {

--- a/tests/rules/quizAttemptLedgerDelete.test.ts
+++ b/tests/rules/quizAttemptLedgerDelete.test.ts
@@ -1,0 +1,240 @@
+// Firestore security-rules tests for the quiz_attempt_ledger (and the
+// parallel video_activity_attempt_ledger) DELETE rule.
+//
+// Regression context:
+//   The teacher monitor's "Remove student" action (`removeStudent` in
+//   useQuizSession.ts) runs an ATOMIC batch: archive the response, delete
+//   the response, and delete the cross-launch attempt ledger. A ledger doc
+//   is only ever written for non-anonymous (SSO/studentRole) joiners that
+//   finalize via `completeQuiz`. Many common states therefore have NO
+//   ledger doc: anonymous PIN joiners, idle/force auto-submitted blanks
+//   (`autoSubmitted: true`), joined-but-never-submitted stubs, and legacy
+//   pre-ledger responses.
+//
+//   The delete rule used to be:
+//       allow delete: if request.auth != null &&
+//         (request.auth.uid == resource.data.teacherUid || isAdmin());
+//   For a NON-EXISTENT ledger, `resource` is null, so `resource.data.teacherUid`
+//   null-derefs and the rule DENIES. Because the remove is one atomic batch,
+//   that denial rolls back the archive + response delete too — surfacing to
+//   the teacher as a "Missing or insufficient permissions" toast (observed in
+//   prod for an SSO student whose attempt was idle auto-submitted blank).
+//
+//   Fix: add a `resource == null ||` short-circuit (mirroring the collection's
+//   READ rule) so deleting a missing ledger is a harmless no-op. The owner /
+//   admin gate still applies whenever the doc actually exists.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, deleteDoc, doc } from 'firebase/firestore';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = 'spartboard-quiz-ledger-delete-test';
+
+const QUIZ_ID = 'quiz-ledger-delete';
+const ACTIVITY_ID = 'activity-ledger-delete';
+const TEACHER_UID = 'teacher-ledger-uid';
+const OTHER_TEACHER_UID = 'other-teacher-ledger-uid';
+const STUDENT_UID = 'student-ledger-uid';
+const ADMIN_UID = 'admin-ledger-uid';
+const ADMIN_EMAIL = 'admin@school.edu';
+
+// Doc ids follow `${quizId}__${studentUid}` / `${activityId}__${studentUid}`
+// (see `quizLedgerKey` / `videoActivityLedgerKey`). The `__existing` /
+// `__missing` suffixes below just give each test its own key so a seeded
+// doc in one case can't leak into a "non-existent" assertion in another.
+const QUIZ_LEDGER_EXISTING = `${QUIZ_ID}__${STUDENT_UID}`;
+const QUIZ_LEDGER_MISSING = `${QUIZ_ID}__missing-${STUDENT_UID}`;
+const VA_LEDGER_EXISTING = `${ACTIVITY_ID}__${STUDENT_UID}`;
+const VA_LEDGER_MISSING = `${ACTIVITY_ID}__missing-${STUDENT_UID}`;
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+// ---------------------------------------------------------------------------
+// Auth contexts
+// ---------------------------------------------------------------------------
+
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext(TEACHER_UID, {
+      email: 'teacher@school.edu',
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asOtherTeacher = () =>
+  testEnv
+    .authenticatedContext(OTHER_TEACHER_UID, {
+      email: 'other-teacher@school.edu',
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+// SSO student-role token — owns the ledger's studentUid but must NOT be able
+// to delete an existing ledger (that would wipe their own attempt cap).
+const asStudent = () =>
+  testEnv
+    .authenticatedContext(STUDENT_UID, {
+      email: 'student@school.edu',
+      studentRole: true,
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asAdmin = () =>
+  testEnv
+    .authenticatedContext(ADMIN_UID, {
+      email: ADMIN_EMAIL,
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  const emulatorHost = process.env.FIRESTORE_EMULATOR_HOST;
+  const [hostPart, portPart] = emulatorHost ? emulatorHost.split(':') : [];
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: hostPart || '127.0.0.1',
+      port: portPart ? Number(portPart) : 8080,
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+const quizLedgerDoc = (teacherUid: string) => ({
+  quizId: QUIZ_ID,
+  studentUid: STUDENT_UID,
+  teacherUid,
+  completedAttempts: 1,
+  lastAttemptAt: 1000,
+});
+
+const vaLedgerDoc = (teacherUid: string) => ({
+  activityId: ACTIVITY_ID,
+  studentUid: STUDENT_UID,
+  teacherUid,
+  completedAttempts: 1,
+  lastAttemptAt: 1000,
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    // Mark ADMIN_EMAIL as an admin (isAdmin() checks /admins/{email.lower()}).
+    await setDoc(doc(db, `admins/${ADMIN_EMAIL}`), {});
+    // Seed the "existing" ledgers owned by TEACHER_UID. The "missing" keys
+    // are intentionally left absent so the non-existent-delete cases hit a
+    // truly null `resource`.
+    await setDoc(
+      doc(db, `quiz_attempt_ledger/${QUIZ_LEDGER_EXISTING}`),
+      quizLedgerDoc(TEACHER_UID)
+    );
+    await setDoc(
+      doc(db, `video_activity_attempt_ledger/${VA_LEDGER_EXISTING}`),
+      vaLedgerDoc(TEACHER_UID)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// quiz_attempt_ledger DELETE
+// ---------------------------------------------------------------------------
+
+describe('quiz_attempt_ledger DELETE', () => {
+  it('REGRESSION: the owning teacher can delete a NON-EXISTENT ledger (removeStudent no-ledger path)', async () => {
+    // This is the exact failure that produced the "Missing or insufficient
+    // permissions" toast: removeStudent batch-deletes a ledger that was
+    // never written (idle auto-submit / anonymous / joined-only). The
+    // `resource == null` short-circuit must make this a harmless no-op.
+    await assertSucceeds(
+      deleteDoc(doc(asTeacher(), `quiz_attempt_ledger/${QUIZ_LEDGER_MISSING}`))
+    );
+  });
+
+  it('the owning teacher can delete their own EXISTING ledger', async () => {
+    await assertSucceeds(
+      deleteDoc(doc(asTeacher(), `quiz_attempt_ledger/${QUIZ_LEDGER_EXISTING}`))
+    );
+  });
+
+  it('a non-owning teacher CANNOT delete an existing ledger', async () => {
+    await assertFails(
+      deleteDoc(
+        doc(asOtherTeacher(), `quiz_attempt_ledger/${QUIZ_LEDGER_EXISTING}`)
+      )
+    );
+  });
+
+  it('the student CANNOT delete their own existing ledger (would wipe the attempt cap)', async () => {
+    await assertFails(
+      deleteDoc(doc(asStudent(), `quiz_attempt_ledger/${QUIZ_LEDGER_EXISTING}`))
+    );
+  });
+
+  it('a student deleting a NON-EXISTENT ledger is an allowed no-op (resource == null; nothing to wipe)', async () => {
+    // The `resource == null` branch admits any authenticated caller, but it
+    // can only ever "delete" a doc that does not exist — a no-op that leaks
+    // and destroys nothing. An EXISTING ledger stays gated (case above).
+    await assertSucceeds(
+      deleteDoc(doc(asStudent(), `quiz_attempt_ledger/${QUIZ_LEDGER_MISSING}`))
+    );
+  });
+
+  it('an admin can delete an existing ledger', async () => {
+    await assertSucceeds(
+      deleteDoc(doc(asAdmin(), `quiz_attempt_ledger/${QUIZ_LEDGER_EXISTING}`))
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// video_activity_attempt_ledger DELETE (same hardening, kept symmetric)
+// ---------------------------------------------------------------------------
+
+describe('video_activity_attempt_ledger DELETE', () => {
+  it('the owning teacher can delete a NON-EXISTENT VA ledger (parity with quiz ledger)', async () => {
+    await assertSucceeds(
+      deleteDoc(
+        doc(asTeacher(), `video_activity_attempt_ledger/${VA_LEDGER_MISSING}`)
+      )
+    );
+  });
+
+  it('a non-owning teacher CANNOT delete an existing VA ledger', async () => {
+    await assertFails(
+      deleteDoc(
+        doc(
+          asOtherTeacher(),
+          `video_activity_attempt_ledger/${VA_LEDGER_EXISTING}`
+        )
+      )
+    );
+  });
+});


### PR DESCRIPTION
Release of [#1818](https://github.com/OPS-PIvers/SpartBoard/pull/1818) from `dev-paul` → `main` (production).

## What ships
Fixes the **"Missing or insufficient permissions"** toast a teacher hit when removing a student whose live-quiz attempt had no `quiz_attempt_ledger` doc (idle auto-submit blank, anonymous PIN joiner, joined-only stub, or legacy pre-ledger response).

- **Client** (`hooks/useQuizSession.ts`): `removeStudent` probes the ledger and only enqueues its delete when it exists; skips the probe entirely for `pin-` keyed anonymous joiners (guaranteed miss).
- **Rules** (`firestore.rules`): `resource == null ||` short-circuit on the `quiz_attempt_ledger` and `video_activity_attempt_ledger` delete rules — deleting a non-existent ledger is now a safe no-op instead of a null-deref denial that rolled back the whole atomic batch.
- **Tests**: rules regression (`tests/rules/quizAttemptLedgerDelete.test.ts`, runs in CI via the emulator) + client unit coverage (no-ledger, has-ledger, pin- skip).

## Regression risk: none
- Rules change is **strictly additive** — only adds an allow-branch for the missing-doc (no-op) case; the owner/admin gate still applies whenever the doc exists. No existing restriction removed.
- Client change is additive failure-handling on the (rare) remove-student path.
- **No `functions/src` changes** → the prod functions deploy is a no-op redeploy (no pnpm-buildpack risk).
- No flags to flip.

## Verification
- #1818 CI green: type-check, lint, format, unit (incl. new client tests), **Firestore rules tests**, E2E, build, docker.
- Root cause confirmed against production data; the live orphan was already cleared manually to unblock the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)