### PR TITLE
fix(Dock): remove spurious processAndUploadImage dep from smart-paste useEffect

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -520,7 +520,11 @@ export const Dock: React.FC = () => {
     addWidget,
     addToast,
     canAccessFeature,
-    processAndUploadImage,
+    // processAndUploadImage is intentionally omitted: it is only used in a JSX
+    // click handler (line ~839), never inside this effect body. Its identity
+    // changes on every auth-state change (useImageUpload wraps it in
+    // useCallback([user, uploadSticker, uploadFn])), so including it would
+    // tear down and re-register the paste listener on every sign-in / sign-out.
     user,
     imagePastePending,
     smartPastePending,

--- a/tests/components/layout/Dock.test.tsx
+++ b/tests/components/layout/Dock.test.tsx
@@ -406,3 +406,89 @@ describe('Dock – InternalToolType permission gate', () => {
     expect(screen.queryByTestId('dock-item-clock')).not.toBeInTheDocument();
   });
 });
+
+// ── Regression: spurious processAndUploadImage dep in smart-paste useEffect ──
+//
+// Bug: `processAndUploadImage` was listed in the deps array of the smart-paste
+// `useEffect` in Dock.tsx even though it is never called inside the effect
+// body (it is only used in a JSX click handler at line ~839).
+//
+// `processAndUploadImage` is wrapped in `useCallback([user, uploadSticker,
+// uploadFn])` inside `useImageUpload`, so it gets a NEW identity every time
+// auth state changes (sign-in / sign-out).  Including it in the effect deps
+// causes the paste listener to be torn down and re-registered on every auth
+// state change — an unnecessary churn that briefly leaves the board without a
+// paste handler.
+//
+// Fix: remove `processAndUploadImage` from the deps array.
+// After the fix the listener must NOT be torn down when only
+// `processAndUploadImage` changes identity.
+
+describe('Dock smart-paste – processAndUploadImage is not a spurious dep', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT remove/re-add the paste listener when processAndUploadImage identity changes', () => {
+    // Spy on the window event listener methods BEFORE rendering.
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    // --- First render with processAndUploadImage = fnA ---
+    const fnA = vi.fn();
+    vi.mocked(useImageUpload).mockReturnValue({
+      processAndUploadImage: fnA,
+      uploading: false,
+    } as unknown as ReturnType<typeof useImageUpload>);
+
+    setupMocks();
+
+    const { rerender } = render(<Dock />);
+
+    // Count how many times the paste listener was added on initial render.
+    const addCountAfterMount = addSpy.mock.calls.filter(
+      ([event]) => event === 'paste'
+    ).length;
+    expect(addCountAfterMount).toBe(1);
+
+    const removeCountAfterMount = removeSpy.mock.calls.filter(
+      ([event]) => event === 'paste'
+    ).length;
+    expect(removeCountAfterMount).toBe(0);
+
+    // Reset spy counts so we only measure what happens on the re-render.
+    addSpy.mockClear();
+    removeSpy.mockClear();
+
+    // --- Re-render with processAndUploadImage = fnB (new identity) ---
+    // This simulates what happens when the user signs in/out and useAuth
+    // gives back a new `user` object, causing useImageUpload to return a
+    // new `processAndUploadImage` callback reference.
+    const fnB = vi.fn(); // different reference, same signature
+    vi.mocked(useImageUpload).mockReturnValue({
+      processAndUploadImage: fnB,
+      uploading: false,
+    } as unknown as ReturnType<typeof useImageUpload>);
+
+    rerender(<Dock />);
+
+    // BUG (before fix): the effect would see the new `processAndUploadImage`
+    // reference in its deps, call cleanup (removeEventListener), then
+    // re-register (addEventListener) — both counts would be 1.
+    //
+    // CORRECT (after fix): `processAndUploadImage` is NOT in the deps array,
+    // so the effect does NOT re-run — both counts stay at 0.
+    const removeCountAfterRerender = removeSpy.mock.calls.filter(
+      ([event]) => event === 'paste'
+    ).length;
+    const addCountAfterRerender = addSpy.mock.calls.filter(
+      ([event]) => event === 'paste'
+    ).length;
+
+    expect(removeCountAfterRerender).toBe(0);
+    expect(addCountAfterRerender).toBe(0);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/tests/components/layout/Dock.test.tsx
+++ b/tests/components/layout/Dock.test.tsx
@@ -434,14 +434,17 @@ describe('Dock smart-paste – processAndUploadImage is not a spurious dep', () 
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');
 
+    // setupMocks() internally mocks useImageUpload with a fresh vi.fn(), so it
+    // must run BEFORE we set the fnA return value below — otherwise it would
+    // overwrite fnA and the first render would not use it.
+    setupMocks();
+
     // --- First render with processAndUploadImage = fnA ---
     const fnA = vi.fn();
     vi.mocked(useImageUpload).mockReturnValue({
       processAndUploadImage: fnA,
       uploading: false,
     } as unknown as ReturnType<typeof useImageUpload>);
-
-    setupMocks();
 
     const { rerender } = render(<Dock />);
 


### PR DESCRIPTION
## Root Cause

`processAndUploadImage` was listed in the deps array of the smart-paste `useEffect` in `Dock.tsx` (line 523) but is **never referenced inside the effect body** — it is only used in a JSX click handler at line ~839. `useImageUpload` wraps it in `useCallback([user, uploadSticker, uploadFn])`, so it receives a new function identity on every Firebase auth-state change.

With the spurious dep present, every sign-in / sign-out triggered the effect cleanup (`window.removeEventListener('paste', handlePaste)`) followed by a re-registration (`window.addEventListener('paste', handlePaste)`). During the gap between cleanup and re-registration, the board has no paste handler — smart-paste is silently swallowed. The churn also causes unnecessary listener GC on every auth transition.

ESLint's `react-hooks/exhaustive-deps` rule only warns about **missing** deps, not extra ones — this is why it passed without a warning.

## Fix

Removed `processAndUploadImage` from the effect's deps array and added an explanatory comment documenting why it's intentionally omitted. The fix is three lines of comment replacing one line of code.

## Rejected Band-Aid

Memoizing `processAndUploadImage` with a stable ref inside `useImageUpload` (the source hook). Rejected: that masks the symptom at the source rather than fixing the erroneous dep at the consumption site. The correct fix is to not list a dep that the effect doesn't use.

## Regression Test

New test in `tests/components/layout/Dock.test.tsx` — renders `<Dock />`, spies on `window.removeEventListener`, then re-renders with a new `processAndUploadImage` identity (simulating auth state change):

- **Before fix**: `removeEventListener('paste', ...)` called once — listener torn down spuriously.
- **After fix**: `removeEventListener('paste', ...)` not called — effect does not re-run.

4176 tests pass (4175 baseline + 1 new), no regressions. Type-check and lint clean.

## Risk

**contained** — one dep removed from one effect's deps array in `Dock.tsx`. All existing behavior preserved; the effect now fires only when its actual dependencies change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hy16oV9xgQGF3eZBquyZw6)_