### PR TITLE
docs(changelog): release entry for 2026-06-03 (Schoology + Google sign-in)

### DIFF
--- a/public/changelog.json
+++ b/public/changelog.json
@@ -1,6 +1,44 @@
 {
   "entries": [
     {
+      "version": "2026.06.03.2",
+      "date": "2026-06-03",
+      "title": "Schoology integration and Google sign-in fixes",
+      "overview": [
+        {
+          "type": "feature",
+          "subtitle": "Schoology",
+          "items": [
+            {
+              "text": "Attach a SpartBoard quiz to a Schoology assignment, and your students take it right inside Schoology."
+            },
+            {
+              "text": "Each student's score posts back to your Schoology gradebook as the points they earned."
+            }
+          ]
+        },
+        {
+          "type": "fix",
+          "subtitle": "Google sign-in",
+          "items": [
+            {
+              "text": "SpartBoard no longer triggers a blocked Google sign-in popup while it quietly refreshes your access to Drive and Sheets in the background."
+            }
+          ]
+        }
+      ],
+      "details": [
+        {
+          "type": "feature",
+          "text": "Schoology — you can now attach a SpartBoard quiz to a Schoology assignment. From an assignment, choose Add Material → SpartBoard, sign in with your Google account, and pick a quiz from your library; your students open and take it right inside Schoology, and each student's score posts back to your Schoology gradebook as the points they earned (a 17 out of 20 quiz reads as 17/20, not a percentage). After you attach the quiz, SpartBoard returns you to your Schoology course on its own — no extra tabs to close. Your school's Schoology administrator needs to add SpartBoard before it shows up in the Add Material list."
+        },
+        {
+          "type": "fix",
+          "text": "Google sign-in — SpartBoard no longer fires a Google sign-in popup in the background while quietly refreshing your access to Google Drive and Sheets. Previously that automatic refresh could open a popup with no click behind it, which your browser blocks, leaving Drive-backed features (like loading a quiz or syncing a board) stuck waiting. When your access genuinely needs renewing, you now see a calm \"Reconnect\" banner you can click instead of a popup that never appears."
+        }
+      ]
+    },
+    {
       "version": "2026.06.03",
       "date": "2026-06-03",
       "title": "Google Classroom linking, scoring, and widget fixes",


### PR DESCRIPTION
## What

Adds a "What's New" changelog entry (`public/changelog.json`, version `2026.06.03.2`) covering everything shipped to production since the last changelog entry (`2026.06.03`).

This was triggered by PR #1848 (dev-paul → main), which has already been merged. Because direct pushes to `dev-paul` aren't permitted from this environment and #1848 was already closed, the entry is delivered via this companion branch (`claude/vibrant-darwin-bHcj5`, which is `dev-paul`'s head + this one commit). The diff here is the changelog entry only.

## Release scope (commits since the last changelog)

- **Schoology** (feature) — the teacher deep-link picker now works end to end: sign in with Google inside Schoology, pick a quiz from your library, attach it to the assignment, and get returned to your course automatically. Students take it in Schoology and scores post back to the gradebook. (Base integration landed in #1821 but was never announced; this batch — #1835, #1837, and the follow-on sign-in/return fixes — is what makes it usable.)
- **Google sign-in** (fix) — background Drive/Sheets token refresh no longer fires a browser-blocked popup; a calm "Reconnect" banner appears only when re-consent is genuinely needed (#1848).

Internal-only change excluded from the entry: force-disabling the auth bypass on deployed origins (#1834).

## Notes for review

- 2 details bullets, 2 overview themes (Schoology / Google sign-in).
- Please review the teacher-facing copy — especially the Schoology framing — before merge.
- JSON validated and Prettier-clean.

https://claude.ai/code/session_015ytf72UALijmxKkYcYLM8i

---
_Generated by [Claude Code](https://claude.ai/code/session_015ytf72UALijmxKkYcYLM8i)_