### PR TITLE
fix(iframe-auth): gate Classroom add-on + LTI teacher surfaces on a real Google session

### DIFF
--- a/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, vi, expect, beforeEach, type Mock } from 'vitest';
+
+import { ClassroomAddonTeacherSpike } from './TeacherDiscoveryRoute';
+import { useAuth } from '@/context/useAuth';
+import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { useVideoActivity } from '@/hooks/useVideoActivity';
+import { useVideoActivityAssignments } from '@/hooks/useVideoActivityAssignments';
+import { usePlcs } from '@/hooks/usePlcs';
+
+// The route lives inside the Google Classroom add-on iframe. It only needs the
+// hooks' return values — the real Firebase wiring is irrelevant to the sign-in
+// gate, so each is mocked to a benign default below.
+vi.mock('@/context/useAuth');
+vi.mock('@/hooks/useQuiz');
+vi.mock('@/hooks/useQuizAssignments');
+vi.mock('@/hooks/useVideoActivity');
+vi.mock('@/hooks/useVideoActivityAssignments');
+vi.mock('@/hooks/usePlcs');
+vi.mock('@/config/firebase', () => ({ db: {}, functions: {} }));
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+  updateDoc: vi.fn(),
+}));
+vi.mock('firebase/functions', () => ({ httpsCallable: vi.fn() }));
+vi.mock('./gisOAuth', () => ({
+  ensureGis: vi.fn(),
+  requestAccessToken: vi.fn(),
+}));
+
+/** A real, interactive Google teacher sign-in: google.com provider + Drive token. */
+const GOOGLE_USER = {
+  uid: 'teacher-uid',
+  providerData: [{ providerId: 'google.com' }],
+  displayName: 'Ms Teacher',
+  email: 'teacher@school.org',
+};
+
+/**
+ * The bug: a leftover custom-token `studentRole` session restored from the
+ * iframe's partitioned storage. It has a uid (so `!!user` is true) but an empty
+ * `providerData` and no Drive token.
+ */
+const STUDENT_ROLE_USER = {
+  uid: 'student-pseudonym-uid',
+  providerData: [] as { providerId: string }[],
+  displayName: null,
+  email: null,
+};
+
+type AuthShape = {
+  user: typeof GOOGLE_USER | typeof STUDENT_ROLE_USER | null;
+  googleAccessToken: string | null;
+};
+
+function setAuth({ user, googleAccessToken }: AuthShape): void {
+  (useAuth as Mock).mockReturnValue({
+    user,
+    signInWithGoogle: vi.fn().mockResolvedValue(undefined),
+    googleAccessToken,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useQuiz as Mock).mockReturnValue({
+    quizzes: [],
+    loadQuizData: vi.fn(),
+    loading: false,
+  });
+  (useQuizAssignments as Mock).mockReturnValue({ createAssignment: vi.fn() });
+  (useVideoActivity as Mock).mockReturnValue({
+    activities: [],
+    loadActivityData: vi.fn(),
+    loading: false,
+  });
+  (useVideoActivityAssignments as Mock).mockReturnValue({
+    createAssignment: vi.fn(),
+  });
+  (usePlcs as Mock).mockReturnValue({ plcs: [] });
+});
+
+describe('ClassroomAddonTeacherSpike (Classroom add-on discovery) — Google-session gate', () => {
+  const signInButton = () =>
+    screen.queryByRole('button', { name: /sign in to spartboard/i });
+  const libraryPicker = () =>
+    screen.queryByRole('tablist', { name: /activity type/i });
+
+  it('shows the sign-in card (not the library) for a stale studentRole session', () => {
+    setAuth({ user: STUDENT_ROLE_USER, googleAccessToken: null });
+    render(<ClassroomAddonTeacherSpike />);
+
+    // The reported bug was the opposite: a stale session was treated as
+    // "signed in", showing the empty library and never the sign-in card.
+    expect(signInButton()).toBeInTheDocument();
+    expect(libraryPicker()).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+    // ...and the library listeners are deferred — no Firestore subscription is
+    // opened under the stale (student) uid (#1837 reviewer concern).
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
+    expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
+  });
+
+  it('shows the sign-in card with the school-account copy for an anonymous (null) session', () => {
+    setAuth({ user: null, googleAccessToken: null });
+    render(<ClassroomAddonTeacherSpike />);
+
+    expect(signInButton()).toBeInTheDocument();
+    expect(libraryPicker()).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/sign in with your school google account/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows the library for a real Google teacher with a Drive token (no regression)', () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: 'drive-token' });
+    render(<ClassroomAddonTeacherSpike />);
+
+    // The working Classroom attach flow must still reach the picker.
+    expect(libraryPicker()).toBeInTheDocument();
+    expect(signInButton()).not.toBeInTheDocument();
+    // ...and the library subscribes under the teacher's own uid.
+    expect(useQuiz).toHaveBeenCalledWith(GOOGLE_USER.uid);
+    expect(useQuizAssignments).toHaveBeenCalledWith(GOOGLE_USER.uid);
+  });
+
+  it('shows the sign-in card for a Google session whose Drive token is missing/expired', () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: null });
+    render(<ClassroomAddonTeacherSpike />);
+
+    // The library genuinely needs the Drive token to load, so an expired token
+    // re-prompts rather than showing an unusable empty picker.
+    expect(signInButton()).toBeInTheDocument();
+    expect(libraryPicker()).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
@@ -100,10 +100,15 @@ describe('ClassroomAddonTeacherSpike (Classroom add-on discovery) — Google-ses
     expect(
       screen.getByText(/sign in with your teacher google account/i)
     ).toBeInTheDocument();
-    // ...and the library listeners are deferred — no Firestore subscription is
-    // opened under the stale (student) uid (#1837 reviewer concern).
+    // ...and ALL library listeners are deferred — no Firestore subscription is
+    // opened under the stale (student) uid (#1837 reviewer concern). The route
+    // loads both the quiz and the video-activity libraries, so assert both.
     expect(useQuiz).toHaveBeenCalledWith(undefined);
     expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
+    expect(useVideoActivity).toHaveBeenCalledWith(undefined);
+    expect(useVideoActivityAssignments).toHaveBeenCalledWith(undefined);
+    // ...and the PLC snapshot is disabled so it can't open under the stale uid.
+    expect(usePlcs).toHaveBeenCalledWith({ enabled: false });
   });
 
   it('shows the sign-in card with the school-account copy for an anonymous (null) session', () => {
@@ -124,9 +129,13 @@ describe('ClassroomAddonTeacherSpike (Classroom add-on discovery) — Google-ses
     // The working Classroom attach flow must still reach the picker.
     expect(libraryPicker()).toBeInTheDocument();
     expect(signInButton()).not.toBeInTheDocument();
-    // ...and the library subscribes under the teacher's own uid.
+    // ...and BOTH libraries subscribe under the teacher's own uid.
     expect(useQuiz).toHaveBeenCalledWith(GOOGLE_USER.uid);
     expect(useQuizAssignments).toHaveBeenCalledWith(GOOGLE_USER.uid);
+    expect(useVideoActivity).toHaveBeenCalledWith(GOOGLE_USER.uid);
+    expect(useVideoActivityAssignments).toHaveBeenCalledWith(GOOGLE_USER.uid);
+    // ...and the PLC snapshot is enabled for the real teacher session.
+    expect(usePlcs).toHaveBeenCalledWith({ enabled: true });
   });
 
   it('shows the sign-in card for a Google session whose Drive token is missing/expired', () => {
@@ -140,5 +149,13 @@ describe('ClassroomAddonTeacherSpike (Classroom add-on discovery) — Google-ses
     expect(
       screen.getByText(/sign in with your teacher google account/i)
     ).toBeInTheDocument();
+    // A Google session without a Drive token is not `teacherReady`, so every
+    // library hook must still be deferred (undefined) — no listeners open until
+    // the token is re-granted.
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
+    expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
+    expect(useVideoActivity).toHaveBeenCalledWith(undefined);
+    expect(useVideoActivityAssignments).toHaveBeenCalledWith(undefined);
+    expect(usePlcs).toHaveBeenCalledWith({ enabled: false });
   });
 });

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -45,6 +45,7 @@ import {
 } from '@/utils/videoActivityBehavior';
 import { buildPlcLinkage } from '@/utils/plcLinkage';
 import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
 import { ensureGis, requestAccessToken } from './gisOAuth';
 import {
   ClipboardList,
@@ -145,15 +146,38 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const existingAttachmentId = params.get('attachmentId') ?? '';
 
   const { user, signInWithGoogle, googleAccessToken } = useAuth();
-  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
-  const { createAssignment } = useQuizAssignments(user?.uid);
+
+  // The discovery route lists + loads the teacher's OWN Drive-backed quiz /
+  // video-activity library and then attaches it, so it needs a real Google
+  // sign-in (uid + Drive token) — NOT just any Firebase session. Inside the
+  // Classroom add-on's cross-origin iframe, partitioned-storage auth can restore
+  // a leftover `studentRole` custom-token session from a prior student launch in
+  // the same partition; that has a uid (empty library) but no `google.com`
+  // provider and no Drive token. Gating on `!!user` would show that stale session
+  // an empty picker and skip the sign-in card. Require a Google session + Drive
+  // token so the sign-in card shows until the teacher signs in as themselves.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+
+  // Only subscribe to the teacher's library/assignments once they're a real
+  // Google session. Passing a stale-session uid (e.g. a restored studentRole
+  // user) would open Firestore listeners under a uid whose library the gated UI
+  // never shows — wasted reads. The library hooks treat an undefined uid as "no
+  // library" (they reset to empty), so this just defers the subscription until
+  // the teacher signs in. (Mirrors the deep-link picker, PR #1837.)
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
+  const { createAssignment } = useQuizAssignments(libraryUid);
   const {
     activities,
     loadActivityData,
     loading: activitiesLoading,
-  } = useVideoActivity(user?.uid);
+  } = useVideoActivity(libraryUid);
   const { createAssignment: createVideoActivityAssignment } =
-    useVideoActivityAssignments(user?.uid);
+    useVideoActivityAssignments(libraryUid);
   // PLC list for the quiz "Share with PLC" picker. usePlcs() reads `useAuth`
   // (mounted on this route) — no DashboardProvider required.
   const { plcs } = usePlcs();
@@ -757,11 +781,12 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
             </p>
           </div>
         </AddonCard>
-      ) : !user ? (
+      ) : !teacherReady ? (
         <AddonCard className="p-6">
           <p className="mb-4 text-sm text-slate-500">
-            Sign in with your school Google account to load your SpartBoard
-            library.
+            {user
+              ? 'Sign in with your teacher Google account to load your SpartBoard library.'
+              : 'Sign in with your school Google account to load your SpartBoard library.'}
           </p>
           <AddonButton onClick={() => void signIn()} loading={busy}>
             Sign in to SpartBoard

--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -179,8 +179,11 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
   const { createAssignment: createVideoActivityAssignment } =
     useVideoActivityAssignments(libraryUid);
   // PLC list for the quiz "Share with PLC" picker. usePlcs() reads `useAuth`
-  // (mounted on this route) — no DashboardProvider required.
-  const { plcs } = usePlcs();
+  // (mounted on this route) — no DashboardProvider required. Gate the snapshot
+  // on `teacherReady` so a restored studentRole session (truthy `user`, but
+  // shown the sign-in card) doesn't open a live PLC listener under the wrong
+  // uid before the teacher signs in — same deferral as the library hooks above.
+  const { plcs } = usePlcs({ enabled: teacherReady });
 
   // User-facing progress line (the latest step) + a sticky error banner. These
   // replace the spike's always-visible scrolling log; no raw diagnostics are

--- a/components/classroomAddon/TeacherReviewRoute.test.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.test.tsx
@@ -8,6 +8,7 @@ import { useQuiz } from '@/hooks/useQuiz';
 import { useQuizAssignments } from '@/hooks/useQuizAssignments';
 import { useQuizSessionTeacher } from '@/hooks/useQuizSession';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+import { getDocs } from 'firebase/firestore';
 
 // The teacher-view grader runs inside the Google Classroom add-on's cross-origin
 // iframe. The sign-in gate only depends on the auth hook + the Drive token;
@@ -113,6 +114,9 @@ describe('ClassroomAddonTeacherReview (Classroom in-iframe grader) — Google-se
     // opened under the stale (student) uid (#1837 reviewer concern).
     expect(useQuiz).toHaveBeenCalledWith(undefined);
     expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
+    // ...and the join-code resolution effect is suppressed too: it now gates on
+    // `teacherReady`, so a stale session triggers zero Firestore reads.
+    expect(getDocs).not.toHaveBeenCalled();
   });
 
   it('shows the sign-in card with the school-account copy for an anonymous (null) session', async () => {
@@ -148,5 +152,10 @@ describe('ClassroomAddonTeacherReview (Classroom in-iframe grader) — Google-se
     expect(
       screen.getByText(/sign in with your teacher google account/i)
     ).toBeInTheDocument();
+    // A Google session without a Drive token is not `teacherReady`, so the
+    // library listeners stay deferred (undefined) — a tokenless session must not
+    // open Firestore listeners under the teacher's library.
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
+    expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
   });
 });

--- a/components/classroomAddon/TeacherReviewRoute.test.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, vi, expect, beforeEach, type Mock } from 'vitest';
+
+import { ClassroomAddonTeacherReview } from './TeacherReviewRoute';
+import { useAuth } from '@/context/useAuth';
+import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { useQuizSessionTeacher } from '@/hooks/useQuizSession';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+
+// The teacher-view grader runs inside the Google Classroom add-on's cross-origin
+// iframe. The sign-in gate only depends on the auth hook + the Drive token;
+// everything else is mocked to a benign default so the gate can be exercised in
+// isolation.
+vi.mock('@/context/useAuth');
+vi.mock('@/hooks/useQuiz');
+vi.mock('@/hooks/useQuizAssignments');
+vi.mock('@/hooks/useAssignmentPseudonyms');
+vi.mock('@/hooks/useQuizSession', () => ({
+  useQuizSessionTeacher: vi.fn(),
+  getResponseDocKey: (r: { id?: string }) => r.id ?? 'k',
+  QUIZ_SESSIONS_COLLECTION: 'quiz_sessions',
+  RESPONSES_COLLECTION: 'responses',
+}));
+vi.mock(
+  '@/components/widgets/QuizWidget/components/WrittenResponseGrader',
+  () => ({
+    WrittenResponseGrader: () => null,
+  })
+);
+vi.mock('@/config/firebase', () => ({ db: {}, functions: {} }));
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  doc: vi.fn(),
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn(),
+  updateDoc: vi.fn(),
+  where: vi.fn(),
+}));
+vi.mock('firebase/functions', () => ({ httpsCallable: vi.fn() }));
+vi.mock('./gisOAuth', () => ({
+  ensureGis: vi.fn(),
+  requestAccessToken: vi.fn(),
+  requestClassroomTeacherToken: vi.fn(),
+}));
+
+/** A real, interactive Google teacher sign-in: google.com provider + Drive token. */
+const GOOGLE_USER = {
+  uid: 'teacher-uid',
+  providerData: [{ providerId: 'google.com' }],
+};
+
+/**
+ * The bug: a leftover custom-token `studentRole` session restored from the
+ * iframe's partitioned storage — a uid (so `!!user` is true) but empty
+ * `providerData` and no Drive token.
+ */
+const STUDENT_ROLE_USER = {
+  uid: 'student-pseudonym-uid',
+  providerData: [] as { providerId: string }[],
+};
+
+type AuthShape = {
+  user: typeof GOOGLE_USER | typeof STUDENT_ROLE_USER | null;
+  googleAccessToken: string | null;
+};
+
+function setAuth({ user, googleAccessToken }: AuthShape): void {
+  (useAuth as Mock).mockReturnValue({
+    user,
+    signInWithGoogle: vi.fn().mockResolvedValue(undefined),
+    googleAccessToken,
+    orgId: 'org-1',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useQuiz as Mock).mockReturnValue({
+    quizzes: [],
+    loadQuizData: vi.fn(),
+    loading: false,
+  });
+  (useQuizAssignments as Mock).mockReturnValue({
+    publishAssignmentScores: vi.fn(),
+  });
+  (useQuizSessionTeacher as Mock).mockReturnValue({
+    session: null,
+    responses: [],
+    loading: false,
+  });
+  (useAssignmentPseudonymsMulti as Mock).mockReturnValue({
+    byStudentUid: new Map(),
+  });
+});
+
+describe('ClassroomAddonTeacherReview (Classroom in-iframe grader) — Google-session gate', () => {
+  const signInButton = () =>
+    screen.queryByRole('button', { name: /sign in to spartboard/i });
+
+  it('shows the sign-in card (not the grader) for a stale studentRole session', async () => {
+    setAuth({ user: STUDENT_ROLE_USER, googleAccessToken: null });
+    render(<ClassroomAddonTeacherReview />);
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+    // The grader body must NOT render under the wrong (student) uid.
+    expect(screen.queryByText(/^responses$/i)).not.toBeInTheDocument();
+    // ...and the library listeners are deferred — no Firestore subscription is
+    // opened under the stale (student) uid (#1837 reviewer concern).
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
+    expect(useQuizAssignments).toHaveBeenCalledWith(undefined);
+  });
+
+  it('shows the sign-in card with the school-account copy for an anonymous (null) session', async () => {
+    setAuth({ user: null, googleAccessToken: null });
+    render(<ClassroomAddonTeacherReview />);
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your school google account/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the grader for a real Google teacher with a Drive token (no regression)', async () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: 'drive-token' });
+    render(<ClassroomAddonTeacherReview />);
+
+    // With no matching session the grader settles on its not-found state — the
+    // point is it reaches the grader body rather than the sign-in card.
+    expect(
+      await screen.findByText(/session is no longer available/i)
+    ).toBeInTheDocument();
+    expect(signInButton()).not.toBeInTheDocument();
+    // ...and the library subscribes under the teacher's own uid.
+    expect(useQuiz).toHaveBeenCalledWith(GOOGLE_USER.uid);
+    expect(useQuizAssignments).toHaveBeenCalledWith(GOOGLE_USER.uid);
+  });
+
+  it('shows the sign-in card for a Google session whose Drive token is missing/expired', async () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: null });
+    render(<ClassroomAddonTeacherReview />);
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -65,6 +65,7 @@ import {
 } from '@/utils/runClassroomGradePush';
 import { requestClassroomTeacherToken } from './gisOAuth';
 import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
 import {
   isWrittenQuestionType,
   type QuizData,
@@ -103,8 +104,31 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const loginHint = params.get('login_hint') ?? undefined;
 
   const { user, signInWithGoogle, googleAccessToken, orgId } = useAuth();
-  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
-  const { publishAssignmentScores } = useQuizAssignments(user?.uid);
+
+  // The teacher view loads the teacher's OWN Drive-backed quiz (questions +
+  // answers) to grade/publish and push grades, so it needs a real Google sign-in
+  // (uid + Drive token) — NOT just any Firebase session. Classroom opens this in
+  // a cross-origin iframe where partitioned-storage auth can restore a leftover
+  // `studentRole` custom-token session from a prior student launch in the same
+  // partition; that has a uid (empty library) but no `google.com` provider and no
+  // Drive token. Gating on `!!user` would skip the sign-in card and strand the
+  // teacher on an ungradeable empty library. Require a Google session + Drive
+  // token so the sign-in card shows until the teacher signs in as themselves.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+
+  // Only subscribe to the teacher's library/assignments once they're a real
+  // Google session. Passing a stale-session uid (e.g. a restored studentRole
+  // user) would open Firestore listeners under a uid whose library the gated UI
+  // never shows — wasted reads. The library hooks treat an undefined uid as "no
+  // library" (they reset to empty), so this just defers the subscription until
+  // the teacher signs in. (Mirrors the deep-link picker, PR #1837.)
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
+  const { publishAssignmentScores } = useQuizAssignments(libraryUid);
 
   const [busy, setBusy] = useState(false);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
@@ -392,13 +416,17 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     );
   }
 
-  if (!user) {
+  if (!teacherReady) {
     return (
       <AddonShell maxWidthClassName="max-w-md">
         <AddonHeader
           icon={GraduationCap}
           title="Grade this assignment"
-          subtitle="Sign in with your school Google account to review and grade student work right here."
+          subtitle={
+            user
+              ? 'Sign in with your teacher Google account to review and grade student work right here.'
+              : 'Sign in with your school Google account to review and grade student work right here.'
+          }
         />
         <AddonCard className="p-6">
           <AddonButton

--- a/components/classroomAddon/TeacherReviewRoute.tsx
+++ b/components/classroomAddon/TeacherReviewRoute.tsx
@@ -139,9 +139,13 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [resolvingSession, setResolvingSession] = useState(true);
   useEffect(() => {
-    if (kind !== 'quiz' || !code || !user) {
+    if (kind !== 'quiz' || !code || !teacherReady) {
       // Clear any prior session id so a stale one (after logout / a code change)
       // can't keep useQuizSessionTeacher subscribed to the previous session.
+      // Gate on `teacherReady` (not a bare `!user`): a restored studentRole
+      // session has a truthy `user` but is rejected by the sign-in card, so it
+      // must not drive a join-code lookup or keep downstream session listeners
+      // alive under an auth session the UI never shows.
       setSessionId(null);
       setResolvingSession(false);
       return;
@@ -169,7 +173,7 @@ export const ClassroomAddonTeacherReview: React.FC = () => {
     return () => {
       active = false;
     };
-  }, [kind, code, user]);
+  }, [kind, code, teacherReady]);
 
   const {
     session,

--- a/components/lti/LtiTeacherGrader.test.tsx
+++ b/components/lti/LtiTeacherGrader.test.tsx
@@ -108,6 +108,9 @@ describe('LtiTeacherGrader — Google-session gate', () => {
     // ...and the library listener is deferred — no Firestore subscription under
     // the stale (student) uid (#1837 reviewer concern).
     expect(useQuiz).toHaveBeenCalledWith(undefined);
+    // ...and the join-code resolution effect is suppressed too: it now gates on
+    // `teacherReady`, so a stale session triggers zero Firestore reads.
+    expect(getDocs).not.toHaveBeenCalled();
   });
 
   it('shows the sign-in card with the school-account copy for an anonymous (null) session', async () => {
@@ -142,5 +145,9 @@ describe('LtiTeacherGrader — Google-session gate', () => {
     expect(
       screen.getByText(/sign in with your teacher google account/i)
     ).toBeInTheDocument();
+    // A Google session without a Drive token is not `teacherReady`, so the
+    // library listener stays deferred (undefined) — a tokenless session must not
+    // open a Firestore listener under the teacher's library.
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
   });
 });

--- a/components/lti/LtiTeacherGrader.test.tsx
+++ b/components/lti/LtiTeacherGrader.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, vi, expect, beforeEach, type Mock } from 'vitest';
+
+import { LtiTeacherGrader } from './LtiTeacherGrader';
+import { useAuth } from '@/context/useAuth';
+import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizSessionTeacher } from '@/hooks/useQuizSession';
+import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+import { getDocs } from 'firebase/firestore';
+
+// The grader runs inside Schoology's cross-origin LTI iframe. The sign-in gate
+// only depends on the auth hook + the Drive token; everything else is mocked to
+// a benign default so the gate can be exercised in isolation.
+vi.mock('@/context/useAuth');
+vi.mock('@/hooks/useQuiz');
+vi.mock('@/hooks/useAssignmentPseudonyms');
+vi.mock('@/hooks/useQuizSession', () => ({
+  useQuizSessionTeacher: vi.fn(),
+  getResponseDocKey: (r: { id?: string }) => r.id ?? 'k',
+  QUIZ_SESSIONS_COLLECTION: 'quiz_sessions',
+}));
+vi.mock('@/config/firebase', () => ({ db: {}, functions: {} }));
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  query: vi.fn(),
+  where: vi.fn(),
+  getDocs: vi.fn(),
+}));
+vi.mock('firebase/functions', () => ({ httpsCallable: vi.fn() }));
+
+/** A real, interactive Google teacher sign-in: google.com provider + Drive token. */
+const GOOGLE_USER = {
+  uid: 'teacher-uid',
+  providerData: [{ providerId: 'google.com' }],
+};
+
+/**
+ * The bug: a leftover custom-token `studentRole` session restored from the
+ * iframe's partitioned storage — a uid (so `!!user` is true) but empty
+ * `providerData` and no Drive token.
+ */
+const STUDENT_ROLE_USER = {
+  uid: 'student-pseudonym-uid',
+  providerData: [] as { providerId: string }[],
+};
+
+type AuthShape = {
+  user: typeof GOOGLE_USER | typeof STUDENT_ROLE_USER | null;
+  googleAccessToken: string | null;
+};
+
+function setAuth({ user, googleAccessToken }: AuthShape): void {
+  (useAuth as Mock).mockReturnValue({
+    user,
+    signInWithGoogle: vi.fn().mockResolvedValue(undefined),
+    googleAccessToken,
+    orgId: 'org-1',
+  });
+}
+
+function renderGrader() {
+  return render(
+    <LtiTeacherGrader
+      quizCode="ABC123"
+      resourceLinkId="resource-link-1"
+      pushAuth="push-auth-token"
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useQuiz as Mock).mockReturnValue({
+    quizzes: [],
+    loadQuizData: vi.fn(),
+    loading: false,
+  });
+  (useQuizSessionTeacher as Mock).mockReturnValue({
+    session: null,
+    responses: [],
+    loading: false,
+  });
+  (useAssignmentPseudonymsMulti as Mock).mockReturnValue({
+    byStudentUid: new Map(),
+  });
+  // The mount effect resolves the session id from the join code. Default to a
+  // resolved-but-empty query so the effect settles deterministically.
+  (getDocs as Mock).mockResolvedValue({ empty: true, docs: [] });
+});
+
+describe('LtiTeacherGrader — Google-session gate', () => {
+  const signInButton = () =>
+    screen.queryByRole('button', { name: /sign in to spartboard/i });
+
+  it('shows the sign-in card (not the grader) for a stale studentRole session', async () => {
+    setAuth({ user: STUDENT_ROLE_USER, googleAccessToken: null });
+    renderGrader();
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+    // The grader body must NOT render under the wrong (student) uid.
+    expect(
+      screen.queryByText(/push grades to schoology/i)
+    ).not.toBeInTheDocument();
+    // ...and the library listener is deferred — no Firestore subscription under
+    // the stale (student) uid (#1837 reviewer concern).
+    expect(useQuiz).toHaveBeenCalledWith(undefined);
+  });
+
+  it('shows the sign-in card with the school-account copy for an anonymous (null) session', async () => {
+    setAuth({ user: null, googleAccessToken: null });
+    renderGrader();
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your school google account/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the grader for a real Google teacher with a Drive token (no regression)', async () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: 'drive-token' });
+    renderGrader();
+
+    // With no matching session the grader settles on its not-found state — the
+    // point is it reaches the grader body rather than the sign-in card.
+    expect(
+      await screen.findByText(/session is no longer available/i)
+    ).toBeInTheDocument();
+    expect(signInButton()).not.toBeInTheDocument();
+    // ...and the library subscribes under the teacher's own uid.
+    expect(useQuiz).toHaveBeenCalledWith(GOOGLE_USER.uid);
+  });
+
+  it('shows the sign-in card for a Google session whose Drive token is missing/expired', async () => {
+    setAuth({ user: GOOGLE_USER, googleAccessToken: null });
+    renderGrader();
+
+    await waitFor(() => expect(signInButton()).toBeInTheDocument());
+    expect(
+      screen.getByText(/sign in with your teacher google account/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/components/lti/LtiTeacherGrader.tsx
+++ b/components/lti/LtiTeacherGrader.tsx
@@ -137,9 +137,13 @@ export const LtiTeacherGrader: React.FC<{
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [resolvingSession, setResolvingSession] = useState(true);
   useEffect(() => {
-    if (!quizCode || !user) {
+    if (!quizCode || !teacherReady) {
       // Clear any prior session id so a stale one (after logout / a code change)
       // can't keep useQuizSessionTeacher subscribed to the previous session.
+      // Gate on `teacherReady` (not a bare `!user`): a restored studentRole
+      // session has a truthy `user` but is rejected by the sign-in card, so it
+      // must not drive a join-code lookup or keep downstream session listeners
+      // alive under an auth session the UI never shows.
       setSessionId(null);
       setResolvingSession(false);
       return;
@@ -167,7 +171,7 @@ export const LtiTeacherGrader: React.FC<{
     return () => {
       active = false;
     };
-  }, [quizCode, user]);
+  }, [quizCode, teacherReady]);
 
   const {
     session,

--- a/components/lti/LtiTeacherGrader.tsx
+++ b/components/lti/LtiTeacherGrader.tsx
@@ -61,6 +61,7 @@ import {
 } from '@/utils/classroomGradePush';
 import { quizMaxPoints } from '@/utils/quizMaxPoints';
 import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
 import { type QuizData } from '@/types';
 import {
   AddonShell,
@@ -102,7 +103,30 @@ export const LtiTeacherGrader: React.FC<{
   pushAuth: string;
 }> = ({ quizCode, resourceLinkId, pushAuth }) => {
   const { user, signInWithGoogle, googleAccessToken, orgId } = useAuth();
-  const { quizzes, loadQuizData, loading: quizzesLoading } = useQuiz(user?.uid);
+
+  // The grader loads the teacher's OWN Drive-backed quiz (answers + points) to
+  // compute scores and push them, so it needs a real Google sign-in (uid + Drive
+  // token) — NOT just any Firebase session. Schoology launches this in a
+  // cross-origin iframe where partitioned-storage auth can restore a leftover
+  // `studentRole` custom-token session from a prior student launch in the same
+  // partition; that has a uid (empty library) but no `google.com` provider and
+  // no Drive token. Gating on `!!user` would skip the sign-in card and strand the
+  // teacher on an ungradeable empty library. Require a Google session + Drive
+  // token so the sign-in card shows until the teacher signs in as themselves.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+
+  // Only subscribe to the teacher's library once they're a real Google session.
+  // Passing a stale-session uid (e.g. a restored studentRole user) would open a
+  // Firestore listener under a uid whose library the gated UI never shows —
+  // wasted reads. useQuiz treats an undefined uid as "no library" (resets to
+  // empty), so this just defers the subscription until the teacher signs in.
+  // (Mirrors the deep-link picker, PR #1837.)
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
 
   const [busy, setBusy] = useState(false);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
@@ -334,13 +358,17 @@ export const LtiTeacherGrader: React.FC<{
 
   // ── Render ────────────────────────────────────────────────────────────────
 
-  if (!user) {
+  if (!teacherReady) {
     return (
       <AddonShell maxWidthClassName="max-w-md">
         <AddonHeader
           icon={GraduationCap}
           title="Grade this assignment"
-          subtitle="Sign in with your school Google account to review and push grades right here."
+          subtitle={
+            user
+              ? 'Sign in with your teacher Google account to review and push grades right here.'
+              : 'Sign in with your school Google account to review and push grades right here.'
+          }
         />
         <AddonCard className="p-6">
           <AddonButton


### PR DESCRIPTION
## Why

The deep-link picker fix (gate on a real `google.com` session **plus** a Drive token, not just any Firebase session — `utils/googleSession.ts`) applies identically to the other teacher surfaces rendered inside **cross-origin iframes**.

Inside a partitioned-storage iframe (Classroom add-on, Schoology LTI), Firebase Auth's `onAuthStateChanged` can restore a leftover `studentRole` custom-token session from a prior **student** launch in the same partition — a uid with **empty `providerData`** and **no Drive token**. Surfaces that gate on a bare `!!user` then operate under the wrong uid (an empty quiz library) and never offer the Google sign-in the teacher needs. This was the confirmed root cause of the Schoology picker showing an empty dropdown with no sign-in prompt.

## What

Apply the same `teacherReady = isGoogleSession(user) && !!googleAccessToken` guard to the three sibling surfaces that still gated on a bare `!user`:

| Surface | Status | Notes |
| --- | --- | --- |
| `components/classroomAddon/TeacherDiscoveryRoute.tsx` | **LIVE in prod** | Classroom attachment-setup / discovery |
| `components/classroomAddon/TeacherReviewRoute.tsx` | **LIVE in prod** | Classroom in-iframe grader (the analogue `LtiTeacherGrader`'s own doc comment points at) |
| `components/lti/LtiTeacherGrader.tsx` | flag-gated off via `LTI_GRADER_ENABLED` | Schoology LTI analogue of the Classroom grader |

**Also defer each surface's library listeners** until the teacher is a real Google session — pass `teacherReady ? user?.uid : undefined` into `useQuiz` / `useQuizAssignments` / `useVideoActivity(Assignments)` so a stale `studentRole` uid never opens Firestore listeners under a library the gated UI never shows (wasted reads). The hooks treat an undefined uid as "no library". This mirrors the picker's **#1837** (the reviewer suggestion on #1835/#1836), which is the parent of this branch.

The sign-in copy now distinguishes a **stale** session (*"...your teacher Google account..."*) from a first sign-in (*"...your school Google account..."*).

> **Scope note:** `TeacherReviewRoute` was not in the original two-surface task — it surfaced during the work as a third instance of the identical bug (same cross-origin iframe, loads the teacher's Drive library via `useQuiz(user?.uid)`, gated on a bare `!user`). Included with maintainer sign-off so all three iframe graders behave consistently.

## No regression for the working flows

A normally-signed-in Google teacher has `google.com` in `providerData` **and** a Drive token, so `teacherReady` is `true` — the working Classroom attach flow and the grader still reach the library and subscribe under the teacher's own uid, exactly as before. The tests cover this explicitly alongside the stale/anonymous/expired-token cases.

## Tests

Gating component tests for all three surfaces (stale `studentRole`, anonymous, real Google+token, Google-without-token), asserting **both** the rendered gate **and** the deferred-listener uid (`useQuiz`/`useQuizAssignments` called with `undefined` when not ready, with the teacher uid when ready). `utils/googleSession.ts` ships its own unit tests on the base branch.

`pnpm run validate` is green (type-check root+functions, lint, format, **396 root files / 4037 tests**, **23 functions files / 410 tests**).

## Base / flow

Rebased onto `dev-paul` (parent commit = #1837) and targets `dev-paul` — reaches prod via the normal dev-paul → main CI flow. **Not hand-deployed.**

## ⚠️ Before trusting in prod

The two **LIVE** Classroom surfaces (`TeacherDiscoveryRoute`, `TeacherReviewRoute`) need a **live Google Classroom smoke test** to confirm a normally-signed-in Google teacher still sees their library and can attach/grade.

https://claude.ai/code/session_01NKY5PvvHi3YgWea7mx71fZ