### PR TITLE
feat(lti): sync the assignment due date to Schoology at attach

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -113,6 +113,9 @@ type SignDeepLinkResponseParams = {
   dlData?: string;
   title: string;
   maxPoints?: number;
+  /** Optional due date (epoch ms). Server emits it as `submission.endDateTime`
+   *  so Schoology sets the created assignment's due date. */
+  dueAt?: number;
 } & ({ kind: 'quiz'; quizCode: string } | { kind: 'va'; sessionId: string });
 
 interface SignDeepLinkResponseResult {
@@ -236,8 +239,18 @@ const LtiDeepLinkFlow: React.FC = () => {
   const createdRef = useRef<
     Map<
       string,
-      | { kind: 'quiz'; quizCode: string; maxPoints: number }
-      | { kind: 'va'; sessionId: string; maxPoints: number }
+      | {
+          kind: 'quiz';
+          quizCode: string;
+          maxPoints: number;
+          dueAt: number | null;
+        }
+      | {
+          kind: 'va';
+          sessionId: string;
+          maxPoints: number;
+          dueAt: number | null;
+        }
     >
   >(new Map());
 
@@ -273,6 +286,19 @@ const LtiDeepLinkFlow: React.FC = () => {
   const [teacherName, setTeacherName] = useState('');
   const [plcShareEnabled, setPlcShareEnabled] = useState(false);
   const [selectedPlcId, setSelectedPlcId] = useState('');
+  // Optional due date (epoch ms; null = none). Mirrors the normal assign modal's
+  // `<input type="date">` convention: the value is UTC midnight of the picked
+  // date. Set on BOTH the SpartBoard assignment AND the Schoology line item
+  // (`submission.endDateTime`) so the teacher enters it once.
+  const dueDateId = useId();
+  const [dueAt, setDueAt] = useState<number | null>(null);
+  const dueDateInputValue = dueAt
+    ? new Date(dueAt).toISOString().slice(0, 10)
+    : '';
+  const handleDueDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target?.value ?? '';
+    setDueAt(val ? new Date(val).getTime() : null);
+  };
 
   const selectedQuiz = useMemo(
     () => quizzes.find((q) => q.id === selectedQuizId),
@@ -412,8 +438,18 @@ const LtiDeepLinkFlow: React.FC = () => {
   const signAndReturn = useCallback(
     async (
       created:
-        | { kind: 'quiz'; quizCode: string; maxPoints: number }
-        | { kind: 'va'; sessionId: string; maxPoints: number },
+        | {
+            kind: 'quiz';
+            quizCode: string;
+            maxPoints: number;
+            dueAt: number | null;
+          }
+        | {
+            kind: 'va';
+            sessionId: string;
+            maxPoints: number;
+            dueAt: number | null;
+          },
       title: string,
       returnUrl: string
     ): Promise<void> => {
@@ -428,6 +464,9 @@ const LtiDeepLinkFlow: React.FC = () => {
           : {}),
         title,
         maxPoints: created.maxPoints,
+        // Forward the due date captured at create time (kept on `created` so a
+        // retry signs the SAME due date that was persisted on the assignment).
+        ...(created.dueAt ? { dueAt: created.dueAt } : {}),
       };
       const params: SignDeepLinkResponseParams =
         created.kind === 'quiz'
@@ -507,6 +546,10 @@ const LtiDeepLinkFlow: React.FC = () => {
               : {}),
             ...(plcLinkage ? { plc: plcLinkage } : {}),
             ...(periodNames ? { periodNames } : {}),
+            // Persist the due date on the SpartBoard assignment too (quiz keeps
+            // it directly on settings), so the teacher's single entry drives
+            // both SpartBoard and the Schoology line item.
+            ...(dueAt ? { dueAt } : {}),
           },
           {
             classIds: [`schoology:${contextId}`],
@@ -514,7 +557,7 @@ const LtiDeepLinkFlow: React.FC = () => {
             ...(classPeriodByClassId ? { classPeriodByClassId } : {}),
           }
         );
-        created = { kind: 'quiz', quizCode, maxPoints };
+        created = { kind: 'quiz', quizCode, maxPoints, dueAt };
         createdRef.current.set(cacheKey, created);
       }
 
@@ -528,6 +571,7 @@ const LtiDeepLinkFlow: React.FC = () => {
       contextTitle,
       teacherName,
       defaultTeacherName,
+      dueAt,
       resolvePlcLinkage,
       signAndReturn,
     ]
@@ -560,6 +604,9 @@ const LtiDeepLinkFlow: React.FC = () => {
         const sessionOptions: VideoActivitySessionOptions = {
           ...behavior.sessionOptions,
           attemptLimit: behavior.attemptLimit,
+          // VA carries its due date on sessionOptions (no top-level settings
+          // field). Persist it so SpartBoard + the Schoology line item match.
+          ...(dueAt ? { dueAt } : {}),
         };
 
         const effectiveTeacherName = teacherName.trim() || defaultTeacherName;
@@ -597,7 +644,7 @@ const LtiDeepLinkFlow: React.FC = () => {
           [`schoology:${contextId}`],
           periodNames
         );
-        created = { kind: 'va', sessionId, maxPoints };
+        created = { kind: 'va', sessionId, maxPoints, dueAt };
         createdRef.current.set(cacheKey, created);
       }
 
@@ -611,6 +658,7 @@ const LtiDeepLinkFlow: React.FC = () => {
       contextTitle,
       teacherName,
       defaultTeacherName,
+      dueAt,
       resolvePlcLinkage,
       signAndReturn,
     ]
@@ -832,6 +880,29 @@ const LtiDeepLinkFlow: React.FC = () => {
                   placeholder={defaultTeacherName || 'Teacher name'}
                   disabled={busy}
                   className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 transition placeholder:text-slate-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
+                />
+              </div>
+
+              {/* Due date — set once here, applied to BOTH the SpartBoard
+                  assignment and the Schoology gradebook item (submission end
+                  date). Optional; date-only, matching the normal assign flow. */}
+              <div>
+                <label
+                  htmlFor={dueDateId}
+                  className="mb-1.5 block text-sm font-medium text-slate-700"
+                >
+                  Due date{' '}
+                  <span className="font-normal text-slate-500">
+                    (optional — also set in Schoology)
+                  </span>
+                </label>
+                <input
+                  id={dueDateId}
+                  type="date"
+                  value={dueDateInputValue}
+                  onChange={handleDueDateChange}
+                  disabled={busy}
+                  className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm text-slate-900 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-light disabled:cursor-not-allowed disabled:opacity-50"
                 />
               </div>
 

--- a/functions/src/lti/deepLink.test.ts
+++ b/functions/src/lti/deepLink.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildQuizContentItem,
   buildDeepLinkResponseClaims,
+  dueAtToSubmissionEndDateTime,
   isSchoologyReturnUrl,
   MESSAGE_TYPE_DL_RESPONSE,
 } from './deepLink';
@@ -36,6 +37,57 @@ describe('buildQuizContentItem', () => {
         maxPoints: 0,
       }).lineItem
     ).toBeUndefined();
+  });
+
+  it('sets submission.endDateTime (the due date) when dueAtMs is given', () => {
+    const item = buildQuizContentItem({
+      launchUrl: 'u',
+      title: 't',
+      custom: {},
+      maxPoints: 10,
+      dueAtMs: Date.UTC(2026, 5, 1), // 2026-06-01 (UTC midnight)
+    });
+    expect(item.submission).toEqual({
+      endDateTime: '2026-06-01T23:59:59.000Z',
+    });
+  });
+
+  it('omits submission when dueAtMs is absent or invalid', () => {
+    expect(
+      buildQuizContentItem({ launchUrl: 'u', title: 't', custom: {} })
+        .submission
+    ).toBeUndefined();
+    expect(
+      buildQuizContentItem({
+        launchUrl: 'u',
+        title: 't',
+        custom: {},
+        dueAtMs: 0,
+      }).submission
+    ).toBeUndefined();
+  });
+});
+
+describe('dueAtToSubmissionEndDateTime', () => {
+  it('maps an epoch-ms due date to end-of-day UTC for the picked calendar day', () => {
+    // SpartBoard stores dueAt as UTC midnight of the picked date; we emit the
+    // END of that UTC day so a "June 1" due date renders as June 1 (not the
+    // prior evening) in US timezones.
+    expect(dueAtToSubmissionEndDateTime(Date.UTC(2026, 5, 1))).toBe(
+      '2026-06-01T23:59:59.000Z'
+    );
+    // A mid-day instant still resolves to that same calendar day's end.
+    expect(dueAtToSubmissionEndDateTime(Date.UTC(2026, 11, 25, 14, 30))).toBe(
+      '2026-12-25T23:59:59.000Z'
+    );
+  });
+
+  it('returns null for absent or invalid input', () => {
+    expect(dueAtToSubmissionEndDateTime(undefined)).toBeNull();
+    expect(dueAtToSubmissionEndDateTime(0)).toBeNull();
+    expect(dueAtToSubmissionEndDateTime(-1)).toBeNull();
+    expect(dueAtToSubmissionEndDateTime(Number.NaN)).toBeNull();
+    expect(dueAtToSubmissionEndDateTime(Number.POSITIVE_INFINITY)).toBeNull();
   });
 });
 

--- a/functions/src/lti/deepLink.ts
+++ b/functions/src/lti/deepLink.ts
@@ -19,6 +19,40 @@ export interface ContentItem {
   title: string;
   custom?: Record<string, string>;
   lineItem?: { scoreMaximum: number; label: string };
+  /**
+   * LTI Deep Linking 2.0 submission window. `endDateTime` is the assignment DUE
+   * date — Schoology applies it to the created assignment. A SIBLING of
+   * `lineItem` on the content item (not nested inside it). We deliberately set
+   * only `submission` (the due date), never `available` — `available.endDateTime`
+   * is the hard LOCK date, which would block late work.
+   */
+  submission?: { endDateTime: string };
+}
+
+/**
+ * Convert a SpartBoard `dueAt` (epoch ms — the assign UI stores UTC midnight of
+ * the picked calendar date) into the LTI `submission.endDateTime` string.
+ *
+ * We emit END-OF-DAY UTC for that calendar date (`…T23:59:59.000Z`) rather than
+ * the raw midnight instant: midnight-UTC renders as the PRIOR evening in US
+ * timezones (e.g. a "June 1" pick would show as May 31 in Central), whereas
+ * end-of-day-UTC lands the due date on the correct calendar day. The exact
+ * wall-clock time Schoology displays is the one live-test calibration item.
+ *
+ * Returns null for absent/invalid input so callers can omit `submission`.
+ */
+export function dueAtToSubmissionEndDateTime(
+  dueAtMs: number | undefined
+): string | null {
+  if (
+    typeof dueAtMs !== 'number' ||
+    !Number.isFinite(dueAtMs) ||
+    dueAtMs <= 0
+  ) {
+    return null;
+  }
+  const day = new Date(dueAtMs).toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+  return `${day}T23:59:59.000Z`;
 }
 
 export function buildQuizContentItem(opts: {
@@ -26,6 +60,8 @@ export function buildQuizContentItem(opts: {
   title: string;
   custom: Record<string, string>;
   maxPoints?: number;
+  /** Optional due date (epoch ms) → emitted as `submission.endDateTime`. */
+  dueAtMs?: number;
 }): ContentItem {
   const item: ContentItem = {
     type: 'ltiResourceLink',
@@ -35,6 +71,10 @@ export function buildQuizContentItem(opts: {
   };
   if (typeof opts.maxPoints === 'number' && opts.maxPoints > 0) {
     item.lineItem = { scoreMaximum: opts.maxPoints, label: opts.title };
+  }
+  const endDateTime = dueAtToSubmissionEndDateTime(opts.dueAtMs);
+  if (endDateTime) {
+    item.submission = { endDateTime };
   }
   return item;
 }

--- a/functions/src/lti/serviceEndpoints.ts
+++ b/functions/src/lti/serviceEndpoints.ts
@@ -64,6 +64,7 @@ export const ltiSignDeepLinkResponseV1 = onCall(
       sessionId?: unknown;
       title?: unknown;
       maxPoints?: unknown;
+      dueAt?: unknown;
     };
 
     const returnUrl = typeof data.returnUrl === 'string' ? data.returnUrl : '';
@@ -80,6 +81,10 @@ export const ltiSignDeepLinkResponseV1 = onCall(
       typeof data.maxPoints === 'number' && data.maxPoints > 0
         ? data.maxPoints
         : undefined;
+    // Optional due date (epoch ms). The builder validates + converts it to the
+    // LTI `submission.endDateTime` (end-of-day UTC); an invalid value is dropped
+    // there, so we only need the coarse number coercion here.
+    const dueAtMs = typeof data.dueAt === 'number' ? data.dueAt : undefined;
 
     const custom: Record<string, string> = { kind };
     if (kind === 'quiz') {
@@ -102,6 +107,7 @@ export const ltiSignDeepLinkResponseV1 = onCall(
       title,
       custom,
       maxPoints,
+      dueAtMs,
     });
     const claims = buildDeepLinkResponseClaims({
       deploymentId: cfg.deploymentId,


### PR DESCRIPTION
## What

Sync the SpartBoard assignment due date to Schoology at attach time. The deep-link picker now has an optional **Due date** field; the value is:

- emitted as the content item's `submission.endDateTime` (the LTI Deep Linking 2.0 due-date field) so Schoology sets the created assignment's due date, **and**
- persisted on the SpartBoard assignment (quiz `settings.dueAt` / VA `sessionOptions.dueAt`).

One entry drives both sides. SpartBoard already had a `dueAt` field, so there's no data-model change.

## Why this works on Schoology but not Google Classroom

Verified against the platform APIs (not dev laziness): **Classroom can't** sync due dates — `courses.courseWork.patch` is restricted to the Developer-Console project that *created* the coursework, and the add-on only *attaches* to teacher-created coursework → `PERMISSION_DENIED`. **Schoology can**, because the tool itself **creates** the assignment via Deep Linking, so it owns the gradebook line item's dates.

## Implementation

- `functions/src/lti/deepLink.ts` — `ContentItem.submission?`; pure helper `dueAtToSubmissionEndDateTime` (epoch-ms → **end-of-day-UTC** ISO so a date-only pick lands on the right calendar day in US timezones, not the prior evening); `buildQuizContentItem` accepts `dueAtMs` and sets only `submission` (never `available`, which would hard-lock late work).
- `functions/src/lti/serviceEndpoints.ts` — `ltiSignDeepLinkResponseV1` forwards `dueAt` through to the content item.
- `components/lti/LtiDeepLinkPicker.tsx` — optional due-date input; forwarded to the signer **and** persisted on the assignment; captured in the create/retry cache so a re-sign uses the same date.

## Tests

- `deepLink.test.ts` — conversion (valid / null / 0 / negative / NaN / Infinity) + builder sets/omits `submission`.
- Local gates green: `type-check:all`, `lint`, `format:check`, functions LTI tests (79), deep-link tests (10).

## ⚠️ One live-test calibration item

Confirm on a Schoology test course that Schoology honors `submission.endDateTime` and renders the expected **calendar day**. End-of-day-UTC should land it correctly for Central time; if it shows a day/hour off, the fix is a one-line tweak in `dueAtToSubmissionEndDateTime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
