### PR TITLE
fix(auth): hard-disable VITE_AUTH_BYPASS in production builds

### DIFF
--- a/config/firebase.ts
+++ b/config/firebase.ts
@@ -17,8 +17,26 @@ export const isConfigured = !!apiKey;
  * IMPORTANT SECURITY WARNING:
  * - This must only ever be used in development or automated testing.
  * - It must NEVER be enabled in production, as it bypasses normal auth.
+ *
+ * Defense-in-depth: the bypass is honored ONLY when the app is served from a
+ * localhost origin (local `pnpm dev` and the Playwright E2E `vite preview`
+ * server, both on localhost:3000). On ANY deployed origin — spartboard.web.app,
+ * *.firebaseapp.com, dev-preview channels — it is force-disabled at runtime,
+ * regardless of how the bundle was built. So even if a production bundle is
+ * accidentally built with VITE_AUTH_BYPASS=true and shipped via a manual
+ * `firebase deploy`, the deployed app can never authenticate as the mock user.
+ *
+ * This is a runtime ORIGIN check rather than `import.meta.env.PROD` on purpose:
+ * the E2E suite runs a *production* build (`vite build && vite preview`) on
+ * localhost and legitimately needs the bypass, so a `!PROD` guard would break
+ * it. Origin distinguishes "served locally for dev/test" from "deployed".
  */
-export const isAuthBypass = import.meta.env.VITE_AUTH_BYPASS === 'true';
+const isLocalhostOrigin =
+  typeof window !== 'undefined' &&
+  /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/.test(window.location.hostname);
+
+export const isAuthBypass =
+  import.meta.env.VITE_AUTH_BYPASS === 'true' && isLocalhostOrigin;
 
 let app: FirebaseApp;
 let auth: Auth;


### PR DESCRIPTION
## What

Force-disables the auth-bypass mock user on any **deployed** origin. `config/firebase.ts`:

```ts
const isLocalhostOrigin =
  typeof window !== 'undefined' &&
  /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/.test(window.location.hostname);

export const isAuthBypass =
  import.meta.env.VITE_AUTH_BYPASS === 'true' && isLocalhostOrigin;
```

## Why

A manual `firebase deploy` of a locally-built bundle whose `.env.local` had `VITE_AUTH_BYPASS=true` shipped the **mock user to production** (`spartboard.web.app`) — every visitor was auto-"signed in" as `mock@example.com` with full client-side admin and a `MOCK_ACCESS_TOKEN` Google Drive 401 storm. Prod was remediated by a clean CI redeploy; this PR removes the failure mode.

## Why an origin check, not `import.meta.env.PROD`

The E2E suite runs a **production build** in CI — `playwright.config.ts` line 36: `process.env.CI ? 'pnpm run build && pnpm run preview' : 'pnpm dev'` — with `VITE_AUTH_BYPASS='true'`. A `!import.meta.env.PROD` guard evaluates to `false` there, disabling the bypass the suite depends on, so every test sits on the login screen and the **E2E job hangs**. A runtime **origin** check distinguishes "served on localhost for dev/test" from "deployed", which is the property we actually care about — and it's strictly stronger: it disables bypass on `spartboard.web.app` even if a bundle were built with the flag baked in.

## Impact

- **Deployed origins** (web.app, firebaseapp.com, dev previews): bypass hard-off, always. ✅
- **Local dev** (`pnpm dev`, localhost): bypass works when `VITE_AUTH_BYPASS=true`. ✅
- **E2E** (`build && preview` on localhost:3000): bypass works → suite passes. ✅
- **Unit tests**: all reference `isAuthBypass` via `vi.mock('@/config/firebase', …)`, so the real computation is overridden — unaffected. ✅

## Validation

- `prettier --check`, `eslint --max-warnings 0`, `tsc --noEmit` clean
- E2E green in CI (the prior `!PROD` attempt hung; this run passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
