### PR TITLE
D3: 4 admin config modal labels → SettingsLabel (building-selector + stems)

### DIFF
--- a/components/admin/BloomsTaxonomyConfigurationModal.tsx
+++ b/components/admin/BloomsTaxonomyConfigurationModal.tsx
@@ -28,6 +28,7 @@ import {
   type ContentCategory,
 } from '@/components/widgets/BloomsTaxonomy/constants';
 import { DEFAULT_BLOOMS_CONTENT } from '@/components/widgets/BloomsTaxonomy/defaultContent';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 
 const normalizeConfig = (raw: unknown): BloomsTaxonomyGlobalConfig => {
   const config = raw as BloomsTaxonomyGlobalConfig | undefined;
@@ -262,10 +263,9 @@ export const BloomsTaxonomyConfigurationModal: React.FC<
           {/* Building Selector */}
           <section className="space-y-4">
             <div>
-              <label className="text-xxs font-black text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
-                <Settings2 className="w-3.5 h-3.5" /> Select Building to
-                Configure
-              </label>
+              <SettingsLabel icon={Settings2}>
+                Select Building to Configure
+              </SettingsLabel>
               <BuildingSelector
                 selectedId={selectedBuildingId}
                 onSelect={setSelectedBuildingId}

--- a/components/admin/CalendarConfigurationModal.tsx
+++ b/components/admin/CalendarConfigurationModal.tsx
@@ -28,6 +28,7 @@ import { Toast } from '@/components/common/Toast';
 import { Modal } from '@/components/common/Modal';
 import { useGoogleCalendar } from '@/hooks/useGoogleCalendar';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 
 interface CalendarConfigurationModalProps {
   isOpen: boolean;
@@ -455,10 +456,9 @@ export const CalendarConfigurationModal: React.FC<
               {/* Building Specific Config */}
               <section className="space-y-6">
                 <div>
-                  <label className="text-xxs font-black text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
-                    <Settings2 className="w-3.5 h-3.5" /> Select Building to
-                    Configure
-                  </label>
+                  <SettingsLabel icon={Settings2}>
+                    Select Building to Configure
+                  </SettingsLabel>
                   <BuildingSelector
                     selectedId={selectedBuildingId}
                     onSelect={setSelectedBuildingId}

--- a/components/admin/SpecialistScheduleConfigurationModal.tsx
+++ b/components/admin/SpecialistScheduleConfigurationModal.tsx
@@ -25,6 +25,7 @@ import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 
 interface SpecialistScheduleConfigurationModalProps {
   isOpen: boolean;
@@ -382,10 +383,9 @@ export const SpecialistScheduleConfigurationModal: React.FC<
               {/* Building Selector */}
               <section className="space-y-4">
                 <div>
-                  <label className="text-xxs font-black text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
-                    <Settings2 className="w-3.5 h-3.5" /> Select Building to
-                    Configure
-                  </label>
+                  <SettingsLabel icon={Settings2}>
+                    Select Building to Configure
+                  </SettingsLabel>
                   <BuildingSelector
                     selectedId={selectedBuildingId}
                     onSelect={setSelectedBuildingId}

--- a/components/admin/TalkingToolConfigurationPanel.tsx
+++ b/components/admin/TalkingToolConfigurationPanel.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2, MessageSquare } from 'lucide-react';
 import { TalkingToolGlobalConfig, TalkingToolCategory } from '@/types';
 import { DEFAULT_TALKING_TOOL_CATEGORIES } from '@/config/talkingToolData';
 import { IconPicker } from '@/components/widgets/InstructionalRoutines/IconPicker';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 
 interface TalkingToolConfigurationPanelProps {
   config: Partial<TalkingToolGlobalConfig>;
@@ -132,9 +133,7 @@ export const TalkingToolConfigurationPanel: React.FC<
 
             {/* Stems List */}
             <div className="p-4 space-y-2">
-              <label className="text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2">
-                Sentence Stems
-              </label>
+              <SettingsLabel>Sentence Stems</SettingsLabel>
               {cat.stems.map((stem) => (
                 <div key={stem.id} className="flex items-center gap-2 group">
                   <input


### PR DESCRIPTION
## Summary

Converts the last 4 open hand-rolled settings-label instances in admin configuration modals to use the canonical `SettingsLabel` component, closing out the D3 admin config modal backlog.

**Canonical form:**
- Icon form: `<SettingsLabel icon={Settings2}>Select Building to Configure</SettingsLabel>`
- Simple form: `<SettingsLabel>Sentence Stems</SettingsLabel>`

**Anti-pattern removed:** `<label className="text-xxs font-black text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">`

## Instances unified

| File | Instance | Form |
|------|----------|------|
| `components/admin/CalendarConfigurationModal.tsx` line ~458 | "Select Building to Configure" | icon (Settings2) |
| `components/admin/BloomsTaxonomyConfigurationModal.tsx` line ~265 | "Select Building to Configure" | icon (Settings2) |
| `components/admin/SpecialistScheduleConfigurationModal.tsx` line ~385 | "Select Building to Configure" | icon (Settings2) |
| `components/admin/TalkingToolConfigurationPanel.tsx` line ~135 | "Sentence Stems" | simple |

The three "Select Building to Configure" instances are identical patterns — the same building-selector label appearing in three different admin configuration modals, each converted identically.

## Enforcement

`SettingsLabel` is the shared component. No additional enforcement beyond the existing pattern; with this PR, all identified D3 open backlog items for admin config panels are closed.

## Behavior preservation

- `mb-3` → canonical `mb-2` (SettingsLabel built-in) — acceptable canonical alignment matching all prior D3 conversions
- Icon size `w-3.5 h-3.5` → canonical `w-3 h-3` inside SettingsLabel — consistent with how other admin config panels render labeled icons
- `Settings2` icon import preserved in all 3 files (still used in icon prop + elsewhere in modals)

**Risk tag:** mechanical (pure canonical substitution, no logic change)

## Validate

`pnpm run validate` exit code 0 — type-check, lint, format-check, 4112 root tests, 470 functions tests all passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vv9uoWLQ46Wdonc1bQy7zy)_