### PR TITLE
refactor(D4): plc authoring→assignments + tabs→assignments imports → @/ alias

### DIFF
--- a/components/plc/authoring/PlcAuthorQuizModal.tsx
+++ b/components/plc/authoring/PlcAuthorQuizModal.tsx
@@ -15,7 +15,7 @@ import { useAuth } from '@/context/useAuth';
 import { useQuiz } from '@/hooks/useQuiz';
 import type { Plc, QuizBehaviorSettings, QuizData } from '@/types';
 import type { AssignmentQuizRef } from '@/hooks/useQuizAssignments';
-import { PlcAssignmentConfigModal } from '../assignments/PlcAssignmentConfigModal';
+import { PlcAssignmentConfigModal } from '@/components/plc/assignments/PlcAssignmentConfigModal';
 
 interface PlcAuthorQuizModalProps {
   plc: Plc;

--- a/components/plc/authoring/PlcAuthorVideoActivityModal.tsx
+++ b/components/plc/authoring/PlcAuthorVideoActivityModal.tsx
@@ -20,7 +20,7 @@ import type {
   VideoActivityData,
 } from '@/types';
 import type { AssignmentActivityRef } from '@/hooks/useVideoActivityAssignments';
-import { PlcAssignmentConfigModal } from '../assignments/PlcAssignmentConfigModal';
+import { PlcAssignmentConfigModal } from '@/components/plc/assignments/PlcAssignmentConfigModal';
 
 interface PlcAuthorVideoActivityModalProps {
   plc: Plc;

--- a/components/plc/tabs/PlcAssignmentsInProgressSubTab.tsx
+++ b/components/plc/tabs/PlcAssignmentsInProgressSubTab.tsx
@@ -23,7 +23,7 @@ import {
 import type { SharedAssignmentImportMode } from '@/hooks/useQuizAssignments';
 import { logError } from '@/utils/logError';
 import { PlcAssignmentImportModal } from '../PlcAssignmentImportModal';
-import { PlcAssignmentSessionModal } from '../assignments/PlcAssignmentSessionModal';
+import { PlcAssignmentSessionModal } from '@/components/plc/assignments/PlcAssignmentSessionModal';
 import { QuizAssignmentImportSetupModal } from '@/components/quiz/QuizAssignmentImportSetupModal';
 import { PlcAssignmentIndexRow } from './PlcAssignmentIndexRow';
 


### PR DESCRIPTION
## Nightly Unifier — D4 Import Path Convention (run 8 · 2026-06-04)

### Canonical Form
`import { X } from '@/components/plc/...'` — the `@/` alias for all cross-directory imports.
Multi-level `'../subdir/Module'` reaching from one `plc/` subdirectory into another is the anti-pattern.

### Instances Unified (3 imports across 3 files)

| File | Old Import | New Import |
|---|---|---|
| `components/plc/authoring/PlcAuthorQuizModal.tsx:18` | `'../assignments/PlcAssignmentConfigModal'` | `'@/components/plc/assignments/PlcAssignmentConfigModal'` |
| `components/plc/authoring/PlcAuthorVideoActivityModal.tsx:23` | `'../assignments/PlcAssignmentConfigModal'` | `'@/components/plc/assignments/PlcAssignmentConfigModal'` |
| `components/plc/tabs/PlcAssignmentsInProgressSubTab.tsx:26` | `'../assignments/PlcAssignmentSessionModal'` | `'@/components/plc/assignments/PlcAssignmentSessionModal'` |

This closes the authoring→assignments and tabs→assignments cross-subdir clusters from the D4 backlog.

### Behavior-Preservation Evidence
- **Mechanical** change: Vite's `@/` alias resolves to the repo root. Both the old relative path and the new alias path resolve to the same physical file. Module identity is unchanged.
- `pnpm exec tsc --noEmit` ✅ · `pnpm exec eslint [3 files] --max-warnings 0` ✅ · `pnpm exec prettier --check [3 files]` ✅
- Branch already based on `c902187` (current dev-paul tip) — no rebase needed.

### Gray-Zone Imports Left Alone
- `PlcAssignmentsInProgressSubTab.tsx:25`: `'../PlcAssignmentImportModal'` — single-level `..` reaching up to the `plc/` root (tabs→root); this is the D4-E2 gray zone, preserved.
- `PlcAssignmentsInProgressSubTab.tsx:28`: `'./PlcAssignmentIndexRow'` — same-directory import, correct per D4-E1.

### Remaining D4 Backlog After This PR
- `hooks/`, `context/`, `utils/` — 43/54/22 relative root-sibling imports (large pass, requires care around test tsconfig resolution)

### Risk Tag
**mechanical** — identical module resolution; only import path syntax changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H72993Z7dvJ4Txyjx6TGuC)_