### PR TITLE
Promote dev-paul → main: break LTI teacher sign-in out of the Schoology iframe

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -155,9 +155,17 @@ const LtiDeepLinkLauncher: React.FC = () => {
           });
         }
       } else if (msg.type === DL_HANDOFF_RESPONSE) {
-        setSubmitted(true);
-        setStatusMsg('Returning to Schoology…');
-        postDeepLinkResponse(msg.response.returnUrl, msg.response.jwt);
+        try {
+          postDeepLinkResponse(msg.response.returnUrl, msg.response.jwt);
+          setSubmitted(true);
+          setStatusMsg('Returning to Schoology…');
+        } catch (err) {
+          setErrorMsg(
+            err instanceof Error
+              ? err.message
+              : 'Failed to return to Schoology.'
+          );
+        }
       }
     };
     window.addEventListener('message', onMessage);

--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -1,49 +1,41 @@
 /**
- * Schoology LTI 1.3 Deep Linking — teacher resource picker (Spike 1).
+ * Schoology LTI 1.3 Deep Linking — teacher resource picker.
  *
- * Route: /lti/teacher?mode=deeplink
- * Schoology opens this iframe for a `LtiDeepLinkingRequest` instructor launch
- * (the teacher clicked "Add Material → SpartBoard" in a course). The browser
- * arrives via a 302 from the ltiLaunch Cloud Function carrying a one-time
- * `?lc=<launchCode>`.
+ * Route: /lti/teacher?mode=deeplink  (Schoology opens this iframe when a teacher
+ * clicks "Add Material → SpartBoard"; the browser arrives via a 302 from the
+ * ltiLaunch Cloud Function carrying a one-time `?lc=<launchCode>`.)
  *
- * Flow (mirrors the Google Classroom add-on TeacherDiscoveryRoute "attach"
- * pipe, adapted for LTI deep linking):
- *   1. Exchange the launch code (`ltiExchange` callable) for the validated
- *      deep-linking context — specifically `deepLinking.deep_link_return_url`
- *      and the opaque `deepLinking.data` round-trip string.
- *   2. The teacher signs into SpartBoard (Google) and we load THEIR quiz
- *      library via `useQuiz` — exactly as TeacherDiscoveryRoute does.
- *   3. The teacher picks one quiz. We load its content from Drive and compute
- *      `maxPoints` = total question points (so Schoology's gradebook column
- *      reads e.g. 17/20, not a percentage) — the same computation as the
- *      Classroom attach flow.
- *   4. `ltiSignDeepLinkResponseV1` signs a JWT deep-linking response carrying
- *      the chosen quiz. We deliver it the LTI way: auto-submit a hidden HTML
- *      form POST to `deep_link_return_url` with a single `JWT` field. Schoology
- *      consumes the response and creates the graded material.
+ * Two modes, dispatched on the `handoff` query param:
  *
- * UI reuses the Classroom add-on's light-theme AddonShell kit (Schoology's
- * chrome is light), matching the add-on's teacher screens.
+ *  - LAUNCHER (default, in the Schoology iframe): the teacher's Google OAuth
+ *    CANNOT run here — a sign-in popup spawned from Schoology's partitioned
+ *    iframe is denied by Google Workspace Context-Aware Access ("Account
+ *    Restricted"). So the iframe is a thin launcher: it exchanges the one-time
+ *    launch code for the deep-link context, opens a TOP-LEVEL window to do the
+ *    real work (LtiDeepLinkWindow), and — when that window hands back the signed
+ *    LtiDeepLinkingResponse — form-POSTs it to Schoology to finish the attach.
+ *
+ *  - WINDOW (`handoff=1`, opened top-level by the launcher): LtiDeepLinkWindow,
+ *    where the first-party Google sign-in + quiz pick + response signing happen.
+ *
+ * See deepLinkHandoff.ts for the cross-window protocol + rationale. UI reuses the
+ * Classroom add-on's light-theme AddonShell kit (Schoology's chrome is light).
  */
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
-import { ClipboardList, CheckCircle2, Send } from 'lucide-react';
+import { ClipboardList, CheckCircle2, ExternalLink } from 'lucide-react';
 import { functions } from '@/config/firebase';
-import { useAuth } from '@/context/useAuth';
-import { useQuiz } from '@/hooks/useQuiz';
-import { useQuizAssignments } from '@/hooks/useQuizAssignments';
-import { getQuizBehavior } from '@/utils/quizBehavior';
-import { quizMaxPoints } from '@/utils/quizMaxPoints';
-import { logError } from '@/utils/logError';
-import { isGoogleSession } from '@/utils/googleSession';
+import {
+  DL_HANDOFF_READY,
+  DL_HANDOFF_RESPONSE,
+  DL_HANDOFF_CONTEXT,
+  DL_HANDOFF_WINDOW_PATH,
+  type DlHandoffContext,
+  parseHandoffMessage,
+  postHandoffMessage,
+  postDeepLinkResponse,
+} from './deepLinkHandoff';
+import { LtiDeepLinkWindow } from './LtiDeepLinkWindow';
 import {
   AddonShell,
   AddonHeader,
@@ -51,7 +43,6 @@ import {
   AddonButton,
   AddonStatus,
   AddonError,
-  AddonSelect,
 } from '@/components/classroomAddon/AddonShell';
 
 /**
@@ -64,29 +55,11 @@ interface DeepLinkingSettings {
   data?: string;
 }
 
-/** Subset of the `ltiExchange` result this picker depends on. */
+/** Subset of the `ltiExchange` result this launcher depends on. */
 interface LtiExchangeResult {
-  role: 'student' | 'teacher' | 'unknown';
-  messageType: string;
   isDeepLinking: boolean;
-  studentRole: boolean;
   contextId?: string | null;
   deepLinking?: DeepLinkingSettings;
-}
-
-/** Pinned contract for the deep-link response signer (built server-side). */
-interface SignDeepLinkResponseParams {
-  returnUrl: string;
-  dlData?: string;
-  kind: 'quiz';
-  quizCode: string;
-  title: string;
-  maxPoints?: number;
-}
-
-interface SignDeepLinkResponseResult {
-  jwt: string;
-  returnUrl: string;
 }
 
 type Phase = 'exchanging' | 'ready' | 'error';
@@ -95,92 +68,33 @@ const NO_CODE_MESSAGE =
   'No launch code found. Add SpartBoard from inside a Schoology course.';
 
 /**
- * Deliver the signed LTI deep-linking response. Per the spec, this is an
- * auto-submitting HTML form POST to the platform's `deep_link_return_url`
- * carrying a single `JWT` field. We build the form detached, attach it to the
- * document just long enough to submit (a detached form cannot navigate), and
- * submit it — which navigates the iframe back to Schoology.
+ * In-iframe launcher: exchanges the launch code, then hands off to a top-level
+ * window for the (Context-Aware-Access-sensitive) Google sign-in + quiz pick,
+ * and completes the deep-link return when the window posts back the signed JWT.
  */
-function postDeepLinkResponse(returnUrl: string, jwt: string): void {
-  const form = document.createElement('form');
-  form.method = 'POST';
-  form.action = returnUrl;
-  // No target → submit navigates this (iframe) window back to the platform.
-  const input = document.createElement('input');
-  input.type = 'hidden';
-  input.name = 'JWT';
-  input.value = jwt;
-  form.appendChild(input);
-  document.body.appendChild(form);
-  form.submit();
-}
-
-export const LtiDeepLinkPicker: React.FC = () => {
-  // Derive the launch code during render (stable for this page load) so the
-  // "missing code" case is handled via initial state — never a synchronous
-  // setState inside an effect (the repo lints react-hooks/set-state-in-effect).
+const LtiDeepLinkLauncher: React.FC = () => {
+  // Derive the launch code during render so the "missing code" case is initial
+  // state, never a synchronous setState inside an effect.
   const code =
     typeof window === 'undefined'
       ? ''
       : (new URLSearchParams(window.location.search).get('lc') ?? '');
 
   const [phase, setPhase] = useState<Phase>(code ? 'exchanging' : 'error');
-  const [deepLinking, setDeepLinking] = useState<DeepLinkingSettings | null>(
-    null
-  );
   const [errorMsg, setErrorMsg] = useState<string | null>(
     code ? null : NO_CODE_MESSAGE
   );
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-  // Latches once the response form is submitted so the picker shows a terminal
-  // "returning to Schoology" state instead of an interactive picker.
+  const [launched, setLaunched] = useState(false);
+  // Latches once the response form is submitted (terminal "returning" state).
   const [submitted, setSubmitted] = useState(false);
-  const [selectedQuizId, setSelectedQuizId] = useState('');
-  const [contextId, setContextId] = useState<string | null>(null);
+
+  // Deep-link context lives in a ref so the (mount-once) message listener always
+  // reads the latest without re-subscribing. Populated by the exchange below.
+  const ctxRef = useRef<DlHandoffContext | null>(null);
   const ranRef = useRef(false);
-  const quizSelectId = useId();
-  // Caches the created assignment per quiz id so a retry after a failed
-  // deep-link POST reuses it instead of creating a second orphaned session.
-  const createdRef = useRef<
-    Map<string, { quizCode: string; maxPoints: number }>
-  >(new Map());
-
-  const { user, signInWithGoogle, googleAccessToken } = useAuth();
-
-  // The picker lists + loads the teacher's OWN Drive-backed quiz library, so it
-  // needs a real Google sign-in (uid + Drive token) — NOT just any Firebase
-  // session. Inside Schoology's cross-origin iframe, partitioned-storage auth
-  // can restore a leftover `studentRole` custom-token session from a prior
-  // student launch; that has a uid (empty library) but no `google.com` provider
-  // and no Drive token. Gating on `!!user` showed that stale session the (empty)
-  // dropdown and skipped the sign-in card entirely — the reported bug. Require a
-  // Google session + Drive token so the sign-in card shows until the teacher
-  // signs in as themselves.
-  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
-
-  // Only subscribe to the teacher's library/assignments once they're a real
-  // Google session. Passing a stale-session uid (e.g. a restored studentRole
-  // user) would open Firestore listeners under a uid whose library the gated UI
-  // never shows — wasted reads. Both hooks treat an undefined uid as "no
-  // library" (they reset to empty), so this just defers the subscription until
-  // the teacher signs in. (Reviewer suggestion, PR #1835/#1836.)
-  const libraryUid = teacherReady ? user?.uid : undefined;
-  const {
-    quizzes,
-    loadQuizData,
-    loading: quizzesLoading,
-  } = useQuiz(libraryUid);
-  const { createAssignment } = useQuizAssignments(libraryUid);
-
-  const selectedQuiz = useMemo(
-    () => quizzes.find((q) => q.id === selectedQuizId),
-    [quizzes, selectedQuizId]
-  );
 
   // Exchange the one-time launch code for the validated deep-linking context.
-  // Effect is the right tool here: it synchronizes with an external system (the
-  // Cloud Function) on mount. Run-once via ref guard.
   useEffect(() => {
     if (!code || ranRef.current) return;
     ranRef.current = true;
@@ -192,7 +106,8 @@ export const LtiDeepLinkPicker: React.FC = () => {
           'ltiExchange'
         );
         const { data } = await exchange({ code });
-        if (!data.isDeepLinking || !data.deepLinking?.deep_link_return_url) {
+        const returnUrl = data.deepLinking?.deep_link_return_url;
+        if (!data.isDeepLinking || !returnUrl) {
           setErrorMsg(
             'This launch is not a deep-linking request. Add SpartBoard from ' +
               'the course materials menu.'
@@ -200,8 +115,20 @@ export const LtiDeepLinkPicker: React.FC = () => {
           setPhase('error');
           return;
         }
-        setDeepLinking(data.deepLinking);
-        setContextId(data.contextId ?? null);
+        if (!data.contextId) {
+          setErrorMsg(
+            'Missing course context — re-open SpartBoard from the course.'
+          );
+          setPhase('error');
+          return;
+        }
+        ctxRef.current = {
+          returnUrl,
+          ...(data.deepLinking?.data !== undefined
+            ? { dlData: data.deepLinking.data }
+            : {}),
+          contextId: data.contextId,
+        };
         setPhase('ready');
       } catch (e) {
         setErrorMsg(
@@ -212,122 +139,52 @@ export const LtiDeepLinkPicker: React.FC = () => {
     })();
   }, [code]);
 
-  const signIn = useCallback(async () => {
-    setBusy(true);
-    setErrorMsg(null);
-    try {
-      setStatusMsg('Signing in to SpartBoard…');
-      await signInWithGoogle();
-      setStatusMsg('Signed in. Pick a quiz to add.');
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      setErrorMsg(`Couldn't sign in: ${message}`);
-      setStatusMsg(null);
-    } finally {
-      setBusy(false);
-    }
-  }, [signInWithGoogle]);
-
-  const addQuiz = useCallback(async () => {
-    if (!selectedQuiz) {
-      setStatusMsg('Pick a quiz first.');
-      return;
-    }
-    const returnUrl = deepLinking?.deep_link_return_url;
-    if (!returnUrl) {
-      setErrorMsg(
-        'Missing the Schoology return URL — re-open SpartBoard from the ' +
-          'course materials menu.'
-      );
-      return;
-    }
-    if (!contextId) {
-      setErrorMsg(
-        'Missing course context — re-open SpartBoard from the course.'
-      );
-      return;
-    }
-
-    setBusy(true);
-    setErrorMsg(null);
-    try {
-      // Reuse a previously-created assignment for this quiz on retry, so a failed
-      // deep-link POST never spawns a SECOND orphaned session + join code. The
-      // create step (load quiz → maxPoints → createAssignment) runs at most once
-      // per quiz; only the idempotent sign + POST re-runs.
-      let created = createdRef.current.get(selectedQuiz.id);
-      if (!created) {
-        setStatusMsg(`Loading "${selectedQuiz.title}"…`);
-        const quizData = await loadQuizData(selectedQuiz.driveFileId);
-
-        // The gradebook scale = the quiz's total points, so a 17/20 quiz reads as
-        // 17/20 in Schoology (not a percentage out of 100). Shared with the
-        // grader via quizMaxPoints so the attach denominator and the push
-        // denominator can't drift. Same computation as the Classroom attach flow.
-        const maxPoints = quizMaxPoints(quizData.questions);
-
-        // Create a class-targeted quiz session (join code) the student runner
-        // joins by — exactly like the Classroom attach flow. classIds scope the
-        // session to this Schoology course so a studentRole token
-        // (classIds: ['schoology:<id>']) passes the Firestore class-gate.
-        setStatusMsg('Creating the assignment…');
-        const { sessionMode, sessionOptions, attemptLimit } =
-          getQuizBehavior(selectedQuiz);
-        const { code: quizCode } = await createAssignment(
-          {
-            id: selectedQuiz.id,
-            title: selectedQuiz.title,
-            driveFileId: selectedQuiz.driveFileId,
-            questions: quizData.questions,
-          },
-          {
-            className: 'Schoology',
-            sessionMode,
-            sessionOptions,
-            attemptLimit,
-          },
-          {
-            classIds: [`schoology:${contextId}`],
-            initialStatus: 'active',
-          }
-        );
-        created = { quizCode, maxPoints };
-        createdRef.current.set(selectedQuiz.id, created);
+  // Listen for the handoff window: reply to its READY with the deep-link context,
+  // and on its signed RESPONSE, navigate this iframe back to Schoology.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const msg = parseHandoffMessage(event);
+      if (!msg) return;
+      if (msg.type === DL_HANDOFF_READY) {
+        const ctx = ctxRef.current;
+        const source = event.source as Window | null;
+        if (ctx && source) {
+          postHandoffMessage(source, {
+            type: DL_HANDOFF_CONTEXT,
+            context: ctx,
+          });
+        }
+      } else if (msg.type === DL_HANDOFF_RESPONSE) {
+        setSubmitted(true);
+        setStatusMsg('Returning to Schoology…');
+        postDeepLinkResponse(msg.response.returnUrl, msg.response.jwt);
       }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
 
-      setStatusMsg('Adding the quiz to Schoology…');
-      const sign = httpsCallable<
-        SignDeepLinkResponseParams,
-        SignDeepLinkResponseResult
-      >(functions, 'ltiSignDeepLinkResponseV1');
-      const { data } = await sign({
-        returnUrl,
-        ...(deepLinking?.data !== undefined
-          ? { dlData: deepLinking.data }
-          : {}),
-        kind: 'quiz',
-        quizCode: created.quizCode,
-        title: selectedQuiz.title,
-        maxPoints: created.maxPoints,
-      });
-
-      setSubmitted(true);
-      setStatusMsg('Returning to Schoology…');
-      // Deliver the signed response: auto-submitting form POST navigates this
-      // iframe back to the platform, which creates the graded material.
-      postDeepLinkResponse(data.returnUrl, data.jwt);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logError('LtiDeepLinkPicker.addQuiz', err, {
-        quizId: selectedQuiz.id,
-      });
-      setErrorMsg(`Couldn't add the quiz: ${message}`);
-      setStatusMsg(null);
-      setSubmitted(false);
-    } finally {
-      setBusy(false);
+  const openWindow = useCallback(() => {
+    setErrorMsg(null);
+    const win = window.open(
+      DL_HANDOFF_WINDOW_PATH,
+      'spartboard_lti_deeplink',
+      'popup,width=560,height=720'
+    );
+    if (!win) {
+      setErrorMsg(
+        'Your browser blocked the SpartBoard window. Allow pop-ups for ' +
+          'Schoology, then click again.'
+      );
+      return;
     }
-  }, [selectedQuiz, deepLinking, loadQuizData, createAssignment, contextId]);
+    win.focus();
+    setLaunched(true);
+    setStatusMsg(
+      'Sign in and pick your quiz in the SpartBoard window. It returns here ' +
+        'automatically when you’re done.'
+    );
+  }, []);
 
   return (
     <AddonShell>
@@ -350,62 +207,39 @@ export const LtiDeepLinkPicker: React.FC = () => {
             </p>
           </div>
         </AddonCard>
-      ) : !teacherReady ? (
+      ) : (
         <AddonCard className="p-6">
-          <p className="mb-4 text-sm text-slate-500">
-            {user
-              ? 'Sign in with your teacher Google account to load your SpartBoard quiz library.'
-              : 'Sign in with your school Google account to load your SpartBoard quiz library.'}
+          <p className="mb-4 text-sm leading-relaxed text-slate-500">
+            Choosing a quiz opens a SpartBoard window where you sign in and
+            pick. It closes and finishes here automatically. (Schoology runs
+            SpartBoard in a frame, so sign-in has to happen in its own window.)
           </p>
-          <AddonButton onClick={() => void signIn()} loading={busy}>
-            Sign in to SpartBoard
+          <AddonButton onClick={openWindow} icon={ExternalLink}>
+            {launched ? 'Reopen the SpartBoard window' : 'Choose a quiz'}
           </AddonButton>
         </AddonCard>
-      ) : (
-        <div className="space-y-4">
-          <AddonCard className="p-4">
-            <label
-              htmlFor={quizSelectId}
-              className="mb-1.5 block text-sm font-medium text-slate-700"
-            >
-              Quiz
-            </label>
-            <AddonSelect
-              id={quizSelectId}
-              ariaLabel="Quiz"
-              value={selectedQuizId}
-              onChange={setSelectedQuizId}
-              disabled={busy || quizzesLoading}
-              placeholder={
-                quizzesLoading
-                  ? 'Loading your quizzes…'
-                  : quizzes.length === 0
-                    ? 'No quizzes in your library yet'
-                    : 'Select a quiz…'
-              }
-              options={quizzes.map((q) => ({ value: q.id, label: q.title }))}
-            />
-          </AddonCard>
-
-          <AddonButton
-            onClick={() => void addQuiz()}
-            loading={busy}
-            disabled={!selectedQuizId}
-            icon={Send}
-          >
-            Add quiz to Schoology
-          </AddonButton>
-        </div>
       )}
 
       {phase !== 'error' && (
         <div className="mt-4 space-y-2">
           <AddonError message={errorMsg} />
-          <AddonStatus message={statusMsg} busy={busy} />
+          <AddonStatus message={statusMsg} />
         </div>
       )}
     </AddonShell>
   );
+};
+
+/**
+ * Dispatcher: the top-level handoff window (`?handoff=1`) renders the real
+ * picker; the in-Schoology iframe renders the launcher.
+ */
+export const LtiDeepLinkPicker: React.FC = () => {
+  const isHandoffWindow =
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('handoff') === '1';
+
+  return isHandoffWindow ? <LtiDeepLinkWindow /> : <LtiDeepLinkLauncher />;
 };
 
 export default LtiDeepLinkPicker;

--- a/components/lti/LtiDeepLinkWindow.tsx
+++ b/components/lti/LtiDeepLinkWindow.tsx
@@ -1,0 +1,353 @@
+/**
+ * Schoology LTI 1.3 Deep Linking — top-level handoff WINDOW.
+ *
+ * Route: /lti/teacher?mode=deeplink&handoff=1 (opened via window.open by the
+ * in-iframe launcher in LtiDeepLinkPicker).
+ *
+ * This window runs at TOP LEVEL on spartboard.web.app (NOT embedded in
+ * Schoology), so the teacher's Google OAuth is first-party and Google Workspace
+ * Context-Aware Access passes — the popup-in-iframe path fails CAA with
+ * "Account Restricted". See deepLinkHandoff.ts for the full rationale.
+ *
+ * Flow:
+ *   1. Signal the opener (the iframe) we're READY; receive the deep-link context
+ *      (`returnUrl` / `dlData` / `contextId`) it got from its one-time launch-code
+ *      exchange. (This window has no launch code — it's single-use, already spent.)
+ *   2. Teacher signs into SpartBoard (Google, first-party → CAA OK); we load
+ *      THEIR quiz library via `useQuiz`.
+ *   3. Teacher picks a quiz → load content → maxPoints → create a class-targeted
+ *      assignment → `ltiSignDeepLinkResponseV1` signs the response JWT.
+ *   4. We hand the signed JWT back to the iframe (postMessage), which form-POSTs
+ *      it to Schoology and finishes the attach — the normal deep-link ending. If
+ *      the opener is gone, we fall back to POSTing the response from here.
+ *
+ * UI reuses the Classroom add-on's light-theme AddonShell kit.
+ */
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { ClipboardList, CheckCircle2, Send } from 'lucide-react';
+import { functions } from '@/config/firebase';
+import { useAuth } from '@/context/useAuth';
+import { useQuiz } from '@/hooks/useQuiz';
+import { useQuizAssignments } from '@/hooks/useQuizAssignments';
+import { getQuizBehavior } from '@/utils/quizBehavior';
+import { quizMaxPoints } from '@/utils/quizMaxPoints';
+import { logError } from '@/utils/logError';
+import { isGoogleSession } from '@/utils/googleSession';
+import {
+  DL_HANDOFF_READY,
+  DL_HANDOFF_CONTEXT,
+  DL_HANDOFF_RESPONSE,
+  type DlHandoffContext,
+  parseHandoffMessage,
+  postHandoffMessage,
+  postDeepLinkResponse,
+} from './deepLinkHandoff';
+import {
+  AddonShell,
+  AddonHeader,
+  AddonCard,
+  AddonButton,
+  AddonStatus,
+  AddonError,
+  AddonSelect,
+} from '@/components/classroomAddon/AddonShell';
+
+/** Pinned contract for the deep-link response signer (built server-side). */
+interface SignDeepLinkResponseParams {
+  returnUrl: string;
+  dlData?: string;
+  kind: 'quiz';
+  quizCode: string;
+  title: string;
+  maxPoints?: number;
+}
+
+interface SignDeepLinkResponseResult {
+  jwt: string;
+  returnUrl: string;
+}
+
+type Phase = 'waiting' | 'ready' | 'error';
+
+const NO_OPENER_MESSAGE =
+  'Open SpartBoard from inside a Schoology course (Add Materials → SpartBoard), then choose your quiz when prompted.';
+
+export const LtiDeepLinkWindow: React.FC = () => {
+  // Whether we were opened by the iframe launcher. Derived at init (not in an
+  // effect) so the "no opener" case is handled via initial state.
+  const initialOpener =
+    typeof window === 'undefined' ? null : (window.opener as Window | null);
+  const hasOpener = !!initialOpener && !initialOpener.closed;
+
+  const [phase, setPhase] = useState<Phase>(hasOpener ? 'waiting' : 'error');
+  const [errorMsg, setErrorMsg] = useState<string | null>(
+    hasOpener ? null : NO_OPENER_MESSAGE
+  );
+  const [ctx, setCtx] = useState<DlHandoffContext | null>(null);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [selectedQuizId, setSelectedQuizId] = useState('');
+  const quizSelectId = useId();
+  // Caches the created assignment per quiz id so a retry after a failed sign /
+  // POST reuses it instead of spawning a SECOND orphaned session + join code.
+  const createdRef = useRef<
+    Map<string, { quizCode: string; maxPoints: number }>
+  >(new Map());
+
+  const { user, signInWithGoogle, googleAccessToken } = useAuth();
+  // First-party Google session required (uid + Drive token) — same guard as the
+  // launcher. Here it WORKS because the window is top-level, not iframed.
+  const teacherReady = isGoogleSession(user) && !!googleAccessToken;
+  const libraryUid = teacherReady ? user?.uid : undefined;
+  const {
+    quizzes,
+    loadQuizData,
+    loading: quizzesLoading,
+  } = useQuiz(libraryUid);
+  const { createAssignment } = useQuizAssignments(libraryUid);
+
+  const selectedQuiz = useMemo(
+    () => quizzes.find((q) => q.id === selectedQuizId),
+    [quizzes, selectedQuizId]
+  );
+
+  // Handshake with the launcher: announce READY, then receive the deep-link
+  // context. Effect is correct here — it wires up a DOM event listener (external
+  // system). setState happens only inside the event handler, never synchronously.
+  useEffect(() => {
+    const opener = window.opener as Window | null;
+    if (!opener || opener.closed) return;
+
+    const onMessage = (event: MessageEvent) => {
+      const msg = parseHandoffMessage(event);
+      if (msg?.type === DL_HANDOFF_CONTEXT) {
+        setCtx(msg.context);
+        setPhase('ready');
+      }
+    };
+    window.addEventListener('message', onMessage);
+    postHandoffMessage(opener, { type: DL_HANDOFF_READY });
+    // Re-announce once in case our first READY landed before the launcher's
+    // listener was attached (it replies with CONTEXT on either).
+    const retry = window.setTimeout(() => {
+      if (!opener.closed)
+        postHandoffMessage(opener, { type: DL_HANDOFF_READY });
+    }, 800);
+
+    return () => {
+      window.removeEventListener('message', onMessage);
+      window.clearTimeout(retry);
+    };
+  }, []);
+
+  const signIn = useCallback(async () => {
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      setStatusMsg('Signing in to SpartBoard…');
+      await signInWithGoogle();
+      setStatusMsg('Signed in. Pick a quiz to add.');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setErrorMsg(`Couldn't sign in: ${message}`);
+      setStatusMsg(null);
+    } finally {
+      setBusy(false);
+    }
+  }, [signInWithGoogle]);
+
+  const addQuiz = useCallback(async () => {
+    if (!selectedQuiz) {
+      setStatusMsg('Pick a quiz first.');
+      return;
+    }
+    if (!ctx) {
+      setErrorMsg(
+        'Lost the Schoology context — reopen SpartBoard from the course.'
+      );
+      return;
+    }
+
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      // Reuse a previously-created assignment for this quiz on retry, so a failed
+      // sign / POST never spawns a SECOND orphaned session + join code. The create
+      // step runs at most once per quiz; only the idempotent sign re-runs.
+      let created = createdRef.current.get(selectedQuiz.id);
+      if (!created) {
+        setStatusMsg(`Loading "${selectedQuiz.title}"…`);
+        const quizData = await loadQuizData(selectedQuiz.driveFileId);
+
+        // Gradebook scale = the quiz's total points, so a 17/20 quiz reads 17/20
+        // in Schoology (not a percentage). Shared with the grader via quizMaxPoints.
+        const maxPoints = quizMaxPoints(quizData.questions);
+
+        // Class-targeted session (join code) the student runner joins by —
+        // classIds scope it to this Schoology course so a studentRole token
+        // (classIds: ['schoology:<id>']) passes the Firestore class-gate.
+        setStatusMsg('Creating the assignment…');
+        const { sessionMode, sessionOptions, attemptLimit } =
+          getQuizBehavior(selectedQuiz);
+        const { code: quizCode } = await createAssignment(
+          {
+            id: selectedQuiz.id,
+            title: selectedQuiz.title,
+            driveFileId: selectedQuiz.driveFileId,
+            questions: quizData.questions,
+          },
+          {
+            className: 'Schoology',
+            sessionMode,
+            sessionOptions,
+            attemptLimit,
+          },
+          {
+            classIds: [`schoology:${ctx.contextId}`],
+            initialStatus: 'active',
+          }
+        );
+        created = { quizCode, maxPoints };
+        createdRef.current.set(selectedQuiz.id, created);
+      }
+
+      setStatusMsg('Adding the quiz to Schoology…');
+      const sign = httpsCallable<
+        SignDeepLinkResponseParams,
+        SignDeepLinkResponseResult
+      >(functions, 'ltiSignDeepLinkResponseV1');
+      const { data } = await sign({
+        returnUrl: ctx.returnUrl,
+        ...(ctx.dlData !== undefined ? { dlData: ctx.dlData } : {}),
+        kind: 'quiz',
+        quizCode: created.quizCode,
+        title: selectedQuiz.title,
+        maxPoints: created.maxPoints,
+      });
+
+      setSubmitted(true);
+
+      // Hand the signed response back to the iframe, which navigates back to
+      // Schoology. If the opener is gone, complete the deep-link return from
+      // this window as a fallback.
+      const opener = window.opener as Window | null;
+      if (opener && !opener.closed) {
+        postHandoffMessage(opener, {
+          type: DL_HANDOFF_RESPONSE,
+          response: { jwt: data.jwt, returnUrl: data.returnUrl },
+        });
+        setStatusMsg('Added — returning to Schoology…');
+        // Give the message a tick to flush before closing ourselves.
+        window.setTimeout(() => {
+          try {
+            window.close();
+          } catch {
+            // Some browsers block close() for non-script-opened windows; the
+            // teacher can close the tab manually — the attach already completed.
+          }
+        }, 500);
+      } else {
+        setStatusMsg('Returning to Schoology…');
+        postDeepLinkResponse(data.returnUrl, data.jwt);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logError('LtiDeepLinkWindow.addQuiz', err, { quizId: selectedQuiz.id });
+      setErrorMsg(`Couldn't add the quiz: ${message}`);
+      setStatusMsg(null);
+      setSubmitted(false);
+    } finally {
+      setBusy(false);
+    }
+  }, [selectedQuiz, ctx, loadQuizData, createAssignment]);
+
+  return (
+    <AddonShell>
+      <AddonHeader
+        icon={ClipboardList}
+        title="Add a SpartBoard quiz"
+        subtitle="Pick a quiz from your library. Students take it inside Schoology and their score posts back to the gradebook."
+      />
+
+      {phase === 'error' ? (
+        <AddonError message={errorMsg} />
+      ) : phase === 'waiting' ? (
+        <AddonStatus message="Connecting to your Schoology course…" busy />
+      ) : submitted ? (
+        <AddonCard className="p-5">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-500" />
+            <p className="text-sm leading-relaxed text-slate-600">
+              Quiz added. You can close this window — it’ll return to Schoology
+              automatically.
+            </p>
+          </div>
+        </AddonCard>
+      ) : !teacherReady ? (
+        <AddonCard className="p-6">
+          <p className="mb-4 text-sm text-slate-500">
+            {user
+              ? 'Sign in with your teacher Google account to load your SpartBoard quiz library.'
+              : 'Sign in with your school Google account to load your SpartBoard quiz library.'}
+          </p>
+          <AddonButton onClick={() => void signIn()} loading={busy}>
+            Sign in to SpartBoard
+          </AddonButton>
+        </AddonCard>
+      ) : (
+        <div className="space-y-4">
+          <AddonCard className="p-4">
+            <label
+              htmlFor={quizSelectId}
+              className="mb-1.5 block text-sm font-medium text-slate-700"
+            >
+              Quiz
+            </label>
+            <AddonSelect
+              id={quizSelectId}
+              ariaLabel="Quiz"
+              value={selectedQuizId}
+              onChange={setSelectedQuizId}
+              disabled={busy || quizzesLoading}
+              placeholder={
+                quizzesLoading
+                  ? 'Loading your quizzes…'
+                  : quizzes.length === 0
+                    ? 'No quizzes in your library yet'
+                    : 'Select a quiz…'
+              }
+              options={quizzes.map((q) => ({ value: q.id, label: q.title }))}
+            />
+          </AddonCard>
+
+          <AddonButton
+            onClick={() => void addQuiz()}
+            loading={busy}
+            disabled={!selectedQuizId}
+            icon={Send}
+          >
+            Add quiz to Schoology
+          </AddonButton>
+        </div>
+      )}
+
+      {phase !== 'error' && (
+        <div className="mt-4 space-y-2">
+          <AddonError message={errorMsg} />
+          <AddonStatus message={statusMsg} busy={busy} />
+        </div>
+      )}
+    </AddonShell>
+  );
+};
+
+export default LtiDeepLinkWindow;

--- a/components/lti/deepLinkHandoff.test.ts
+++ b/components/lti/deepLinkHandoff.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  parseHandoffMessage,
+  DL_HANDOFF_READY,
+  DL_HANDOFF_CONTEXT,
+  DL_HANDOFF_RESPONSE,
+} from './deepLinkHandoff';
+
+const ORIGIN = window.location.origin;
+
+function evt(data: unknown, origin: string = ORIGIN): MessageEvent {
+  return new MessageEvent('message', { data, origin });
+}
+
+describe('parseHandoffMessage', () => {
+  it('accepts a READY message from our origin', () => {
+    expect(parseHandoffMessage(evt({ type: DL_HANDOFF_READY }))).toEqual({
+      type: DL_HANDOFF_READY,
+    });
+  });
+
+  it('accepts a well-formed CONTEXT message (with optional dlData)', () => {
+    const context = {
+      returnUrl: 'https://schoology.example/return',
+      dlData: 'opaque',
+      contextId: '7595131723',
+    };
+    expect(
+      parseHandoffMessage(evt({ type: DL_HANDOFF_CONTEXT, context }))
+    ).toEqual({ type: DL_HANDOFF_CONTEXT, context });
+  });
+
+  it('accepts a CONTEXT message without dlData', () => {
+    const context = {
+      returnUrl: 'https://schoology.example/return',
+      contextId: '7595131723',
+    };
+    expect(
+      parseHandoffMessage(evt({ type: DL_HANDOFF_CONTEXT, context }))
+    ).toEqual({ type: DL_HANDOFF_CONTEXT, context });
+  });
+
+  it('rejects a CONTEXT message missing returnUrl or contextId', () => {
+    expect(
+      parseHandoffMessage(
+        evt({ type: DL_HANDOFF_CONTEXT, context: { contextId: 'x' } })
+      )
+    ).toBeNull();
+    expect(
+      parseHandoffMessage(
+        evt({
+          type: DL_HANDOFF_CONTEXT,
+          context: { returnUrl: 'https://x' },
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('accepts a well-formed RESPONSE message', () => {
+    const response = {
+      jwt: 'eyJ...',
+      returnUrl: 'https://schoology.example/r',
+    };
+    expect(
+      parseHandoffMessage(evt({ type: DL_HANDOFF_RESPONSE, response }))
+    ).toEqual({ type: DL_HANDOFF_RESPONSE, response });
+  });
+
+  it('rejects a RESPONSE message missing jwt', () => {
+    expect(
+      parseHandoffMessage(
+        evt({ type: DL_HANDOFF_RESPONSE, response: { returnUrl: 'https://x' } })
+      )
+    ).toBeNull();
+  });
+
+  it('rejects messages from a foreign origin (the core security check)', () => {
+    expect(
+      parseHandoffMessage(
+        evt({ type: DL_HANDOFF_READY }, 'https://evil.example')
+      )
+    ).toBeNull();
+    const context = { returnUrl: 'https://x', contextId: 'y' };
+    expect(
+      parseHandoffMessage(
+        evt({ type: DL_HANDOFF_CONTEXT, context }, 'https://evil.example')
+      )
+    ).toBeNull();
+  });
+
+  it('rejects non-object / unknown-type payloads', () => {
+    expect(parseHandoffMessage(evt(null))).toBeNull();
+    expect(parseHandoffMessage(evt('a string'))).toBeNull();
+    expect(parseHandoffMessage(evt({ type: 'something-else' }))).toBeNull();
+    expect(parseHandoffMessage(evt({}))).toBeNull();
+  });
+});

--- a/components/lti/deepLinkHandoff.ts
+++ b/components/lti/deepLinkHandoff.ts
@@ -121,11 +121,34 @@ export function postHandoffMessage(
  * navigate); submitting navigates the current window back to the platform.
  * Used by the launcher (navigates the Schoology iframe) and, as a fallback when
  * the opener is gone, by the window itself.
+ *
+ * SECURITY: the return URL is platform-supplied (validated server-side before
+ * signing), but we re-validate it here — inline, so the guard dominates the
+ * `form.action` sink — against the same https + schoology.com allowlist the
+ * server uses (`isSchoologyReturnUrl`), then submit the PARSED href. A
+ * tampered/forged value — a `javascript:`/`data:` scheme (DOM XSS) or a foreign
+ * host (open redirect) — is rejected, never assigned to the form.
  */
 export function postDeepLinkResponse(returnUrl: string, jwt: string): void {
+  let parsed: URL | null = null;
+  try {
+    parsed = new URL(returnUrl);
+  } catch {
+    parsed = null;
+  }
+  if (
+    !parsed ||
+    parsed.protocol !== 'https:' ||
+    !/(^|\.)schoology\.com$/.test(parsed.hostname)
+  ) {
+    throw new Error(
+      'Refusing to submit the deep-link response: invalid or non-Schoology return URL.'
+    );
+  }
+
   const form = document.createElement('form');
   form.method = 'POST';
-  form.action = returnUrl;
+  form.action = parsed.href;
   const input = document.createElement('input');
   input.type = 'hidden';
   input.name = 'JWT';

--- a/components/lti/deepLinkHandoff.ts
+++ b/components/lti/deepLinkHandoff.ts
@@ -1,0 +1,136 @@
+/**
+ * postMessage handoff protocol between the in-iframe deep-link LAUNCHER
+ * (LtiDeepLinkPicker, embedded in Schoology) and the top-level handoff WINDOW
+ * (LtiDeepLinkWindow, opened via window.open).
+ *
+ * Why a handoff at all: Google Workspace Context-Aware Access denies the
+ * teacher's Google OAuth token when the sign-in popup is spawned from the
+ * partitioned Schoology iframe ("Account Restricted" — access_not_configured).
+ * Running sign-in + quiz pick in a TOP-LEVEL spartboard.web.app window makes the
+ * OAuth first-party, so CAA passes (it's the same context where the normal app
+ * sign-in already works). The window then hands the signed
+ * LtiDeepLinkingResponse JWT back to the iframe, which form-POSTs it to
+ * Schoology's return URL — the normal deep-link ending. (Students are
+ * unaffected: their session is a server-minted custom token, no popup.)
+ *
+ * Both ends are the SAME origin (spartboard.web.app ↔ spartboard.web.app), so
+ * every message is validated against `window.location.origin`.
+ */
+
+/** Path the launcher opens as a top-level window. Relative → resolves to our origin. */
+export const DL_HANDOFF_WINDOW_PATH = '/lti/teacher?mode=deeplink&handoff=1';
+
+export const DL_HANDOFF_READY = 'lti-dl-handoff-ready';
+export const DL_HANDOFF_CONTEXT = 'lti-dl-handoff-context';
+export const DL_HANDOFF_RESPONSE = 'lti-dl-handoff-response';
+
+/**
+ * Deep-link context the launcher hands to the window. Sourced from the
+ * launcher's one-time launch-code exchange (the window has no launch code of its
+ * own — it's single-use and already consumed by the iframe).
+ */
+export interface DlHandoffContext {
+  /** Schoology's `deep_link_return_url` — where the signed response is POSTed. */
+  returnUrl: string;
+  /** Opaque platform round-trip value that MUST be echoed back in the response. */
+  dlData?: string;
+  /** LTI context id → scopes the created quiz session (`schoology:<contextId>`). */
+  contextId: string;
+}
+
+/** Window → launcher: the signed LtiDeepLinkingResponse JWT to POST back. */
+export interface DlHandoffResponse {
+  jwt: string;
+  returnUrl: string;
+}
+
+type ReadyMsg = { type: typeof DL_HANDOFF_READY };
+type ContextMsg = {
+  type: typeof DL_HANDOFF_CONTEXT;
+  context: DlHandoffContext;
+};
+type ResponseMsg = {
+  type: typeof DL_HANDOFF_RESPONSE;
+  response: DlHandoffResponse;
+};
+export type DlHandoffMessage = ReadyMsg | ContextMsg | ResponseMsg;
+
+function isContext(v: unknown): v is DlHandoffContext {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.returnUrl === 'string' &&
+    o.returnUrl.length > 0 &&
+    typeof o.contextId === 'string' &&
+    o.contextId.length > 0 &&
+    (o.dlData === undefined || typeof o.dlData === 'string')
+  );
+}
+
+function isResponse(v: unknown): v is DlHandoffResponse {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.jwt === 'string' &&
+    o.jwt.length > 0 &&
+    typeof o.returnUrl === 'string' &&
+    o.returnUrl.length > 0
+  );
+}
+
+/**
+ * Parse a MessageEvent into a typed handoff message, or `null` if it isn't a
+ * well-formed handoff message FROM OUR OWN ORIGIN. Centralizes the origin check
+ * both ends depend on, so a message from any other frame/extension is dropped.
+ */
+export function parseHandoffMessage(
+  event: MessageEvent
+): DlHandoffMessage | null {
+  if (typeof window === 'undefined') return null;
+  if (event.origin !== window.location.origin) return null;
+  const data: unknown = event.data;
+  if (!data || typeof data !== 'object') return null;
+  const type = (data as { type?: unknown }).type;
+  if (type === DL_HANDOFF_READY) return { type: DL_HANDOFF_READY };
+  if (type === DL_HANDOFF_CONTEXT) {
+    const context = (data as { context?: unknown }).context;
+    return isContext(context) ? { type: DL_HANDOFF_CONTEXT, context } : null;
+  }
+  if (type === DL_HANDOFF_RESPONSE) {
+    const response = (data as { response?: unknown }).response;
+    return isResponse(response)
+      ? { type: DL_HANDOFF_RESPONSE, response }
+      : null;
+  }
+  return null;
+}
+
+/** Post a typed handoff message to `target`, constrained to our own origin. */
+export function postHandoffMessage(
+  target: Window,
+  msg: DlHandoffMessage
+): void {
+  if (typeof window === 'undefined') return;
+  target.postMessage(msg, window.location.origin);
+}
+
+/**
+ * Deliver the signed LTI deep-linking response: an auto-submitting hidden-form
+ * POST to the platform's `deep_link_return_url` carrying a single `JWT` field.
+ * The form is attached just long enough to submit (a detached form cannot
+ * navigate); submitting navigates the current window back to the platform.
+ * Used by the launcher (navigates the Schoology iframe) and, as a fallback when
+ * the opener is gone, by the window itself.
+ */
+export function postDeepLinkResponse(returnUrl: string, jwt: string): void {
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = returnUrl;
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = 'JWT';
+  input.value = jwt;
+  form.appendChild(input);
+  document.body.appendChild(form);
+  form.submit();
+}


### PR DESCRIPTION
Promotes `dev-paul` → `main`. **Merge with a regular merge commit — NOT squash.** This push to `main` deploys production (`spartboard.web.app`) so the Schoology deep-link flow can be tested live.

## What's being promoted

`feat(lti): break teacher deep-link sign-in out of the Schoology iframe` (`c3faf9e4`)

**Problem:** Google Workspace Context-Aware Access denies the teacher's Google OAuth token when the sign-in popup is spawned from Schoology's partitioned iframe (`Account Restricted` / `access_not_configured`). The normal top-level app sign-in works fine; the Classroom add-on only escapes this because it's embedded in `classroom.google.com` (Google first-party).

**Fix:** the in-iframe picker becomes a thin **launcher** that opens a **top-level** `spartboard.web.app` window (first-party → CAA passes) for Google sign-in + quiz pick + response signing, then receives the signed `LtiDeepLinkingResponse` back via same-origin `postMessage` and form-POSTs it to Schoology to finish the attach — the normal deep-link ending.

- `deepLinkHandoff.ts` — same-origin postMessage protocol (READY/CONTEXT/RESPONSE) with strict origin validation + shared deep-link form-POST.
- `LtiDeepLinkWindow.tsx` — top-level handoff picker (sign-in + pick + sign + post back; opener-gone fallback; retry-safe).
- `LtiDeepLinkPicker.tsx` — dispatches `handoff=1` → window; else the launcher.

Students are unaffected (server-minted custom token, no popup). 14 unit tests green; type-check/lint/format clean.

## Live test after deploy
**Add Materials → SpartBoard** in Schoology → **Choose a quiz** → a SpartBoard window opens (sign in there — CAA should now pass) → pick a quiz → window closes → Schoology shows the quiz attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)