### PR TITLE
fix(auth): unblock Drive-token refresh — non-popping silent GIS + COOP

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -380,24 +380,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       const email = user?.email;
 
       const runRefreshChain = async (): Promise<string | null> => {
-        // GIS `requestAccessToken({ prompt: '' })` is only truly silent when the
-        // user has a live Google session; with no session it surfaces a popup,
-        // and the browser BLOCKS popups that aren't tied to a user gesture — and
-        // our background timers + startup effect call this with silent=true. A
-        // blocked popup can't mint the Drive/Sheets access token, so the quiz
-        // library (and every other Drive read) silently stalls. Gate the GIS
-        // interactive request behind `!silent`: background refreshes use ONLY
-        // the popup-free backend refresh_token path below. When that can't
-        // produce a token the call returns null and `DriveDisconnectBanner`
-        // prompts the teacher to reconnect from a real click — which runs the
-        // code flow (access_type:offline) and captures a refresh_token, so
-        // every subsequent background refresh then succeeds silently server-side.
-        if (
-          !silent &&
-          clientId &&
-          email &&
-          typeof window.google !== 'undefined'
-        ) {
+        // Try the GIS token client first — it silently re-mints the
+        // Drive/Sheets access token from the user's live Google session, which
+        // is the ONLY zero-touch renewal path for the majority of teachers (a
+        // plain signInWithGoogle() popup yields a 1h token but no server-side
+        // refresh_token, so the backend path below can't renew theirs). The
+        // catch: `requestAccessToken({ prompt: '' })` is only silent when a
+        // grant can be reissued; otherwise it opens a popup, and a popup fired
+        // from our background timers/startup effect (silent=true) has no user
+        // gesture and gets BLOCKED — stalling every Drive read. So pass
+        // `prompt: 'none'` for silent calls (see requestAccessToken below): GIS
+        // then fails via error_callback with no popup when re-consent is truly
+        // needed, the chain returns null, and `DriveDisconnectBanner` lets the
+        // teacher reconnect from a real click (which runs the code flow and
+        // finally captures a refresh_token).
+        if (clientId && email && typeof window.google !== 'undefined') {
           let gisToken: string | null = null;
           try {
             gisToken = await new Promise<string | null>((resolve) => {
@@ -446,9 +443,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
                 resolve(null);
                 return;
               }
-              // prompt: '' = attempt silent authorization without showing a popup.
-              // A popup only appears when the user's Google session has expired.
-              tokenClient.requestAccessToken({ prompt: '' });
+              // Background/timer calls (silent) use `prompt: 'none'` so GIS
+              // never opens a gesture-less popup the browser would block — it
+              // fails via error_callback instead. User-gesture reconnects
+              // (silent=false) use `''`, which may surface the consent/account
+              // popup (allowed, since a click backs it).
+              tokenClient.requestAccessToken({ prompt: silent ? 'none' : '' });
             });
           } catch {
             // initTokenClient or requestAccessToken threw synchronously.

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -380,9 +380,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       const email = user?.email;
 
       const runRefreshChain = async (): Promise<string | null> => {
-        // Prefer GIS silent refresh when the client ID env var is configured.
-        // google.accounts is loaded asynchronously via the GIS script tag in index.html.
-        if (clientId && email && typeof window.google !== 'undefined') {
+        // GIS `requestAccessToken({ prompt: '' })` is only truly silent when the
+        // user has a live Google session; with no session it surfaces a popup,
+        // and the browser BLOCKS popups that aren't tied to a user gesture — and
+        // our background timers + startup effect call this with silent=true. A
+        // blocked popup can't mint the Drive/Sheets access token, so the quiz
+        // library (and every other Drive read) silently stalls. Gate the GIS
+        // interactive request behind `!silent`: background refreshes use ONLY
+        // the popup-free backend refresh_token path below. When that can't
+        // produce a token the call returns null and `DriveDisconnectBanner`
+        // prompts the teacher to reconnect from a real click — which runs the
+        // code flow (access_type:offline) and captures a refresh_token, so
+        // every subsequent background refresh then succeeds silently server-side.
+        if (
+          !silent &&
+          clientId &&
+          email &&
+          typeof window.google !== 'undefined'
+        ) {
           let gisToken: string | null = null;
           try {
             gisToken = await new Promise<string | null>((resolve) => {

--- a/firebase.json
+++ b/firebase.json
@@ -58,6 +58,15 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cross-Origin-Opener-Policy",
+            "value": "same-origin-allow-popups"
+          }
+        ]
+      },
+      {
         "source": "/activity/**",
         "headers": [
           {


### PR DESCRIPTION
## What
Restores Drive/Sheets/Calendar token refresh after the Workspace admin fixed the underlying sign-in outage (an under-scoped Marketplace listing was blocking those scopes; resolved by trusting the prod OAuth client). Two changes:

- **context/AuthContext.tsx** — the background Google-token refresh fired a gesture-less GIS popup the browser blocked, stalling the quiz library. Keep the silent GIS renewal but pass `prompt: 'none'` so it never opens a blockable popup: it renews silently when a grant can be reissued and falls to the `DriveDisconnectBanner` (gesture reconnect) when re-consent is genuinely needed. Gesture reconnects keep `prompt: ''`.
- **firebase.json** — add `Cross-Origin-Opener-Policy: same-origin-allow-popups` so the page can manage the OAuth popup it opens.

## Review
Ran `/code-review`. COOP verified safe (no COEP present → can't sever popups). The first cut (an `!silent` gate) was caught as removing the only zero-touch renewal for the majority of teachers (standard `signInWithGoogle()` yields no server refresh_token) → corrected to `prompt: 'none'`.

## Validation
type-check ✓ · eslint ✓ · prettier ✓ · 4025 tests ✓ · verified on the dev-paul preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)