### PR TITLE
D1: WorkSymbols "select a symbol" empty state → ScaledEmptyState

### DIFF
--- a/components/widgets/WorkSymbols/Widget.tsx
+++ b/components/widgets/WorkSymbols/Widget.tsx
@@ -112,18 +112,10 @@ export const WorkSymbolsWidget: React.FC<{ widget: WidgetData }> = ({
                 </div>
               </div>
             ) : (
-              <div className="h-full flex flex-col items-center justify-center text-slate-400">
-                <ImageIcon
-                  style={{
-                    width: 'min(48px, 12cqmin)',
-                    height: 'min(48px, 12cqmin)',
-                  }}
-                  className="mb-2 opacity-20"
-                />
-                <span style={{ fontSize: 'min(14px, 4cqmin)' }}>
-                  Select a symbol below
-                </span>
-              </div>
+              <ScaledEmptyState
+                icon={ImageIcon}
+                title="Select a symbol below"
+              />
             )}
           </div>
 


### PR DESCRIPTION
## Summary

Converts the one remaining hand-rolled empty state in `WorkSymbols/Widget.tsx` to use the canonical `ScaledEmptyState` component.

**Canonical form:** `<ScaledEmptyState icon={ImageIcon} title="Select a symbol below" />`

**Anti-pattern removed:** hand-rolled `<div className="h-full flex flex-col items-center justify-center text-slate-400">` with explicit icon sizing and a `<span>` for text.

## Instances unified

- `components/widgets/WorkSymbols/Widget.tsx` line ~115 — the "focused with symbols but nothing selected" guard. 12 lines → 4 lines. No new imports needed (`ScaledEmptyState` and `ImageIcon` were both already imported).

## Enforcement

`ScaledEmptyState` is already the established canonical component. No additional enforcement needed beyond the existing pattern; the prior `ScaledEmptyState` usage (line 70) in the same file now makes the component consistently used for all empty states in this widget.

## Behavior preservation

- Same render location (inside the `isFocused` branch when `selectedSymbol` is null)
- Same `ImageIcon` and label text "Select a symbol below"
- `ScaledEmptyState` handles container-query scaling internally (`cqmin` units) — equivalent to or better than the hand-rolled approach
- Icon color shifts from `text-slate-400 opacity-20` to canonical `text-slate-300` — acceptable canonical alignment

**Risk tag:** mechanical (pure canonical substitution, no logic change)

## Validate

`pnpm run validate` exit code 0 — type-check, lint, format-check, 4112 root tests, 470 functions tests all passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv9uoWLQ46Wdonc1bQy7zy)_