### PR TITLE
fix(NumberLine): apply toFixed(4) baseline to all display modes to prevent FP artifact labels

### DIFF
--- a/components/widgets/NumberLine/Widget.test.tsx
+++ b/components/widgets/NumberLine/Widget.test.tsx
@@ -158,6 +158,45 @@ describe('NumberLineWidget', () => {
     expect(screen.getAllByText('1')[0]).toBeInTheDocument();
   });
 
+  it('shows clean labels in integers mode with decimal step (FP accumulation guard)', () => {
+    // step=0.1 causes floating-point accumulation: 0 + 3×0.1 =
+    // 0.30000000000000004. Without the toFixed(4) baseline, the default
+    // val.toString() label path renders the raw FP artifact for the
+    // 'integers' display mode — the same bug that was already fixed for
+    // 'fractions' mode. This test confirms the fix covers all display modes.
+    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+      defaultDashboardMock
+    );
+
+    const widget: WidgetData = {
+      ...baseWidget,
+      config: {
+        ...baseWidget.config,
+        min: 0,
+        max: 1,
+        step: 0.1,
+        displayMode: 'integers',
+        markers: [],
+        jumps: [],
+        showArrows: true,
+      },
+    };
+
+    render(<NumberLineWidget widget={widget} />);
+
+    // These ticks accumulate FP error. The raw val.toString() produces
+    // '0.30000000000000004', '0.6000000000000001', '0.7000000000000001'.
+    // After the fix they must render as clean '0.3', '0.6', '0.7'.
+    expect(screen.getByText('0.3')).toBeInTheDocument();
+    expect(screen.getByText('0.6')).toBeInTheDocument();
+    expect(screen.getByText('0.7')).toBeInTheDocument();
+
+    // The raw FP-artifact strings must NOT appear as text nodes.
+    expect(screen.queryByText('0.30000000000000004')).not.toBeInTheDocument();
+    expect(screen.queryByText('0.6000000000000001')).not.toBeInTheDocument();
+    expect(screen.queryByText('0.7000000000000001')).not.toBeInTheDocument();
+  });
+
   it('caps number of ticks if range is too large compared to step', () => {
     vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
       defaultDashboardMock

--- a/components/widgets/NumberLine/Widget.tsx
+++ b/components/widgets/NumberLine/Widget.tsx
@@ -226,11 +226,7 @@ export const NumberLineWidget: React.FC<{ widget: WidgetData }> = ({
                 // and the fractions fallback, and strips the long mantissa that
                 // would otherwise confuse teachers on classroom projectors.
                 let labelText = Number(val.toFixed(4)).toString();
-                if (displayMode === 'decimals') {
-                  // Already handled by the baseline round-trip above; this
-                  // branch is now a no-op but kept for clarity/intent.
-                  labelText = Number(val.toFixed(4)).toString();
-                } else if (displayMode === 'fractions') {
+                if (displayMode === 'fractions') {
                   // Simple fraction conversion if step suggests a common denominator (e.g. 0.25 -> 4)
                   const denom = Math.round(1 / safeStep);
                   // Use Math.round + epsilon guard instead of strict modulo check:

--- a/components/widgets/NumberLine/Widget.tsx
+++ b/components/widgets/NumberLine/Widget.tsx
@@ -218,9 +218,17 @@ export const NumberLineWidget: React.FC<{ widget: WidgetData }> = ({
                 const x = padL + (val - min) * pxPerUnit;
                 const isHovered = hoveredTick === i;
 
-                let labelText = val.toString();
+                // Apply toFixed(4) round-trip as the baseline label for ALL
+                // display modes. FP accumulation (e.g. 0 + 3×0.1 =
+                // 0.30000000000000004) makes val.toString() produce garbage
+                // labels even in 'integers' mode when a decimal step is used.
+                // Four decimal places matches the 'decimals' branch precision
+                // and the fractions fallback, and strips the long mantissa that
+                // would otherwise confuse teachers on classroom projectors.
+                let labelText = Number(val.toFixed(4)).toString();
                 if (displayMode === 'decimals') {
-                  // Try to format nicely, avoiding 1.000000000001
+                  // Already handled by the baseline round-trip above; this
+                  // branch is now a no-op but kept for clarity/intent.
                   labelText = Number(val.toFixed(4)).toString();
                 } else if (displayMode === 'fractions') {
                   // Simple fraction conversion if step suggests a common denominator (e.g. 0.25 -> 4)


### PR DESCRIPTION
## Root Cause

`NumberLine/Widget.tsx` computed tick labels in three branches:
- **`decimals`**: `Number(val.toFixed(4)).toString()` — FP-clean ✓
- **`fractions`**: epsilon-guarded `Math.round` — FP-clean ✓ (fixed in prior run)
- **`integers` / default**: raw `val.toString()` — **no FP cleanup** ✗

Tick values are accumulated as `min + i * effectiveStep`. With `step=0.1`, JavaScript's binary float gives `0 + 3×0.1 = 0.30000000000000004`. In `integers` display mode, `val.toString()` produced that raw string as the SVG tick label — a multi-digit floating-point artifact visible on classroom projectors.

## Fix

Changed the baseline label from `val.toString()` to `Number(val.toFixed(4)).toString()` for **all** display modes. The `decimals` branch becomes a no-op (same formula); fractions still overrides via the epsilon guard. This is the minimal consistent change — the same approach already used by the `decimals` branch.

## Band-Aid Rejected

Checking `Number.isInteger(val)` to decide whether to apply cleanup would only help for whole-number ticks. The bug triggers on any tick that accumulated FP error, regardless of whether the conceptual value is an integer. It would also silently produce `"0"` instead of `"0.3"` for a legitimate decimal tick rendered in integers mode — wrong behavior for a different reason.

## Regression Test

`components/widgets/NumberLine/Widget.test.tsx` — new test:  
`'shows clean labels in integers mode with decimal step (FP accumulation guard)'`

- **Before fix**: ticks 0.3, 0.6, 0.7 rendered as `0.30000000000000004`, `0.6000000000000001`, `0.7000000000000001` — test **fails** (clean labels not found in DOM)
- **After fix**: clean `0.3`, `0.6`, `0.7` labels rendered — test **passes** (6/6)

## Evidence

- TypeScript: exit 0
- ESLint (changed files): no warnings/errors
- Prettier: clean
- Widget tests (6 tests): all pass

## Risk

**contained** — change is isolated to the label-text baseline in `NumberLine/Widget.tsx`. Only affects what string is rendered as an SVG text node; no state, no config, no other components touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01US1gVX7fL5buF5eLJoxqvv)_