### PR TITLE
fix(NumberLine): epsilon guard for fraction labels when step=0.1

### DIFF
--- a/components/widgets/NumberLine/Widget.test.tsx
+++ b/components/widgets/NumberLine/Widget.test.tsx
@@ -119,6 +119,45 @@ describe('NumberLineWidget', () => {
     expect(screen.getAllByText('-1')[0]).toBeInTheDocument();
   });
 
+  it('shows fraction labels for all tenths ticks when step=0.1 (floating-point epsilon guard)', () => {
+    // step=0.1 causes floating-point accumulation: min + 3*0.1 = 0.30000000000000004.
+    // Multiplying by denom=10 gives 3.0000000000000004, so (val*denom)%1 !== 0 with
+    // strict equality — the affected ticks fall back to decimal labels ("0.3", "0.6",
+    // "0.7") instead of fractional ones ("3/10", "6/10", "7/10"). The fix must use
+    // an epsilon check so every tenth is consistently formatted as a fraction.
+    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+      defaultDashboardMock
+    );
+
+    const widget: WidgetData = {
+      ...baseWidget,
+      config: {
+        ...baseWidget.config,
+        min: 0,
+        max: 1,
+        step: 0.1,
+        displayMode: 'fractions',
+        markers: [],
+        jumps: [],
+        showArrows: true,
+      },
+    };
+
+    render(<NumberLineWidget widget={widget} />);
+
+    // All three ticks that fail with strict (val*denom)%1===0 must show as fractions.
+    // Confirming all three together verifies the epsilon fix, not just one lucky tick.
+    expect(screen.getByText('3/10')).toBeInTheDocument();
+    expect(screen.getByText('6/10')).toBeInTheDocument();
+    expect(screen.getByText('7/10')).toBeInTheDocument();
+    // Sanity-check: non-problematic ticks still show correctly.
+    expect(screen.getByText('1/10')).toBeInTheDocument();
+    expect(screen.getByText('5/10')).toBeInTheDocument(); // fractionLabel does not simplify fractions
+    // 0 and 1 are whole-number endpoints
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getAllByText('1')[0]).toBeInTheDocument();
+  });
+
   it('caps number of ticks if range is too large compared to step', () => {
     vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
       defaultDashboardMock

--- a/components/widgets/NumberLine/Widget.tsx
+++ b/components/widgets/NumberLine/Widget.tsx
@@ -225,8 +225,19 @@ export const NumberLineWidget: React.FC<{ widget: WidgetData }> = ({
                 } else if (displayMode === 'fractions') {
                   // Simple fraction conversion if step suggests a common denominator (e.g. 0.25 -> 4)
                   const denom = Math.round(1 / safeStep);
-                  if (denom > 1 && denom <= 100 && (val * denom) % 1 === 0) {
-                    labelText = fractionLabel(val * denom, denom);
+                  // Use Math.round + epsilon guard instead of strict modulo check:
+                  // `val * denom` accumulates floating-point error (e.g. 3 × 0.1
+                  // yields 0.30000000000000004, so `(val*denom)%1 !== 0` even
+                  // though the tick is a perfect tenth). Round to the nearest
+                  // integer and confirm it's within 1e-9 of the raw product.
+                  const rawNumerator = val * denom;
+                  const roundedNumerator = Math.round(rawNumerator);
+                  const isFractional =
+                    denom > 1 &&
+                    denom <= 100 &&
+                    Math.abs(rawNumerator - roundedNumerator) < 1e-9;
+                  if (isFractional) {
+                    labelText = fractionLabel(roundedNumerator, denom);
                   } else {
                     labelText = Number(val.toFixed(4)).toString(); // Fallback
                   }


### PR DESCRIPTION
## Root Cause

`NumberLine/Widget.tsx` used `(val * denom) % 1 === 0` to decide whether a tick gets a fraction label. Tick values are computed as `min + i * step`, which accumulates IEEE-754 floating-point error. With `step=0.1`:

- `3 × 0.1 = 0.30000000000000004` in JavaScript
- `0.30000000000000004 * 10 = 3.0000000000000004`
- `3.0000000000000004 % 1 ≈ 4.4e-16 ≠ 0` → silently falls back to decimal label

Result: ticks at 0.3, 0.6, and 0.7 showed decimal labels on an axis where the teacher selected fractions mode, producing a mixed axis: `0, 1/10, 2/10, 0.3, 4/10, 5/10, 0.6, 0.7, 8/10, 9/10, 1`.

## Fix

Compute `rawNumerator = val * denom`, then `roundedNumerator = Math.round(rawNumerator)`. Accept the fraction label only when `|rawNumerator − roundedNumerator| < 1e-9`. Pass the rounded integer to `fractionLabel` so the displayed fraction is exact. This is localized to the label-rendering block and does not affect tick positions or marker math.

## Band-Aid Rejected

Rounding tick values during generation — would have changed `tickValues`, potentially breaking marker placement arithmetic and label key stability.

## Regression Test

New test `"shows fraction labels for all tenths ticks when step=0.1 (floating-point epsilon guard)"` in `Widget.test.tsx`:
- **Before fix**: fails — `getByText('3/10')` throws, element shows `'0.3'` instead
- **After fix**: all 5 tests pass

## Evidence

```
Before: 1 failed | 4 passed (5)  [3/10, 6/10, 7/10 missing fraction labels]
After:  5 passed (5)
```

## Risk

**Contained** — change is limited to 3 lines in the per-tick label block inside `NumberLine/Widget.tsx`. No other code paths affected.

https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR)_