### PR TITLE
fix(lti): defer picker library listeners until teacher is Google-signed-in

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -147,8 +147,6 @@ export const LtiDeepLinkPicker: React.FC = () => {
   >(new Map());
 
   const { user, signInWithGoogle, googleAccessToken } = useAuth();
-  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
-  const { createAssignment } = useQuizAssignments(user?.uid);
 
   // The picker lists + loads the teacher's OWN Drive-backed quiz library, so it
   // needs a real Google sign-in (uid + Drive token) — NOT just any Firebase
@@ -160,6 +158,20 @@ export const LtiDeepLinkPicker: React.FC = () => {
   // Google session + Drive token so the sign-in card shows until the teacher
   // signs in as themselves.
   const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+
+  // Only subscribe to the teacher's library/assignments once they're a real
+  // Google session. Passing a stale-session uid (e.g. a restored studentRole
+  // user) would open Firestore listeners under a uid whose library the gated UI
+  // never shows — wasted reads. Both hooks treat an undefined uid as "no
+  // library" (they reset to empty), so this just defers the subscription until
+  // the teacher signs in. (Reviewer suggestion, PR #1835/#1836.)
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
+  const { createAssignment } = useQuizAssignments(libraryUid);
 
   const selectedQuiz = useMemo(
     () => quizzes.find((q) => q.id === selectedQuizId),


### PR DESCRIPTION
Reviewer follow-up to #1835 — both **Gemini** and **Copilot** flagged the same point on `LtiDeepLinkPicker.tsx`.

## What

The picker passed `user?.uid` directly into `useQuiz` / `useQuizAssignments`. When a stale `studentRole` session is restored in Schoology's partitioned iframe, that opens Firestore real-time listeners under a uid whose library the (gated) UI never shows — wasted reads.

Gate the hooks' uid on `teacherReady`:

```ts
const libraryUid = teacherReady ? user?.uid : undefined;
const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(libraryUid);
const { createAssignment } = useQuizAssignments(libraryUid);
```

Both hooks already treat an `undefined` uid as "no library" (they reset to empty via their adjust-state-on-uid-change path), so this only **defers** the subscription until the teacher signs in. The sign-in gate behavior itself is unchanged.

## Verification

- `tsc --noEmit` — 0 errors
- `eslint --max-warnings 0` — clean
- `prettier --check` — clean
- `googleSession.test.ts` — 6/6 pass

Once merged to `dev-paul`, it rolls into the pending `dev-paul → main` promotion (#1836).

🤖 Generated with [Claude Code](https://claude.com/claude-code)