### PR TITLE
docs(changelog): release entry for 2026-06-03 (Schoology quiz add)

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,7 +1,7 @@
 {
   "entries": [
     {
-      "version": "2026.06.03.2",
+      "version": "2026.06.03.1",
       "date": "2026-06-03",
       "title": "Adding a SpartBoard quiz to Schoology",
       "details": [

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,17 @@
 {
   "entries": [
     {
+      "version": "2026.06.03.2",
+      "date": "2026-06-03",
+      "title": "Adding a SpartBoard quiz to Schoology",
+      "details": [
+        {
+          "type": "fix",
+          "text": "Schoology — adding a SpartBoard quiz to your course now finishes cleanly. Previously, even when the quiz was added successfully, you could be shown a confusing error and left on a blank page. Now the quiz is added without that error and you're taken straight back to your course's materials, with a \"Return to your course\" link as a backup in case the automatic redirect doesn't happen."
+        }
+      ]
+    },
+    {
       "version": "2026.06.03",
       "date": "2026-06-03",
       "title": "Google Classroom linking, scoring, and widget fixes",


### PR DESCRIPTION
Adds a "What's New" changelog entry for the release shipping in #1846 (dev-paul → main).

The release batch since the last changelog entry (`2026.06.03`) contains a single user-facing change: the Schoology deep-link fix from `d55d463`, which previously surfaced a confusing duplicate-request error after a quiz was added and left the teacher on a blank page. The new entry (`2026.06.03.2`) describes the outcome in teacher terms — one `fix` detail, no overview (small release).

**Why this is a separate PR instead of a direct commit on `dev-paul`:** this environment's git proxy only permits pushes to `claude/vibrant-darwin-C4BO8` and returns `403 Forbidden` for `dev-paul`. Merging this small doc PR into `dev-paul` lands the entry in the #1846 release.

Review the copy before merging.

https://claude.ai/code/session_01HpctxmDjdfyjV6aajPdXPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpctxmDjdfyjV6aajPdXPS)_