### PR TITLE
Promote dev-paul → main: per-assignment attempt ledger (+ LTI picker polish)

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -250,13 +250,14 @@ const LtiDeepLinkFlow: React.FC = () => {
     setBusy(true);
     setErrorMsg(null);
     try {
-      setStatusMsg('Signing in to SpartBoard…');
       await signInWithGoogle();
-      setStatusMsg('Signed in. Pick a quiz to add.');
+      // No success status here: the button's own spinner covers the popup, and
+      // the next screen ("Validating…" then the picker) is itself the signal. A
+      // lingering "Signed in. Pick a quiz to add." used to show before the picker
+      // even appeared and stay under it afterward — confusing noise.
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setErrorMsg(`Couldn't sign in: ${message}`);
-      setStatusMsg(null);
     } finally {
       setBusy(false);
     }
@@ -403,7 +404,9 @@ const LtiDeepLinkFlow: React.FC = () => {
           )}
         </AddonCard>
       ) : phase === 'exchanging' || !deepLinking ? (
-        <AddonStatus message="Validating your Schoology launch…" busy />
+        <div className="flex justify-center py-2">
+          <AddonStatus message="Validating your Schoology launch…" busy />
+        </div>
       ) : (
         <div className="space-y-4">
           <AddonCard className="p-4">
@@ -411,7 +414,7 @@ const LtiDeepLinkFlow: React.FC = () => {
               htmlFor={quizSelectId}
               className="mb-1.5 block text-sm font-medium text-slate-700"
             >
-              Quiz
+              Select a quiz
             </label>
             <AddonSelect
               id={quizSelectId}
@@ -430,18 +433,20 @@ const LtiDeepLinkFlow: React.FC = () => {
             />
           </AddonCard>
 
-          <AddonButton
-            onClick={() => void addQuiz()}
-            loading={busy}
-            disabled={!selectedQuizId}
-            icon={Send}
-          >
-            Add quiz to Schoology
-          </AddonButton>
+          <div className="flex justify-center">
+            <AddonButton
+              onClick={() => void addQuiz()}
+              loading={busy}
+              disabled={!selectedQuizId}
+              icon={Send}
+            >
+              Add quiz to Schoology
+            </AddonButton>
+          </div>
         </div>
       )}
 
-      {phase !== 'error' && (
+      {phase !== 'error' && !submitted && (
         <div className="mt-4 space-y-2">
           <AddonError message={errorMsg} />
           <AddonStatus message={statusMsg} busy={busy} />

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -622,11 +622,15 @@ const QuizJoinFlow: React.FC<{
     // failed) until `joined` flips. Periods picker is rendered earlier in
     // the function and short-circuits before we reach this branch.
     //
-    // Prefer the hook's `error` (more specific, e.g. attempt-limit reached)
-    // when available, falling back to `ssoAutoJoinError` which captures
-    // failures from `lookupSession` that never reach the hook.
+    // Prefer `ssoAutoJoinError` — it holds the ACTUAL auto-join failure (the
+    // join's SessionEndedError / AttemptLimitReachedError message, or a
+    // lookupSession failure). When the auto-join falls back to review and that
+    // review finds no submission (a student opening an ENDED assignment they
+    // never took), the hook's `error` is the misleading "No submission found…";
+    // the original "This quiz session has already ended." in `ssoAutoJoinError`
+    // is the right message. Fall back to the hook `error` for non-SSO joiners.
     if (isStudentRole) {
-      const ssoError = error ?? ssoAutoJoinError;
+      const ssoError = ssoAutoJoinError ?? error;
       if (ssoError) {
         // SSO students arrive from /my-assignments or the Classroom add-on —
         // always the async/self-paced flow, so this surface is LIGHT.

--- a/components/quiz/QuizStudentApp.tsx
+++ b/components/quiz/QuizStudentApp.tsx
@@ -288,6 +288,12 @@ const QuizJoinFlow: React.FC<{
   // failure, Firestore unavailable) the hook stays silent, so without this
   // the student would sit on the "Joining quiz…" loader forever.
   const [ssoAutoJoinError, setSsoAutoJoinError] = useState<string | null>(null);
+  // Terminal SSO message that OVERRIDES both the hook `error` and
+  // `ssoAutoJoinError`. Set only when the auto-join fell back to review and the
+  // review found no submission — a student opening a CLOSED assignment they
+  // never took. The hook `error` is then the misleading "No submission found…",
+  // so we surface the real reason (e.g. "This quiz session has already ended.").
+  const [ssoTerminalError, setSsoTerminalError] = useState<string | null>(null);
 
   // SSO gate (feature-flagged). Anonymous joiners on a ClassLink-rostered
   // session are offered Google sign-in by default — which keys their response
@@ -403,6 +409,14 @@ const QuizJoinFlow: React.FC<{
               '[QuizStudentApp] subscribeForReview fallback failed:',
               reviewErr
             );
+            // No submission to review → the student is opening a closed
+            // assignment they never took. The hook `error` is now the
+            // misleading "No submission found…"; surface the real join reason
+            // (e.g. "This quiz session has already ended.") with top precedence.
+            setSsoTerminalError(
+              err instanceof Error ? err.message : 'This quiz is closed.'
+            );
+            return;
           }
         }
         console.warn('[QuizStudentApp] SSO auto-join failed:', err);
@@ -622,15 +636,14 @@ const QuizJoinFlow: React.FC<{
     // failed) until `joined` flips. Periods picker is rendered earlier in
     // the function and short-circuits before we reach this branch.
     //
-    // Prefer `ssoAutoJoinError` — it holds the ACTUAL auto-join failure (the
-    // join's SessionEndedError / AttemptLimitReachedError message, or a
-    // lookupSession failure). When the auto-join falls back to review and that
-    // review finds no submission (a student opening an ENDED assignment they
-    // never took), the hook's `error` is the misleading "No submission found…";
-    // the original "This quiz session has already ended." in `ssoAutoJoinError`
-    // is the right message. Fall back to the hook `error` for non-SSO joiners.
+    // Precedence: `ssoTerminalError` wins — set only when the review fallback
+    // found no submission for a CLOSED assignment, it carries the real "…has
+    // already ended." reason over the hook's misleading "No submission found…".
+    // Otherwise prefer the hook `error` (e.g. the friendly "ask your teacher to
+    // enroll you" hint on a class-gate denial), then `ssoAutoJoinError` (which
+    // captures lookupSession failures the hook never sees).
     if (isStudentRole) {
-      const ssoError = ssoAutoJoinError ?? error;
+      const ssoError = ssoTerminalError ?? error ?? ssoAutoJoinError;
       if (ssoError) {
         // SSO students arrive from /my-assignments or the Classroom add-on —
         // always the async/self-paced flow, so this surface is LIGHT.

--- a/firestore.rules
+++ b/firestore.rules
@@ -2476,11 +2476,12 @@ service cloud.firestore {
     }
 
     // Quiz Attempt Ledger — top-level, cross-launch attempt counter per
-    // (quiz, student). See `QuizAttemptLedger` in types.ts and
-    // `QUIZ_ATTEMPT_LEDGER_COLLECTION` in `useQuizSession.ts` for the
-    // rationale. The doc id is `${quizId}__${studentUid}`; the
-    // `studentUid` field on the doc must equal the student's auth uid
-    // (the rules can't decompose the doc id back into its halves).
+    // (ASSIGNMENT, student), NOT per quiz template. See `QuizAttemptLedger` in
+    // types.ts and `QUIZ_ATTEMPT_LEDGER_COLLECTION` in `useQuizSession.ts` for
+    // the rationale. The doc id is `${assignmentId}__${studentUid}` (the
+    // assignmentId is the session id); the `quizId` field is retained as
+    // metadata. The `studentUid` field on the doc must equal the student's auth
+    // uid (the rules can't decompose the doc id back into its halves).
     //
     // Ledger writes happen only inside the `completeQuiz` transaction
     // alongside the response status flip, so the rules' append-only
@@ -2569,7 +2570,8 @@ service cloud.firestore {
     }
 
     // Video Activity Attempt Ledger — same shape as the Quiz ledger.
-    // Doc id: `${activityId}__${studentUid}`.
+    // Doc id: `${assignmentId}__${studentUid}` (assignmentId = session id);
+    // scoped per assignment, not per activity template.
     match /video_activity_attempt_ledger/{ledgerId} {
       // See `quiz_attempt_ledger` above for the `resource == null`
       // rationale — same pattern, same threat model.

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -87,25 +87,31 @@ export const RESPONSE_HISTORY_COLLECTION = 'history';
 const HISTORY_SNAPSHOT_THROTTLE_MS = 5000;
 /**
  * Top-level cross-launch attempt ledger. Sits alongside `/quiz_sessions/`
- * and accumulates a student's completed-attempt count across every session
- * the teacher creates for the same quiz. Without this collection, the
- * per-session counter on `responses/{key}` resets every launch and a
- * teacher's "1 attempt" intent is bypassed by relaunching the quiz.
+ * and accumulates a student's completed-attempt count across every LAUNCH of a
+ * single ASSIGNMENT. It is scoped per (assignment, student) — NOT per quiz
+ * template — so a student can complete every assignment a teacher builds from
+ * the same library quiz; the cap only stops re-attempts of the SAME assignment
+ * across re-launches (where the per-session `responses/{key}` counter resets
+ * each launch and a teacher's "1 attempt" intent would otherwise be bypassed).
  *
- * Doc id: `${quizId}__${studentUid}` (see `quizLedgerKey`). Schema:
- * `QuizAttemptLedger` in types.ts.
+ * Doc id: `${assignmentId}__${studentUid}` (see `quizLedgerKey`), where
+ * `assignmentId` is the session id — a deep-link/Classroom attach is 1:1 with a
+ * session, and re-launching the same assignment resolves to the same session by
+ * code. Schema: `QuizAttemptLedger` in types.ts.
  */
 export const QUIZ_ATTEMPT_LEDGER_COLLECTION = 'quiz_attempt_ledger';
 
 /**
- * Deterministic ledger doc id. Two underscores keep us safe even if a
- * future quizId or studentUid contains a single underscore (Firestore
- * doc ids allow underscores). HMAC pseudonyms are hex, current quizIds
- * are UUIDs, so collisions are not realistic, but the separator is
- * cheap insurance.
+ * Deterministic ledger doc id. Two underscores keep us safe even if a future
+ * id contains a single underscore (Firestore doc ids allow underscores).
+ * assignmentIds/sessionIds are UUIDs and HMAC pseudonyms are hex, so collisions
+ * are not realistic, but the separator is cheap insurance.
  */
-export function quizLedgerKey(quizId: string, studentUid: string): string {
-  return `${quizId}__${studentUid}`;
+export function quizLedgerKey(
+  assignmentId: string,
+  studentUid: string
+): string {
+  return `${assignmentId}__${studentUid}`;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -812,11 +818,11 @@ export const useQuizSessionTeacher = (
       }
 
       const ledgerRef =
-        target && session?.quizId
+        target && sessionId
           ? doc(
               db,
               QUIZ_ATTEMPT_LEDGER_COLLECTION,
-              quizLedgerKey(session.quizId, target.studentUid)
+              quizLedgerKey(sessionId, target.studentUid)
             )
           : null;
 
@@ -921,7 +927,7 @@ export const useQuizSessionTeacher = (
       if (ledgerRef && ledgerSnap?.exists()) batch.delete(ledgerRef);
       await batch.commit();
     },
-    [sessionId, responses, session?.quizId]
+    [sessionId, responses]
   );
 
   const unlockStudentAttempt = useCallback(
@@ -947,11 +953,11 @@ export const useQuizSessionTeacher = (
         RESPONSES_COLLECTION,
         responseKey
       );
-      const ledgerRef = session?.quizId
+      const ledgerRef = sessionId
         ? doc(
             db,
             QUIZ_ATTEMPT_LEDGER_COLLECTION,
-            quizLedgerKey(session.quizId, target.studentUid)
+            quizLedgerKey(sessionId, target.studentUid)
           )
         : null;
       const currentAttempts = target.completedAttempts ?? 0;
@@ -988,7 +994,7 @@ export const useQuizSessionTeacher = (
       }
       await batch.commit();
     },
-    [sessionId, responses, session?.quizId]
+    [sessionId, responses]
   );
 
   const unlockResultsForStudent = useCallback(
@@ -1683,15 +1689,14 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
         // same uid space, at which point this same code automatically
         // covers PIN joiners.
         let ledgerCompleted = 0;
-        if (
-          !isAnonymous &&
-          typeof sessionData.quizId === 'string' &&
-          sessionData.quizId.length > 0
-        ) {
+        if (!isAnonymous) {
+          // Keyed by the session id (= assignmentId) so the cap is per
+          // assignment, not per quiz template — a fresh assignment of the same
+          // quiz has no ledger entry yet and is independently takeable.
           const ledgerRef = doc(
             db,
             QUIZ_ATTEMPT_LEDGER_COLLECTION,
-            quizLedgerKey(sessionData.quizId, studentUid)
+            quizLedgerKey(sessionDoc.id, studentUid)
           );
           const ledgerSnap = await getDoc(ledgerRef).catch((err: unknown) => {
             // Ledger reads can fail with permission-denied for legacy
@@ -2240,6 +2245,10 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       !isAnonymous &&
       typeof studentUid === 'string' &&
       studentUid.length > 0 &&
+      // `sessionId` is the ledger key (per-assignment scope); `quizId` is still
+      // stored as a metadata field the rules require, so both must be present.
+      typeof sessionId === 'string' &&
+      sessionId.length > 0 &&
       typeof quizId === 'string' &&
       quizId.length > 0 &&
       typeof teacherUid === 'string' &&
@@ -2248,7 +2257,7 @@ export const useQuizSessionStudent = (): UseQuizSessionStudentResult => {
       ? doc(
           db,
           QUIZ_ATTEMPT_LEDGER_COLLECTION,
-          quizLedgerKey(quizId, studentUid)
+          quizLedgerKey(sessionId, studentUid)
         )
       : null;
 

--- a/hooks/useVideoActivitySession.ts
+++ b/hooks/useVideoActivitySession.ts
@@ -50,18 +50,20 @@ import {
 const SESSIONS_COLLECTION = 'video_activity_sessions';
 const RESPONSES_SUBCOLLECTION = 'responses';
 /**
- * Top-level cross-launch attempt ledger for Video Activity. Mirrors the
- * Quiz ledger collection — see `QUIZ_ATTEMPT_LEDGER_COLLECTION` in
- * `useQuizSession.ts` for the rationale and key shape.
+ * Top-level cross-launch attempt ledger for Video Activity. Mirrors the Quiz
+ * ledger — see `QUIZ_ATTEMPT_LEDGER_COLLECTION` in `useQuizSession.ts`. Scoped
+ * per (assignment, student): keyed by the session id (= assignmentId), NOT the
+ * activity template, so each assignment built from an activity is independently
+ * completable.
  */
 const VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION =
   'video_activity_attempt_ledger';
 
 function videoActivityLedgerKey(
-  activityId: string,
+  assignmentId: string,
   studentUid: string
 ): string {
-  return `${activityId}__${studentUid}`;
+  return `${assignmentId}__${studentUid}`;
 }
 
 const normalizeSession = (
@@ -431,24 +433,18 @@ export const useVideoActivitySessionTeacher =
         const currentAttempts = existing.completedAttempts ?? 0;
         const refundedAttempts = Math.max(0, currentAttempts - 1);
 
-        const sessionSnap = await getDoc(
-          doc(db, SESSIONS_COLLECTION, sessionId)
-        );
-        const activityId =
-          (sessionSnap.data() as Partial<VideoActivitySession> | undefined)
-            ?.activityId ?? null;
         // Probe the ledger BEFORE writing so we don't blindly create a
         // partial doc via `set(merge:true)` on a missing ledger entry
-        // (which would land without the required `activityId`/
-        // `studentUid`/`teacherUid` identity fields). For anonymous-PIN
-        // students or any student whose cross-launch ledger hasn't been
-        // touched yet there's simply nothing to refund.
+        // (which would land without the required identity fields). For
+        // anonymous-PIN students or any student whose cross-launch ledger
+        // hasn't been touched yet there's simply nothing to refund. Keyed by
+        // the session id (= assignmentId), matching the student's write.
         const ledgerRef =
-          activityId && existing.studentUid
+          sessionId && existing.studentUid
             ? doc(
                 db,
                 VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
-                videoActivityLedgerKey(activityId, existing.studentUid)
+                videoActivityLedgerKey(sessionId, existing.studentUid)
               )
             : null;
         const ledgerSnap = ledgerRef ? await getDoc(ledgerRef) : null;
@@ -885,22 +881,20 @@ export const useVideoActivitySessionStudent =
           // non-anonymous (SSO/studentRole) joiners — see the matching
           // comment in `useQuizSession.joinQuizSession` for the rationale.
           let ledgerCompleted = 0;
-          if (
-            !isAnonymous &&
-            typeof sessionData.activityId === 'string' &&
-            sessionData.activityId.length > 0
-          ) {
+          if (!isAnonymous) {
+            // Keyed by session id (= assignmentId) so the cap is per
+            // assignment, not per activity template.
             const ledgerRef = doc(
               db,
               VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
-              videoActivityLedgerKey(sessionData.activityId, currentUser.uid)
+              videoActivityLedgerKey(targetSessionId, currentUser.uid)
             );
             const ledgerSnap = await getDoc(ledgerRef).catch((err: unknown) => {
               logError(
                 'useVideoActivitySessionStudent.ledgerRead',
                 err as Error,
                 {
-                  activityId: sessionData.activityId,
+                  sessionId: targetSessionId,
                   studentUid: currentUser.uid,
                 }
               );
@@ -1080,6 +1074,10 @@ export const useVideoActivitySessionStudent =
         !isAnonymous &&
         typeof studentUid === 'string' &&
         studentUid.length > 0 &&
+        // `sessionId` is the ledger key (per-assignment scope); `activityId`
+        // stays as a metadata field the rules require, so both must be present.
+        typeof sessionId === 'string' &&
+        sessionId.length > 0 &&
         typeof activityId === 'string' &&
         activityId.length > 0 &&
         typeof teacherUid === 'string' &&
@@ -1088,7 +1086,7 @@ export const useVideoActivitySessionStudent =
         ? doc(
             db,
             VIDEO_ACTIVITY_ATTEMPT_LEDGER_COLLECTION,
-            videoActivityLedgerKey(activityId, studentUid)
+            videoActivityLedgerKey(sessionId, studentUid)
           )
         : null;
 

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -799,6 +799,13 @@ describe('useQuizSessionStudent — lookupSession', () => {
 describe('useQuizSessionStudent — joinQuizSession', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default getDoc resolution: any read not explicitly stubbed with a
+    // `mockResolvedValueOnce` — notably the per-assignment attempt-ledger probe
+    // joinQuizSession now runs for every non-anonymous joiner — resolves to a
+    // non-existent doc. Per-test `...Once` stubs are consumed first and win.
+    (firestore.getDoc as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      { exists: () => false }
+    );
     // Default current user has no `isAnonymous` flag (falsy), matching the
     // pre-SSO test expectations: response doc is keyed by `auth.uid` and the
     // legacy-key probe is skipped. Tests that need the anonymous PIN-join
@@ -1276,6 +1283,48 @@ describe('useQuizSessionStudent — joinQuizSession', () => {
     expect(
       responseKeys.some((k) => typeof k === 'string' && k.startsWith('pin-'))
     ).toBe(false);
+  });
+
+  it('keys the attempt ledger by SESSION id (per-assignment), not quiz id', async () => {
+    // Regression for the per-assignment ledger fix: the cross-launch attempt
+    // ledger was keyed `${quizId}__${uid}`, which capped a student across EVERY
+    // assignment built from the same library quiz. It must key by the session id
+    // (= assignmentId) so each assignment from a quiz template is independently
+    // takeable.
+    (
+      auth as unknown as {
+        currentUser: { uid: string; isAnonymous: boolean } | null;
+      }
+    ).currentUser = { uid: 'sso-uid', isAnonymous: false };
+
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({
+      empty: false,
+      docs: [buildSessionDoc('sess-1', { status: 'active', quizId: 'quiz-1' })],
+    });
+    // Response existence probe → not found (a fresh response is created); the
+    // ledger probe falls through to the beforeEach default (non-existent).
+    (
+      firestore.getDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ exists: () => false });
+    (
+      firestore.setDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(undefined);
+
+    const docMock = firestore.doc as unknown as ReturnType<typeof vi.fn>;
+    const { result } = renderHook(() => useQuizSessionStudent());
+    await act(async () => {
+      await result.current.joinQuizSession('ABC123', undefined, undefined);
+    });
+
+    const lastSegments = (docMock.mock.calls as unknown[][])
+      .map((args) => args[args.length - 1])
+      .filter((v): v is string => typeof v === 'string');
+    // The ledger is resolved at the SESSION-keyed path…
+    expect(lastSegments).toContain('sess-1__sso-uid');
+    // …and never at the quiz-template-keyed path.
+    expect(lastSegments).not.toContain('quiz-1__sso-uid');
   });
 
   it('still rejects anonymous joiners with no PIN', async () => {
@@ -2082,7 +2131,7 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
     );
     expect(deletedPaths).toContainEqual([
       'quiz_attempt_ledger',
-      'quiz-1__sso-uid',
+      'sess-1__sso-uid',
     ]);
   });
 

--- a/types.ts
+++ b/types.ts
@@ -3152,14 +3152,16 @@ export interface RosterPinIndexEntry {
 
 /**
  * Cross-launch attempt ledger. Stored at the top level
- * `/quiz_attempt_ledger/{ledgerId}` where `ledgerId = ${quizId}__${studentUid}`.
+ * `/quiz_attempt_ledger/{ledgerId}` where
+ * `ledgerId = ${assignmentId}__${studentUid}` (`assignmentId` = the session id).
  *
- * Per-session response docs are scoped under the session and reset every time
- * a teacher launches a new session for the same quiz, so the per-session
- * `completedAttempts` counter cannot enforce "1 attempt for this quiz, ever"
- * across re-launches. The ledger sits above sessions and accumulates a
- * student's attempts on a specific quiz regardless of how many times the
- * teacher launches it.
+ * Per-session response docs reset every launch, so they can't enforce a
+ * teacher's "1 attempt" intent across re-launches of the SAME assignment. The
+ * ledger sits above the per-launch responses and accumulates a student's
+ * completed attempts on ONE assignment — scoped per ASSIGNMENT, NOT per quiz
+ * template. Each assignment a teacher builds from the same library quiz gets its
+ * own ledger entry, so a student can complete every one of them; the cap only
+ * blocks re-attempts of the same assignment.
  *
  * Identity: keyed by the student's auth.uid, which for SSO joiners is the
  * stable HMAC pseudonym minted by `studentLoginV1`. PIN joiners' anonymous
@@ -3169,7 +3171,11 @@ export interface RosterPinIndexEntry {
  * any change to this shape.
  */
 export interface QuizAttemptLedger {
-  /** Matches `QuizSession.quizId`. Half of the deterministic ledger key. */
+  /**
+   * The quiz template id (`QuizSession.quizId`). Metadata only — retained for
+   * reference/analytics and required by the Firestore rules; NOT part of the
+   * ledger key (the key is `${assignmentId}__${studentUid}`).
+   */
   quizId: string;
   /** Matches `auth.uid`. Other half of the deterministic ledger key. */
   studentUid: string;
@@ -4033,10 +4039,14 @@ export interface VideoActivityResponse {
  * Cross-launch attempt ledger for Video Activity. Mirrors
  * `QuizAttemptLedger` exactly — see that type's docs for the rationale.
  * Stored at `/video_activity_attempt_ledger/{ledgerId}` where
- * `ledgerId = ${activityId}__${studentUid}`.
+ * `ledgerId = ${assignmentId}__${studentUid}` (`assignmentId` = the session id):
+ * scoped per ASSIGNMENT, not per activity template.
  */
 export interface VideoActivityAttemptLedger {
-  /** Matches `VideoActivitySession.activityId`. */
+  /**
+   * The activity template id (`VideoActivitySession.activityId`). Metadata only
+   * — required by the Firestore rules; NOT part of the ledger key.
+   */
   activityId: string;
   /** Matches `auth.uid`. */
   studentUid: string;


### PR DESCRIPTION
Promotes to production:

- `4fd5fe42` **fix(quiz/va): scope the attempt-limit ledger per assignment, not per quiz** — re-keys the cross-launch ledger `${quizId}__uid` → `${sessionId}__uid` so each assignment from a library quiz is independently completable (a student no longer gets locked out of 9/10 assignments built from one template). Same-assignment re-launch still respects the limit. `firestore.rules` change is comment-only (CI `test:rules` runs the emulator). Includes the closed-assignment message fix + a regression test.
- `769eb2b6` **fix(quiz): preserve the friendly class-gate hint on SSO join denial** — review-caught regression fix (dedicated `ssoTerminalError` precedence).
- `1e35d9d7` **polish(lti): tidy the deep-link picker copy + layout** — the cosmetic modal fixes (centered status/button, 'Select a quiz', removed the noisy status line).

Reviewed by 3 parallel agents (key-consistency/cap-security, VA-mirror/message-precedence, deploy/migration/in-progress) — 2 clean, 1 finding fixed (`769eb2b6`). Validation: type-check ✓ · lint ✓ · 4053 unit tests ✓ · firestore.rules compiles ✓.

**Migration note:** existing quizId-keyed ledgers go orphaned → current per-quiz caps reset once (benign/desired). In-progress sessions are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)