### PR TITLE
refactor(D4): convert plc tabs↔bodies cross-subdir imports to @/ alias

### DIFF
--- a/components/plc/bodies/PlcQuizzesBody.tsx
+++ b/components/plc/bodies/PlcQuizzesBody.tsx
@@ -25,8 +25,8 @@ import { Plc } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useQuiz } from '@/hooks/useQuiz';
 import { PlcQuizLibraryBody } from './PlcQuizLibraryBody';
-import { PlcAssignmentsInProgressSubTab } from '../tabs/PlcAssignmentsInProgressSubTab';
-import { PlcAssignmentsCompletedSubTab } from '../tabs/PlcAssignmentsCompletedSubTab';
+import { PlcAssignmentsInProgressSubTab } from '@/components/plc/tabs/PlcAssignmentsInProgressSubTab';
+import { PlcAssignmentsCompletedSubTab } from '@/components/plc/tabs/PlcAssignmentsCompletedSubTab';
 import { PlcNewQuizAssignmentModal } from '../PlcNewQuizAssignmentModal';
 
 type SubTabId = 'library' | 'inProgress' | 'completed';

--- a/components/plc/bodies/PlcVideoActivitiesTabsBody.tsx
+++ b/components/plc/bodies/PlcVideoActivitiesTabsBody.tsx
@@ -33,8 +33,8 @@ import { Plc } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useVideoActivity } from '@/hooks/useVideoActivity';
 import { PlcVideoActivitiesBody } from './PlcVideoActivitiesBody';
-import { PlcAssignmentsInProgressSubTab } from '../tabs/PlcAssignmentsInProgressSubTab';
-import { PlcAssignmentsCompletedSubTab } from '../tabs/PlcAssignmentsCompletedSubTab';
+import { PlcAssignmentsInProgressSubTab } from '@/components/plc/tabs/PlcAssignmentsInProgressSubTab';
+import { PlcAssignmentsCompletedSubTab } from '@/components/plc/tabs/PlcAssignmentsCompletedSubTab';
 import { PlcNewVideoActivityAssignmentModal } from '../PlcNewVideoActivityAssignmentModal';
 
 type SubTabId = 'library' | 'inProgress' | 'completed';

--- a/components/plc/tabs/PlcNotesTab.tsx
+++ b/components/plc/tabs/PlcNotesTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Plc } from '@/types';
-import { NotesBody } from '../bodies/NotesBody';
+import { NotesBody } from '@/components/plc/bodies/NotesBody';
 
 interface PlcNotesTabProps {
   plc: Plc;

--- a/components/plc/tabs/PlcQuizLibraryTab.tsx
+++ b/components/plc/tabs/PlcQuizLibraryTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Plc } from '@/types';
-import { PlcQuizzesBody } from '../bodies/PlcQuizzesBody';
+import { PlcQuizzesBody } from '@/components/plc/bodies/PlcQuizzesBody';
 
 interface PlcQuizLibraryTabProps {
   plc: Plc;

--- a/components/plc/tabs/PlcSharedBoardsTab.tsx
+++ b/components/plc/tabs/PlcSharedBoardsTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Plc } from '@/types';
-import { PlcSharedBoardsBody } from '../bodies/PlcSharedBoardsBody';
+import { PlcSharedBoardsBody } from '@/components/plc/bodies/PlcSharedBoardsBody';
 
 interface PlcSharedBoardsTabProps {
   plc: Plc;

--- a/components/plc/tabs/PlcTodosTab.tsx
+++ b/components/plc/tabs/PlcTodosTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Plc } from '@/types';
-import { TodosBody } from '../bodies/TodosBody';
+import { TodosBody } from '@/components/plc/bodies/TodosBody';
 
 interface PlcTodosTabProps {
   plc: Plc;

--- a/components/plc/tabs/PlcVideoActivitiesTab.tsx
+++ b/components/plc/tabs/PlcVideoActivitiesTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Plc } from '@/types';
-import { PlcVideoActivitiesTabsBody } from '../bodies/PlcVideoActivitiesTabsBody';
+import { PlcVideoActivitiesTabsBody } from '@/components/plc/bodies/PlcVideoActivitiesTabsBody';
 
 interface PlcVideoActivitiesTabProps {
   plc: Plc;


### PR DESCRIPTION
## Canonical form
`import { X } from '@/components/plc/...'` — the `@/` alias for all cross-directory imports. Multi-level or cross-subdir `'../foo'` reaching into a sibling feature directory is the anti-pattern.

## Instances unified (7 files, 9 imports)

**`tabs/` → `bodies/` (5 files, 1 import each):**

| File | Before | After |
|---|---|---|
| `tabs/PlcNotesTab.tsx` | `'../bodies/NotesBody'` | `'@/components/plc/bodies/NotesBody'` |
| `tabs/PlcQuizLibraryTab.tsx` | `'../bodies/PlcQuizzesBody'` | `'@/components/plc/bodies/PlcQuizzesBody'` |
| `tabs/PlcSharedBoardsTab.tsx` | `'../bodies/PlcSharedBoardsBody'` | `'@/components/plc/bodies/PlcSharedBoardsBody'` |
| `tabs/PlcTodosTab.tsx` | `'../bodies/TodosBody'` | `'@/components/plc/bodies/TodosBody'` |
| `tabs/PlcVideoActivitiesTab.tsx` | `'../bodies/PlcVideoActivitiesTabsBody'` | `'@/components/plc/bodies/PlcVideoActivitiesTabsBody'` |

**`bodies/` → `tabs/` (2 files, 2 imports each):**

| File | Before | After |
|---|---|---|
| `bodies/PlcQuizzesBody.tsx` | `'../tabs/PlcAssignmentsInProgressSubTab'` | `'@/components/plc/tabs/PlcAssignmentsInProgressSubTab'` |
| `bodies/PlcQuizzesBody.tsx` | `'../tabs/PlcAssignmentsCompletedSubTab'` | `'@/components/plc/tabs/PlcAssignmentsCompletedSubTab'` |
| `bodies/PlcVideoActivitiesTabsBody.tsx` | `'../tabs/PlcAssignmentsInProgressSubTab'` | `'@/components/plc/tabs/PlcAssignmentsInProgressSubTab'` |
| `bodies/PlcVideoActivitiesTabsBody.tsx` | `'../tabs/PlcAssignmentsCompletedSubTab'` | `'@/components/plc/tabs/PlcAssignmentsCompletedSubTab'` |

**Gray-zone imports intentionally left alone:**
- `PlcQuizzesBody.tsx`: `'../PlcNewQuizAssignmentModal'` (bodies → plc root, single-level up — D4-E2 gray zone)
- `PlcVideoActivitiesTabsBody.tsx`: `'../PlcNewVideoActivityAssignmentModal'` (same)

## Enforcement added
None mechanical added — this is the same structural enforcement pattern. The `@/` alias is already the project-wide convention and TypeScript path resolution enforces it at build time.

## Behavior-preservation evidence
Pure import path rename. TypeScript resolved both paths to the same module at compile time (type-check passes). Runtime behavior is identical — bundler resolves `@/` to the repo root, producing the same chunk. No logic, no exports, no types changed.

**validate (type-check + lint + format-check + 375 test files + 18 functions test files):** ✅ exit code 0, rebased on `origin/dev-paul`.

## Risk tag
**mechanical** — pure import path equivalence verified by TypeScript type-check.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154TNxJcbyunjEsWWE9pdqj)_