### PR TITLE
fix(classroom): verify teacher via courses.list (fixes 403 on link + assign)

### DIFF
--- a/functions/src/classroomAddonAuth.test.ts
+++ b/functions/src/classroomAddonAuth.test.ts
@@ -1254,53 +1254,77 @@ describe('classroomAddonNet.patchStudentSubmissionGrade URL construction', () =>
   });
 });
 
-// The single-course teacher-verification seam — the trust anchor for
-// linkClassroomCourse. The linkClassroomCourse tests stub it, so these pin the
-// real URL it builds (courses.teachers.get, one call — NOT a teacherId=me
-// enumeration) and the 200 / 404 / other-status mapping that drives the
-// fail-closed semantics.
+// The teacher-verification seam — the trust anchor for linkClassroomCourse +
+// assignToClassroomV1. Those tests stub it, so these pin the REAL call it makes.
+// It must NOT use courses.teachers.get (/teachers/me needs a rosters/profile
+// scope our tokens lack → 403); it enumerates `courses.list?teacherId=me`
+// (covered by classroom.courses.readonly) and checks membership.
 describe('classroomAddonNet.verifyTeacherOfCourse (real seam)', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it('GETs /courses/{courseId}/teachers/me once and maps 200 → isTeacher:true', async () => {
+  it('lists courses?teacherId=me and maps a found course → isTeacher:true', async () => {
     let calledUrl = '';
     const fetchMock = vi.fn(async (url: unknown) => {
       calledUrl = url as string;
-      return { ok: true, status: 200, json: async () => ({ userId: 'me' }) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ courses: [{ id: 'C0' }, { id: 'C1' }] }),
+      };
     });
     vi.stubGlobal('fetch', fetchMock);
 
     const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
 
     expect(res).toEqual({ ok: true, status: 200, isTeacher: true });
-    // Exactly one call — no enumeration / pagination of the teacher's catalog.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(calledUrl).toBe(
-      'https://classroom.googleapis.com/v1/courses/C1/teachers/me'
-    );
-    // State-agnostic: there is no courseStates filter on this endpoint.
-    expect(calledUrl).not.toContain('courseStates');
-    expect(calledUrl).not.toContain('teacherId=me');
+    // Uses the courses.list endpoint (covered by courses.readonly), NOT the
+    // teachers.get endpoint (which 403s on our scope set).
+    expect(calledUrl).toContain('https://classroom.googleapis.com/v1/courses?');
+    expect(calledUrl).toContain('teacherId=me');
+    expect(calledUrl).not.toContain('/teachers/me');
+    // State-agnostic: ACTIVE + ARCHIVED + PROVISIONED.
+    expect(calledUrl).toContain('courseStates=ACTIVE');
+    expect(calledUrl).toContain('courseStates=ARCHIVED');
   });
 
-  it('maps a 404 to a DEFINITIVE not-a-teacher answer (ok:true, isTeacher:false)', async () => {
+  it('maps a fully-enumerated list WITHOUT the course → isTeacher:false (ok:true)', async () => {
     const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
+      ok: true,
+      status: 200,
+      json: async () => ({ courses: [{ id: 'OTHER' }] }), // no nextPageToken
     }));
     vi.stubGlobal('fetch', fetchMock);
 
     const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
 
-    // ok:true (definitive) but isTeacher:false — the caller turns this into
-    // permission-denied.
-    expect(res).toEqual({ ok: true, status: 404, isTeacher: false });
+    // Definitive not-a-teacher → ok:true / isTeacher:false (caller → denied).
+    expect(res).toEqual({ ok: true, status: 200, isTeacher: false });
   });
 
-  it('fails closed (ok:false) on a non-404 non-2xx response', async () => {
+  it('paginates: finds the course on a later page (follows nextPageToken)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ courses: [{ id: 'A' }], nextPageToken: 'p2' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ courses: [{ id: 'C1' }] }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
+
+    expect(res).toEqual({ ok: true, status: 200, isTeacher: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed (ok:false) on a non-2xx response (e.g. 403 missing scope)', async () => {
     const fetchMock = vi.fn(async () => ({
       ok: false,
       status: 403,
@@ -1310,7 +1334,7 @@ describe('classroomAddonNet.verifyTeacherOfCourse (real seam)', () => {
 
     const res = await classroomAddonNet.verifyTeacherOfCourse('tok', 'C1');
 
-    // 403/5xx are UNVERIFIABLE → ok:false (the caller fails closed), never
+    // 401/403/5xx are UNVERIFIABLE → ok:false (the caller fails closed), never
     // misread as a clean "not a teacher".
     expect(res).toEqual({ ok: false, status: 403, isTeacher: false });
   });

--- a/functions/src/classroomAddonAuth.ts
+++ b/functions/src/classroomAddonAuth.ts
@@ -83,6 +83,12 @@ const DEFAULT_MAX_POINTS = 100;
  */
 const CLASSROOM_CAPABILITY_PREVIEW_VERSION = 'V1_20240930_PREVIEW';
 
+/**
+ * Runaway guard on `verifyTeacherOfCourse` pagination — a single teacher with
+ * >2500 courses is implausible; this caps the loop, it's not an expected limit.
+ */
+const MAX_TEACHER_VERIFY_PAGES = 25;
+
 type ItemType = 'courseWork' | 'courseWorkMaterials' | 'announcements';
 
 interface AddOnContext {
@@ -428,63 +434,70 @@ export const classroomAddonNet = {
   },
 
   /**
-   * Verify the access token's owner TEACHES a specific Google Classroom course
-   * with a SINGLE `courses.teachers.get` call
-   * (`GET /v1/courses/{courseId}/teachers/me`). This is the trust anchor for
-   * `linkClassroomCourse`: Classroom returns 200 here ONLY when the
-   * authenticated token owner is a teacher of `courseId`, proving teaching
-   * authority that Firestore rules can't verify. Unlike a
-   * `courses.list?courseStates=ACTIVE` enumeration, this is STATE-AGNOSTIC — a
-   * teacher of an ACTIVE, ARCHIVED, or PROVISIONED course is verified the same
-   * way — and costs exactly one API call instead of paging the teacher's whole
-   * catalog.
+   * Verify the access token's owner TEACHES a specific Google Classroom course.
    *
-   * Return contract (the caller maps it to fail-closed semantics):
-   *   - 200            → { ok: true,  status: 200, isTeacher: true }  (write allowed)
-   *   - 404            → { ok: true,  status: 404, isTeacher: false } (definitively NOT a teacher)
-   *   - other non-2xx / network / timeout
-   *                    → { ok: false, status,      isTeacher: false } (UNVERIFIABLE → fail closed)
+   * IMPORTANT — this does NOT use `courses.teachers.get`
+   * (`GET .../teachers/me`): that method requires a roster/profile scope
+   * (`classroom.rosters[.readonly]` / `classroom.profile.*`) which NONE of our
+   * tokens carry (they hold `classroom.courses.readonly` + the add-on/coursework
+   * scopes), so it returns **403 ACCESS_TOKEN_SCOPE_INSUFFICIENT for every
+   * caller** — the root cause of the "Could not verify that you teach this
+   * course (status 403)" failures in both linkClassroomCourse and
+   * assignToClassroomV1. Instead we enumerate the caller's TAUGHT courses via
+   * `courses.list?teacherId=me` — which IS covered by `classroom.courses.readonly`
+   * (the exact call the dashboard course picker uses) — and check whether
+   * `courseId` is among them. `teacherId=me` is teacher-specific, so a student
+   * can't pass this gate (preserving the no-squatting invariant the link CF
+   * relies on). State-agnostic via repeated `courseStates`
+   * (ACTIVE/ARCHIVED/PROVISIONED).
    *
-   * `ok` means Classroom gave a DEFINITIVE teacher / not-a-teacher answer; only
-   * 200 and 404 are definitive. A 401/403 (bad/expired/insufficient-scope
-   * token), a 5xx, or a network failure is UNVERIFIABLE — never treat it as
-   * "not a teacher" (the caller fails closed on it, never links). Seam so tests
-   * can stub it without a live Classroom call.
+   * Return contract (callers map it to fail-closed semantics):
+   *   - course found in the teacher's list → { ok: true,  status: 200, isTeacher: true }
+   *   - list fully enumerated, not found    → { ok: true,  status: 200, isTeacher: false }
+   *   - any non-2xx (401/403/5xx) / network / timeout
+   *                                         → { ok: false, status,      isTeacher: false } (UNVERIFIABLE → fail closed)
+   *
+   * Seam so tests can stub it without a live Classroom call.
    */
   async verifyTeacherOfCourse(
     accessToken: string,
     courseId: string
   ): Promise<{ ok: boolean; status: number; isTeacher: boolean }> {
-    const url = `${CLASSROOM_API}/courses/${encodeURIComponent(
-      courseId
-    )}/teachers/me`;
+    let pageToken: string | undefined;
+    let pages = 0;
     try {
-      const res = await fetch(url, {
-        headers: bearer(accessToken),
-        signal: AbortSignal.timeout(API_TIMEOUT_MS),
-      });
-      // This is the one outbound call here that never reads its body (it
-      // decides purely on the status code), so under Node's fetch (undici) the
-      // socket would be held open until GC instead of returning to the pool.
-      // Drain it on every path. Guarded for the unit-test fetch mocks, which
-      // return a bare `{ ok, status }` with no `text`.
-      if (typeof res.text === 'function') {
-        await res.text();
-      }
-      // 2xx → the token owner is a teacher of this course.
-      if (res.ok) {
-        return { ok: true, status: res.status, isTeacher: true };
-      }
-      // 404 → the token owner is NOT a teacher of this course (or it doesn't
-      // exist). Either way the caller must deny the link; this is a DEFINITIVE
-      // answer, so `ok: true`.
-      if (res.status === 404) {
-        return { ok: true, status: 404, isTeacher: false };
-      }
-      // Everything else (401/403/5xx/…) is UNVERIFIABLE — the caller fails
-      // closed on it rather than reading it as "not a teacher".
-      console.warn(`[classroomAddon] verifyTeacherOfCourse ${res.status}`);
-      return { ok: false, status: res.status, isTeacher: false };
+      do {
+        const qs = new URLSearchParams({ teacherId: 'me', pageSize: '100' });
+        // State-agnostic: a teacher of an ACTIVE / ARCHIVED / PROVISIONED course
+        // all verify. `courseStates` is repeatable.
+        qs.append('courseStates', 'ACTIVE');
+        qs.append('courseStates', 'ARCHIVED');
+        qs.append('courseStates', 'PROVISIONED');
+        if (pageToken) qs.set('pageToken', pageToken);
+        const res = await fetch(`${CLASSROOM_API}/courses?${qs.toString()}`, {
+          headers: bearer(accessToken),
+          signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        });
+        if (!res.ok) {
+          // 401/403/5xx are UNVERIFIABLE → fail closed (never read as "not a
+          // teacher"). A 403 here would mean the courses.readonly scope itself
+          // is missing/ungranted.
+          console.warn(`[classroomAddon] verifyTeacherOfCourse ${res.status}`);
+          return { ok: false, status: res.status, isTeacher: false };
+        }
+        const data = (await res.json()) as {
+          courses?: Array<{ id?: string }>;
+          nextPageToken?: string;
+        };
+        if ((data.courses ?? []).some((c) => c.id === courseId)) {
+          return { ok: true, status: 200, isTeacher: true };
+        }
+        pageToken = data.nextPageToken;
+        pages += 1;
+      } while (pageToken && pages < MAX_TEACHER_VERIFY_PAGES);
+      // Enumerated the caller's taught courses without a match → definitively
+      // not a teacher of this course (the old 404 outcome).
+      return { ok: true, status: 200, isTeacher: false };
     } catch (err) {
       // Network failure / timeout / abort → unverifiable; caller fails closed.
       console.warn(


### PR DESCRIPTION
## Fix: Google Classroom "Could not verify that you teach this course (status 403)"

**Bug:** Both **Link to Google Classroom** (`linkClassroomCourse`) and the new **Assign to Google Classroom** (`assignToClassroomV1`) fail with a 403 — confirmed in prod logs + against Google's docs.

**Root cause:** `verifyTeacherOfCourse` used `courses.teachers.get` (`GET .../teachers/me`), which **requires a `classroom.rosters[.readonly]` / `classroom.profile.*` scope** that none of our tokens carry (they hold `classroom.courses.readonly` + add-on/coursework scopes) → `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT` for every caller. Latently broken; the course *picker* only worked because it uses `courses.list?teacherId=me`.

**Fix:** verify by enumerating `courses.list?teacherId=me` (covered by `classroom.courses.readonly` — the exact call the picker uses) and checking membership. `teacherId=me` is teacher-specific, preserving the no-squatting gate `linkClassroomCourse` relies on. State-agnostic (ACTIVE/ARCHIVED/PROVISIONED), paginated, fail-closed on any non-2xx/network. **No new OAuth scope** (so no Marketplace change). Real-seam unit tests updated; 75 pass, tsc/lint clean.

Fixes all three callers: `linkClassroomCourse`, `unlinkClassroomCourse`, `assignToClassroomV1`.
