### PR TITLE
fix(lti): remove redundant deep-link 'Adding…' status line

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -166,7 +166,6 @@ const LtiDeepLinkFlow: React.FC = () => {
   const [errorMsg, setErrorMsg] = useState<string | null>(
     code ? null : NO_CODE_MESSAGE
   );
-  const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [selectedQuizId, setSelectedQuizId] = useState('');
@@ -264,10 +263,9 @@ const LtiDeepLinkFlow: React.FC = () => {
   }, [signInWithGoogle]);
 
   const addQuiz = useCallback(async () => {
-    if (!selectedQuiz) {
-      setStatusMsg('Pick a quiz first.');
-      return;
-    }
+    // The "Add quiz" button is disabled until a quiz is selected, so this is a
+    // defensive guard only.
+    if (!selectedQuiz) return;
     const returnUrl = deepLinking?.deep_link_return_url;
     if (!returnUrl) {
       setErrorMsg(
@@ -291,7 +289,6 @@ const LtiDeepLinkFlow: React.FC = () => {
       // step runs at most once per quiz; only the idempotent sign re-runs.
       let created = createdRef.current.get(selectedQuiz.id);
       if (!created) {
-        setStatusMsg(`Loading "${selectedQuiz.title}"…`);
         const quizData = await loadQuizData(selectedQuiz.driveFileId);
 
         // Gradebook scale = the quiz's total points, so a 17/20 quiz reads 17/20
@@ -301,7 +298,6 @@ const LtiDeepLinkFlow: React.FC = () => {
         // Class-targeted session (join code) the student runner joins by —
         // classIds scope it to this Schoology course so a studentRole token
         // (classIds: ['schoology:<id>']) passes the Firestore class-gate.
-        setStatusMsg('Creating the assignment…');
         const { sessionMode, sessionOptions, attemptLimit } =
           getQuizBehavior(selectedQuiz);
         const { code: quizCode } = await createAssignment(
@@ -326,7 +322,6 @@ const LtiDeepLinkFlow: React.FC = () => {
         createdRef.current.set(selectedQuiz.id, created);
       }
 
-      setStatusMsg('Adding the quiz to Schoology…');
       const sign = httpsCallable<
         SignDeepLinkResponseParams,
         SignDeepLinkResponseResult
@@ -343,7 +338,6 @@ const LtiDeepLinkFlow: React.FC = () => {
       });
 
       setSubmitted(true);
-      setStatusMsg('Returning to Schoology…');
       // Auto-submitting form POST navigates this browsing context back to the
       // platform, which creates the graded material. Framed (the normal case),
       // this navigates the Schoology iframe, so the content-return page runs in
@@ -353,7 +347,6 @@ const LtiDeepLinkFlow: React.FC = () => {
       const message = err instanceof Error ? err.message : String(err);
       logError('LtiDeepLinkFlow.addQuiz', err, { quizId: selectedQuiz.id });
       setErrorMsg(`Couldn't add the quiz: ${message}`);
-      setStatusMsg(null);
       setSubmitted(false);
     } finally {
       setBusy(false);
@@ -447,9 +440,8 @@ const LtiDeepLinkFlow: React.FC = () => {
       )}
 
       {phase !== 'error' && !submitted && (
-        <div className="mt-4 space-y-2">
+        <div className="mt-4">
           <AddonError message={errorMsg} />
-          <AddonStatus message={statusMsg} busy={busy} />
         </div>
       )}
     </AddonShell>

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -327,18 +327,6 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
       try {
         const members = await fetchNrpsMembers(url, accessToken);
         contextsFetched += 1;
-        // TEMP DIAGNOSTIC — raw NRPS user_id → computed pseudonym uid (ids only,
-        // never names) to confirm whether Schoology's membership user_id matches
-        // the launch `sub` that keys the response docs. Remove once mapping fixed.
-        console.log(
-          '[ltiResolveNames] member-ids',
-          JSON.stringify(
-            members.map((m) => ({
-              userId: m.userId,
-              uid: ltiStudentUid(m.userId, hmacSecret),
-            }))
-          )
-        );
         for (const m of members) {
           const uid = ltiStudentUid(m.userId, hmacSecret);
           names[uid] = {

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -327,6 +327,18 @@ export const ltiResolveNamesForAssignmentV1 = onCall(
       try {
         const members = await fetchNrpsMembers(url, accessToken);
         contextsFetched += 1;
+        // TEMP DIAGNOSTIC — raw NRPS user_id → computed pseudonym uid (ids only,
+        // never names) to confirm whether Schoology's membership user_id matches
+        // the launch `sub` that keys the response docs. Remove once mapping fixed.
+        console.log(
+          '[ltiResolveNames] member-ids',
+          JSON.stringify(
+            members.map((m) => ({
+              userId: m.userId,
+              uid: ltiStudentUid(m.userId, hmacSecret),
+            }))
+          )
+        );
         for (const m of members) {
           const uid = ltiStudentUid(m.userId, hmacSecret);
           names[uid] = {


### PR DESCRIPTION
The deep-link picker's "Add quiz to Schoology" button already shows a spinner while busy, so the separate "Adding the quiz to Schoology…" status line below it was duplicate progress UI. Removed the `statusMsg` state, its setters, and the redundant `<AddonStatus>` render. The launch-validation status line and the error line are unchanged.

Net diff is this single cosmetic change — the NRPS work (already on main via #1865) is unaffected; a temporary diagnostic added on dev-paul during NRPS verification was removed in the same branch, so it cancels out.

Context: NRPS student-name resolution is now confirmed working end-to-end in prod (Schoology's membership `user_id` == launch `sub`; `members=3 withName=3`; names display after a browser cache refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)