### PR TITLE
fix(functions): register dashboard-layout and instructional-routine in per-feature AI tracking

### DIFF
--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -445,6 +445,8 @@ export async function computeAnalyticsForOrg(
     'guided-learning',
     'blooms-ai',
     'video-activity-recommend',
+    'dashboard-layout',
+    'instructional-routine',
   ];
 
   const aiUsageStream = db

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -942,6 +942,75 @@ describe('adminAnalytics', () => {
     expect(result.api.byFeature['video-activity-recommend']).toBe(4);
   });
 
+  it('counts dashboard-layout usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: dashboard-layout was missing from GEMINI_SPECIFIC_FEATURES
+    // in adminAnalyticsCompute.ts AND had no specificFeatureId assignment in
+    // generateWithAI. A doc like `uid1_dashboard-layout_2026-06-05` was treated
+    // as an "overall" doc with uid = `uid1_dashboard-layout`, which never
+    // matched any org member, so the call was silently dropped from totalCalls
+    // and byFeature['dashboard-layout'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-05', data: { count: 6 } },
+      // Per-feature dashboard-layout doc — should count toward
+      // byFeature['dashboard-layout'] but NOT toward totalCalls
+      { id: 'uid1_dashboard-layout_2026-06-05', data: { count: 2 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(6);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['dashboard-layout']).toBe(2);
+  });
+
+  it('counts instructional-routine usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: instructional-routine was missing from
+    // GEMINI_SPECIFIC_FEATURES in adminAnalyticsCompute.ts AND had no
+    // specificFeatureId assignment in generateWithAI. A doc like
+    // `uid1_instructional-routine_2026-06-05` was treated as an "overall" doc
+    // with uid = `uid1_instructional-routine`, which never matched any org
+    // member, so the call was silently dropped from totalCalls and
+    // byFeature['instructional-routine'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-05', data: { count: 4 } },
+      // Per-feature instructional-routine doc — should count toward
+      // byFeature['instructional-routine'] but NOT toward totalCalls
+      { id: 'uid1_instructional-routine_2026-06-05', data: { count: 3 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(4);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['instructional-routine']).toBe(3);
+  });
+
   it('returns topUsers with resolved email and unknown fallback', async () => {
     mockFirestoreState.users = [
       {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -642,6 +642,9 @@ export const generateWithAI = onCall(
     if (genType === 'blooms-ai') specificFeatureId = 'blooms-ai';
     if (genType === 'video-activity-recommend')
       specificFeatureId = 'video-activity-recommend';
+    if (genType === 'dashboard-layout') specificFeatureId = 'dashboard-layout';
+    if (genType === 'instructional-routine')
+      specificFeatureId = 'instructional-routine';
 
     const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 


### PR DESCRIPTION
## Root cause

Two `genType` values in `generateWithAI`'s `promptMap` — `dashboard-layout` and `instructional-routine` — had no `specificFeatureId` assignment and were absent from `GEMINI_SPECIFIC_FEATURES` in `adminAnalyticsCompute.ts`. Same class of bug as #1805 (`blooms-ai`) and #1857 (`video-activity-recommend`).

**Consequence 1 — No per-feature rate limiting:** No per-feature daily-cap docs were written for these genTypes, so teachers could call `dashboard-layout` and `instructional-routine` generation without hitting the per-feature rate limit (only the global limit applied).

**Consequence 2 — Silent analytics corruption:** Any per-feature doc like `uid1_dashboard-layout_2026-06-05` was misidentified by the analytics parser as an "overall" doc with uid `uid1_dashboard-layout`. That uid matches no org member → call silently dropped from `totalCalls` and `byFeature['dashboard-layout']` never populated.

## Fix

- `functions/src/index.ts`: Added `specificFeatureId = 'dashboard-layout'` and `specificFeatureId = 'instructional-routine'` in the assignment block (enables per-feature rate-limit doc writes)
- `functions/src/adminAnalyticsCompute.ts`: Added both feature ids to `GEMINI_SPECIFIC_FEATURES` (enables correct uid parsing and `byFeature` accumulation)

## Band-aid rejected

Adding a catch-all fallback in the analytics parser (`if unknown genType, skip doc`) — this would silently hide future regressions of the same class. The correct fix is to keep the `GEMINI_SPECIFIC_FEATURES` array complete and add the missing entries.

## Regression test

Two new tests in `functions/src/index.test.ts` (lines 945–1012) each simulate a Firestore `ai_usage` collection containing a per-feature doc for the respective genType and assert it counts toward `byFeature[genType]` rather than being dropped. Both tests **fail on unpatched `dev-paul`** and **pass on this branch**.

## Evidence

```
# On dev-paul (unpatched):
× counts dashboard-layout usage docs toward byFeature without corrupting uid parsing
× counts instructional-routine usage docs toward byFeature without corrupting uid parsing

# On this branch:
✓ counts dashboard-layout usage docs toward byFeature without corrupting uid parsing
✓ counts instructional-routine usage docs toward byFeature without corrupting uid parsing
```

All 452 functions tests pass. Full `pnpm run validate` green.

## Risk

**contained** — changes are isolated to two files in `functions/src/`. No breaking surface change; adding entries to an array and adding two `if` assignments in an existing block.

https://claude.ai/code/session_01KS8i7oAZ2sRNRmcUAYBN3R

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS8i7oAZ2sRNRmcUAYBN3R)_