### PR TITLE
fix(functions): register widget-builder and widget-explainer in per-feature AI tracking

### DIFF
--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -447,6 +447,8 @@ export async function computeAnalyticsForOrg(
     'video-activity-recommend',
     'dashboard-layout',
     'instructional-routine',
+    'widget-builder',
+    'widget-explainer',
   ];
 
   const aiUsageStream = db

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1011,6 +1011,74 @@ describe('adminAnalytics', () => {
     expect(result.api.byFeature['instructional-routine']).toBe(3);
   });
 
+  it('counts widget-builder usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: widget-builder was missing from GEMINI_SPECIFIC_FEATURES
+    // in adminAnalyticsCompute.ts AND had no specificFeatureId assignment in
+    // generateWithAI. A doc like `uid1_widget-builder_2026-06-07` was treated
+    // as an "overall" doc with uid = `uid1_widget-builder`, which never
+    // matched any org member, so the call was silently dropped from totalCalls
+    // and byFeature['widget-builder'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-07', data: { count: 8 } },
+      // Per-feature widget-builder doc — should count toward
+      // byFeature['widget-builder'] but NOT toward totalCalls
+      { id: 'uid1_widget-builder_2026-06-07', data: { count: 5 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(8);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['widget-builder']).toBe(5);
+  });
+
+  it('counts widget-explainer usage docs toward byFeature without corrupting uid parsing', async () => {
+    // Regression for: widget-explainer was missing from GEMINI_SPECIFIC_FEATURES
+    // in adminAnalyticsCompute.ts AND had no specificFeatureId assignment in
+    // generateWithAI. A doc like `uid1_widget-explainer_2026-06-07` was treated
+    // as an "overall" doc with uid = `uid1_widget-explainer`, which never
+    // matched any org member, so the call was silently dropped from totalCalls
+    // and byFeature['widget-explainer'] was never populated.
+    mockFirestoreState.users = [
+      {
+        id: 'uid1',
+        data: {
+          email: 'teacher@district.org',
+          lastLogin: Date.now(),
+          buildings: [],
+        },
+      },
+    ];
+    mockFirestoreState.dashboards = [];
+    mockFirestoreState.aiUsage = [
+      // Overall usage doc — should count toward totalCalls
+      { id: 'uid1_2026-06-07', data: { count: 6 } },
+      // Per-feature widget-explainer doc — should count toward
+      // byFeature['widget-explainer'] but NOT toward totalCalls
+      { id: 'uid1_widget-explainer_2026-06-07', data: { count: 2 } },
+    ];
+
+    const result = await computeAnalyticsForOrg('orono');
+
+    // totalCalls must only count the overall doc, not the per-feature doc
+    expect(result.api.totalCalls).toBe(6);
+    // byFeature must accumulate the per-feature doc
+    expect(result.api.byFeature['widget-explainer']).toBe(2);
+  });
+
   it('returns topUsers with resolved email and unknown fallback', async () => {
     mockFirestoreState.users = [
       {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -645,6 +645,8 @@ export const generateWithAI = onCall(
     if (genType === 'dashboard-layout') specificFeatureId = 'dashboard-layout';
     if (genType === 'instructional-routine')
       specificFeatureId = 'instructional-routine';
+    if (genType === 'widget-builder') specificFeatureId = 'widget-builder';
+    if (genType === 'widget-explainer') specificFeatureId = 'widget-explainer';
 
     const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 


### PR DESCRIPTION
## Root Cause

`widget-builder` and `widget-explainer` are valid `AIData.type` values handled by `generateWithAI`, but were missing from the `specificFeatureId` assignment block (lines 635–647 of `functions/src/index.ts`). Every other genType (`mini-app`, `poll`, `quiz`, `video-activity`, `ocr`, `guided-learning`, `blooms-ai`, `video-activity-recommend`, `dashboard-layout`, `instructional-routine`) has an explicit assignment; these two were omitted when first added to the dispatch table. No comment suggests intentional exclusion — this is the same oversight pattern as #1873, #1857, and #1805.

With `specificFeatureId = null`:
1. **No per-feature analytics**: `ai_usage` docs of the form `uid_widget-builder_YYYY-MM-DD` were never written. Admin usage appears only in the per-uid overall counter; `byFeature['widget-builder']` and `byFeature['widget-explainer']` were always zero in the analytics dashboard.
2. **Secondary misparsing**: `GEMINI_SPECIFIC_FEATURES` in `adminAnalyticsCompute.ts` didn't include these strings, so any hypothetical per-feature doc would be misparsed as an "overall" doc with a mangled uid — dropping calls silently from `totalCalls`.
3. **global_permissions gate silently skipped**: A `global_permissions/widget-builder` daily limit would be bypassed entirely (admins bypass rate-limits anyway, but the door was left open for future confusion).

## Fix

- **`functions/src/index.ts`**: Added `specificFeatureId` assignments for `widget-builder` and `widget-explainer` in the existing if-chain, matching the pattern for all other genTypes.
- **`functions/src/adminAnalyticsCompute.ts`**: Added `'widget-builder'` and `'widget-explainer'` to `GEMINI_SPECIFIC_FEATURES`.

## Rejected Band-Aid

Putting the assignment inside the `if (!isAdmin)` guard. Rejected: `specificFeatureId` controls two independent things — the rate-limit check (already admin-gated) and the per-feature usage write (which should track admin calls for analytics). The fix belongs unconditionally, identical to all other feature types.

## Regression Test

Two tests added to `functions/src/index.test.ts` following the exact pattern of the `dashboard-layout` and `instructional-routine` regressions from #1873. Each test sets up an overall doc + per-feature doc and asserts:
- `totalCalls` counts only the overall doc (not the per-feature doc)
- `byFeature['widget-builder']` / `byFeature['widget-explainer']` accumulates the per-feature doc

**Before fix**: 2 new tests fail — `byFeature['widget-builder']` and `byFeature['widget-explainer']` are both `undefined`.
**After fix**: 515 tests pass (27 test files), no regressions.

## Risk

**contained** — changes are confined to the `specificFeatureId` assignment block and `GEMINI_SPECIFIC_FEATURES`. No behavioral change for existing features; new per-feature tracking is additive only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hy16oV9xgQGF3eZBquyZw6)_