### PR TITLE
fix(lti): resolve the Schoology due date in the teacher's local timezone

### DIFF
--- a/components/lti/LtiDeepLinkPicker.tsx
+++ b/components/lti/LtiDeepLinkPicker.tsx
@@ -143,6 +143,31 @@ const VA_SESSION_SETTINGS: VideoActivitySessionSettings = {
   allowSkipping: false,
 };
 
+/**
+ * Parse a `<input type="date">` value (`YYYY-MM-DD`) into the epoch ms for LOCAL
+ * end-of-day (23:59:59 in the browser's timezone) on that date. Returns null for
+ * an empty/malformed value. Local — not UTC — so the deadline lands on the
+ * picked calendar day in the teacher's zone (Central for Orono).
+ */
+function localEndOfDayMs(dateValue: string): number | null {
+  const parts = dateValue.split('-').map(Number);
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null;
+  const [year, month, day] = parts;
+  return new Date(year, month - 1, day, 23, 59, 59, 0).getTime();
+}
+
+/**
+ * Format an epoch (ms) as a LOCAL-timezone `YYYY-MM-DD` for `<input type="date">`.
+ * Uses local date components (not `toISOString`, which is UTC and would show the
+ * next day for a local-end-of-day value in US timezones).
+ */
+function toLocalDateInputValue(ms: number): string {
+  const d = new Date(ms);
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
 /** True when we're rendered inside a frame (the Schoology iframe), not a tab. */
 function isFramed(): boolean {
   if (typeof window === 'undefined') return false;
@@ -286,18 +311,20 @@ const LtiDeepLinkFlow: React.FC = () => {
   const [teacherName, setTeacherName] = useState('');
   const [plcShareEnabled, setPlcShareEnabled] = useState(false);
   const [selectedPlcId, setSelectedPlcId] = useState('');
-  // Optional due date (epoch ms; null = none). Mirrors the normal assign modal's
-  // `<input type="date">` convention: the value is UTC midnight of the picked
-  // date. Set on BOTH the SpartBoard assignment AND the Schoology line item
-  // (`submission.endDateTime`) so the teacher enters it once.
+  // Optional due date (epoch ms; null = none). Stored as LOCAL end-of-day
+  // (11:59:59 PM in the teacher's timezone) on the picked date, so the deadline
+  // lands on that calendar day for both the SpartBoard assignment AND the
+  // Schoology line item (`submission.endDateTime`) — for Orono (Central) that's
+  // 11:59 PM Central. Resolving the timezone in the browser (where the picker
+  // runs) avoids any backend TZ assumption and dodges the UTC-midnight footgun
+  // (which renders as the PRIOR evening in US timezones). The teacher enters it
+  // once and it drives both sides. (Diverges intentionally from the normal
+  // assign modal's UTC-midnight convention — local end-of-day is more correct.)
   const dueDateId = useId();
   const [dueAt, setDueAt] = useState<number | null>(null);
-  const dueDateInputValue = dueAt
-    ? new Date(dueAt).toISOString().slice(0, 10)
-    : '';
+  const dueDateInputValue = dueAt ? toLocalDateInputValue(dueAt) : '';
   const handleDueDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const val = e.target?.value ?? '';
-    setDueAt(val ? new Date(val).getTime() : null);
+    setDueAt(localEndOfDayMs(e.target?.value ?? ''));
   };
 
   const selectedQuiz = useMemo(

--- a/functions/src/lti/deepLink.test.ts
+++ b/functions/src/lti/deepLink.test.ts
@@ -40,15 +40,18 @@ describe('buildQuizContentItem', () => {
   });
 
   it('sets submission.endDateTime (the due date) when dueAtMs is given', () => {
+    // The client sends an absolute instant (local end-of-day). The builder
+    // serializes it verbatim — here, 11:59 PM Central on 2026-06-01 (CDT) is
+    // 04:59:59Z on 2026-06-02.
     const item = buildQuizContentItem({
       launchUrl: 'u',
       title: 't',
       custom: {},
       maxPoints: 10,
-      dueAtMs: Date.UTC(2026, 5, 1), // 2026-06-01 (UTC midnight)
+      dueAtMs: Date.UTC(2026, 5, 2, 4, 59, 59),
     });
     expect(item.submission).toEqual({
-      endDateTime: '2026-06-01T23:59:59.000Z',
+      endDateTime: '2026-06-02T04:59:59.000Z',
     });
   });
 
@@ -69,17 +72,17 @@ describe('buildQuizContentItem', () => {
 });
 
 describe('dueAtToSubmissionEndDateTime', () => {
-  it('maps an epoch-ms due date to end-of-day UTC for the picked calendar day', () => {
-    // SpartBoard stores dueAt as UTC midnight of the picked date; we emit the
-    // END of that UTC day so a "June 1" due date renders as June 1 (not the
-    // prior evening) in US timezones.
-    expect(dueAtToSubmissionEndDateTime(Date.UTC(2026, 5, 1))).toBe(
-      '2026-06-01T23:59:59.000Z'
+  it('serializes the absolute due instant to ISO 8601 (no TZ assumption)', () => {
+    // The client resolves the local-timezone end-of-day to an absolute instant;
+    // the server serializes it verbatim. 11:59 PM Central on 2026-06-01 (CDT) is
+    // 04:59:59Z on 2026-06-02.
+    expect(dueAtToSubmissionEndDateTime(Date.UTC(2026, 5, 2, 4, 59, 59))).toBe(
+      '2026-06-02T04:59:59.000Z'
     );
-    // A mid-day instant still resolves to that same calendar day's end.
-    expect(dueAtToSubmissionEndDateTime(Date.UTC(2026, 11, 25, 14, 30))).toBe(
-      '2026-12-25T23:59:59.000Z'
-    );
+    // 11:59 PM Central on 2026-12-24 (CST, UTC-6) is 05:59:59Z on 2026-12-25.
+    expect(
+      dueAtToSubmissionEndDateTime(Date.UTC(2026, 11, 25, 5, 59, 59))
+    ).toBe('2026-12-25T05:59:59.000Z');
   });
 
   it('returns null for absent or invalid input', () => {

--- a/functions/src/lti/deepLink.ts
+++ b/functions/src/lti/deepLink.ts
@@ -30,16 +30,12 @@ export interface ContentItem {
 }
 
 /**
- * Convert a SpartBoard `dueAt` (epoch ms — the assign UI stores UTC midnight of
- * the picked calendar date) into the LTI `submission.endDateTime` string.
- *
- * We emit END-OF-DAY UTC for that calendar date (`…T23:59:59.000Z`) rather than
- * the raw midnight instant: midnight-UTC renders as the PRIOR evening in US
- * timezones (e.g. a "June 1" pick would show as May 31 in Central), whereas
- * end-of-day-UTC lands the due date on the correct calendar day. The exact
- * wall-clock time Schoology displays is the one live-test calibration item.
- *
- * Returns null for absent/invalid input so callers can omit `submission`.
+ * Serialize a due-date instant (epoch ms) into the LTI `submission.endDateTime`
+ * ISO 8601 string. The client (picker) already resolved the due date to an
+ * ABSOLUTE instant in the teacher's local timezone (local end-of-day — 11:59 PM
+ * Central for Orono), so the server makes NO timezone assumption: it just
+ * serializes the instant. Returns null for absent/invalid input so callers can
+ * omit `submission`.
  */
 export function dueAtToSubmissionEndDateTime(
   dueAtMs: number | undefined
@@ -51,8 +47,7 @@ export function dueAtToSubmissionEndDateTime(
   ) {
     return null;
   }
-  const day = new Date(dueAtMs).toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
-  return `${day}T23:59:59.000Z`;
+  return new Date(dueAtMs).toISOString();
 }
 
 export function buildQuizContentItem(opts: {


### PR DESCRIPTION
## What

Follow-up to #1868. The Schoology due date is now resolved in the **teacher's local timezone** (local end-of-day, 11:59:59 PM) instead of end-of-day UTC.

- **Before:** end-of-day UTC (`…T23:59:59Z`) → rendered as **6:59 PM Central** in Schoology. Right day, wrong time.
- **After:** local end-of-day, computed in the browser where the picker runs → for Orono (Central) renders as **11:59 PM Central**.

## Why local (not UTC, not hard-coded Central)

The picker runs in the teacher's browser, so the timezone is available there for free. Resolving it client-side keeps the Cloud Function **timezone-agnostic** (it just serializes the absolute instant to ISO 8601) and is future-proof if tenancy ever expands beyond Central — while still giving every Orono teacher 11:59 PM Central. DST is handled automatically by the browser.

## Changes

- `components/lti/LtiDeepLinkPicker.tsx` — `localEndOfDayMs` (date string → local 23:59:59 epoch) + `toLocalDateInputValue` (epoch → local `YYYY-MM-DD` for the input). `dueAt` is now local end-of-day.
- `functions/src/lti/deepLink.ts` — `dueAtToSubmissionEndDateTime` simplified to serialize the instant (`new Date(ms).toISOString()`); no backend TZ assumption.
- `deepLink.test.ts` — updated to assert ISO serialization of the absolute instant.

Side benefit: also fixes SpartBoard's own display of the due date (UTC-midnight previously rendered as the prior calendar day in Central).

## Tests

Local gates green: `type-check:all`, `lint`, `format:check`, deep-link tests (10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
