### PR TITLE
fix(layout): include SELECT in keyboard-handler isInput guards

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -716,6 +716,55 @@ describe('DraggableWindow', () => {
     );
   });
 
+  it('does not minimize widget when Escape is pressed while a <select> is the event target', () => {
+    // Regression: isInput guard only checked INPUT/TEXTAREA, not SELECT.
+    // Pressing Escape to dismiss a dropdown would fall through the guard and
+    // minimize the widget instead of just closing the native dropdown.
+    renderComponent(
+      {},
+      <select data-testid="widget-select">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </select>
+    );
+
+    const selectEl = screen.getByTestId('widget-select');
+
+    // Fire Escape with the SELECT element as the target (simulates keyboard
+    // event originating from the focused <select>).
+    fireEvent.keyDown(selectEl, { key: 'Escape', bubbles: true });
+
+    // The widget must NOT be minimized — Escape on a select should only
+    // dismiss the dropdown, not affect widget state.
+    expect(mockUpdateWidget).not.toHaveBeenCalledWith(
+      'test-widget',
+      expect.objectContaining({ minimized: true })
+    );
+  });
+
+  it('does not trigger delete confirmation when Delete is pressed while a <select> is the event target', () => {
+    // Regression: isInput guard only checked INPUT/TEXTAREA, not SELECT.
+    // Pressing Delete while a select is focused would skip the typing-field
+    // guard and show the widget-delete confirmation dialog unexpectedly.
+    renderComponent(
+      {},
+      <select data-testid="widget-select">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </select>
+    );
+
+    const selectEl = screen.getByTestId('widget-select');
+
+    fireEvent.keyDown(selectEl, { key: 'Delete', bubbles: true });
+
+    // No confirmation dialog must appear and no remove must be dispatched.
+    expect(mockRemoveWidget).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText(/Close widget\? Data will be lost\./i)
+    ).not.toBeInTheDocument();
+  });
+
   it('shows confirmation on Delete key press', () => {
     renderComponent();
     const windowEl = screen.getByTestId('draggable-window');

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -811,7 +811,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     // Stop propagation if we're in an input to prevent global shortcuts
     const target = e.target as HTMLElement;
     const isInput =
-      ['INPUT', 'TEXTAREA'].includes(target?.tagName || '') ||
+      ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName || '') ||
       target?.isContentEditable;
 
     if (isInput) {

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1196,8 +1196,9 @@ export const DashboardView: React.FC = () => {
       if (e.key === 'Escape') {
         const activeElement = document.activeElement as HTMLElement;
         const isInput =
-          ['INPUT', 'TEXTAREA'].includes(activeElement?.tagName || '') ||
-          activeElement?.isContentEditable;
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(
+            activeElement?.tagName || ''
+          ) || activeElement?.isContentEditable;
 
         if (isInput) {
           activeElement.blur();
@@ -1245,7 +1246,7 @@ export const DashboardView: React.FC = () => {
         // (e.preventDefault() was called before this check was added).
         const activeEl = document.activeElement as HTMLElement;
         const isTypingField =
-          ['INPUT', 'TEXTAREA'].includes(activeEl?.tagName || '') ||
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeEl?.tagName || '') ||
           activeEl?.isContentEditable;
         if (isTypingField) return;
 


### PR DESCRIPTION
## Bug

`SELECT` elements were excluded from the `isInput`/`isTypingField` guards in widget keyboard handlers.

**Root cause:** Three places checked `['INPUT', 'TEXTAREA']` only:
- `DraggableWindow.handleKeyDown` (widget-local React synthetic handler)
- `DashboardView.handleKeyDown` — Escape guard (global `window` listener)
- `DashboardView.handleKeyDown` — Delete guard (same global listener)

`SELECT` elements do not match either tag name, so events originating from a focused `<select>` fell through the guard:
- **Escape** while a native dropdown was open would collapse the entire widget (`updateWidget({ minimized: true })`) instead of just dismissing the dropdown.
- **Delete** while a `<select>` was focused would open the widget-deletion confirmation dialog.

**Impact:** Reproducible in any widget that contains a `<select>` in its settings or content area — GuidedLearning, LunchCount, SpecialistSchedule, ActivityWall, Embed, MathTools, NumberLine, and more.

**Band-aid rejected:** Adding `onKeyDown`/`stopPropagation` to every `<select>` across dozens of widget files is a symptom-level patch requiring perpetual maintenance for each new widget.

## Fix

Added `'SELECT'` to the three `includes` arrays (one in `DraggableWindow.tsx`, two in `DashboardView.tsx`).

## Verification

- 2 new tests **FAIL** on `dev-paul` baseline (Escape minimizes widget, Delete triggers confirmation)
- Both tests **PASS** with fix applied; all 49 DraggableWindow tests green
- `pnpm run validate` passes (type-check ✓, lint ✓, format ✓)

## Files changed
- `components/common/DraggableWindow.tsx` — `isInput` guard: add `'SELECT'`
- `components/layout/DashboardView.tsx` — `isInput` and `isTypingField` guards: add `'SELECT'`
- `components/common/DraggableWindow.test.tsx` — 2 new regression tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01KS8i7oAZ2sRNRmcUAYBN3R)_