### PR TITLE
fix(widgets): restore breathing phase position on pause/resume

### DIFF
--- a/components/widgets/Breathing/useBreathing.test.ts
+++ b/components/widgets/Breathing/useBreathing.test.ts
@@ -1,0 +1,168 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useBreathing } from './useBreathing';
+
+describe('useBreathing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(performance, 'now').mockImplementation(() => Date.now());
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      clearTimeout(id as unknown as number);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('starts in ready state', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('transitions to inhale phase on first start', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.phase).toBe('inhale');
+    expect(result.current.isActive).toBe(true);
+  });
+
+  /**
+   * Regression test for pause/resume bug:
+   *
+   * Before the fix, calling toggleActive() while paused mid-phase would
+   * always reset the phase back to 'inhale' with full duration, losing the
+   * user's position in the cycle. After the fix, resuming reconstructs
+   * startTime from the saved progress so the sequence continues from where
+   * it was paused.
+   *
+   * Scenario: start → let 2 s elapse into the 4 s inhale phase (progress=0.5)
+   * → pause → resume → phase should still be 'inhale', not snapped back to
+   * the beginning of 'inhale' from zero.
+   */
+  it('resumes from the correct position after pause (does not restart inhale from zero)', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+
+    // Start the sequence
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.phase).toBe('inhale');
+
+    // Advance time by 2 s (halfway through the 4 s inhale phase)
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // Verify we are mid-inhale with ~2 s remaining
+    const progressBeforePause = result.current.progress;
+    expect(result.current.phase).toBe('inhale');
+    expect(progressBeforePause).toBeGreaterThan(0);
+    expect(progressBeforePause).toBeLessThan(1);
+
+    // Pause
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.phase).toBe('inhale');
+
+    // Advance fake time while paused — the timer must NOT change phase
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(result.current.phase).toBe('inhale');
+
+    // Resume — the phase must remain 'inhale' (not jump to the start of a
+    // new 'inhale' phase with full 4 s duration)
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.isActive).toBe(true);
+    // The phase must still be 'inhale' immediately after resuming — the old
+    // bug would also have the phase as 'inhale' right after resume, but the
+    // key difference is that timeLeft should reflect the remaining time, not
+    // the full duration. We advance time slightly to let the RAF tick fire.
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(result.current.phase).toBe('inhale');
+    // After resuming and advancing 50ms, timeLeft should be approximately
+    // 2 s (the remaining portion), not the full 4 s. This proves the timer
+    // resumed from its paused position rather than restarting.
+    expect(result.current.timeLeft).toBeLessThanOrEqual(2);
+    expect(result.current.timeLeft).toBeGreaterThanOrEqual(1);
+  });
+
+  it('completing inhale phase transitions to hold1 for 4-4-4-4 pattern', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    // Advance past the 4 s inhale phase
+    act(() => {
+      vi.advanceTimersByTime(4500);
+    });
+
+    expect(result.current.phase).toBe('hold1');
+  });
+
+  it('reset returns to ready state', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.phase).toBe('inhale');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('after reset, starting again begins a fresh inhale phase', () => {
+    const { result } = renderHook(() => useBreathing('4-4-4-4'));
+
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.phase).toBe('ready');
+
+    // Start again — should begin at inhale with full duration
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.phase).toBe('inhale');
+    expect(result.current.isActive).toBe(true);
+  });
+});

--- a/components/widgets/Breathing/useBreathing.ts
+++ b/components/widgets/Breathing/useBreathing.ts
@@ -61,17 +61,30 @@ export const useBreathing = (patternId: BreathingPattern) => {
   const toggleActive = useCallback(() => {
     setIsActive((prev) => {
       if (!prev) {
-        // Starting
-        const newPhase = 'inhale';
-        setPhase(newPhase);
-        const duration = patternRef.current[newPhase];
-        setTimeLeft(duration);
-        setProgress(0);
-        stateRef.current.startTime = performance.now();
-        stateRef.current.phaseDuration = duration * 1000;
+        const now = performance.now();
+        const currentPhase = stateRef.current.phase;
+
+        if (currentPhase === 'ready') {
+          // Fresh start from idle state
+          const newPhase = 'inhale';
+          setPhase(newPhase);
+          const duration = patternRef.current[newPhase];
+          setTimeLeft(duration);
+          setProgress(0);
+          stateRef.current.startTime = now;
+          stateRef.current.phaseDuration = duration * 1000;
+        } else {
+          // Resuming from a paused mid-phase position. Reconstruct startTime
+          // so that elapsed = progress * phaseDuration, preserving the
+          // exact position in the current phase rather than jumping back to
+          // the beginning of inhale.
+          const { phaseDuration, progress } = stateRef.current;
+          const elapsedAlready = progress * phaseDuration;
+          stateRef.current.startTime = now - elapsedAlready;
+        }
         return true;
       } else {
-        // Pausing
+        // Pausing — RAF loop will be cancelled by the isActive effect cleanup.
         return false;
       }
     });


### PR DESCRIPTION
## Root cause

`useBreathing` (`components/widgets/Breathing/useBreathing.ts`) — `toggleActive` always reset to the `'inhale'` phase with full duration on every activation, regardless of whether the user was starting fresh or resuming from a paused mid-cycle position.

The code checked only `!prev` (was inactive?), and in that branch unconditionally set `phase='inhale'`, `stateRef.current.startTime = performance.now()`, and `phaseDuration = inhale duration`. A teacher who paused mid-exhale and pressed Resume was silently dropped back to the very start of a new inhale cycle.

## Fix

In the `!prev` branch, inspect `stateRef.current.phase`:
- `'ready'` → fresh start, initialise as before.
- any other phase → resuming; reconstruct `startTime` as `performance.now() - (progress * phaseDuration)` so the RAF tick loop picks up exactly where it was paused.

**Band-aid rejected:** A debounce or guard on the Play button would not fix the logic at all — the phase reset was synchronous, not a timing side-effect.

## Regression test

`components/widgets/Breathing/useBreathing.test.ts` (new file, 6 tests)

Key test: `resumes from the correct position after pause (does not restart inhale from zero)`
- Starts the breathing sequence, advances 2 s into the 4 s inhale phase (progress ≈ 0.5), pauses, resumes, advances one RAF tick.
- **Before fix:** `timeLeft === 4` (restarted from zero). Test fails: `expected 4 to be less than or equal to 2`.
- **After fix:** `timeLeft ≈ 2` (remaining time preserved). All 6 tests pass.

## Risk

**contained** — change is isolated to the `toggleActive` activation branch in one hook; RAF loop, phase transitions, and reset path are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQNp4kpbaRnzYXsbvbhHZU)_