### PR TITLE
docs(changelog): release entry for 2026-06-02 (removeStudent fix)

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,17 @@
 {
   "entries": [
     {
+      "version": "2026.06.02.3",
+      "date": "2026-06-02",
+      "title": "Removing a student from a live quiz",
+      "details": [
+        {
+          "type": "fix",
+          "text": "Live quiz — removing a student from a session no longer fails with a \"Missing or insufficient permissions\" error. This could happen for students whose attempt hadn't recorded the usual progress — for example, a student who joined with a PIN, a blank attempt that was auto-submitted after sitting idle, a student who joined but never started, or an older response from before recent quiz updates. Removing any of these students now works the first time."
+        }
+      ]
+    },
+    {
       "version": "2026.06.02.2",
       "date": "2026-06-02",
       "title": "Quiz grading accuracy fixes",


### PR DESCRIPTION
Adds the "What's New" changelog entry for the release shipping in #1819 (`dev-paul` → `main`).

This release batch contains a single user-facing change — the quiz `removeStudent` missing-ledger permission fix from #1818 — so the entry is **details only** (no overview, per the small-release path).

New entry (`2026.06.02.3`):
- **Fix** — Live quiz: removing a student no longer fails with a "Missing or insufficient permissions" error for students whose attempt hadn't recorded the usual progress (PIN joiner, idle auto-submit blank, joined-but-never-started, or an older pre-update response).

Merging this into `dev-paul` folds the entry into release PR #1819 before it ships to production.

> Note: the changelog commit was routed through this branch because direct pushes to `dev-paul` are blocked in this environment; the diff is exactly the one changelog entry.

Review the copy before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MyMnceyXToQLQ7LhZNSPjj)_