### PR TITLE
fix(functions): track video-activity-recommend AI usage per-feature

### DIFF
--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -444,6 +444,7 @@ export async function computeAnalyticsForOrg(
     'ocr',
     'guided-learning',
     'blooms-ai',
+    'video-activity-recommend',
   ];
 
   const aiUsageStream = db

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -907,6 +907,41 @@ describe('adminAnalytics', () => {
     expect(result.api.byFeature['blooms-ai']).toBe(3);
   });
 
+  it('counts video-activity-recommend usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: video-activity-recommend was missing from
+    // GEMINI_SPECIFIC_FEATURES in adminAnalyticsCompute.ts AND had no
+    // specificFeatureId assignment in generateWithAI. A doc like
+    // `uid1_video-activity-recommend_2026-06-04` was treated as an "overall"
+    // doc with uid = `uid1_video-activity-recommend`, which never matched any
+    // org member, so the call was silently dropped from totalCalls and
+    // byFeature['video-activity-recommend'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-04', data: { count: 7 } },
+      // Per-feature video-activity-recommend doc — should count toward
+      // byFeature['video-activity-recommend'] but NOT toward totalCalls
+      { id: 'uid1_video-activity-recommend_2026-06-04', data: { count: 4 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(7);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['video-activity-recommend']).toBe(4);
+  });
+
   it('returns topUsers with resolved email and unknown fallback', async () => {
     mockFirestoreState.users = [
       {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -95,7 +95,8 @@ interface AIData {
     | 'quiz'
     | 'widget-builder'
     | 'widget-explainer'
-    | 'blooms-ai';
+    | 'blooms-ai'
+    | 'video-activity-recommend';
   prompt?: string;
   image?: string; // base64 data
   /**
@@ -639,6 +640,8 @@ export const generateWithAI = onCall(
     if (genType === 'ocr') specificFeatureId = 'ocr';
     if (genType === 'guided-learning') specificFeatureId = 'guided-learning';
     if (genType === 'blooms-ai') specificFeatureId = 'blooms-ai';
+    if (genType === 'video-activity-recommend')
+      specificFeatureId = 'video-activity-recommend';
 
     const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 


### PR DESCRIPTION
## Root cause

`generateWithAI` in `functions/src/index.ts` assigns a `specificFeatureId` for each `genType` that should get per-feature rate limiting and analytics tracking. The `'video-activity-recommend'` type existed in `promptMap` but had no `specificFeatureId` assignment and was absent from `GEMINI_SPECIFIC_FEATURES` in `adminAnalyticsCompute.ts`.

Two consequences:
1. **No per-feature rate limiting** — `video-activity-recommend` calls never wrote a `{uid}_video-activity-recommend_{date}` doc, so the daily per-feature quota check was never enforced for this type.
2. **Silent analytics drop** — if such a doc had existed, `GEMINI_SPECIFIC_FEATURES` not including `'video-activity-recommend'` would cause the doc ID parser to treat `uid_video-activity-recommend_date` as an "overall" doc with UID `uid_video-activity-recommend`, which matches no org member — silently discarding every call from `totalCalls`, `byFeature`, and `topUsers`.

Note: the 2026-06-03 memory doc audit note claiming `video-activity-recommend` was already in the array was **incorrect** — the array never contained it.

## Fix

- `functions/src/index.ts`: Added `if (genType === 'video-activity-recommend') specificFeatureId = 'video-activity-recommend';` immediately after the `blooms-ai` assignment. Also added `'video-activity-recommend'` to the `AIData.type` union.
- `functions/src/adminAnalyticsCompute.ts`: Added `'video-activity-recommend'` to `GEMINI_SPECIFIC_FEATURES`.

**Band-aid rejected:** Adding only the analytics entry without the `specificFeatureId` assignment (or vice versa) would leave half the problem in place. Both changes are required together.

## Regression test

`functions/src/index.test.ts` — new test: `counts video-activity-recommend usage docs toward byFeature without corrupting uid parsing`

Feeds a `uid1_video-activity-recommend_2026-06-04` usage doc into `computeAnalyticsForOrg` and asserts `result.api.byFeature['video-activity-recommend'] === 4`.

- **Before fix:** `byFeature['video-activity-recommend']` is `undefined` (doc misparsed as overall). Test fails.
- **After fix:** All 61 tests pass.

## Risk

**contained** — two matching additions (one per file) following the established `blooms-ai` pattern from #1805. No existing behaviour changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQNp4kpbaRnzYXsbvbhHZU)_