### PR TITLE
fix(i18n): add missing widgets.lunchCount namespace to DE, ES, and FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -616,6 +616,13 @@
     "fr": "Français"
   },
   "widgets": {
+    "lunchCount": {
+      "syncSuccess": "Menü von Nutrislice synchronisiert",
+      "syncError": "Menü konnte nicht synchronisiert werden",
+      "noHotLunch": "Kein Mittagessen aufgelistet",
+      "noBentoBox": "Keine Bento-Box aufgelistet",
+      "hotLunch": "Mittagessen"
+    },
     "quiz": {
       "leaderboard": {
         "title": "Live-Bestenliste",

--- a/locales/es.json
+++ b/locales/es.json
@@ -623,7 +623,7 @@
       "syncSuccess": "Menú sincronizado desde Nutrislice",
       "syncError": "Error al sincronizar el menú",
       "noHotLunch": "Sin almuerzo caliente listado",
-      "noBentoBox": "Sin bento box listado",
+      "noBentoBox": "Sin bento box listada",
       "hotLunch": "Almuerzo Caliente"
     },
     "quiz": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -619,6 +619,13 @@
     "fr": "Français"
   },
   "widgets": {
+    "lunchCount": {
+      "syncSuccess": "Menú sincronizado desde Nutrislice",
+      "syncError": "Error al sincronizar el menú",
+      "noHotLunch": "Sin almuerzo caliente listado",
+      "noBentoBox": "Sin bento box listado",
+      "hotLunch": "Almuerzo Caliente"
+    },
     "quiz": {
       "leaderboard": {
         "title": "Tabla en Vivo",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -616,6 +616,13 @@
     "fr": "Français"
   },
   "widgets": {
+    "lunchCount": {
+      "syncSuccess": "Menu synchronisé depuis Nutrislice",
+      "syncError": "Échec de la synchronisation du menu",
+      "noHotLunch": "Aucun déjeuner chaud répertorié",
+      "noBentoBox": "Aucune bento box répertoriée",
+      "hotLunch": "Déjeuner Chaud"
+    },
     "quiz": {
       "leaderboard": {
         "title": "Classement en Direct",

--- a/tests/i18n/widgetLunchCountLocales.test.ts
+++ b/tests/i18n/widgetLunchCountLocales.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression test for the missing widgets.lunchCount sub-namespace in DE, ES,
+ * and FR locales.
+ *
+ * The `widgets.lunchCount` namespace was added to EN when the Lunch Count widget
+ * received Nutrislice integration, but the entire namespace was never propagated
+ * to DE, ES, or FR.
+ *
+ * Affected call sites that use these keys WITHOUT a `defaultValue` fallback:
+ *
+ *   components/widgets/LunchCount/useNutrislice.ts
+ *     t('widgets.lunchCount.noHotLunch')    — lines 148, 284, 307
+ *     t('widgets.lunchCount.noBentoBox')    — lines 149, 285, 308
+ *     t('widgets.lunchCount.syncSuccess')   — line 269
+ *     t('widgets.lunchCount.syncError')     — line 318
+ *
+ *   components/widgets/LunchCount/Widget.tsx
+ *     t('widgets.lunchCount.hotLunch')      — line 573
+ *
+ * When a German, Spanish, or French user has the Lunch Count widget open, every
+ * one of these strings renders as the raw key path (e.g.
+ * "widgets.lunchCount.syncError") instead of a translated or even English
+ * string.  The toast shown after a sync attempt and the "Hot Lunch" label
+ * visible on the widget face are both affected.
+ *
+ * This test loads each locale JSON directly so the assertion fires even before
+ * the i18next runtime would attempt (and silently skip) the fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+/**
+ * Keys within widgets.lunchCount that are called via t() without a
+ * defaultValue fallback — meaning non-EN users see raw key paths in the UI.
+ */
+const REQUIRED_LUNCH_COUNT_KEYS = [
+  'syncSuccess',
+  'syncError',
+  'noHotLunch',
+  'noBentoBox',
+  'hotLunch',
+] as const;
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — widgets.lunchCount baseline', () => {
+  it('has a widgets.lunchCount section', () => {
+    expect(en).toHaveProperty(['widgets', 'lunchCount']);
+  });
+
+  it('has all required widgets.lunchCount keys', () => {
+    for (const key of REQUIRED_LUNCH_COUNT_KEYS) {
+      expect(
+        en.widgets.lunchCount,
+        `en.widgets.lunchCount.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity ─────────────────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
+])('$code locale — widgets.lunchCount parity with EN', ({ code, locale }) => {
+  it(`${code}: has a widgets.lunchCount section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.lunchCount section is entirely missing`
+    ).toHaveProperty(['widgets', 'lunchCount']);
+  });
+
+  it(`${code}: has all required widgets.lunchCount keys`, () => {
+    for (const key of REQUIRED_LUNCH_COUNT_KEYS) {
+      expect(
+        locale,
+        `${code}.widgets.lunchCount.${key} is missing`
+      ).toHaveProperty(['widgets', 'lunchCount', key]);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

The `widgets.lunchCount` namespace (5 keys: `syncSuccess`, `syncError`, `noHotLunch`, `noBentoBox`, `hotLunch`) was present in `locales/en.json` but completely absent from `locales/de.json`, `locales/es.json`, and `locales/fr.json`.

All five keys are used in production code **without any `defaultValue` fallback**:
- `components/widgets/LunchCount/useNutrislice.ts` — toast messages after Nutrislice sync and fallback menu item labels
- `components/widgets/LunchCount/Widget.tsx` — "Hot Lunch" label rendered on the widget face

German, Spanish, and French users saw raw key paths like `"widgets.lunchCount.syncError"` in toast notifications and on the widget itself.

## Fix

Added translated `widgets.lunchCount` entries to all three non-English locale files (DE, ES, FR).

**Band-aid rejected:** Adding `defaultValue: 'Hot Lunch'` etc. to each `t()` call site would only degrade to English text, not translate anything, and scatter fallback strings across multiple call sites rather than fixing the locale files which are the canonical source of truth.

## Regression test

`tests/i18n/widgetLunchCountLocales.test.ts` (new file, 8 tests) — asserts that all 5 `widgets.lunchCount` keys exist in DE, ES, and FR.

- **Before fix:** 6 failures (all 5 keys missing × 3 locales — 2 EN tests pass).
- **After fix:** 8/8 pass.

## Risk

**contained** — locale JSON files only; no logic changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQNp4kpbaRnzYXsbvbhHZU)_