### PR TITLE
fix: dedup questions denominator in getResponseScore to prevent score deflation

### DIFF
--- a/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.test.ts
@@ -450,6 +450,21 @@ describe('quizScoreboard', () => {
       expect(getResponseScore(response, questions)).toBe(50);
     });
 
+    it('is not deflated when the questions array contains duplicate question ids (Drive-sync race)', () => {
+      // Drive-sync duplication / arrayUnion races can write the same question
+      // id twice into the `questions` array. `getEarnedPoints` correctly
+      // deduplicates the *answer* side via `seenQuestionIds`, but the old
+      // `maxPoints` denominator in `getResponseScore` iterated the raw
+      // `questions` array and counted each duplicate entry — inflating maxPoints
+      // while earned stayed correct. A student who answered the only real
+      // question correctly would score 50% instead of 100%.
+      const dupQuestions = [makeQuestion('q1', 'A'), makeQuestion('q1', 'A')]; // same id twice
+      const response = makeResponse('01', [{ questionId: 'q1', answer: 'A' }]);
+      // maxPoints must be 1 (one unique question worth 1 pt), not 2.
+      // earned = 1 → score should be 100%, not 50%.
+      expect(getResponseScore(response, dupQuestions)).toBe(100);
+    });
+
     it('returns 100 for all correct', () => {
       const questions = [makeQuestion('q1', 'A')];
       const response = makeResponse('01', [{ questionId: 'q1', answer: 'A' }]);

--- a/components/widgets/QuizWidget/utils/quizScoreboard.ts
+++ b/components/widgets/QuizWidget/utils/quizScoreboard.ts
@@ -124,13 +124,29 @@ export function isGamificationActive(session?: QuizScoringSession): boolean {
 
 /**
  * Compute a student's percentage score using per-question point values.
+ *
+ * Drive-sync duplication and arrayUnion races can write the same question id
+ * twice into `questions`. `getEarnedPoints` already guards the *answer* side
+ * via `seenQuestionIds`, but the *denominator* must also dedup — otherwise
+ * `maxPoints` inflates while `earned` stays correct, deflating the score (e.g.
+ * a student who answered the only real question correctly scores 50% instead of
+ * 100% when that question appears twice). Mirrors the identical guard in
+ * `buildContributionDoc` (plcContributions.ts) and `buildResultsSheetData`
+ * (assignmentExportShared.ts).
  */
 export function getResponseScore(
   r: QuizResponse,
   questions: QuizQuestion[],
   session?: QuizScoringSession
 ): number {
-  const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
+  // Deduplicate by question id before summing maxPoints so a Drive-sync
+  // duplicate doesn't inflate the denominator while earned stays correct.
+  const seenIds = new Set<string>();
+  const maxPoints = questions.reduce((sum, q) => {
+    if (seenIds.has(q.id)) return sum;
+    seenIds.add(q.id);
+    return sum + (q.points ?? 1);
+  }, 0);
   if (maxPoints === 0) return 0;
   return Math.round((getEarnedPoints(r, questions, session) / maxPoints) * 100);
 }


### PR DESCRIPTION
## Root Cause

`getResponseScore` (`components/widgets/QuizWidget/utils/quizScoreboard.ts`) computed `maxPoints` by reducing the raw `questions` array without deduplication:

```ts
const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0); // no dedup
```

`getEarnedPoints` — called on line 135 to produce the numerator — already correctly deduplicates the **answer** side via `seenQuestionIds`. But the denominator remained blind to duplicates.

Drive-sync / `arrayUnion` races can write the same question ID twice into the `questions` array. When that happens, `maxPoints` is inflated (double-counted) while `earned` stays correct → the displayed score is deflated. Concrete failure: a student who answered the only real question correctly scores **50% instead of 100%** when that question appears twice in the array.

This bug survived previous rounds because all prior fixes in this family (#1728, #1777, #1787, #1803, #1827, #1855, #1875) patched the scoring paths they introduced. `getResponseScore` is a **read-path helper** for the live monitor and results view — it is never called by `publishAssignmentScores` — so it was in scope for this pattern but untouched by those PRs. PR #1827 fixed `getEarnedPoints` (the numerator path) but left the denominator path unguarded.

## Fix

Added a `seenIds: Set<string>` inside the `reduce` in `getResponseScore`, mirroring the identical guard already in:
- `getEarnedPoints` (same file, line 65)
- `buildContributionDoc` (`utils/plcContributions.ts`)
- `buildResultsSheetData` (`utils/assignmentExportShared.ts`)

## Rejected Band-Aid

Fixing only in the "gamification active" branch where `getDisplayScore` calls `getEarnedPoints` directly. Rejected: the percentage path (`getResponseScore`) is equally broken and is the primary code path for the live scoreboard and results view.

## Regression Test

New test added to `components/widgets/QuizWidget/utils/quizScoreboard.test.ts`:

> `"is not deflated when the questions array contains duplicate question ids (Drive-sync race)"`

Sets up `questions = [q1, q1]` (same ID twice), response with a correct answer for `q1` — expects `getResponseScore` to return 100, not 50.

**Before fix**: test returns 50 (inflated denominator → deflated score).
**After fix**: 4176 tests pass (4175 baseline + 1 new), no regressions. Type-check and lint clean.

## Risk

**contained** — single function in `quizScoreboard.ts`. No schema changes, no Firestore writes. Purely a read-path computation fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hy16oV9xgQGF3eZBquyZw6)_