### PR TITLE
fix(i18n): add widgets.stickers translations to DE and FR locales

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -697,6 +697,20 @@
     "dashboard": {
       "emptyBoardHint": "Ziehen Sie Werkzeuge aus dem Dock unten, um zu beginnen",
       "switchBoardsHint": "Verwenden Sie die Tafelnavigation unten links, um zwischen Tafeln zu wechseln"
+    },
+    "stickers": {
+      "collectionTitle": "Sticker-Sammlung",
+      "clearAll": "Alle Sticker vom Board löschen",
+      "wait": "Warten...",
+      "dropOrPaste": "Bild ablegen oder einfügen",
+      "toAddCustom": "um benutzerdefinierte Sticker hinzuzufügen",
+      "essentials": "Grundlagen",
+      "globalCollection": "Globale Sammlung",
+      "myCollection": "Meine Sammlung",
+      "dragOrClick": "Ziehen oder klicken zum Hinzufügen",
+      "deleteSticker": "Sticker löschen",
+      "dragFromLibrary": "Sticker aus der Bibliothek auf das Board ziehen",
+      "stickerAdded": "Sticker zum Board hinzugefügt!"
     }
   },
   "boardBreadcrumb": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -710,7 +710,12 @@
       "dragOrClick": "Ziehen oder klicken zum Hinzufügen",
       "deleteSticker": "Sticker löschen",
       "dragFromLibrary": "Sticker aus der Bibliothek auf das Board ziehen",
-      "stickerAdded": "Sticker zum Board hinzugefügt!"
+      "stickerAdded": "Sticker zum Board hinzugefügt!",
+      "filterAll": "Alle",
+      "filterFavorites": "Favoriten",
+      "filterMine": "Meine",
+      "reorganizeSticker": "Neu anordnen",
+      "favoriteSticker": "Favorisieren"
     }
   },
   "boardBreadcrumb": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -820,7 +820,12 @@
       "dragOrClick": "Drag or Click to add",
       "deleteSticker": "Delete Sticker",
       "dragFromLibrary": "Drag stickers from library to the board",
-      "stickerAdded": "Sticker added to board!"
+      "stickerAdded": "Sticker added to board!",
+      "filterAll": "All",
+      "filterFavorites": "Favorites",
+      "filterMine": "Mine",
+      "reorganizeSticker": "Reorder",
+      "favoriteSticker": "Favorite"
     },
     "onboarding": {
       "title": "Getting Started",

--- a/locales/es.json
+++ b/locales/es.json
@@ -734,7 +734,12 @@
       "dragOrClick": "Arrastra o Haz Clic para añadir",
       "deleteSticker": "Eliminar Sticker",
       "dragFromLibrary": "Arrastra stickers desde la biblioteca al tablero",
-      "stickerAdded": "¡Sticker añadido al tablero!"
+      "stickerAdded": "¡Sticker añadido al tablero!",
+      "filterAll": "Todos",
+      "filterFavorites": "Favoritos",
+      "filterMine": "Míos",
+      "reorganizeSticker": "Reorganizar",
+      "favoriteSticker": "Favorito"
     },
     "onboarding": {
       "title": "Primeros Pasos",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -710,7 +710,12 @@
       "dragOrClick": "Glisser ou cliquer pour ajouter",
       "deleteSticker": "Supprimer l'autocollant",
       "dragFromLibrary": "Faites glisser les autocollants de la bibliothèque vers le tableau",
-      "stickerAdded": "Autocollant ajouté au tableau !"
+      "stickerAdded": "Autocollant ajouté au tableau !",
+      "filterAll": "Tout",
+      "filterFavorites": "Favoris",
+      "filterMine": "Mes autocollants",
+      "reorganizeSticker": "Réorganiser",
+      "favoriteSticker": "Ajouter aux favoris"
     }
   },
   "boardBreadcrumb": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -697,6 +697,20 @@
     "dashboard": {
       "emptyBoardHint": "Faites glisser des outils depuis le Dock ci-dessous pour commencer",
       "switchBoardsHint": "Utilisez les commandes de navigation en bas à gauche pour changer de tableau"
+    },
+    "stickers": {
+      "collectionTitle": "Collection d'autocollants",
+      "clearAll": "Effacer tous les autocollants du tableau",
+      "wait": "Veuillez patienter...",
+      "dropOrPaste": "Déposer ou coller une image",
+      "toAddCustom": "pour ajouter des autocollants personnalisés",
+      "essentials": "Essentiels",
+      "globalCollection": "Collection globale",
+      "myCollection": "Ma collection",
+      "dragOrClick": "Glisser ou cliquer pour ajouter",
+      "deleteSticker": "Supprimer l'autocollant",
+      "dragFromLibrary": "Faites glisser les autocollants de la bibliothèque vers le tableau",
+      "stickerAdded": "Autocollant ajouté au tableau !"
     }
   },
   "boardBreadcrumb": {

--- a/tests/i18n/widgetStickersLocales.test.ts
+++ b/tests/i18n/widgetStickersLocales.test.ts
@@ -77,23 +77,20 @@ describe.each([
   { code: 'de', locale: de },
   { code: 'es', locale: es },
   { code: 'fr', locale: fr },
-])(
-  '$code locale — widgets.stickers parity with EN',
-  ({ code, locale }) => {
-    it(`${code}: has a widgets.stickers section`, () => {
+])('$code locale — widgets.stickers parity with EN', ({ code, locale }) => {
+  it(`${code}: has a widgets.stickers section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.stickers section is entirely missing`
+    ).toHaveProperty(['widgets', 'stickers']);
+  });
+
+  it(`${code}: has all required widgets.stickers keys`, () => {
+    for (const key of REQUIRED_WIDGET_STICKERS_KEYS) {
       expect(
         locale,
-        `${code}.widgets.stickers section is entirely missing`
-      ).toHaveProperty(['widgets', 'stickers']);
-    });
-
-    it(`${code}: has all required widgets.stickers keys`, () => {
-      for (const key of REQUIRED_WIDGET_STICKERS_KEYS) {
-        expect(
-          locale,
-          `${code}.widgets.stickers.${key} is missing`
-        ).toHaveProperty(['widgets', 'stickers', key]);
-      }
-    });
-  }
-);
+        `${code}.widgets.stickers.${key} is missing`
+      ).toHaveProperty(['widgets', 'stickers', key]);
+    }
+  });
+});

--- a/tests/i18n/widgetStickersLocales.test.ts
+++ b/tests/i18n/widgetStickersLocales.test.ts
@@ -36,8 +36,12 @@ import es from '@/locales/es.json';
 import fr from '@/locales/fr.json';
 
 /**
- * Keys within widgets.stickers that StickerBookWidget.tsx calls t() on without
- * a defaultValue fallback — these show raw key paths to non-EN users if absent.
+ * Keys within widgets.stickers that StickerBookWidget.tsx resolves via t().
+ * The first group is called without a defaultValue fallback — those show raw
+ * key paths to non-EN users if absent. The filter/favorite/reorder keys are
+ * called with an English defaultValue, so they degrade to English (not a raw
+ * key) when missing, but they are tracked here too so every locale stays in
+ * full parity rather than silently falling back to English.
  */
 const REQUIRED_WIDGET_STICKERS_KEYS = [
   'collectionTitle',
@@ -52,6 +56,11 @@ const REQUIRED_WIDGET_STICKERS_KEYS = [
   'deleteSticker',
   'dragFromLibrary',
   'stickerAdded',
+  'filterAll',
+  'filterFavorites',
+  'filterMine',
+  'reorganizeSticker',
+  'favoriteSticker',
 ] as const;
 
 // ─── EN baseline ─────────────────────────────────────────────────────────────

--- a/tests/i18n/widgetStickersLocales.test.ts
+++ b/tests/i18n/widgetStickersLocales.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test for the missing widgets.stickers sub-namespace in DE and FR.
+ *
+ * The `widgets.stickers` namespace was added to EN when the Sticker Book widget
+ * received its i18n pass.  The companion `admin.stickers` namespace (used by
+ * StickerLibraryModal) was correctly propagated to all locales in #1788, but
+ * the `widgets.stickers` path — which is what StickerBookWidget.tsx resolves —
+ * was never added to DE or FR.
+ *
+ * Affected call sites in `components/widgets/stickers/StickerBookWidget.tsx`
+ * and `components/admin/StickerLibraryModal.tsx` that use the widgets.stickers
+ * path WITHOUT a `defaultValue` fallback:
+ *
+ *   t('widgets.stickers.dragOrClick')      — line 94
+ *   t('widgets.stickers.deleteSticker')    — lines 155, 156
+ *   t('widgets.stickers.stickerAdded')     — line 396
+ *   t('widgets.stickers.collectionTitle')  — line 482
+ *   t('widgets.stickers.clearAll')         — line 493
+ *   t('widgets.stickers.wait')             — line 527
+ *   t('widgets.stickers.dropOrPaste')      — lines 627, 292 (StickerLibraryModal)
+ *   t('widgets.stickers.toAddCustom')      — line 633
+ *   t('widgets.stickers.dragFromLibrary')  — line 696
+ *
+ * When a German or French user opens the Sticker Book widget, every one of
+ * these strings renders as the raw key path (e.g. "widgets.stickers.clearAll")
+ * instead of a translated or even English string.
+ *
+ * This test loads each locale JSON directly so the assertion fires even before
+ * the i18next runtime would attempt (and silently skip) the fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+/**
+ * Keys within widgets.stickers that StickerBookWidget.tsx calls t() on without
+ * a defaultValue fallback — these show raw key paths to non-EN users if absent.
+ */
+const REQUIRED_WIDGET_STICKERS_KEYS = [
+  'collectionTitle',
+  'clearAll',
+  'wait',
+  'dropOrPaste',
+  'toAddCustom',
+  'essentials',
+  'globalCollection',
+  'myCollection',
+  'dragOrClick',
+  'deleteSticker',
+  'dragFromLibrary',
+  'stickerAdded',
+] as const;
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — widgets.stickers baseline', () => {
+  it('has a widgets.stickers section', () => {
+    expect(en).toHaveProperty(['widgets', 'stickers']);
+  });
+
+  it('has all required widgets.stickers keys', () => {
+    for (const key of REQUIRED_WIDGET_STICKERS_KEYS) {
+      expect(
+        en.widgets.stickers,
+        `en.widgets.stickers.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity ─────────────────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
+])(
+  '$code locale — widgets.stickers parity with EN',
+  ({ code, locale }) => {
+    it(`${code}: has a widgets.stickers section`, () => {
+      expect(
+        locale,
+        `${code}.widgets.stickers section is entirely missing`
+      ).toHaveProperty(['widgets', 'stickers']);
+    });
+
+    it(`${code}: has all required widgets.stickers keys`, () => {
+      for (const key of REQUIRED_WIDGET_STICKERS_KEYS) {
+        expect(
+          locale,
+          `${code}.widgets.stickers.${key} is missing`
+        ).toHaveProperty(['widgets', 'stickers', key]);
+      }
+    });
+  }
+);


### PR DESCRIPTION
## Root Cause

The `widgets.stickers` namespace was added to EN for the Sticker Book widget but never propagated to DE or FR. ES had it correctly. Twelve keys — including `clearAll`, `deleteSticker`, `stickerAdded`, and `dragFromLibrary` — are called in `StickerBookWidget.tsx` via bare `t('widgets.stickers.<key>')` with **no `defaultValue` fallback**, so German and French users see raw key paths rendered in every sticker-related button, tooltip, and toast.

Note: the related `admin.stickers` namespace (used by `StickerLibraryModal`) was correctly translated in #1788. The widget-level path is separate and was missed.

## Fix

Added `widgets.stickers` to `locales/de.json` and `locales/fr.json`, populated from the existing `admin.stickers` translations already human-translated in #1788. No new translation work required.

## Band-Aid Rejected

Adding `defaultValue` to each `t()` call site — would suppress the visible symptom but leave the namespace missing, and any future keys added to EN would again be absent from DE/FR.

## Regression Test

New `tests/i18n/widgetStickersLocales.test.ts` following the pattern of `widgetWindowLocales.test.ts` (#1804):
- **Before fix**: 4 failed | 4 passed (8) — DE and FR missing `widgets.stickers` entirely
- **After fix**: 8 passed (8)

## Risk

**Contained** — locale JSON additions only; no logic changes.

https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFfvp5iAmb1hveURBiNWqR)_