### PR TITLE
fix(quizScoreboard): deduplicate answers by questionId in getEarnedPoints

### DIFF
--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -387,6 +387,57 @@ describe('quizScoreboard', () => {
         expect(getEarnedPoints(response, questions)).toBe(1);
       });
     });
+
+    describe('duplicate answer deduplication (arrayUnion race)', () => {
+      it('credits a question only once when the answers array contains duplicate questionIds', () => {
+        // Firestore arrayUnion races (or Drive-sync double-writes) can produce
+        // two identical answer entries for the same questionId. Without dedup
+        // the question is graded twice and the student's score is inflated.
+        const questions = [makeQuestion('q1', 'A', 5)];
+        const response = makeResponse('01', [
+          { questionId: 'q1', answer: 'A', answeredAt: 100 },
+          { questionId: 'q1', answer: 'A', answeredAt: 101 }, // duplicate
+        ]);
+        // Should earn 5 pts (one question, answered correctly once), not 10.
+        expect(getEarnedPoints(response, questions)).toBe(5);
+      });
+
+      it('getResponseScore stays at most 100% when duplicate answers exist', () => {
+        const questions = [makeQuestion('q1', 'A')];
+        const response = makeResponse('01', [
+          { questionId: 'q1', answer: 'A', answeredAt: 100 },
+          { questionId: 'q1', answer: 'A', answeredAt: 101 }, // duplicate
+        ]);
+        // Without dedup: earned=2, max=1 → 200%. With dedup: earned=1, max=1 → 100%.
+        expect(getResponseScore(response, questions)).toBe(100);
+      });
+
+      it('keeps the chronologically-first answer when duplicates disagree', () => {
+        // The earlier answer is the "real" one; the later duplicate may be a
+        // stale autosave echo. The first (by answeredAt) should win.
+        // Use streakBonusEnabled to expose the duplicate: without dedup the
+        // second (wrong) duplicate resets the streak to 0 before q2 is scored,
+        // turning q2's 1.5x multiplier into 1x → total differs.
+        const questions = [
+          makeQuestion('q1', 'A', 2),
+          makeQuestion('q2', 'B', 2),
+        ];
+        const session = makeSession({ streakBonusEnabled: true });
+        const response = makeResponse('01', [
+          { questionId: 'q1', answer: 'A', answeredAt: 100 }, // correct
+          { questionId: 'q1', answer: 'wrong', answeredAt: 150 }, // duplicate, wrong — resets streak without dedup
+          { questionId: 'q2', answer: 'B', answeredAt: 200 }, // correct
+        ]);
+        // With dedup (only answeredAt=100 for q1 counted):
+        //   q1: 2pts × 1.0 = 2 (streak=1)
+        //   q2: 2pts × 1.5 = 3 (streak=2) → total = 5
+        // Without dedup:
+        //   q1(correct): 2pts × 1.0 = 2 (streak=1)
+        //   q1(wrong duplicate): 0pts, streak resets to 0
+        //   q2: 2pts × 1.0 = 2 (streak=1, not 2) → total = 4
+        expect(getEarnedPoints(response, questions, session)).toBe(5);
+      });
+    });
   });
 
   describe('getResponseScore', () => {

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -58,9 +58,17 @@ export function getEarnedPoints(
   let totalPoints = 0;
   let streak = 0;
 
+  // Deduplicate by questionId: credit only the first (chronologically earliest)
+  // answer per question. Firestore arrayUnion races and Drive-sync double-writes
+  // can produce duplicate entries; without this guard a student's score is
+  // inflated (same fix applied to computeVideoActivityScorePct, #1728/#1777).
+  const seenQuestionIds = new Set<string>();
+
   for (const ans of sortedAnswers) {
     const q = qMap.get(ans.questionId);
     if (!q) continue;
+    if (seenQuestionIds.has(ans.questionId)) continue;
+    seenQuestionIds.add(ans.questionId);
 
     // Written types (`short`/`essay`) get their points from the response's
     // top-level `grading` map. Without this thread-through, scoreboard


### PR DESCRIPTION
## Root Cause

`getEarnedPoints` in `components/widgets/QuizWidget/utils/quizScoreboard.ts` iterates over `sortedAnswers` without deduplicating by `questionId`. Firestore `arrayUnion` races and Drive-sync double-writes can land two answer entries for the same question in a `QuizResponse.answers` array. Without deduplication, both entries are graded:

- A student with two identical correct answers for a 5-point question scores 10 instead of 5
- `getResponseScore` can return values above 100%
- A wrong duplicate entry arriving after a correct first answer resets the streak to 0 for all subsequent questions — even though the student already answered correctly

## Fix

Added a `seenQuestionIds: Set<string>` immediately before the loop. After sorting by `answeredAt`, any answer whose `questionId` is already in the Set is skipped — only the chronologically-first answer per question is graded. This is the identical fix applied to `computeVideoActivityScorePct` (#1728), `buildContributionDoc` (#1777), `publishAssignmentScores` in `useVideoActivityAssignments` (#1787), and `useQuizAssignments` (#1803).

## Band-Aid Rejected

Capping `getResponseScore` at `Math.min(100, ...)` — would hide the display but leave raw `getEarnedPoints` wrong. Scoreboard sorting, speed-bonus totals, and all other callers use `getEarnedPoints` directly.

## Regression Test

Three new tests in `quizScoreboard.test.ts` under `"duplicate answer deduplication (arrayUnion race)"`:
1. Duplicate correct entries score only once (not twice)
2. `getResponseScore` stays ≤ 100% with duplicate entries
3. A wrong duplicate after a correct first answer cannot reset the streak

- **Before fix**: 3 failed | 64 passed (67)
- **After fix**: 67 passed (67)

## Risk

**Contained** — 3-line `Set` guard added before an existing loop; no callers changed.

https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR)_