### PR TITLE
refactor(d4): relative imports → @/ alias in context/ directory

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -29,7 +29,7 @@ import {
   db,
   isAuthBypass,
   GOOGLE_OAUTH_SCOPES,
-} from '../config/firebase';
+} from '@/config/firebase';
 import {
   FeaturePermission,
   WidgetType,
@@ -42,28 +42,28 @@ import {
   DockPosition,
   AssignmentMode,
   AssignmentWidgetKey,
-} from '../types';
-import type { MemberRecord, BuildingRecord } from '../types/organization';
+} from '@/types';
+import type { MemberRecord, BuildingRecord } from '@/types/organization';
 import { AuthContext } from './AuthContextValue';
 import {
   buildingRecordToBuilding,
   canonicalizeBuildingIds,
   canonicalizeBuildingKeyedRecord,
   getBuildingGradeLevels,
-} from '../config/buildings';
-import i18n from '../i18n';
-import { GoogleDriveService } from '../utils/googleDriveService';
-import { onDriveTokenChange } from '../utils/driveAuthErrors';
-import { reportGlobalPermissionsError } from '../utils/globalPermissionsErrors';
+} from '@/config/buildings';
+import i18n from '@/i18n';
+import { GoogleDriveService } from '@/utils/googleDriveService';
+import { onDriveTokenChange } from '@/utils/driveAuthErrors';
+import { reportGlobalPermissionsError } from '@/utils/globalPermissionsErrors';
 import {
   refreshAccessTokenViaBackend,
   requestAndExchangeAuthCode,
   revokeBackendRefreshToken,
-} from '../utils/googleOAuthRefresh';
-import { logError } from '../utils/logError';
-import { FEATURE_DEFAULTS } from '../config/featureDefaults';
-import { stripTransientKeys } from '../utils/widgetConfigPersistence';
-import { parseAssignmentModesConfig } from '../utils/assignmentModesConfig';
+} from '@/utils/googleOAuthRefresh';
+import { logError } from '@/utils/logError';
+import { FEATURE_DEFAULTS } from '@/config/featureDefaults';
+import { stripTransientKeys } from '@/utils/widgetConfigPersistence';
+import { parseAssignmentModesConfig } from '@/utils/assignmentModesConfig';
 import {
   canWriteLastActive,
   stampLastActive,

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -12,8 +12,8 @@ import {
   DockPosition,
   AssignmentMode,
   AssignmentWidgetKey,
-} from '../types';
-import type { BuildingRecord } from '../types/organization';
+} from '@/types';
+import type { BuildingRecord } from '@/types/organization';
 
 export interface AuthContextType {
   user: User | null;

--- a/context/CustomWidgetsContext.tsx
+++ b/context/CustomWidgetsContext.tsx
@@ -10,8 +10,8 @@ import {
   where,
 } from 'firebase/firestore';
 import { Puzzle } from 'lucide-react';
-import { db, isConfigured, isAuthBypass } from '../config/firebase';
-import { CustomWidgetDoc, ToolMetadata } from '../types';
+import { db, isConfigured, isAuthBypass } from '@/config/firebase';
+import { CustomWidgetDoc, ToolMetadata } from '@/types';
 import { useAuth } from './useAuth';
 import { CustomWidgetsContext } from './CustomWidgetsContextValue';
 

--- a/context/CustomWidgetsContextValue.ts
+++ b/context/CustomWidgetsContextValue.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { CustomWidgetDoc, ToolMetadata } from '../types';
+import { CustomWidgetDoc, ToolMetadata } from '@/types';
 
 export interface CustomWidgetsContextValue {
   /** All custom widget docs (admins see all; non-admins see only published) */

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -28,57 +28,57 @@ import {
   ROOT_COLLECTION_KEY,
   Collection,
   CollectionSubstituteShareInput,
-} from '../types';
+} from '@/types';
 import { doc, getDoc, setDoc, updateDoc, writeBatch } from 'firebase/firestore';
-import { db, isAuthBypass } from '../config/firebase';
+import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from './useAuth';
-import { mergeWidgetConfig } from '../utils/widgetConfigPersistence';
-import { useFirestore, type SharedBoardSnapshot } from '../hooks/useFirestore';
-import { TOOLS } from '../config/tools';
+import { mergeWidgetConfig } from '@/utils/widgetConfigPersistence';
+import { useFirestore, type SharedBoardSnapshot } from '@/hooks/useFirestore';
+import { TOOLS } from '@/config/tools';
 import { canonicalizeBuildingKeyedRecord } from '@/config/buildings';
 import {
   WIDGET_DEFAULTS,
   WIDGET_STRETCH_BEHAVIOR,
-} from '../config/widgetDefaults';
+} from '@/config/widgetDefaults';
 import {
   migrateLocalStorageToFirestore,
   migrateWidget,
-} from '../utils/migration';
+} from '@/utils/migration';
 import {
   migrateDrawingToSubcollection,
   needsSubcollectionMigration,
-} from '../utils/migrateDrawingToSubcollection';
-import { migrateDrawingConfig } from '../utils/migrateDrawingConfig';
+} from '@/utils/migrateDrawingToSubcollection';
+import { migrateDrawingConfig } from '@/utils/migrateDrawingConfig';
 import {
   REFERENCE_VIEWPORT,
   pixelToProp,
   computeWidgetPixelRect,
-} from '../utils/proportionalLayout';
+} from '@/utils/proportionalLayout';
 import {
   migrateDashboardWidgets,
   hydrateWidgetPixels,
-} from '../utils/migrateProportionalLayout';
+} from '@/utils/migrateProportionalLayout';
 import {
   scrubDashboardPII,
   extractDashboardPII,
   mergeDashboardPII,
   dashboardHasPII,
-} from '../utils/dashboardPII';
-import { migrateBoardForCollections } from '../utils/collectionsMigration';
-import { pickInitialBoard } from '../utils/pickInitialBoard';
-import { sanitizeBoardSnapshot } from '../utils/dashboardSanitize';
-import { logError } from '../utils/logError';
-import { useRosters } from '../hooks/useRosters';
-import { useGoogleDrive } from '../hooks/useGoogleDrive';
-import { useDriveReconnected } from '../hooks/useDriveReconnected';
-import { useCollections } from '../hooks/useCollections';
-import { useSharedCollection } from '../hooks/useSharedCollection';
-import { setDriveAuthErrorHandler } from '../utils/driveAuthErrors';
-import { setGlobalPermissionsErrorHandler } from '../utils/globalPermissionsErrors';
+} from '@/utils/dashboardPII';
+import { migrateBoardForCollections } from '@/utils/collectionsMigration';
+import { pickInitialBoard } from '@/utils/pickInitialBoard';
+import { sanitizeBoardSnapshot } from '@/utils/dashboardSanitize';
+import { logError } from '@/utils/logError';
+import { useRosters } from '@/hooks/useRosters';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useDriveReconnected } from '@/hooks/useDriveReconnected';
+import { useCollections } from '@/hooks/useCollections';
+import { useSharedCollection } from '@/hooks/useSharedCollection';
+import { setDriveAuthErrorHandler } from '@/utils/driveAuthErrors';
+import { setGlobalPermissionsErrorHandler } from '@/utils/globalPermissionsErrors';
 import {
   setAiModelConfigFallbackHandler,
   resetAiModelConfigFallbackLatch,
-} from '../utils/aiModelConfigFallback';
+} from '@/utils/aiModelConfigFallback';
 import {
   DashboardContext,
   PendingShareImport,
@@ -86,11 +86,11 @@ import {
   SubstituteShareInput,
   SubstituteShareResult,
 } from './DashboardContextValue';
-import { validateGridConfig, sanitizeAIConfig } from '../utils/ai_security';
-import { getAdminBuildingConfig as getAdminBuildingConfigPure } from '../utils/adminBuildingConfig';
+import { validateGridConfig, sanitizeAIConfig } from '@/utils/ai_security';
+import { getAdminBuildingConfig as getAdminBuildingConfigPure } from '@/utils/adminBuildingConfig';
 import { AnnotationState } from './DashboardContextValue';
-import { DRAWING_DEFAULTS } from '../components/widgets/DrawingWidget/constants';
-import { STANDARD_COLORS } from '../config/colors';
+import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
+import { STANDARD_COLORS } from '@/config/colors';
 
 // Helper to migrate legacy visibleTools to dockItems
 const migrateToDockItems = (

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -17,11 +17,11 @@ import {
   ShapeTool,
   Collection,
   CollectionSubstituteShareInput,
-} from '../types';
-import type { RosterCreateMeta } from '../hooks/useRosters';
-import type { GoogleDriveService } from '../utils/googleDriveService';
-import type { UseCollectionsResult } from '../hooks/useCollections';
-import type { LoadSharedCollectionResult } from '../hooks/useSharedCollection';
+} from '@/types';
+import type { RosterCreateMeta } from '@/hooks/useRosters';
+import type { GoogleDriveService } from '@/utils/googleDriveService';
+import type { UseCollectionsResult } from '@/hooks/useCollections';
+import type { LoadSharedCollectionResult } from '@/hooks/useSharedCollection';
 
 /**
  * Mode applied to a shared-board import. Substitute shares are intentionally

--- a/context/SavedWidgetsContext.tsx
+++ b/context/SavedWidgetsContext.tsx
@@ -9,8 +9,8 @@ import {
   setDoc,
   updateDoc,
 } from 'firebase/firestore';
-import { db, isConfigured, isAuthBypass } from '../config/firebase';
-import { SavedWidget } from '../types';
+import { db, isConfigured, isAuthBypass } from '@/config/firebase';
+import { SavedWidget } from '@/types';
 import { useAuth } from './useAuth';
 import { SavedWidgetsContext } from './SavedWidgetsContextValue';
 

--- a/context/SavedWidgetsContextValue.ts
+++ b/context/SavedWidgetsContextValue.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { SavedWidget } from '../types';
+import { SavedWidget } from '@/types';
 
 export interface SavedWidgetsContextValue {
   /** All of the signed-in user's saved widgets */


### PR DESCRIPTION
## Nightly Consistency Run — D4 Import Path Convention (Run 8)

### Canonical Form
`import { X } from '@/config/...'` — the `@/` alias for all cross-directory imports. The alias maps to the repo root.

### Files Converted (all 8 context/ source files)

| File | Imports Converted |
|---|---|
| `context/DashboardContext.tsx` | 28 |
| `context/AuthContext.tsx` | 13 |
| `context/DashboardContextValue.ts` | 5 |
| `context/SavedWidgetsContext.tsx` | 2 |
| `context/CustomWidgetsContext.tsx` | 2 |
| `context/AuthContextValue.ts` | 2 |
| `context/SavedWidgetsContextValue.ts` | 1 |
| `context/CustomWidgetsContextValue.ts` | 1 |

**Total: 54 cross-directory relative imports converted**

### Conversion patterns applied
- `'../types'` → `'@/types'`
- `'../types/organization'` → `'@/types/organization'`
- `'../config/firebase'`, `'../config/buildings'`, etc. → `'@/config/...'`
- `'../hooks/useFirestore'`, `'../hooks/useRosters'`, etc. → `'@/hooks/...'`
- `'../utils/googleDriveService'`, etc. → `'@/utils/...'`
- `'../i18n'` → `'@/i18n'`
- `'../components/widgets/DrawingWidget/constants'` → `'@/components/widgets/DrawingWidget/constants'`

### Imports Left Alone
Same-directory `'./'` imports (e.g. `'./useAuth'`, `'./AuthContextValue'`) — correct same-directory references, not cross-directory anti-patterns.

### Behavior-Preservation Evidence
Import path aliases with equivalent resolution produce identical compiled output. TypeScript and the bundler resolve `@/types` and `../types` to the same file. This is a source-only change with zero runtime impact.

**Risk tag: mechanical** — pure import path alias substitution.

### Validate Result
`pnpm run validate` ✅ — full suite pass (type-check, lint, format-check, all tests)

### Next D4 Target (future runs)
`hooks/` directory (~43 relative imports), then `utils/` (~22 relative imports). Remaining plc/ body→root single-level imports remain in the D4-E2 gray zone.

https://claude.ai/code/session_01Ms91aXFDBh6EARLi4d2J9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ms91aXFDBh6EARLi4d2J9r)_