### PR TITLE
fix(lti): require a Google session in the deep-link picker

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -43,6 +43,7 @@ import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { getQuizBehavior } from '@/utils/quizBehavior';
 import { quizMaxPoints } from '@/utils/quizMaxPoints';
 import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
 import {
   AddonShell,
   AddonHeader,
@@ -145,9 +146,20 @@ export const LtiDeepLinkPicker: React.FC = () => {
     Map<string, { quizCode: string; maxPoints: number }>
   >(new Map());
 
-  const { user, signInWithGoogle } = useAuth();
+  const { user, signInWithGoogle, googleAccessToken } = useAuth();
   const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
   const { createAssignment } = useQuizAssignments(user?.uid);
+
+  // The picker lists + loads the teacher's OWN Drive-backed quiz library, so it
+  // needs a real Google sign-in (uid + Drive token) — NOT just any Firebase
+  // session. Inside Schoology's cross-origin iframe, partitioned-storage auth
+  // can restore a leftover `studentRole` custom-token session from a prior
+  // student launch; that has a uid (empty library) but no `google.com` provider
+  // and no Drive token. Gating on `!!user` showed that stale session the (empty)
+  // dropdown and skipped the sign-in card entirely — the reported bug. Require a
+  // Google session + Drive token so the sign-in card shows until the teacher
+  // signs in as themselves.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
 
   const selectedQuiz = useMemo(
     () => quizzes.find((q) => q.id === selectedQuizId),
@@ -326,11 +338,12 @@ export const LtiDeepLinkPicker: React.FC = () => {
             </p>
           </div>
         </AddonCard>
-      ) : !user ? (
+      ) : !teacherReady ? (
         <AddonCard className="p-6">
           <p className="mb-4 text-sm text-slate-500">
-            Sign in with your school Google account to load your SpartBoard quiz
-            library.
+            {user
+              ? 'Sign in with your teacher Google account to load your SpartBoard quiz library.'
+              : 'Sign in with your school Google account to load your SpartBoard quiz library.'}
           </p>
           <AddonButton onClick={() => void signIn()} loading={busy}>
             Sign in to SpartBoard

--- a/utils/googleSession.test.ts
+++ b/utils/googleSession.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isGoogleSession } from './googleSession';
+
+describe('isGoogleSession', () => {
+  it('is true for a Google-provider user', () => {
+    expect(
+      isGoogleSession({ providerData: [{ providerId: 'google.com' }] })
+    ).toBe(true);
+  });
+
+  it('is true when google.com is one of several providers', () => {
+    expect(
+      isGoogleSession({
+        providerData: [
+          { providerId: 'password' },
+          { providerId: 'google.com' },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  // The bug: a leftover studentRole custom-token session in a partitioned LTI
+  // iframe has an empty providerData but is still a "user". The picker used to
+  // treat it as signed in → skipped the Google sign-in card and listed the
+  // wrong uid's (empty) quiz library.
+  it('is false for a custom-token / studentRole session (empty providerData)', () => {
+    expect(isGoogleSession({ providerData: [] })).toBe(false);
+  });
+
+  it('is false for an anonymous session (empty providerData)', () => {
+    expect(isGoogleSession({ providerData: [] })).toBe(false);
+  });
+
+  it('is false when only a non-Google provider is present', () => {
+    expect(
+      isGoogleSession({ providerData: [{ providerId: 'password' }] })
+    ).toBe(false);
+  });
+
+  it('is false for null / undefined / missing providerData', () => {
+    expect(isGoogleSession(null)).toBe(false);
+    expect(isGoogleSession(undefined)).toBe(false);
+    expect(isGoogleSession({})).toBe(false);
+  });
+});

--- a/utils/googleSession.ts
+++ b/utils/googleSession.ts
@@ -1,0 +1,34 @@
+/**
+ * Google-session guard for teacher surfaces rendered inside cross-origin
+ * iframes (the Schoology LTI deep-link picker / grader, the Google Classroom
+ * add-on discovery route).
+ *
+ * Why this exists: inside a cross-origin iframe, Firebase Auth uses partitioned
+ * storage, and `onAuthStateChanged` restores ANY Firebase session left in that
+ * partition — including a leftover `studentRole` custom-token user from a prior
+ * student launch in the SAME partition. Those teacher surfaces only function as
+ * the teacher's own Google account (they list/load the teacher's Drive-backed
+ * quiz library), so a bare `!!user` check is wrong: it treats a student/anonymous
+ * session as "signed in", silently operating under the wrong uid (an empty
+ * library) and never offering the Google sign-in the teacher actually needs.
+ *
+ * Anonymous and custom-token sessions carry an empty `providerData`; only an
+ * interactive Google sign-in adds a `google.com` provider entry. Gate on that.
+ */
+
+/** The slice of a Firebase `UserInfo`/`User` this guard reads. */
+type ProviderInfoLike = { readonly providerId?: string | null };
+
+/**
+ * True when the Firebase user authenticated through Google (the `google.com`
+ * provider) — i.e. a real teacher session, not an anonymous or custom-token
+ * (e.g. `studentRole`) session. Returns false for null/undefined.
+ */
+export function isGoogleSession(
+  user:
+    | { readonly providerData?: ReadonlyArray<ProviderInfoLike> }
+    | null
+    | undefined
+): boolean {
+  return !!user?.providerData?.some((p) => p.providerId === 'google.com');
+}


### PR DESCRIPTION
## Problem

Creating a SpartBoard quiz from Schoology (**Add Materials → SpartBoard**) showed an **empty quiz dropdown with no sign-in prompt**, so teachers couldn't attach any of their existing quizzes.

The server side was never the issue — live Cloud Function logs show every launch validating correctly (`role=teacher`, `messageType=LtiDeepLinkingRequest`, `hasDeepLinking=true`). The bug was client-side in the deep-link picker.

## Root cause

Inside Schoology's cross-origin iframe, Firebase Auth uses **partitioned storage**, and `onAuthStateChanged` ([AuthContext.tsx](context/AuthContext.tsx)) restores **any** session left in that partition — including a leftover `studentRole` custom-token session from a prior student launch (which has a uid but an empty `providerData` and no Drive token).

The picker gated its library on a bare `!user`, so:
- the stale session made `user` truthy → the "Sign in to SpartBoard" card was skipped (**"never prompted to authorize"**), and
- `useQuiz(user.uid)` listed quizzes under the student pseudonym's uid → **empty library**.

## Fix

- New shared guard `utils/googleSession.ts` → `isGoogleSession(user)` (true only for a real `google.com` provider session; anonymous / custom-token sessions have empty `providerData`).
- `LtiDeepLinkPicker` now gates on `isGoogleSession(user) && !!googleAccessToken` — the library genuinely needs the teacher's own uid **and** a Drive token. The sign-in card shows until the teacher signs in as themselves; the Google popup replaces the stale session and the real library loads.
- `utils/googleSession.test.ts` — 6 unit tests covering the empty-`providerData` bug pattern.

## Verification

- `googleSession.test.ts` — 6/6 pass
- `tsc --noEmit` — 0 errors
- `eslint --max-warnings 0` — clean
- `prettier --check` — clean

**Live Schoology end-to-end test still pending** — needs this on the live channel (`spartboard.web.app`), i.e. promoted `dev-paul → main`. The remaining unknown to confirm live: that the Google sign-in popup works inside Schoology's iframe (the Classroom add-on uses the identical popup and works, so this is expected to pass).

Cherry-picked from `feat/schoology-lti` (`150495e3`) onto `dev-paul`, since `feat/schoology-lti` is stale post-#1821 squash.

## Follow-up (separate)

The Classroom add-on `TeacherDiscoveryRoute` and the (flag-off) LTI grader share the same latent `!user` gate and should adopt the same `isGoogleSession` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)