### PR TITLE
feat(admin): per-building appearance defaults for ConceptWeb & Checklist

### DIFF
--- a/components/admin/ChecklistConfigurationPanel.tsx
+++ b/components/admin/ChecklistConfigurationPanel.tsx
@@ -6,9 +6,11 @@ import {
   ChecklistGlobalConfig,
   BuildingChecklistDefaults,
   ChecklistDefaultItem,
+  GlobalFontFamily,
 } from '@/types';
 import { Plus, Trash2, GripVertical } from 'lucide-react';
 import { Card } from '@/components/common/Card';
+import { HexColorField } from './HexColorField';
 
 interface ChecklistConfigurationPanelProps {
   config: ChecklistGlobalConfig;
@@ -123,6 +125,86 @@ export const ChecklistConfigurationPanel: React.FC<
             <span>0.5x (Small)</span>
             <span>1.0x (Normal)</span>
             <span>2.5x (Large)</span>
+          </div>
+        </div>
+
+        {/* Appearance Defaults */}
+        <div className="border-t border-slate-200 pt-4 space-y-3">
+          <span className="text-xxs font-bold text-slate-500 uppercase block">
+            Appearance Defaults
+          </span>
+          <div>
+            <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+              Default Font Family
+            </label>
+            <select
+              value={currentBuildingConfig.fontFamily ?? 'global'}
+              onChange={(e) => {
+                const selected = e.target.value;
+                handleUpdateBuilding({
+                  fontFamily:
+                    selected === 'global'
+                      ? undefined
+                      : (selected as GlobalFontFamily),
+                });
+              }}
+              className="w-full px-2 py-1.5 text-xs border border-slate-200 rounded focus:ring-1 focus:ring-brand-blue-primary outline-none bg-white"
+            >
+              <option value="global">Global (Dashboard default)</option>
+              <option value="sans">Sans Serif</option>
+              <option value="serif">Serif</option>
+              <option value="mono">Monospace</option>
+              <option value="handwritten">Handwritten</option>
+              <option value="rounded">Rounded</option>
+              <option value="comic">Comic</option>
+              <option value="slab">Slab Serif</option>
+              <option value="retro">Retro</option>
+              <option value="fun">Fun</option>
+              <option value="marker">Marker</option>
+              <option value="cursive">Cursive</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+              Default Text Colour
+            </label>
+            <HexColorField
+              value={currentBuildingConfig.fontColor}
+              onChange={(fontColor) => handleUpdateBuilding({ fontColor })}
+              fallback="#334155"
+              ariaLabel="Pick default checklist text colour"
+            />
+          </div>
+          <div>
+            <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+              Default Surface Colour
+            </label>
+            <HexColorField
+              value={currentBuildingConfig.cardColor}
+              onChange={(cardColor) => handleUpdateBuilding({ cardColor })}
+              fallback="#ffffff"
+              ariaLabel="Pick default checklist surface colour"
+            />
+          </div>
+          <div>
+            <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+              Default Surface Opacity (
+              {Math.round((currentBuildingConfig.cardOpacity ?? 1) * 100)}%)
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={currentBuildingConfig.cardOpacity ?? 1}
+              onChange={(e) =>
+                handleUpdateBuilding({
+                  cardOpacity: parseFloat(e.target.value),
+                })
+              }
+              className="w-full accent-brand-blue-primary"
+              aria-label="Default checklist surface opacity"
+            />
           </div>
         </div>
 

--- a/components/admin/ConceptWebConfigurationPanel.tsx
+++ b/components/admin/ConceptWebConfigurationPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ConceptWebGlobalConfig, GlobalFontFamily } from '@/types';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useBuildingSelection } from '@/hooks/useBuildingSelection';
+import { HexColorField } from './HexColorField';
 interface Props {
   config: Record<string, unknown>;
   onChange: (newConfig: Record<string, unknown>) => void;
@@ -133,6 +134,50 @@ export const ConceptWebConfigurationPanel: React.FC<Props> = ({
             <option value="comic">Comic</option>
             <option value="handwritten">Handwritten</option>
           </select>
+        </div>
+
+        <div className="border-t border-slate-200 pt-5">
+          <h3 className="text-sm font-black text-slate-700 uppercase tracking-widest mb-1">
+            Appearance Defaults
+          </h3>
+          <p className="text-xs text-slate-500 mb-4 font-bold">
+            Set the default node surface colour and opacity for new Concept Web
+            widgets in this building. Teachers can still change these per
+            widget.
+          </p>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-xs font-bold text-slate-600 uppercase mb-2">
+                Default Surface Colour
+              </label>
+              <HexColorField
+                value={buildingConfig.cardColor}
+                onChange={(cardColor) => updateBuildingConfig({ cardColor })}
+                fallback="#ffffff"
+                ariaLabel="Pick default node surface colour"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-bold text-slate-600 uppercase mb-2">
+                Default Surface Opacity (
+                {Math.round((buildingConfig.cardOpacity ?? 1) * 100)}%)
+              </label>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.05"
+                value={buildingConfig.cardOpacity ?? 1}
+                onChange={(e) =>
+                  updateBuildingConfig({
+                    cardOpacity: parseFloat(e.target.value),
+                  })
+                }
+                className="w-full accent-brand-blue-primary"
+                aria-label="Default node surface opacity"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/components/admin/HexColorField.tsx
+++ b/components/admin/HexColorField.tsx
@@ -11,6 +11,28 @@ const isValidHex = (color?: string): boolean =>
   typeof color === 'string' &&
   /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(color);
 
+// Bare hex digits (3/6/8) without the leading '#', for the forgiving on-blur path.
+const BARE_HEX_RE = /^([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * Normalise a stored hex colour to the 6-digit lowercase form that the native
+ * `<input type="color">` swatch requires. The text field and the server
+ * validator also accept 3-digit (`#abc`) and 8-digit alpha (`#aabbccdd`) hex,
+ * but the swatch silently renders those as black — so expand shortform and
+ * drop the alpha byte before handing the value to the swatch. `fallback` is
+ * always a valid 6-digit colour supplied by the panel.
+ */
+const toStandardHex = (color: string | undefined, fallback: string): string => {
+  const hex = (color && isValidHex(color) ? color : fallback).replace('#', '');
+  if (hex.length === 3) {
+    return `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`.toLowerCase();
+  }
+  if (hex.length === 8) {
+    return `#${hex.slice(0, 6)}`.toLowerCase();
+  }
+  return `#${hex}`.toLowerCase();
+};
+
 interface HexColorFieldProps {
   value: string | undefined;
   onChange: (next: string | undefined) => void;
@@ -56,7 +78,7 @@ export const HexColorField: React.FC<HexColorFieldProps> = ({
     <div className="flex items-center gap-3">
       <input
         type="color"
-        value={isValidHex(value) ? value : fallback}
+        value={toStandardHex(value, fallback)}
         onChange={(e) => onChange(e.target.value)}
         className={swatchClassName}
         aria-label={ariaLabel}
@@ -66,15 +88,21 @@ export const HexColorField: React.FC<HexColorFieldProps> = ({
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={() => {
-          const trimmed = draft.trim();
-          // Empty → clear the field; valid hex → commit; invalid
-          // (e.g. `#banana`, `#12`) → revert to the last committed value
-          // rather than persisting garbage downstream consumers would have
-          // to defensively re-validate.
-          if (trimmed === '') {
+          let next = draft.trim();
+          // Be forgiving: a bare hex string ("334155") gets its '#' prepended
+          // rather than being rejected as invalid.
+          if (next !== '' && !next.startsWith('#') && BARE_HEX_RE.test(next)) {
+            next = `#${next}`;
+          }
+          // Empty → clear the field; valid hex → commit (and snap the draft to
+          // the normalised value); invalid (e.g. `#banana`, `#12`) → revert to
+          // the last committed value rather than persisting garbage downstream
+          // consumers would have to defensively re-validate.
+          if (next === '') {
             onChange(undefined);
-          } else if (isValidHex(trimmed)) {
-            onChange(trimmed);
+          } else if (isValidHex(next)) {
+            onChange(next);
+            setDraft(next);
           } else {
             setDraft(value ?? '');
           }

--- a/components/admin/HexColorField.tsx
+++ b/components/admin/HexColorField.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+
+/**
+ * Accepts the three CSS-valid hex forms an HTML color picker / Tailwind
+ * palette may emit: 3-digit shortform, 6-digit standard, 8-digit alpha.
+ * Matches the server-side `isHexColor` validator in
+ * `utils/adminBuildingConfig.ts` so the panel and validator agree on what
+ * counts as a valid persistable color.
+ */
+const isValidHex = (color?: string): boolean =>
+  typeof color === 'string' &&
+  /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(color);
+
+interface HexColorFieldProps {
+  value: string | undefined;
+  onChange: (next: string | undefined) => void;
+  /** Swatch/placeholder shown when no valid value is set yet. */
+  fallback: string;
+  ariaLabel: string;
+  swatchClassName?: string;
+  inputClassName?: string;
+}
+
+/**
+ * Reusable admin colour control: a native colour swatch paired with a
+ * debounced hex text input and a Clear button. The text input keeps the
+ * user's keystrokes in local state and only commits the (validated,
+ * non-empty) value on blur — without this, every character of "#334155"
+ * would trigger a Firestore write AND persist intermediate invalid values
+ * ("#3", "#33", …) that the downstream validator then has to paper over.
+ * Cost-conscious for school-district Firestore budgets.
+ *
+ * Surrounding label/section styling is left to each ConfigurationPanel so
+ * the control matches that panel's local visual language.
+ */
+export const HexColorField: React.FC<HexColorFieldProps> = ({
+  value,
+  onChange,
+  fallback,
+  ariaLabel,
+  swatchClassName = 'w-10 h-8 rounded border border-slate-300 cursor-pointer p-0.5 bg-white shrink-0',
+  inputClassName = 'flex-1 px-2 py-1.5 text-xs font-mono border border-slate-300 rounded focus:ring-1 focus:ring-blue-500 outline-none',
+}) => {
+  const [draft, setDraft] = useState(value ?? '');
+  // Resync when the committed value changes externally (e.g. the colour
+  // picker writes a new value, or the admin switches buildings). Uses the
+  // "adjust state during render" pattern with useState rather than
+  // useEffect (extra commit) or useRef (react-hooks/refs lint).
+  const [prevValue, setPrevValue] = useState(value);
+  if (prevValue !== value) {
+    setPrevValue(value);
+    setDraft(value ?? '');
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <input
+        type="color"
+        value={isValidHex(value) ? value : fallback}
+        onChange={(e) => onChange(e.target.value)}
+        className={swatchClassName}
+        aria-label={ariaLabel}
+      />
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          const trimmed = draft.trim();
+          // Empty → clear the field; valid hex → commit; invalid
+          // (e.g. `#banana`, `#12`) → revert to the last committed value
+          // rather than persisting garbage downstream consumers would have
+          // to defensively re-validate.
+          if (trimmed === '') {
+            onChange(undefined);
+          } else if (isValidHex(trimmed)) {
+            onChange(trimmed);
+          } else {
+            setDraft(value ?? '');
+          }
+        }}
+        placeholder={fallback}
+        className={inputClassName}
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange(undefined)}
+          className="text-xs text-slate-500 hover:text-red-500 font-semibold transition-colors"
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+};

--- a/tests/utils/adminBuildingConfig.test.ts
+++ b/tests/utils/adminBuildingConfig.test.ts
@@ -324,16 +324,33 @@ describe('getAdminBuildingConfig', () => {
       ]);
     });
 
-    it('rejects invalid appearance values and unknown font families', () => {
+    it('rejects invalid appearance values, unknown font families, and malformed scale', () => {
       const perm = makePerm('checklist', {
         high: {
           fontFamily: 'wingdings',
           cardColor: 'white',
           cardOpacity: -0.5,
           fontColor: '#12', // too short to be a valid hex
+          scaleMultiplier: 'large', // invalid type
         },
       });
       expect(getAdminBuildingConfig('checklist', [perm], ['high'])).toEqual({});
+    });
+
+    it('clamps scaleMultiplier to the panel slider range [0.5, 2.5]', () => {
+      const permHigh = makePerm('checklist', {
+        high: { scaleMultiplier: 5 },
+      });
+      expect(getAdminBuildingConfig('checklist', [permHigh], ['high'])).toEqual(
+        { scaleMultiplier: 2.5 }
+      );
+
+      const permLow = makePerm('checklist', {
+        high: { scaleMultiplier: 0.1 },
+      });
+      expect(getAdminBuildingConfig('checklist', [permLow], ['high'])).toEqual({
+        scaleMultiplier: 0.5,
+      });
     });
   });
 

--- a/tests/utils/adminBuildingConfig.test.ts
+++ b/tests/utils/adminBuildingConfig.test.ts
@@ -243,6 +243,100 @@ describe('getAdminBuildingConfig', () => {
     });
   });
 
+  describe('concept-web', () => {
+    it('passes through node dimensions, font family, and surface fields', () => {
+      const perm = makePerm('concept-web', {
+        high: {
+          defaultNodeWidth: 20,
+          defaultNodeHeight: 12,
+          fontFamily: 'comic',
+          cardColor: '#fef3c7',
+          cardOpacity: 0.6,
+        },
+      });
+      expect(getAdminBuildingConfig('concept-web', [perm], ['high'])).toEqual({
+        defaultNodeWidth: 20,
+        defaultNodeHeight: 12,
+        fontFamily: 'comic',
+        cardColor: '#fef3c7',
+        cardOpacity: 0.6,
+      });
+    });
+
+    it('does not wire fontColor (ConceptWeb node text is hardcoded)', () => {
+      const perm = makePerm('concept-web', {
+        high: { fontColor: '#1e293b' },
+      });
+      expect(getAdminBuildingConfig('concept-web', [perm], ['high'])).toEqual(
+        {}
+      );
+    });
+
+    it('rejects invalid surface values and unknown font families', () => {
+      const perm = makePerm('concept-web', {
+        high: {
+          fontFamily: 'not-a-font',
+          cardColor: 'rgb(0,0,0)',
+          cardOpacity: 2,
+        },
+      });
+      expect(getAdminBuildingConfig('concept-web', [perm], ['high'])).toEqual(
+        {}
+      );
+    });
+
+    it('accepts cardOpacity at exact bounds 0 and 1', () => {
+      const permZero = makePerm('concept-web', { high: { cardOpacity: 0 } });
+      expect(
+        getAdminBuildingConfig('concept-web', [permZero], ['high'])
+      ).toEqual({ cardOpacity: 0 });
+
+      const permOne = makePerm('concept-web', { high: { cardOpacity: 1 } });
+      expect(
+        getAdminBuildingConfig('concept-web', [permOne], ['high'])
+      ).toEqual({ cardOpacity: 1 });
+    });
+  });
+
+  describe('checklist', () => {
+    it('passes through scale, items, font family, and appearance fields', () => {
+      const perm = makePerm('checklist', {
+        high: {
+          scaleMultiplier: 1.5,
+          items: [{ id: 'a', text: 'Sharpen pencil' }],
+          fontFamily: 'handwritten',
+          cardColor: '#e0f2fe',
+          cardOpacity: 0.75,
+          fontColor: '#0f172a',
+        },
+      });
+      const result = getAdminBuildingConfig('checklist', [perm], ['high']);
+      expect(result).toMatchObject({
+        scaleMultiplier: 1.5,
+        fontFamily: 'handwritten',
+        cardColor: '#e0f2fe',
+        cardOpacity: 0.75,
+        fontColor: '#0f172a',
+      });
+      // items get fresh UUIDs but preserve text and reset completion.
+      expect(result.items).toEqual([
+        { id: expect.any(String), text: 'Sharpen pencil', completed: false },
+      ]);
+    });
+
+    it('rejects invalid appearance values and unknown font families', () => {
+      const perm = makePerm('checklist', {
+        high: {
+          fontFamily: 'wingdings',
+          cardColor: 'white',
+          cardOpacity: -0.5,
+          fontColor: '#12', // too short to be a valid hex
+        },
+      });
+      expect(getAdminBuildingConfig('checklist', [perm], ['high'])).toEqual({});
+    });
+  });
+
   it('returns empty for unknown widget types', () => {
     const perm = makePerm('clock', { high: { format24: true } });
     // Pass a type that has no case in the switch.

--- a/types.ts
+++ b/types.ts
@@ -1671,6 +1671,10 @@ export interface BuildingChecklistDefaults {
   buildingId: string;
   items?: ChecklistDefaultItem[]; // Default item labels pre-populated on widget creation
   scaleMultiplier?: number;
+  fontFamily?: GlobalFontFamily;
+  fontColor?: string;
+  cardColor?: string;
+  cardOpacity?: number;
 }
 
 export interface ChecklistGlobalConfig {
@@ -4432,6 +4436,12 @@ export interface BuildingConceptWebDefaults {
   defaultNodeWidth?: number;
   defaultNodeHeight?: number;
   fontFamily?: GlobalFontFamily;
+  cardColor?: string;
+  cardOpacity?: number;
+  // NOTE: `ConceptWebConfig.fontColor` exists (written by the shared
+  // TypographySettings panel) but ConceptWeb's widget renders node text with
+  // a hardcoded `text-slate-800` and never reads it — so there is no
+  // per-building `fontColor` default here (it would be a dead control).
 }
 
 export interface ConceptWebGlobalConfig {

--- a/utils/adminBuildingConfig.ts
+++ b/utils/adminBuildingConfig.ts
@@ -231,8 +231,13 @@ export const getAdminBuildingConfig = (
           })
         );
       }
-      if (raw.scaleMultiplier !== undefined)
-        out.scaleMultiplier = raw.scaleMultiplier;
+      if (
+        typeof raw.scaleMultiplier === 'number' &&
+        Number.isFinite(raw.scaleMultiplier)
+      )
+        // Clamp to the panel slider's range so a malformed/out-of-range value
+        // can't break the widget layout; in-range legacy values pass through.
+        out.scaleMultiplier = Math.max(0.5, Math.min(2.5, raw.scaleMultiplier));
       if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
       if (

--- a/utils/adminBuildingConfig.ts
+++ b/utils/adminBuildingConfig.ts
@@ -21,6 +21,30 @@ const isHexColor = (value: unknown): value is string =>
   typeof value === 'string' && HEX_COLOR_RE.test(value.trim());
 
 /**
+ * The `GlobalFontFamily` union values, used to validate per-building
+ * `fontFamily` defaults so an admin can only persist a font the widgets
+ * actually know how to render. Mirrors the `GlobalFontFamily` type in
+ * `types.ts` — kept as a runtime array because TypeScript unions are
+ * erased at runtime and the validator needs a membership check.
+ */
+const VALID_FONT_FAMILIES = [
+  'sans',
+  'serif',
+  'mono',
+  'handwritten',
+  'rounded',
+  'fun',
+  'comic',
+  'slab',
+  'retro',
+  'marker',
+  'cursive',
+] as const;
+const isGlobalFontFamily = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  (VALID_FONT_FAMILIES as readonly string[]).includes(value);
+
+/**
  * Extracts building-level config overrides for a widget type from the admin's
  * feature_permissions config. These are applied between widget defaults and
  * explicit overrides so that per-building admin settings pre-configure new
@@ -116,19 +140,6 @@ export const getAdminBuildingConfig = (
     }
     case 'numberLine': {
       const validDisplayModes = ['integers', 'decimals', 'fractions'] as const;
-      const validFontFamilies = [
-        'sans',
-        'serif',
-        'mono',
-        'handwritten',
-        'rounded',
-        'fun',
-        'comic',
-        'slab',
-        'retro',
-        'marker',
-        'cursive',
-      ] as const;
       if (typeof raw.min === 'number' && Number.isFinite(raw.min))
         out.min = raw.min;
       if (typeof raw.max === 'number' && Number.isFinite(raw.max))
@@ -153,11 +164,7 @@ export const getAdminBuildingConfig = (
         raw.cardOpacity <= 1
       )
         out.cardOpacity = raw.cardOpacity;
-      if (
-        typeof raw.fontFamily === 'string' &&
-        (validFontFamilies as readonly string[]).includes(raw.fontFamily)
-      )
-        out.fontFamily = raw.fontFamily;
+      if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
       break;
     }
@@ -226,6 +233,16 @@ export const getAdminBuildingConfig = (
       }
       if (raw.scaleMultiplier !== undefined)
         out.scaleMultiplier = raw.scaleMultiplier;
+      if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
+      if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
+      if (
+        typeof raw.cardOpacity === 'number' &&
+        Number.isFinite(raw.cardOpacity) &&
+        raw.cardOpacity >= 0 &&
+        raw.cardOpacity <= 1
+      )
+        out.cardOpacity = raw.cardOpacity;
+      if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
       break;
     case 'sound':
       if (raw.visual) out.visual = raw.visual;
@@ -347,7 +364,17 @@ export const getAdminBuildingConfig = (
           Math.min(50, Math.round(raw.defaultNodeHeight))
         );
       }
-      if (typeof raw.fontFamily === 'string') out.fontFamily = raw.fontFamily;
+      if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
+      if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
+      if (
+        typeof raw.cardOpacity === 'number' &&
+        Number.isFinite(raw.cardOpacity) &&
+        raw.cardOpacity >= 0 &&
+        raw.cardOpacity <= 1
+      )
+        out.cardOpacity = raw.cardOpacity;
+      // No `fontColor` default: ConceptWeb's widget renders node text with a
+      // hardcoded `text-slate-800` and never reads `config.fontColor`.
       break;
     case 'classes':
       if (typeof raw.classLinkEnabled === 'boolean') {


### PR DESCRIPTION
## What

Wires the appearance fields that **ConceptWeb** and **Checklist** actually consume into the admin per-building defaults pipeline (`getAdminBuildingConfig` + the ConfigurationPanels), matching the existing **NumberLine** treatment. Resolves two sub-items of the long-standing "appearance settings exposed in user Settings but absent from admin building config" MEDIUM (`docs/scheduled-tasks/admin-settings-alignment.md`).

Previously these widgets exposed `cardColor`/`cardOpacity`/`fontFamily`/`fontColor` in their user Settings panels, but admins could not set per-building defaults — `getAdminBuildingConfig` passed through only node dimensions (ConceptWeb) and items/scaleMultiplier (Checklist).

## Changes

- **ConceptWeb** — add `cardColor` + `cardOpacity` to `BuildingConceptWebDefaults`, the `case 'concept-web'` validator (hex / `0..1` checks; existing `fontFamily` check tightened to the shared allowlist), and an **Appearance Defaults** section (surface colour + opacity) in `ConceptWebConfigurationPanel`.
  - `fontColor` is **intentionally not wired**: ConceptWeb renders node text with a hardcoded `text-slate-800` and never reads `config.fontColor`, so a per-building default would be a dead control. Documented inline in `types.ts` and `utils/adminBuildingConfig.ts`.
- **Checklist** — add `fontFamily` + `fontColor` + `cardColor` + `cardOpacity` to `BuildingChecklistDefaults`, the `case 'checklist'` validator, and an **Appearance Defaults** section (font family + text colour + surface colour + opacity) in `ChecklistConfigurationPanel`. All four fields are consumed by `Checklist/components/ChecklistCard.tsx`.
- **Shared infra** — hoist a module-level `VALID_FONT_FAMILIES` allowlist + `isGlobalFontFamily()` guard in `adminBuildingConfig.ts` (the `numberLine` case is refactored to reuse it, removing a duplicated inline array). Extract a reusable `HexColorField` admin control (native colour swatch + debounced on-blur hex text input + Clear button — cost-conscious for Firestore) used by both panels.

## Tests

- New `describe('concept-web')` (3 cases, incl. a "does not wire fontColor" guard and opacity-bounds) and `describe('checklist')` (2 cases, incl. UUID-refresh assertion on items) in `tests/utils/adminBuildingConfig.test.ts`.
- `pnpm run type-check`, `pnpm exec eslint --max-warnings 0`, `pnpm exec prettier --check`, and the targeted vitest suite (25 tests) all pass.

## Notes

Remaining sub-items in the group (tracked in the journal): `smartNotebook` (deferred for file-recency) and `stations` (needs new `BuildingStationsDefaults` interface + panel + registration).

---
_Generated by [Claude Code](https://claude.ai/code/session_0141FdyNqsHpoNAF489WS6Dp)_