### PR TITLE
Promote dev-paul → main: LTI picker Google-session fix (#1835) + auth-bypass prod guard (#1834)

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -147,8 +147,6 @@ export const LtiDeepLinkPicker: React.FC = () => {
   >(new Map());
 
   const { user, signInWithGoogle, googleAccessToken } = useAuth();
-  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
-  const { createAssignment } = useQuizAssignments(user?.uid);
 
   // The picker lists + loads the teacher's OWN Drive-backed quiz library, so it
   // needs a real Google sign-in (uid + Drive token) — NOT just any Firebase
@@ -160,6 +158,20 @@ export const LtiDeepLinkPicker: React.FC = () => {
   // Google session + Drive token so the sign-in card shows until the teacher
   // signs in as themselves.
   const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+
+  // Only subscribe to the teacher's library/assignments once they're a real
+  // Google session. Passing a stale-session uid (e.g. a restored studentRole
+  // user) would open Firestore listeners under a uid whose library the gated UI
+  // never shows — wasted reads. Both hooks treat an undefined uid as "no
+  // library" (they reset to empty), so this just defers the subscription until
+  // the teacher signs in. (Reviewer suggestion, PR #1835/#1836.)
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
+  const { createAssignment } = useQuizAssignments(libraryUid);
 
   const selectedQuiz = useMemo(
     () => quizzes.find((q) => q.id === selectedQuizId),

--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -43,6 +43,7 @@ import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { getQuizBehavior } from '@/utils/quizBehavior';
 import { quizMaxPoints } from '@/utils/quizMaxPoints';
 import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
 import {
   AddonShell,
   AddonHeader,
@@ -145,9 +146,20 @@ export const LtiDeepLinkPicker: React.FC = () => {
     Map<string, { quizCode: string; maxPoints: number }>
   >(new Map());
 
-  const { user, signInWithGoogle } = useAuth();
+  const { user, signInWithGoogle, googleAccessToken } = useAuth();
   const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
   const { createAssignment } = useQuizAssignments(user?.uid);
+
+  // The picker lists + loads the teacher's OWN Drive-backed quiz library, so it
+  // needs a real Google sign-in (uid + Drive token) — NOT just any Firebase
+  // session. Inside Schoology's cross-origin iframe, partitioned-storage auth
+  // can restore a leftover `studentRole` custom-token session from a prior
+  // student launch; that has a uid (empty library) but no `google.com` provider
+  // and no Drive token. Gating on `!!user` showed that stale session the (empty)
+  // dropdown and skipped the sign-in card entirely — the reported bug. Require a
+  // Google session + Drive token so the sign-in card shows until the teacher
+  // signs in as themselves.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
 
   const selectedQuiz = useMemo(
     () => quizzes.find((q) => q.id === selectedQuizId),
@@ -326,11 +338,12 @@ export const LtiDeepLinkPicker: React.FC = () => {
             </p>
           </div>
         </AddonCard>
-      ) : !user ? (
+      ) : !teacherReady ? (
         <AddonCard className="p-6">
           <p className="mb-4 text-sm text-slate-500">
-            Sign in with your school Google account to load your SpartBoard quiz
-            library.
+            {user
+              ? 'Sign in with your teacher Google account to load your SpartBoard quiz library.'
+              : 'Sign in with your school Google account to load your SpartBoard quiz library.'}
           </p>
           <AddonButton onClick={() => void signIn()} loading={busy}>
             Sign in to SpartBoard

--- a/config/firebase.ts
+++ b/config/firebase.ts
@@ -17,8 +17,26 @@ export const isConfigured = !!apiKey;
  * IMPORTANT SECURITY WARNING:
  * - This must only ever be used in development or automated testing.
  * - It must NEVER be enabled in production, as it bypasses normal auth.
+ *
+ * Defense-in-depth: the bypass is honored ONLY when the app is served from a
+ * localhost origin (local `pnpm dev` and the Playwright E2E `vite preview`
+ * server, both on localhost:3000). On ANY deployed origin — spartboard.web.app,
+ * *.firebaseapp.com, dev-preview channels — it is force-disabled at runtime,
+ * regardless of how the bundle was built. So even if a production bundle is
+ * accidentally built with VITE_AUTH_BYPASS=true and shipped via a manual
+ * `firebase deploy`, the deployed app can never authenticate as the mock user.
+ *
+ * This is a runtime ORIGIN check rather than `import.meta.env.PROD` on purpose:
+ * the E2E suite runs a *production* build (`vite build && vite preview`) on
+ * localhost and legitimately needs the bypass, so a `!PROD` guard would break
+ * it. Origin distinguishes "served locally for dev/test" from "deployed".
  */
-export const isAuthBypass = import.meta.env.VITE_AUTH_BYPASS === 'true';
+const isLocalhostOrigin =
+  typeof window !== 'undefined' &&
+  /^(localhost|127\.0\.0\.1|\[::1\]|::1)$/.test(window.location.hostname);
+
+export const isAuthBypass =
+  import.meta.env.VITE_AUTH_BYPASS === 'true' && isLocalhostOrigin;
 
 let app: FirebaseApp;
 let auth: Auth;

--- a/utils/googleSession.test.ts
+++ b/utils/googleSession.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isGoogleSession } from './googleSession';
+
+describe('isGoogleSession', () => {
+  it('is true for a Google-provider user', () => {
+    expect(
+      isGoogleSession({ providerData: [{ providerId: 'google.com' }] })
+    ).toBe(true);
+  });
+
+  it('is true when google.com is one of several providers', () => {
+    expect(
+      isGoogleSession({
+        providerData: [
+          { providerId: 'password' },
+          { providerId: 'google.com' },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  // The bug: a leftover studentRole custom-token session in a partitioned LTI
+  // iframe has an empty providerData but is still a "user". The picker used to
+  // treat it as signed in → skipped the Google sign-in card and listed the
+  // wrong uid's (empty) quiz library.
+  it('is false for a custom-token / studentRole session (empty providerData)', () => {
+    expect(isGoogleSession({ providerData: [] })).toBe(false);
+  });
+
+  it('is false for an anonymous session (empty providerData)', () => {
+    expect(isGoogleSession({ providerData: [] })).toBe(false);
+  });
+
+  it('is false when only a non-Google provider is present', () => {
+    expect(
+      isGoogleSession({ providerData: [{ providerId: 'password' }] })
+    ).toBe(false);
+  });
+
+  it('is false for null / undefined / missing providerData', () => {
+    expect(isGoogleSession(null)).toBe(false);
+    expect(isGoogleSession(undefined)).toBe(false);
+    expect(isGoogleSession({})).toBe(false);
+  });
+});

--- a/utils/googleSession.ts
+++ b/utils/googleSession.ts
@@ -1,0 +1,34 @@
+/**
+ * Google-session guard for teacher surfaces rendered inside cross-origin
+ * iframes (the Schoology LTI deep-link picker / grader, the Google Classroom
+ * add-on discovery route).
+ *
+ * Why this exists: inside a cross-origin iframe, Firebase Auth uses partitioned
+ * storage, and `onAuthStateChanged` restores ANY Firebase session left in that
+ * partition — including a leftover `studentRole` custom-token user from a prior
+ * student launch in the SAME partition. Those teacher surfaces only function as
+ * the teacher's own Google account (they list/load the teacher's Drive-backed
+ * quiz library), so a bare `!!user` check is wrong: it treats a student/anonymous
+ * session as "signed in", silently operating under the wrong uid (an empty
+ * library) and never offering the Google sign-in the teacher actually needs.
+ *
+ * Anonymous and custom-token sessions carry an empty `providerData`; only an
+ * interactive Google sign-in adds a `google.com` provider entry. Gate on that.
+ */
+
+/** The slice of a Firebase `UserInfo`/`User` this guard reads. */
+type ProviderInfoLike = { readonly providerId?: string | null };
+
+/**
+ * True when the Firebase user authenticated through Google (the `google.com`
+ * provider) — i.e. a real teacher session, not an anonymous or custom-token
+ * (e.g. `studentRole`) session. Returns false for null/undefined.
+ */
+export function isGoogleSession(
+  user:
+    | { readonly providerData?: ReadonlyArray<ProviderInfoLike> }
+    | null
+    | undefined
+): boolean {
+  return !!user?.providerData?.some((p) => p.providerId === 'google.com');
+}


### PR DESCRIPTION
Promotes `dev-paul` → `main`. **Merge with a regular merge commit — NOT squash** (per the dev-branch flow). This push to `main` is what triggers the production deploy to `spartboard.web.app`.

## What's being promoted (2 commits, 4 files)

- **#1835 — `fix(lti): require a Google session in the deep-link picker`**
  Fixes the reported Schoology bug: **Add Materials → SpartBoard** showed an empty quiz dropdown with no sign-in prompt, because the picker treated any persisted iframe Firebase session (e.g. a leftover `studentRole` session in Schoology's partitioned storage) as the signed-in teacher. Now gates on a real `google.com` session + Drive token, so the sign-in card shows until the teacher signs in as themselves. **This is what we need on the live channel to run the end-to-end Schoology test.**

- **#1834 — `fix(auth): force-disable VITE_AUTH_BYPASS on deployed origins`**
  The permanent guard that neutralizes `VITE_AUTH_BYPASS` in prod builds (defense-in-depth for the earlier prod auth-bypass incident). Currently on `dev-paul` but not yet `main` — this promotion lands it on `main`/prod.

## After deploy

Re-launch **Add Materials → SpartBoard** in Schoology → expect the **"Sign in to SpartBoard"** card → Google popup → real quiz library loads.

Remaining unknown to confirm live: that the Google sign-in popup works inside Schoology's iframe (the Classroom add-on uses the identical popup and works, so this is expected to pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)