### PR TITLE
feat(lti): resolve Schoology student names via NRPS (zero PII at rest)

### DIFF
--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -69,6 +69,7 @@ import {
   findDuplicateResponseIds,
 } from '../utils/resolveDisplayName';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
 import { db } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
@@ -328,11 +329,24 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       return session.classIds;
     return session.classId ? [session.classId] : [];
   }, [session.classIds, session.classId]);
-  const { byStudentUid } = useAssignmentPseudonymsMulti(
+  const { byStudentUid: classLinkNames } = useAssignmentPseudonymsMulti(
     session.id,
     sessionClassIds,
     orgId
   );
+  // Schoology LTI students aren't in any ClassLink roster, so resolve their
+  // names on-read via NRPS and merge in. ClassLink (the district's
+  // authoritative roster) wins on the rare uid collision. Gated on `ltiNrps`
+  // so non-LTI sessions never make the call.
+  const ltiNames = useLtiSessionNames(session.id, session.ltiNrps === true);
+  const byStudentUid = useMemo(() => {
+    if (ltiNames.size === 0) return classLinkNames;
+    const merged = new Map(classLinkNames);
+    for (const [uid, name] of ltiNames) {
+      if (!merged.has(uid)) merged.set(uid, name);
+    }
+    return merged;
+  }, [classLinkNames, ltiNames]);
   const scoringConfig = useMemo(
     () => ({
       speedBonusEnabled: session.speedBonusEnabled,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -64,6 +64,7 @@ import {
 import { resolveResponseDisplayName } from '../utils/resolveDisplayName';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
+import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
 import { PlcTab } from '@/components/common/library/PlcTab';
 import { WrittenResponseGrader } from './WrittenResponseGrader';
 import { doc, updateDoc } from 'firebase/firestore';
@@ -352,11 +353,26 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       return session.classIds;
     return session?.classId ? [session.classId] : [];
   }, [session?.classIds, session?.classId]);
-  const { byStudentUid } = useAssignmentPseudonymsMulti(
+  const { byStudentUid: classLinkNames } = useAssignmentPseudonymsMulti(
     session?.id ?? null,
     sessionClassIds,
     orgId
   );
+  // Schoology LTI students aren't in any ClassLink roster — resolve their names
+  // on-read via NRPS and merge in (ClassLink wins on the rare uid collision).
+  // Gated on `ltiNrps` so non-LTI sessions never make the call.
+  const ltiNames = useLtiSessionNames(
+    session?.id ?? null,
+    session?.ltiNrps === true
+  );
+  const byStudentUid = useMemo(() => {
+    if (ltiNames.size === 0) return classLinkNames;
+    const merged = new Map(classLinkNames);
+    for (const [uid, name] of ltiNames) {
+      if (!merged.has(uid)) merged.set(uid, name);
+    }
+    return merged;
+  }, [classLinkNames, ltiNames]);
   const exportPinToName = useMemo(
     () => buildPinToExportNameMap(rosters, resolvedPeriods),
     [rosters, resolvedPeriods]

--- a/firestore.rules
+++ b/firestore.rules
@@ -720,6 +720,17 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    // PII-free NRPS membership endpoints, keyed by quiz session → context. The
+    // launch-exchange CF writes the context's `context_memberships_url` here and
+    // the name-resolver CF reads it — BOTH via the Admin SDK, which bypasses
+    // these rules. No client path ever touches them (a doc holds a roster
+    // service URL that no authenticated user should enumerate), so deny all
+    // client access. The `{document=**}` recursive wildcard covers the
+    // `contexts/{contextId}` subcollection too.
+    match /lti_session_memberships/{sessionId}/{document=**} {
+      allow read, write: if false;
+    }
+
     // Global permissions - all authenticated users can read, only admins can write
     match /global_permissions/{featureId=**} {
       allow read: if request.auth != null;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4314,4 +4314,5 @@ export { ltiLogin, ltiLaunch, ltiExchange } from './lti/launchEndpoints';
 export {
   ltiSignDeepLinkResponseV1,
   ltiPushGradesForAssignmentV1,
+  ltiResolveNamesForAssignmentV1,
 } from './lti/serviceEndpoints';

--- a/functions/src/lti/identity.ts
+++ b/functions/src/lti/identity.ts
@@ -1,0 +1,24 @@
+// Schoology LTI 1.3 — student pseudonym derivation.
+//
+// One canonical helper, imported by BOTH the launch endpoint (which mints the
+// studentRole custom token under this uid) AND the NRPS name resolver (which
+// must compute the SAME uid from a membership entry to map it back to a
+// response doc). Keeping it in one place guarantees the write-side and the
+// read-side never drift — if they did, the resolver would map names to uids
+// that match nothing and every Schoology student would silently fall back to
+// "Student".
+
+import * as CryptoJS from 'crypto-js';
+
+/**
+ * Stable Firebase uid for a Schoology user, namespaced off their LTI `sub`.
+ * The `sub` is the platform's stable per-user id — it is the SAME value the
+ * launch id_token carries and that NRPS returns as `user_id`, so a name
+ * resolved from NRPS maps deterministically onto the response doc keyed by
+ * this uid. PII-free: the input is an opaque platform id, never a name/email.
+ */
+export function ltiStudentUid(sub: string, hmacSecret: string): string {
+  return CryptoJS.HmacSHA256(`schoology-sub:${sub}`, hmacSecret).toString(
+    CryptoJS.enc.Hex
+  );
+}

--- a/functions/src/lti/launchEndpoints.ts
+++ b/functions/src/lti/launchEndpoints.ts
@@ -11,7 +11,6 @@
 import { onRequest, onCall, HttpsError } from 'firebase-functions/v2/https';
 import { defineSecret } from 'firebase-functions/params';
 import * as admin from 'firebase-admin';
-import * as CryptoJS from 'crypto-js';
 
 import {
   getLtiPlatformConfig,
@@ -20,6 +19,9 @@ import {
   MESSAGE_TYPE_DEEP_LINKING,
 } from './config';
 import { verifyLaunchJwt, launchRedirectTarget } from './jwt';
+import type { NrpsEndpoint } from './jwt';
+import { ltiStudentUid } from './identity';
+import { persistNrpsMembershipForLaunch } from './nrpsStore';
 import {
   putOidcState,
   consumeOidcState,
@@ -37,13 +39,6 @@ import {
 const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
   'STUDENT_PSEUDONYM_HMAC_SECRET'
 );
-
-/** Stable Firebase uid for a Schoology user, namespaced off their LTI `sub`. */
-function ltiStudentUid(sub: string, hmacSecret: string): string {
-  return CryptoJS.HmacSHA256(`schoology-sub:${sub}`, hmacSecret).toString(
-    CryptoJS.enc.Hex
-  );
-}
 
 function mergedParams(req: {
   query?: Record<string, unknown>;
@@ -172,6 +167,11 @@ export const ltiLaunch = onRequest(
         hasAgs: !!claims.ags,
         hasNrps: !!claims.nrps,
         hasDeepLinking: !!claims.deepLinking,
+        // PII-free presence flags only (never log the values) — confirms
+        // whether the platform is releasing the name/email claims that the
+        // NRPS membership payload should also carry.
+        hasName: !!claims.name,
+        hasEmail: !!claims.email,
       });
 
       const code = await mintLaunchCode(db, {
@@ -332,6 +332,32 @@ export const ltiExchange = onCall(
       } catch (err) {
         console.warn(
           '[ltiExchange] grade-link persist failed (non-fatal)',
+          err
+        );
+      }
+    }
+
+    // Persist the PII-free NRPS membership endpoint so the teacher's monitor can
+    // resolve this (and every) Schoology student's name ON READ — no name is
+    // stored, only the context's membership URL keyed by the quiz session. Best
+    // effort: a failure here must never block the student from taking the quiz.
+    const membershipUrl = (launch.nrps as NrpsEndpoint | null)
+      ?.contextMembershipsUrl;
+    const quizCode =
+      typeof launch.custom?.['quiz_code'] === 'string'
+        ? launch.custom['quiz_code']
+        : '';
+    if (membershipUrl && quizCode && launch.contextId) {
+      try {
+        await persistNrpsMembershipForLaunch(db, {
+          quizCode,
+          contextId: launch.contextId,
+          membershipUrl,
+          deploymentId: launch.deploymentId,
+        });
+      } catch (err) {
+        console.warn(
+          '[ltiExchange] NRPS membership persist failed (non-fatal)',
           err
         );
       }

--- a/functions/src/lti/nrps.test.ts
+++ b/functions/src/lti/nrps.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the NRPS membership client. The single network call goes through
+ * the `nrpsNet` seam so these stay pure: they pin pagination, name composition
+ * (structured vs. composite `name`), member filtering, and the first-page-error
+ * vs. partial-roster semantics.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchNrpsMembers, parseNextLink, nrpsNet } from './nrps';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('parseNextLink', () => {
+  it('extracts the rel="next" target', () => {
+    expect(parseNextLink('<https://lms/memberships?page=2>; rel="next"')).toBe(
+      'https://lms/memberships?page=2'
+    );
+  });
+
+  it('ignores other rels and returns the next among many', () => {
+    const header =
+      '<https://lms/m?page=1>; rel="first", <https://lms/m?page=3>; rel="next", <https://lms/m?page=9>; rel="last"';
+    expect(parseNextLink(header)).toBe('https://lms/m?page=3');
+  });
+
+  it('returns null when no next link / empty / null', () => {
+    expect(parseNextLink('<https://lms/m>; rel="first"')).toBeNull();
+    expect(parseNextLink('')).toBeNull();
+    expect(parseNextLink(null)).toBeNull();
+  });
+});
+
+describe('fetchNrpsMembers', () => {
+  it('maps structured given/family names and the LTI sub', async () => {
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: true,
+      status: 200,
+      members: [
+        {
+          user_id: 'sub-1',
+          given_name: 'Ada',
+          family_name: 'Lovelace',
+          name: 'Ada Lovelace',
+          roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'],
+          status: 'Active',
+        },
+      ],
+      nextUrl: null,
+    });
+
+    const members = await fetchNrpsMembers('https://lms/m', 'tok');
+    expect(members).toEqual([
+      {
+        userId: 'sub-1',
+        givenName: 'Ada',
+        familyName: 'Lovelace',
+        roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'],
+        status: 'Active',
+      },
+    ]);
+  });
+
+  it('falls back to the composite name when given/family are absent', async () => {
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: true,
+      status: 200,
+      members: [{ user_id: 'sub-2', name: 'Grace Hopper' }],
+      nextUrl: null,
+    });
+
+    const members = await fetchNrpsMembers('https://lms/m', 'tok');
+    expect(members[0]).toMatchObject({
+      userId: 'sub-2',
+      givenName: 'Grace Hopper',
+      familyName: '',
+    });
+  });
+
+  it('skips members with no user_id (cannot map to a response doc)', async () => {
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: true,
+      status: 200,
+      members: [
+        { given_name: 'No', family_name: 'Id' },
+        { user_id: 'sub-3', given_name: 'Has', family_name: 'Id' },
+      ],
+      nextUrl: null,
+    });
+
+    const members = await fetchNrpsMembers('https://lms/m', 'tok');
+    expect(members.map((m) => m.userId)).toEqual(['sub-3']);
+  });
+
+  it('follows Link rel=next pagination and concatenates pages', async () => {
+    const spy = vi
+      .spyOn(nrpsNet, 'fetchMembershipPage')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        members: [{ user_id: 'a', given_name: 'A', family_name: 'A' }],
+        nextUrl: 'https://lms/m?page=2',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        members: [{ user_id: 'b', given_name: 'B', family_name: 'B' }],
+        nextUrl: null,
+      });
+
+    const members = await fetchNrpsMembers('https://lms/m?page=1', 'tok');
+    expect(members.map((m) => m.userId)).toEqual(['a', 'b']);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[1][0]).toBe('https://lms/m?page=2');
+  });
+
+  it('throws when the FIRST page errors (distinguishes no-access from empty)', async () => {
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: false,
+      status: 403,
+      members: [],
+      nextUrl: null,
+    });
+    await expect(fetchNrpsMembers('https://lms/m', 'tok')).rejects.toThrow(
+      /403/
+    );
+  });
+
+  it('returns the partial roster when a LATER page errors', async () => {
+    vi.spyOn(nrpsNet, 'fetchMembershipPage')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        members: [{ user_id: 'a', given_name: 'A', family_name: 'A' }],
+        nextUrl: 'https://lms/m?page=2',
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        members: [],
+        nextUrl: null,
+      });
+
+    const members = await fetchNrpsMembers('https://lms/m', 'tok');
+    expect(members.map((m) => m.userId)).toEqual(['a']);
+  });
+
+  it('caps pagination at MAX_PAGES so a self-referential next loop terminates', async () => {
+    const spy = vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: true,
+      status: 200,
+      members: [{ user_id: 'x', given_name: 'X', family_name: 'X' }],
+      nextUrl: 'https://lms/m?page=next', // always points onward
+    });
+    await fetchNrpsMembers('https://lms/m', 'tok');
+    // MAX_PAGES is 20 — the loop must stop rather than spin forever.
+    expect(spy).toHaveBeenCalledTimes(20);
+  });
+});

--- a/functions/src/lti/nrps.ts
+++ b/functions/src/lti/nrps.ts
@@ -1,0 +1,159 @@
+// Schoology LTI 1.3 — Names and Role Provisioning Service (NRPS) client.
+//
+// Fetches a context's membership roster from the platform-hosted
+// `context_memberships_url` (carried on the launch) so the teacher monitor can
+// resolve a Schoology student's pseudonym uid → real name ON READ — exactly
+// like the ClassLink/OneRoster path. Names are returned to the caller and
+// never persisted; nothing about a student's name comes to rest in Firestore.
+//
+// Auth is the same client_credentials + signed-JWT bearer the AGS client uses
+// (getAgsAccessToken), just scoped to NRPS_SCOPE. We only ever GET.
+
+// NRPS v2 membership container media type — sent as `Accept` so the platform
+// returns the v2 shape (members[] with user_id + name claims).
+const MEMBERSHIP_ACCEPT =
+  'application/vnd.ims.lti-nrps.v2.membershipcontainer+json';
+const NET_TIMEOUT_MS = 15000;
+// Hard cap on pages followed via the `Link: rel="next"` header so a malformed
+// or hostile pagination loop can't pin the function. A class is ≤ ~40 members
+// and platforms page generously; 20 pages is far more than any real roster.
+const MAX_PAGES = 20;
+
+/** A single resolved member, reduced to the PII we surface (name only). */
+export interface NrpsMember {
+  /** The LTI `sub` (platform user id) — same value the launch carries. */
+  userId: string;
+  givenName: string;
+  familyName: string;
+  /** LIS role URIs; lets callers filter to Learners if they want. */
+  roles: string[];
+  /** Membership status, e.g. 'Active' / 'Inactive' (absent on some platforms). */
+  status: string;
+}
+
+interface RawMember {
+  user_id?: unknown;
+  given_name?: unknown;
+  family_name?: unknown;
+  name?: unknown;
+  roles?: unknown;
+  status?: unknown;
+}
+
+interface MembershipPage {
+  ok: boolean;
+  status: number;
+  members: RawMember[];
+  /** Absolute URL of the next page, or null when there is none. */
+  nextUrl: string | null;
+}
+
+const asStr = (v: unknown): string =>
+  typeof v === 'string' && v.length > 0 ? v : '';
+
+/** Parse a single RFC5988 `Link` header for the `rel="next"` target. */
+export function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  // Header form: `<https://…?page=2>; rel="next", <https://…>; rel="first"`
+  for (const part of linkHeader.split(',')) {
+    const m = part.match(/<([^>]+)>\s*;\s*rel\s*=\s*"?([^";]+)"?/i);
+    if (m && m[2].trim().toLowerCase() === 'next') return m[1].trim();
+  }
+  return null;
+}
+
+/**
+ * Seam for the single outbound GET so unit tests can stub it without a live
+ * platform. Mirrors `classroomAddonNet` / the AGS client style.
+ */
+export const nrpsNet = {
+  async fetchMembershipPage(
+    url: string,
+    accessToken: string
+  ): Promise<MembershipPage> {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: MEMBERSHIP_ACCEPT,
+        },
+        signal: AbortSignal.timeout(NET_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        // Drain so undici returns the socket to the pool even on the error path.
+        if (typeof res.text === 'function') await res.text().catch(() => '');
+        console.warn(`[nrps] membership fetch ${res.status}`);
+        return { ok: false, status: res.status, members: [], nextUrl: null };
+      }
+      const body = (await res.json()) as { members?: unknown };
+      const members = Array.isArray(body.members)
+        ? (body.members as RawMember[])
+        : [];
+      const nextUrl = parseNextLink(res.headers.get('link'));
+      return { ok: true, status: res.status, members, nextUrl };
+    } catch (err) {
+      // Network failure / timeout / abort → empty page; the caller surfaces a
+      // clean "couldn't resolve names" rather than an unhandled rejection.
+      console.warn('[nrps] membership fetch failed (network/timeout):', err);
+      return { ok: false, status: 0, members: [], nextUrl: null };
+    }
+  },
+};
+
+/**
+ * Fetch every member of a context, following `Link: rel="next"` pagination up
+ * to MAX_PAGES. Returns reduced {userId, givenName, familyName, roles, status}.
+ * Members missing a `user_id` are skipped (can't be mapped to a response doc).
+ *
+ * When the platform sends only a composite `name` (no given/family parts —
+ * some privacy configurations do this), the whole name is placed in
+ * `givenName` so the teacher still sees a full label (`formatStudentName`
+ * joins given + family).
+ *
+ * Throws only if the FIRST page errors (so the caller can distinguish "no
+ * access / bad URL" from "empty roster"). Subsequent page errors stop
+ * pagination and return what was collected so far.
+ */
+export async function fetchNrpsMembers(
+  membershipUrl: string,
+  accessToken: string
+): Promise<NrpsMember[]> {
+  const out: NrpsMember[] = [];
+  let url: string | null = membershipUrl;
+  let page = 0;
+  while (url && page < MAX_PAGES) {
+    const result: MembershipPage = await nrpsNet.fetchMembershipPage(
+      url,
+      accessToken
+    );
+    if (!result.ok) {
+      if (page === 0) {
+        throw new Error(
+          `NRPS membership fetch failed (status ${result.status})`
+        );
+      }
+      break; // partial roster is better than none
+    }
+    for (const m of result.members) {
+      const userId = asStr(m.user_id);
+      if (!userId) continue;
+      const given = asStr(m.given_name);
+      const family = asStr(m.family_name);
+      const full = asStr(m.name);
+      // Prefer structured given/family; fall back to the composite `name`.
+      const hasStructured = !!(given || family);
+      out.push({
+        userId,
+        givenName: hasStructured ? given : full,
+        familyName: hasStructured ? family : '',
+        roles: Array.isArray(m.roles)
+          ? m.roles.filter((r): r is string => typeof r === 'string')
+          : [],
+        status: asStr(m.status),
+      });
+    }
+    url = result.nextUrl;
+    page += 1;
+  }
+  return out;
+}

--- a/functions/src/lti/nrpsStore.test.ts
+++ b/functions/src/lti/nrpsStore.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for persistNrpsMembershipForLaunch — the PII-free NRPS-endpoint
+ * persistence. Pins: (1) it files the membership under the JOINABLE, most-recent
+ * session matching the code (the same one the student joins); (2) it keys by
+ * sessionId → contextId; (3) it flips `ltiNrps` on the session only the FIRST
+ * time a context is seen (no per-launch session-doc churn); (4) it is a no-op
+ * when no joinable session matches; (5) it never writes a name/email.
+ */
+
+/* eslint-disable @typescript-eslint/require-await -- the structural Admin-SDK
+   mock methods are async to match the real surface but don't await anything. */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import type * as admin from 'firebase-admin';
+import {
+  persistNrpsMembershipForLaunch,
+  LTI_SESSION_MEMBERSHIPS_COLLECTION,
+} from './nrpsStore';
+
+interface SessionRow {
+  id: string;
+  code: string;
+  status: string;
+  startedAt: number | null;
+  teacherUid?: string;
+}
+
+interface Write {
+  path: string;
+  data: Record<string, unknown>;
+}
+
+let sessions: SessionRow[] = [];
+// Paths whose context doc should report `exists: true` on get().
+let existingContextPaths: Set<string>;
+let writes: Write[];
+
+// Minimal structural Admin-SDK mock. Only the call shapes
+// persistNrpsMembershipForLaunch uses are implemented.
+function makeDb() {
+  const ctxDocRef = (sessionId: string, contextId: string) => {
+    const path = `${LTI_SESSION_MEMBERSHIPS_COLLECTION}/${sessionId}/contexts/${contextId}`;
+    return {
+      get: async () => ({ exists: existingContextPaths.has(path) }),
+      set: async (data: Record<string, unknown>) => {
+        writes.push({ path, data });
+      },
+    };
+  };
+  return {
+    collection: (name: string) => {
+      if (name === 'quiz_sessions') {
+        return {
+          where: (_field: string, _op: string, value: string) => ({
+            get: async () => ({
+              docs: sessions
+                .filter((s) => s.code === value)
+                .map((s) => ({ id: s.id, data: () => s })),
+            }),
+          }),
+          doc: (id: string) => ({
+            set: async (data: Record<string, unknown>) => {
+              writes.push({ path: `quiz_sessions/${id}`, data });
+            },
+          }),
+        };
+      }
+      if (name === LTI_SESSION_MEMBERSHIPS_COLLECTION) {
+        return {
+          doc: (sessionId: string) => ({
+            collection: () => ({
+              doc: (contextId: string) => ctxDocRef(sessionId, contextId),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+  };
+}
+
+const db = (): admin.firestore.Firestore =>
+  makeDb() as unknown as admin.firestore.Firestore;
+
+const ARGS = {
+  quizCode: 'abc123', // normalizeQuizCode → 'ABC123'
+  contextId: 'ctx-1',
+  membershipUrl: 'https://lms/contexts/ctx-1/memberships',
+  deploymentId: 'dep-1',
+};
+
+beforeEach(() => {
+  sessions = [];
+  existingContextPaths = new Set();
+  writes = [];
+});
+
+describe('persistNrpsMembershipForLaunch', () => {
+  it('files the membership under the joinable session and flips ltiNrps on first context', async () => {
+    sessions = [
+      { id: 'sess-1', code: 'ABC123', status: 'active', startedAt: 100 },
+    ];
+    const sessionId = await persistNrpsMembershipForLaunch(db(), ARGS);
+    expect(sessionId).toBe('sess-1');
+
+    const ctxWrite = writes.find((w) =>
+      w.path.startsWith(
+        `${LTI_SESSION_MEMBERSHIPS_COLLECTION}/sess-1/contexts/`
+      )
+    );
+    expect(ctxWrite?.path).toBe(
+      `${LTI_SESSION_MEMBERSHIPS_COLLECTION}/sess-1/contexts/ctx-1`
+    );
+    expect(ctxWrite?.data).toMatchObject({
+      contextMembershipsUrl: ARGS.membershipUrl,
+      deploymentId: 'dep-1',
+    });
+    // PII gate: only the URL + ids are persisted.
+    expect(Object.keys(ctxWrite?.data ?? {}).sort()).toEqual([
+      'contextMembershipsUrl',
+      'deploymentId',
+      'updatedAt',
+    ]);
+
+    const flagWrite = writes.find((w) => w.path === 'quiz_sessions/sess-1');
+    expect(flagWrite?.data).toEqual({ ltiNrps: true });
+  });
+
+  it('does NOT re-flip ltiNrps when the context already exists (no per-launch churn)', async () => {
+    sessions = [
+      { id: 'sess-1', code: 'ABC123', status: 'active', startedAt: 100 },
+    ];
+    existingContextPaths.add(
+      `${LTI_SESSION_MEMBERSHIPS_COLLECTION}/sess-1/contexts/ctx-1`
+    );
+    await persistNrpsMembershipForLaunch(db(), ARGS);
+
+    // Membership URL is still refreshed…
+    expect(
+      writes.some((w) =>
+        w.path.endsWith('lti_session_memberships/sess-1/contexts/ctx-1')
+      )
+    ).toBe(true);
+    // …but the session doc is NOT written again.
+    expect(writes.some((w) => w.path === 'quiz_sessions/sess-1')).toBe(false);
+  });
+
+  it('picks the most-recent joinable session and ignores ended ones', async () => {
+    sessions = [
+      { id: 'old', code: 'ABC123', status: 'active', startedAt: 100 },
+      { id: 'new', code: 'ABC123', status: 'active', startedAt: 500 },
+      { id: 'ended', code: 'ABC123', status: 'ended', startedAt: 999 },
+    ];
+    const sessionId = await persistNrpsMembershipForLaunch(db(), ARGS);
+    expect(sessionId).toBe('new');
+  });
+
+  it('is a no-op (returns null, no writes) when no joinable session matches', async () => {
+    sessions = [{ id: 'ended', code: 'ABC123', status: 'ended', startedAt: 1 }];
+    const sessionId = await persistNrpsMembershipForLaunch(db(), ARGS);
+    expect(sessionId).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+
+  it('returns null for an empty/garbage code without touching Firestore', async () => {
+    const sessionId = await persistNrpsMembershipForLaunch(db(), {
+      ...ARGS,
+      quizCode: '   ',
+    });
+    expect(sessionId).toBeNull();
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/functions/src/lti/nrpsStore.ts
+++ b/functions/src/lti/nrpsStore.ts
@@ -1,0 +1,101 @@
+// Schoology LTI 1.3 — NRPS membership-endpoint persistence (PII-free).
+//
+// When a Schoology student launches a deep-linked quiz, the launch carries the
+// context's `context_memberships_url` (NRPS). We file that URL under the quiz
+// SESSION the student is joining so the teacher's monitor can later resolve
+// every Schoology student's name on-read. ONLY the URL + platform ids are
+// stored — never a name or email. Keyed by sessionId (not the recyclable join
+// code) so a recycled code can never leak one teacher's roster to another: the
+// resolver reads only its own session's contexts and is gated on session
+// ownership.
+//
+// Admin-SDK only; `firestore.rules` denies all client access to this tree.
+
+import type * as admin from 'firebase-admin';
+import { normalizeQuizCode } from '../quizCode';
+
+type Db = admin.firestore.Firestore;
+
+export const QUIZ_SESSIONS_COLLECTION = 'quiz_sessions';
+/** `lti_session_memberships/{sessionId}/contexts/{contextId}` */
+export const LTI_SESSION_MEMBERSHIPS_COLLECTION = 'lti_session_memberships';
+
+// The session statuses that are still accepting joins — mirrors the client's
+// join-target selection in useQuizSession so the membership is filed under the
+// SAME session the student's responses land in.
+const JOINABLE_STATUSES = new Set(['waiting', 'active', 'paused']);
+
+export interface PersistNrpsArgs {
+  /** The quiz join code embedded in the deep-link (`custom.quiz_code`). */
+  quizCode: string;
+  /** The Schoology context (course) id from the launch. */
+  contextId: string;
+  /** The platform-hosted NRPS membership URL (PII-free service endpoint). */
+  membershipUrl: string;
+  /** Launch deployment id, stored for diagnostics / future multi-deployment. */
+  deploymentId: string;
+}
+
+/**
+ * Resolve the joinable quiz session for `quizCode` and persist the context's
+ * NRPS membership URL under it. Sets `ltiNrps: true` on the session the FIRST
+ * time a context is filed (so the monitor knows to call the resolver, and so
+ * we don't re-write the session doc — and re-fire its snapshot listeners — on
+ * every subsequent student launch).
+ *
+ * Returns the resolved sessionId, or null when no joinable session matched
+ * (e.g. the session ended between launch and exchange) — a benign no-op.
+ */
+export async function persistNrpsMembershipForLaunch(
+  db: Db,
+  args: PersistNrpsArgs
+): Promise<string | null> {
+  const normCode = normalizeQuizCode(args.quizCode);
+  if (!normCode) return null;
+
+  const snap = await db
+    .collection(QUIZ_SESSIONS_COLLECTION)
+    .where('code', '==', normCode)
+    .get();
+
+  // Filter to joinable docs and prefer the most recently started — identical
+  // to the client's join-target selection, so the membership is filed under
+  // the exact session the student joined.
+  const joinable = snap.docs
+    .filter((d) => JOINABLE_STATUSES.has((d.data().status as string) ?? ''))
+    .sort(
+      (a, b) =>
+        ((b.data().startedAt as number) ?? 0) -
+        ((a.data().startedAt as number) ?? 0)
+    );
+  const sessionDoc = joinable[0];
+  if (!sessionDoc) return null;
+
+  const sessionId = sessionDoc.id;
+  const ctxRef = db
+    .collection(LTI_SESSION_MEMBERSHIPS_COLLECTION)
+    .doc(sessionId)
+    .collection('contexts')
+    .doc(args.contextId);
+
+  // First-context check: only flip the session flag when this context is new,
+  // bounding session-doc writes to the number of distinct Schoology contexts
+  // (1 for a single-course attach; a handful for a multi-section one) rather
+  // than once per student launch.
+  const existing = await ctxRef.get();
+  await ctxRef.set(
+    {
+      contextMembershipsUrl: args.membershipUrl,
+      deploymentId: args.deploymentId,
+      updatedAt: Date.now(),
+    },
+    { merge: true }
+  );
+  if (!existing.exists) {
+    await db
+      .collection(QUIZ_SESSIONS_COLLECTION)
+      .doc(sessionId)
+      .set({ ltiNrps: true }, { merge: true });
+  }
+  return sessionId;
+}

--- a/functions/src/lti/serviceEndpoints.test.ts
+++ b/functions/src/lti/serviceEndpoints.test.ts
@@ -118,6 +118,16 @@ describe('ltiResolveNamesForAssignmentV1 — security gate', () => {
     );
   });
 
+  it('rejects a token with no email (defense-in-depth teacher gate)', async () => {
+    await expectCode(
+      callResolve({
+        auth: { uid: 'teacher-1', token: {} },
+        data: { sessionId: 's1' },
+      }),
+      'permission-denied'
+    );
+  });
+
   it('rejects when the session is owned by a different teacher', async () => {
     sessionDoc = { exists: true, data: () => ({ teacherUid: 'someone-else' }) };
     await expectCode(
@@ -172,6 +182,27 @@ describe('ltiResolveNamesForAssignmentV1 — resolution', () => {
     const uidB = ltiStudentUid('sub-B', 'test-hmac-secret');
     expect(res.names[uidA]).toEqual({ givenName: 'Ada', familyName: 'L' });
     expect(res.names[uidB]).toEqual({ givenName: 'Bob', familyName: 'H' });
+  });
+
+  it('throws `unavailable` when every context fetch fails (real NRPS outage, not empty)', async () => {
+    contextDocs = [
+      {
+        id: 'ctx-1',
+        data: () => ({ contextMembershipsUrl: 'https://lms/m1' }),
+      },
+    ];
+    // First-page error → fetchNrpsMembers throws → resolver records the failure;
+    // with no context successfully fetched it must surface, not return {}.
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: false,
+      status: 403,
+      members: [],
+      nextUrl: null,
+    });
+    await expectCode(
+      callResolve({ auth: TEACHER, data: { sessionId: 's1' } }),
+      'unavailable'
+    );
   });
 
   it('unions members across multiple contexts (multi-section attach)', async () => {

--- a/functions/src/lti/serviceEndpoints.test.ts
+++ b/functions/src/lti/serviceEndpoints.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for ltiResolveNamesForAssignmentV1 — the teacher-side NRPS name
+ * resolver. The security-critical invariant is the gate: names are returned
+ * ONLY to the teacher who owns the session, never to a student, an
+ * unauthenticated caller, or a teacher querying someone else's session. Also
+ * pins the happy path: members map onto the SAME pseudonym uid that keys the
+ * response docs (`ltiStudentUid`).
+ */
+
+/* eslint-disable @typescript-eslint/require-await -- mock async handlers mirror
+   the async Admin-SDK / network surface without awaiting anything. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mocks (hoisted) ─────────────────────────────────────────────────────────
+vi.mock('firebase-functions/v2/https', () => {
+  class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+      this.name = 'HttpsError';
+    }
+  }
+  return {
+    onCall: (_options: unknown, handler: unknown) => handler,
+    HttpsError,
+  };
+});
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: () => ({ value: () => 'test-hmac-secret' }),
+}));
+
+// Configurable Firestore state.
+let sessionDoc: { exists: boolean; data: () => unknown };
+let contextDocs: Array<{ id: string; data: () => unknown }>;
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  firestore: vi.fn(() => ({
+    collection: (name: string) => {
+      if (name === 'quiz_sessions') {
+        return { doc: () => ({ get: async () => sessionDoc }) };
+      }
+      if (name === 'lti_session_memberships') {
+        return {
+          doc: () => ({
+            collection: () => ({
+              get: async () => ({
+                empty: contextDocs.length === 0,
+                size: contextDocs.length,
+                docs: contextDocs,
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected collection ${name}`);
+    },
+  })),
+}));
+
+vi.mock('./config', async (orig) => ({
+  ...(await orig<typeof import('./config')>()),
+  getLtiPlatformConfig: vi.fn().mockResolvedValue({
+    clientId: 'client-1',
+    tokenUrl: 'https://lms/token',
+  }),
+}));
+
+vi.mock('./ags', async (orig) => ({
+  ...(await orig<typeof import('./ags')>()),
+  getAgsAccessToken: vi.fn().mockResolvedValue('nrps-access-token'),
+}));
+
+// Imported AFTER the mocks so the module picks them up.
+import { ltiResolveNamesForAssignmentV1 } from './serviceEndpoints';
+import { ltiStudentUid } from './identity';
+import { nrpsNet } from './nrps';
+
+interface ResolveResult {
+  names: Record<string, { givenName: string; familyName: string }>;
+}
+const callResolve = ltiResolveNamesForAssignmentV1 as unknown as (req: {
+  auth?: { uid: string; token: Record<string, unknown> };
+  data: unknown;
+}) => Promise<ResolveResult>;
+
+const TEACHER = { uid: 'teacher-1', token: { email: 't@orono.k12.mn.us' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionDoc = { exists: true, data: () => ({ teacherUid: 'teacher-1' }) };
+  contextDocs = [];
+});
+
+async function expectCode(p: Promise<unknown>, code: string) {
+  await expect(p).rejects.toMatchObject({ code });
+}
+
+describe('ltiResolveNamesForAssignmentV1 — security gate', () => {
+  it('rejects an unauthenticated caller', async () => {
+    await expectCode(
+      callResolve({ data: { sessionId: 's1' } }),
+      'unauthenticated'
+    );
+  });
+
+  it('rejects a studentRole token', async () => {
+    await expectCode(
+      callResolve({
+        auth: { uid: 'kid', token: { studentRole: true } },
+        data: { sessionId: 's1' },
+      }),
+      'permission-denied'
+    );
+  });
+
+  it('rejects when the session is owned by a different teacher', async () => {
+    sessionDoc = { exists: true, data: () => ({ teacherUid: 'someone-else' }) };
+    await expectCode(
+      callResolve({ auth: TEACHER, data: { sessionId: 's1' } }),
+      'permission-denied'
+    );
+  });
+
+  it('rejects when the session does not exist', async () => {
+    sessionDoc = { exists: false, data: () => undefined };
+    await expectCode(
+      callResolve({ auth: TEACHER, data: { sessionId: 's1' } }),
+      'permission-denied'
+    );
+  });
+
+  it('requires a sessionId', async () => {
+    await expectCode(
+      callResolve({ auth: TEACHER, data: {} }),
+      'invalid-argument'
+    );
+  });
+});
+
+describe('ltiResolveNamesForAssignmentV1 — resolution', () => {
+  it('returns an empty map for a session with no persisted contexts', async () => {
+    contextDocs = [];
+    const res = await callResolve({ auth: TEACHER, data: { sessionId: 's1' } });
+    expect(res.names).toEqual({});
+  });
+
+  it('maps members onto the response-doc pseudonym uid', async () => {
+    contextDocs = [
+      {
+        id: 'ctx-1',
+        data: () => ({ contextMembershipsUrl: 'https://lms/m1' }),
+      },
+    ];
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockResolvedValue({
+      ok: true,
+      status: 200,
+      members: [
+        { user_id: 'sub-A', given_name: 'Ada', family_name: 'L' },
+        { user_id: 'sub-B', given_name: 'Bob', family_name: 'H' },
+      ],
+      nextUrl: null,
+    });
+
+    const res = await callResolve({ auth: TEACHER, data: { sessionId: 's1' } });
+
+    const uidA = ltiStudentUid('sub-A', 'test-hmac-secret');
+    const uidB = ltiStudentUid('sub-B', 'test-hmac-secret');
+    expect(res.names[uidA]).toEqual({ givenName: 'Ada', familyName: 'L' });
+    expect(res.names[uidB]).toEqual({ givenName: 'Bob', familyName: 'H' });
+  });
+
+  it('unions members across multiple contexts (multi-section attach)', async () => {
+    contextDocs = [
+      {
+        id: 'ctx-1',
+        data: () => ({ contextMembershipsUrl: 'https://lms/m1' }),
+      },
+      {
+        id: 'ctx-2',
+        data: () => ({ contextMembershipsUrl: 'https://lms/m2' }),
+      },
+    ];
+    vi.spyOn(nrpsNet, 'fetchMembershipPage').mockImplementation(
+      async (url: string) => ({
+        ok: true,
+        status: 200,
+        members:
+          url === 'https://lms/m1'
+            ? [{ user_id: 'sub-A', given_name: 'Ada', family_name: 'L' }]
+            : [{ user_id: 'sub-C', given_name: 'Cy', family_name: 'P' }],
+        nextUrl: null,
+      })
+    );
+
+    const res = await callResolve({ auth: TEACHER, data: { sessionId: 's1' } });
+    expect(Object.keys(res.names)).toHaveLength(2);
+    expect(res.names[ltiStudentUid('sub-C', 'test-hmac-secret')]).toEqual({
+      givenName: 'Cy',
+      familyName: 'P',
+    });
+  });
+});

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -247,9 +247,11 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
     if (!request.auth) {
       throw new HttpsError('unauthenticated', 'Sign in required.');
     }
-    // Teachers only. Students carry `studentRole` and never own a session, but
-    // short-circuit them explicitly (mirrors getPseudonymsForAssignmentV1).
-    if (request.auth.token.studentRole === true) {
+    // Teachers only. Teachers authenticate with standard Firebase Auth (email
+    // present on the token); students never have email and carry `studentRole`.
+    // Require email + reject studentRole (mirrors getPseudonymsForAssignmentV1)
+    // — defense in depth on top of the session-ownership gate below.
+    if (!request.auth.token.email || request.auth.token.studentRole === true) {
       throw new HttpsError('permission-denied', 'Teacher account required.');
     }
     const data = (request.data ?? {}) as { sessionId?: unknown };
@@ -314,6 +316,8 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
     // partial map is strictly better than none.
     const names: Record<string, { givenName: string; familyName: string }> = {};
     let withName = 0;
+    let contextsFetched = 0;
+    let contextsFailed = 0;
     for (const doc of ctxSnap.docs) {
       const url =
         typeof doc.data().contextMembershipsUrl === 'string'
@@ -322,6 +326,7 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
       if (!url) continue;
       try {
         const members = await fetchNrpsMembers(url, accessToken);
+        contextsFetched += 1;
         for (const m of members) {
           const uid = ltiStudentUid(m.userId, hmacSecret);
           names[uid] = {
@@ -331,15 +336,42 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
           if (m.givenName || m.familyName) withName += 1;
         }
       } catch (err) {
+        contextsFailed += 1;
         console.warn(`[ltiResolveNames] context ${doc.id} fetch failed:`, err);
       }
     }
 
-    // PII-free diagnostics: counts only, never names. `withName` confirms the
-    // platform is releasing names in the membership payload (the one unknown).
+    // If EVERY context with a URL failed, this is a real NRPS outage (scope
+    // denied on the membership endpoint, expired/invalid URL, platform down) —
+    // NOT the benign "no LTI students" case (which already returned {} above
+    // when there were no contexts). Throw so the client's catch fires
+    // (observability + cache eviction → retry on the next monitor open) instead
+    // of silently rendering every student as "Student", which is byte-identical
+    // to an empty resolve.
+    if (contextsFetched === 0 && contextsFailed > 0) {
+      throw new HttpsError(
+        'unavailable',
+        'Could not reach the Schoology roster service.'
+      );
+    }
+
+    const total = Object.keys(names).length;
+    // Members present but ZERO names = the platform connected yet is WITHHOLDING
+    // names (the NRPS name-release / privacy config — the one unknown this whole
+    // feature depends on). Warn (not info) so it's greppable/alertable: the fix
+    // is in the Schoology app config, not the code.
+    if (total > 0 && withName === 0) {
+      console.warn(
+        `[ltiResolveNames] session=${sessionId} platform returned ${total} ` +
+          `members but ZERO names — check the Schoology NRPS name-release config`
+      );
+    }
+
+    // PII-free diagnostics: counts only, never names.
     console.log(
       `[ltiResolveNames] session=${sessionId} contexts=${ctxSnap.size} ` +
-        `members=${Object.keys(names).length} withName=${withName}`
+        `fetched=${contextsFetched} failed=${contextsFailed} ` +
+        `members=${total} withName=${withName}`
     );
     return { names };
   }

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -16,6 +16,7 @@ import {
   getLtiPlatformConfig,
   TOOL_LAUNCH_URL,
   AGS_SCOPE_SCORE,
+  NRPS_SCOPE,
 } from './config';
 import { ALLOWED_ORIGINS } from '../classlinkShared';
 import { signToolJwt } from './toolKey';
@@ -25,9 +26,18 @@ import {
   isSchoologyReturnUrl,
 } from './deepLink';
 import { getAgsAccessToken, postScore } from './ags';
+import { fetchNrpsMembers } from './nrps';
+import { ltiStudentUid } from './identity';
+import {
+  QUIZ_SESSIONS_COLLECTION,
+  LTI_SESSION_MEMBERSHIPS_COLLECTION,
+} from './nrpsStore';
 import { validateGradePushAuth } from './stores';
 
 const LTI_TOOL_PRIVATE_KEY = defineSecret('LTI_TOOL_PRIVATE_KEY');
+const STUDENT_PSEUDONYM_HMAC_SECRET = defineSecret(
+  'STUDENT_PSEUDONYM_HMAC_SECRET'
+);
 
 // ── ltiSignDeepLinkResponseV1 ───────────────────────────────────────────────
 export const ltiSignDeepLinkResponseV1 = onCall(
@@ -212,5 +222,125 @@ export const ltiPushGradesForAssignmentV1 = onCall(
 
     const pushed = results.filter((r) => r.ok).length;
     return { results, pushed, total: rawGrades.length };
+  }
+);
+
+// ── ltiResolveNamesForAssignmentV1 ──────────────────────────────────────────
+//
+// Teacher-side name resolution for Schoology students — the NRPS analogue of
+// `getPseudonymsForAssignmentV1` (the ClassLink resolver). Given a quiz session
+// the caller TEACHES, fetch the persisted NRPS membership URL(s) for that
+// session, mint an NRPS-scoped service token, GET the membership roster(s), and
+// map each member's LTI `sub` → the SAME pseudonym uid that keys the response
+// docs → their name. Names are returned to the teacher's browser and NEVER
+// persisted (mirrors ClassLink: nothing about a name comes to rest in
+// Firestore). Gated on session ownership, so a teacher only ever resolves their
+// own session's contexts.
+export const ltiResolveNamesForAssignmentV1 = onCall(
+  {
+    region: 'us-central1',
+    invoker: 'public',
+    cors: ALLOWED_ORIGINS,
+    secrets: [LTI_TOOL_PRIVATE_KEY, STUDENT_PSEUDONYM_HMAC_SECRET],
+  },
+  async (request) => {
+    if (!request.auth) {
+      throw new HttpsError('unauthenticated', 'Sign in required.');
+    }
+    // Teachers only. Students carry `studentRole` and never own a session, but
+    // short-circuit them explicitly (mirrors getPseudonymsForAssignmentV1).
+    if (request.auth.token.studentRole === true) {
+      throw new HttpsError('permission-denied', 'Teacher account required.');
+    }
+    const data = (request.data ?? {}) as { sessionId?: unknown };
+    const sessionId = typeof data.sessionId === 'string' ? data.sessionId : '';
+    if (!sessionId) {
+      throw new HttpsError('invalid-argument', 'sessionId is required.');
+    }
+
+    const db = admin.firestore();
+
+    // SECURITY GATE: the caller must own the session. Same opaque error for
+    // "no session" and "not your session" so we don't reveal session existence.
+    const sessSnap = await db
+      .collection(QUIZ_SESSIONS_COLLECTION)
+      .doc(sessionId)
+      .get();
+    const sessTeacherUid =
+      typeof sessSnap.data()?.teacherUid === 'string'
+        ? (sessSnap.data()?.teacherUid as string)
+        : '';
+    if (!sessSnap.exists || sessTeacherUid !== request.auth.uid) {
+      throw new HttpsError(
+        'permission-denied',
+        'Not the teacher of this session.'
+      );
+    }
+
+    const ctxSnap = await db
+      .collection(LTI_SESSION_MEMBERSHIPS_COLLECTION)
+      .doc(sessionId)
+      .collection('contexts')
+      .get();
+    if (ctxSnap.empty) {
+      // Non-LTI session (or no student has launched yet) — nothing to resolve.
+      return { names: {} };
+    }
+
+    const hmacSecret = STUDENT_PSEUDONYM_HMAC_SECRET.value();
+    if (!hmacSecret) {
+      throw new HttpsError('internal', 'Server not configured.');
+    }
+
+    const cfg = await getLtiPlatformConfig(db);
+    let accessToken: string;
+    try {
+      accessToken = await getAgsAccessToken({
+        clientId: cfg.clientId,
+        tokenUrl: cfg.tokenUrl,
+        privatePem: LTI_TOOL_PRIVATE_KEY.value(),
+        scopes: [NRPS_SCOPE],
+      });
+    } catch (err) {
+      console.error('[ltiResolveNames] NRPS token mint failed:', err);
+      throw new HttpsError(
+        'internal',
+        'Could not authorize the roster service.'
+      );
+    }
+
+    // Union every context filed under this session (a multi-section attach has
+    // more than one). A per-context fetch failure is logged and skipped — a
+    // partial map is strictly better than none.
+    const names: Record<string, { givenName: string; familyName: string }> = {};
+    let withName = 0;
+    for (const doc of ctxSnap.docs) {
+      const url =
+        typeof doc.data().contextMembershipsUrl === 'string'
+          ? (doc.data().contextMembershipsUrl as string)
+          : '';
+      if (!url) continue;
+      try {
+        const members = await fetchNrpsMembers(url, accessToken);
+        for (const m of members) {
+          const uid = ltiStudentUid(m.userId, hmacSecret);
+          names[uid] = {
+            givenName: m.givenName,
+            familyName: m.familyName,
+          };
+          if (m.givenName || m.familyName) withName += 1;
+        }
+      } catch (err) {
+        console.warn(`[ltiResolveNames] context ${doc.id} fetch failed:`, err);
+      }
+    }
+
+    // PII-free diagnostics: counts only, never names. `withName` confirms the
+    // platform is releasing names in the membership payload (the one unknown).
+    console.log(
+      `[ltiResolveNames] session=${sessionId} contexts=${ctxSnap.size} ` +
+        `members=${Object.keys(names).length} withName=${withName}`
+    );
+    return { names };
   }
 );

--- a/hooks/useLtiSessionNames.ts
+++ b/hooks/useLtiSessionNames.ts
@@ -1,0 +1,99 @@
+/**
+ * useLtiSessionNames — teacher-side name resolution for Schoology LTI students.
+ *
+ * The NRPS analogue of `useAssignmentPseudonymsMulti`. A Schoology student's
+ * response doc is keyed by a `schoology-sub` pseudonym uid that lives in no
+ * ClassLink roster, so the ClassLink resolver can't name them. Instead this
+ * hook calls `ltiResolveNamesForAssignmentV1`, which fetches the session's
+ * Schoology context roster over NRPS and returns `{ uid → name }` — resolved
+ * ON READ, never stored. The result merges into the monitor's existing
+ * `byStudentUid` map, so `resolveResponseDisplayName` names Schoology students
+ * exactly like ClassLink ones.
+ *
+ * Gated by `enabled` (the session's `ltiNrps` flag) so it is a complete no-op —
+ * zero callable invocations — for every non-LTI session, which is the vast
+ * majority. The NRPS roster is the whole class (not just joined students) and
+ * stable for the session, so a single cached fetch covers everyone; the
+ * module-level promise cache de-dupes sibling viewers and is invalidated when
+ * the authenticated teacher changes.
+ */
+
+import { useEffect, useState } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import { auth, functions } from '@/config/firebase';
+import { logError } from '@/utils/logError';
+import type { StudentName } from '@/hooks/useAssignmentPseudonyms';
+
+interface ResolveNamesResponse {
+  names?: Record<string, { givenName?: string; familyName?: string }>;
+}
+
+const EMPTY = new Map<string, StudentName>();
+
+let cacheOwnerUid: string | null = null;
+let cache = new Map<string, Promise<Map<string, StudentName>>>();
+
+function fetchSessionNames(
+  sessionId: string,
+  teacherUid: string
+): Promise<Map<string, StudentName>> {
+  if (cacheOwnerUid !== teacherUid) {
+    cache = new Map();
+    cacheOwnerUid = teacherUid;
+  }
+  const cached = cache.get(sessionId);
+  if (cached) return cached;
+
+  const callable = httpsCallable<{ sessionId: string }, ResolveNamesResponse>(
+    functions,
+    'ltiResolveNamesForAssignmentV1'
+  );
+  const promise = callable({ sessionId }).then((res) => {
+    const entries = res.data?.names ?? {};
+    const map = new Map<string, StudentName>();
+    for (const [uid, n] of Object.entries(entries)) {
+      map.set(uid, {
+        givenName: n.givenName ?? '',
+        familyName: n.familyName ?? '',
+      });
+    }
+    return map;
+  });
+
+  cache.set(sessionId, promise);
+  // Evict on failure so a transient CF error doesn't poison the cache forever.
+  promise.catch(() => {
+    if (cache.get(sessionId) === promise) cache.delete(sessionId);
+  });
+  return promise;
+}
+
+export function useLtiSessionNames(
+  sessionId: string | null | undefined,
+  enabled: boolean
+): Map<string, StudentName> {
+  const [resolved, setResolved] = useState<{
+    key: string;
+    map: Map<string, StudentName>;
+  }>({ key: '', map: EMPTY });
+
+  useEffect(() => {
+    if (!enabled || !sessionId) return;
+    const teacherUid = auth.currentUser?.uid ?? '';
+    if (!teacherUid) return;
+    let cancelled = false;
+    fetchSessionNames(sessionId, teacherUid)
+      .then((map) => {
+        if (!cancelled) setResolved({ key: sessionId, map });
+      })
+      .catch((err) => {
+        if (!cancelled)
+          logError('useLtiSessionNames.fetch', err, { sessionId });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, enabled]);
+
+  return resolved.key === sessionId && sessionId ? resolved.map : EMPTY;
+}

--- a/tests/hooks/useLtiSessionNames.test.ts
+++ b/tests/hooks/useLtiSessionNames.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/require-await -- mock callable returns
+   Promise-shaped data without awaiting; matches production contract. */
+/**
+ * Tests for `useLtiSessionNames` — the NRPS teacher-side name resolver hook.
+ *
+ * Pins: (1) it resolves `{ uid → name }` when enabled; (2) it makes ZERO
+ * callable invocations when `enabled` is false (the `ltiNrps` gate keeps every
+ * non-LTI session free of the round trip); (3) it stays silent (no call) when
+ * the sessionId is absent; (4) a callable failure logs and degrades to an empty
+ * map rather than throwing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const loggedErrors: { scope: string; error: unknown; ctx?: unknown }[] = [];
+vi.mock('@/utils/logError', () => ({
+  logError: (scope: string, error: unknown, ctx?: unknown) => {
+    loggedErrors.push({ scope, error, ctx });
+  },
+}));
+
+type CallableInput = { sessionId: string };
+interface CallableResult {
+  names: Record<string, { givenName: string; familyName: string }>;
+}
+type CallableReturn =
+  | Promise<{ data: CallableResult }>
+  | { data: CallableResult };
+type CallableHandler = (input: CallableInput) => CallableReturn;
+
+let callCount = 0;
+vi.mock('firebase/functions', () => ({
+  httpsCallable: (_functions: unknown, _name: string) => {
+    return (data: CallableInput) => {
+      callCount++;
+      const state = (
+        globalThis as { __ltiNamesMock?: { handler: CallableHandler } }
+      ).__ltiNamesMock;
+      if (!state?.handler) throw new Error('callable handler not set for test');
+      return Promise.resolve(state.handler(data));
+    };
+  },
+}));
+
+vi.mock('@/config/firebase', () => ({
+  functions: {},
+  auth: {
+    get currentUser() {
+      return { uid: 'teacher-1' };
+    },
+  },
+}));
+
+const setHandler = (handler: CallableHandler): void => {
+  (
+    globalThis as { __ltiNamesMock?: { handler: CallableHandler } }
+  ).__ltiNamesMock = { handler };
+};
+
+import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
+
+let uniqueSessionId = 0;
+const nextSessionId = () => `session-${++uniqueSessionId}`;
+
+beforeEach(() => {
+  loggedErrors.length = 0;
+  callCount = 0;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useLtiSessionNames', () => {
+  it('resolves names when enabled', async () => {
+    setHandler(() => ({
+      data: {
+        names: {
+          'uid-a': { givenName: 'Ada', familyName: 'Lovelace' },
+          'uid-b': { givenName: 'Grace', familyName: 'Hopper' },
+        },
+      },
+    }));
+
+    const sid = nextSessionId();
+    const { result } = renderHook(() => useLtiSessionNames(sid, true));
+
+    await waitFor(() => expect(result.current.size).toBe(2));
+    expect(result.current.get('uid-a')?.givenName).toBe('Ada');
+    expect(result.current.get('uid-b')?.familyName).toBe('Hopper');
+    expect(callCount).toBe(1);
+  });
+
+  it('makes NO callable invocation when disabled (the ltiNrps gate)', async () => {
+    setHandler(() => ({ data: { names: {} } }));
+    const sid = nextSessionId();
+    const { result } = renderHook(() => useLtiSessionNames(sid, false));
+    expect(result.current.size).toBe(0);
+    expect(callCount).toBe(0);
+  });
+
+  it('makes NO call when the sessionId is absent', async () => {
+    setHandler(() => ({ data: { names: {} } }));
+    const { result } = renderHook(() => useLtiSessionNames(null, true));
+    expect(result.current.size).toBe(0);
+    expect(callCount).toBe(0);
+  });
+
+  it('degrades to an empty map and logs when the callable fails', async () => {
+    setHandler(() => Promise.reject(new Error('roster service unavailable')));
+    const sid = nextSessionId();
+    const { result } = renderHook(() => useLtiSessionNames(sid, true));
+
+    await waitFor(() => expect(loggedErrors).toHaveLength(1));
+    expect(loggedErrors[0].scope).toBe('useLtiSessionNames.fetch');
+    expect(result.current.size).toBe(0);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -2697,6 +2697,16 @@ export interface QuizSession {
    */
   publicQuestions: QuizPublicQuestion[];
 
+  /**
+   * True once at least one Schoology LTI student has launched this session and
+   * the launch carried an NRPS membership endpoint (set server-side by the
+   * launch-exchange CF). Signals the teacher monitor to resolve Schoology
+   * student names on-read via `ltiResolveNamesForAssignmentV1`. Absent/false on
+   * every non-LTI session, so the monitor skips that call entirely. No PII —
+   * just a routing flag.
+   */
+  ltiNrps?: boolean;
+
   // ─── Toggles (Phase 1) ─────────────────────────────────────────────────────
   /** Whether tab-switch detection is active on student devices (default true) */
   tabWarningsEnabled?: boolean;


### PR DESCRIPTION
## Problem
Schoology LTI students show as the generic **"Student"** in the teacher's quiz monitor. Their response docs are keyed by a `schoology-sub` pseudonym uid that lives in no ClassLink roster, and (until now) the launch carried no NRPS endpoint — so the existing name pipeline can't resolve them.

## Fix — resolve on read, store zero PII
With **NRPS now enabled** on the Schoology app (confirmed live: `hasNrps: true` on student launches), names resolve exactly like the ClassLink/OneRoster path — **nothing name-bearing is ever persisted in Firestore**:

- **`ltiExchange`** persists only the PII-free `context_memberships_url`, keyed by the quiz **session → context** (`lti_session_memberships/{sessionId}/contexts/{contextId}`), and flips `QuizSession.ltiNrps` on first context. Best-effort; never blocks a student. Keyed by **sessionId** (not the recyclable join code) so a recycled code can't leak one teacher's roster to another.
- **`ltiResolveNamesForAssignmentV1`** (new, teacher-gated CF) mints an NRPS-scoped service token (reusing the AGS client-credentials flow), GETs the membership roster, and maps each member's LTI `sub` → the **same** pseudonym uid that keys the response docs (shared `ltiStudentUid`) → name. Gated on session ownership.
- **`useLtiSessionNames`** merges resolved names into the monitor's existing `byStudentUid` (ClassLink wins on collision); gated on `ltiNrps` so non-LTI sessions make **zero** extra calls.

Names are returned to the teacher's browser only — response/pseudonym docs stay PII-free, preserving the roster-resolve invariant. Rules deny all client access to `lti_session_memberships` (Admin SDK only).

## Observability
Total NRPS outage throws `unavailable` (vs. a silent `200 {}` that looked identical to "no LTI students"); `members>0 withName=0` (platform withholding names — the one config unknown) logs at `warn`. Launch log gains PII-free `hasName`/`hasEmail` flags.

## Review
3 parallel agents (security/PII + tenant isolation, silent-failure, correctness). Security: all 6 invariants hold, no critical/high. Correctness: all 7 checks confirmed. Silent-failure HIGH/MEDIUM findings on observability — **addressed** in the follow-up commit.

## Tests
65 LTI tests (NRPS pagination/parse, persistence keying + flag-on-first-context, resolver security gate + sub→uid mapping + outage, client hook gating). Type-check + lint + format clean; rules compile clean.

## Verify after deploy
Re-launch as the sample student (seeds the membership URL), then open the quiz monitor — the real name should show. The `withName` log line confirms whether Schoology releases names in the membership payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)