### PR TITLE
fix(widgets): update phaseDuration when patternId changes mid-cycle in useBreathing

### DIFF
--- a/components/widgets/Breathing/useBreathing.test.ts
+++ b/components/widgets/Breathing/useBreathing.test.ts
@@ -165,4 +165,70 @@ describe('useBreathing', () => {
     expect(result.current.phase).toBe('inhale');
     expect(result.current.isActive).toBe(true);
   });
+
+  /**
+   * Regression test for pattern-change mid-cycle edge case.
+   *
+   * Bug: when patternId changes while the timer is active, patternRef.current
+   * is updated (via useEffect) but stateRef.current.phaseDuration is NOT
+   * updated for the current phase.  The tick loop reads phaseDuration from
+   * stateRef, so the current phase runs for the OLD pattern's duration.
+   *
+   * Scenario:
+   *   - Start with 4-4-4-4 (inhale=4s). stateRef.phaseDuration is set to 4000.
+   *   - After 1 s, switch to 5-5 (inhale=5s).
+   *   - The inhale should now last 5 s total (4 s remaining after the switch),
+   *     so the phase must NOT end at the 4 s mark.
+   *   - If the bug is present, stateRef.phaseDuration stays at 4000, the phase
+   *     ends at the 4 s mark (only 3 s after the switch), and the test fails.
+   */
+  it('switching pattern mid-cycle updates phaseDuration to the new pattern value', () => {
+    const patternIdRef = {
+      current: '4-4-4-4' as Parameters<typeof useBreathing>[0],
+    };
+    const { result, rerender } = renderHook(() =>
+      useBreathing(patternIdRef.current)
+    );
+
+    // Start with 4-4-4-4 (inhale = 4 s)
+    act(() => {
+      result.current.toggleActive();
+    });
+
+    expect(result.current.phase).toBe('inhale');
+
+    // Advance 1 s into the 4 s inhale
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.phase).toBe('inhale');
+
+    // Switch to 5-5 (inhale = 5 s). The current inhale phase now has a
+    // 5 s total duration, meaning 4 s should remain after the 1 s already
+    // elapsed.
+    act(() => {
+      patternIdRef.current = '5-5';
+      rerender();
+    });
+
+    // Advance to just past the OLD pattern's end mark (4000 ms from start).
+    // With the bug, the phase ends here. With the fix, it must still be inhale.
+    act(() => {
+      vi.advanceTimersByTime(3100); // total elapsed = 4100 ms > old 4000 ms limit
+    });
+
+    // The phase should still be 'inhale' — the new pattern's 5 s duration
+    // means the phase should not end until 5000 ms from the phase start.
+    expect(result.current.phase).toBe('inhale');
+
+    // Now advance past the NEW pattern's end mark (total 5000 ms from start)
+    act(() => {
+      vi.advanceTimersByTime(1000); // total elapsed = 5100 ms > new 5000 ms limit
+    });
+
+    // The inhale phase should now be complete and we should be in exhale
+    // (5-5 pattern has hold1=0, so inhale → exhale directly)
+    expect(result.current.phase).toBe('exhale');
+  });
 });

--- a/components/widgets/Breathing/useBreathing.ts
+++ b/components/widgets/Breathing/useBreathing.ts
@@ -52,10 +52,40 @@ export const useBreathing = (patternId: BreathingPattern) => {
     setProgress(0);
   }, []);
 
-  // Update phase durations when pattern changes
+  // Update phase durations when pattern changes.
+  // When the timer is active mid-cycle, also update stateRef.phaseDuration and
+  // stateRef.startTime so the CURRENT phase runs for the new pattern's duration
+  // rather than the stale old value.  The startTime is recalculated to preserve
+  // the fraction of the phase already elapsed (progress), so the animation
+  // continues smoothly from the same visual position.
   const patternRef = useRef(pattern);
   useEffect(() => {
-    patternRef.current = PATTERNS[patternId];
+    const newPattern = PATTERNS[patternId];
+    patternRef.current = newPattern;
+
+    // Only rebase timing when the timer is actively running and we are in a
+    // real phase (not 'ready').  If we are paused, stateRef.phaseDuration will
+    // be re-derived from the saved progress when toggleActive() resumes, so no
+    // update is needed here.
+    if (stateRef.current.isActive) {
+      const currentPhase = stateRef.current.phase;
+      if (currentPhase !== 'ready') {
+        const newDurationSeconds =
+          newPattern[currentPhase as keyof PatternData];
+        if (newDurationSeconds > 0) {
+          const newPhaseDuration = newDurationSeconds * 1000;
+          const now = performance.now();
+          // Preserve the fraction of the phase already elapsed so the visual
+          // circle does not jump.
+          const elapsedAlready = stateRef.current.progress * newPhaseDuration;
+          stateRef.current.phaseDuration = newPhaseDuration;
+          stateRef.current.startTime = now - elapsedAlready;
+        }
+        // If newDurationSeconds === 0 (e.g., in hold2 but new pattern has none),
+        // let the next RAF tick detect elapsed >= phaseDuration and transition
+        // immediately — no special handling needed here.
+      }
+    }
   }, [patternId]);
 
   const toggleActive = useCallback(() => {

--- a/components/widgets/Breathing/useBreathing.ts
+++ b/components/widgets/Breathing/useBreathing.ts
@@ -80,10 +80,14 @@ export const useBreathing = (patternId: BreathingPattern) => {
           const elapsedAlready = stateRef.current.progress * newPhaseDuration;
           stateRef.current.phaseDuration = newPhaseDuration;
           stateRef.current.startTime = now - elapsedAlready;
+        } else {
+          // New pattern does not have this phase (duration === 0, e.g. hold1/hold2
+          // when switching to a two-phase pattern).  Set phaseDuration to 0 so the
+          // next RAF tick sees elapsed (≥ 0) >= phaseDuration (0) and transitions
+          // immediately, rather than waiting out the stale old duration.
+          stateRef.current.phaseDuration = 0;
+          stateRef.current.startTime = performance.now();
         }
-        // If newDurationSeconds === 0 (e.g., in hold2 but new pattern has none),
-        // let the next RAF tick detect elapsed >= phaseDuration and transition
-        // immediately — no special handling needed here.
       }
     }
   }, [patternId]);


### PR DESCRIPTION
## Bug

`useBreathing` stale `phaseDuration` on mid-cycle pattern change.

**Root cause:** `useEffect([patternId])` updated `patternRef.current` when the user changed the breathing pattern, but never updated `stateRef.current.phaseDuration`. The RAF tick loop reads `phaseDuration` exclusively from `stateRef`, so the running phase always completed at the *old* pattern's scheduled time.

**Concrete failure:** Start `4-4-4-4` (inhale=4 s), advance 1 s, switch to `5-5` (inhale=5 s). With the bug, `stateRef.phaseDuration` stays at 4000 ms. At t=4.1 s the tick fires `elapsed (4100) >= phaseDuration (4000)` and immediately transitions to `exhale` — cutting 1 s off the inhale the user just requested.

## Fix

In `useEffect([patternId])`, after updating `patternRef.current`, when the timer is actively running and the current phase exists in the new pattern:
1. Set `stateRef.current.phaseDuration = newDurationSeconds * 1000`
2. Recompute `stateRef.current.startTime = now - (progress * newPhaseDuration)` to preserve the fraction of the phase already elapsed so the visual animation doesn't jump.

## Verification

- Test 7 `switching pattern mid-cycle updates phaseDuration to the new pattern value` **FAILS** on `dev-paul` baseline: `expected 'exhale' to be 'inhale'`
- Test 7 **PASSES** with fix applied; all 7 tests green
- `pnpm run validate` passes (type-check ✓, lint ✓, format ✓)

## Files changed
- `components/widgets/Breathing/useBreathing.ts` — fix
- `components/widgets/Breathing/useBreathing.test.ts` — regression test (test #7)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS8i7oAZ2sRNRmcUAYBN3R)_