### PR TITLE
Promote dev-paul → main: LTI deep-link response nonce (#1844)

### DIFF
--- a/functions/src/lti/deepLink.test.ts
+++ b/functions/src/lti/deepLink.test.ts
@@ -51,6 +51,7 @@ describe('buildDeepLinkResponseClaims', () => {
     ];
     const claims = buildDeepLinkResponseClaims({
       deploymentId: 'dep-1',
+      nonce: 'nonce-123',
       data: 'opaque-xyz',
       contentItems: items,
     });
@@ -59,14 +60,17 @@ describe('buildDeepLinkResponseClaims', () => {
     expect(claims[LTI.DEPLOYMENT_ID]).toBe('dep-1');
     expect(claims[LTI.DL_CONTENT_ITEMS]).toEqual(items);
     expect(claims[LTI.DL_DATA]).toBe('opaque-xyz');
+    expect(claims.nonce).toBe('nonce-123');
   });
 
-  it('omits data when absent', () => {
+  it('omits data when absent but still sets a nonce', () => {
     const claims = buildDeepLinkResponseClaims({
       deploymentId: 'd',
+      nonce: 'n',
       contentItems: [],
     });
     expect(LTI.DL_DATA in claims).toBe(false);
+    expect(claims.nonce).toBe('n');
   });
 });
 

--- a/functions/src/lti/deepLink.ts
+++ b/functions/src/lti/deepLink.ts
@@ -41,6 +41,14 @@ export function buildQuizContentItem(opts: {
 
 export function buildDeepLinkResponseClaims(opts: {
   deploymentId: string;
+  /**
+   * A fresh nonce for THIS response message. LTI 1.3 requires every message JWT
+   * — including the deep-linking response — to carry a `nonce`; Schoology rejects
+   * the response without it ("Invalid parameter: nonce is required"). It is the
+   * tool's own nonce for the response, NOT the launch nonce echoed back, so the
+   * caller generates a random value per response.
+   */
+  nonce: string;
   data?: string;
   contentItems: ContentItem[];
 }): Record<string, unknown> {
@@ -49,6 +57,7 @@ export function buildDeepLinkResponseClaims(opts: {
     [LTI.VERSION]: '1.3.0',
     [LTI.DEPLOYMENT_ID]: opts.deploymentId,
     [LTI.DL_CONTENT_ITEMS]: opts.contentItems,
+    nonce: opts.nonce,
   };
   // Echo the platform's opaque `data` exactly when present (DL spec requirement).
   if (opts.data) claims[LTI.DL_DATA] = opts.data;

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -9,6 +9,7 @@
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https';
 import { defineSecret } from 'firebase-functions/params';
+import { randomBytes } from 'node:crypto';
 import * as admin from 'firebase-admin';
 
 import {
@@ -86,6 +87,7 @@ export const ltiSignDeepLinkResponseV1 = onCall(
     });
     const claims = buildDeepLinkResponseClaims({
       deploymentId: cfg.deploymentId,
+      nonce: randomBytes(16).toString('hex'),
       data: typeof data.dlData === 'string' ? data.dlData : undefined,
       contentItems: [item],
     });


### PR DESCRIPTION
Promotes #1844 (adds the required `nonce` to the LtiDeepLinkingResponse JWT) to prod so the deep-link attach round-trip can be re-tested live.

Builds on the already-merged #1842 (full-tab redirect). Live test confirmed top-nav works + CAA passes first-party + the quiz library loads; this is the last spec-compliance gap (Schoology rejected the response without a nonce).

Regular merge (NOT squash) per the dev-paul→main flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)