### PR TITLE
fix(i18n): add missing widgets.clock, widgets.schedule, and sidebar.boards keys to DE/ES/FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -92,7 +92,7 @@
       "rootBoards": "Boards",
       "manageAll": "Manage all boards",
       "create": "Erstellen",
-      "enterBoardData": "Tafel-Daten hier einfügen:",
+      "enterBoardData": "Tafeldaten hier einfügen:",
       "imported": "Importiert"
     },
     "classes": {
@@ -843,7 +843,7 @@
       "colorPalette": "Farbpalette",
       "glow": "Leuchten",
       "fonts": {
-        "inherit": "Übernehmen",
+        "inherit": "Vom Board",
         "digital": "Digital",
         "modern": "Modern",
         "school": "Schule"

--- a/locales/de.json
+++ b/locales/de.json
@@ -90,7 +90,10 @@
       "boardName": "Tafelname",
       "activeCollection": "Active Collection",
       "rootBoards": "Boards",
-      "manageAll": "Manage all boards"
+      "manageAll": "Manage all boards",
+      "create": "Erstellen",
+      "enterBoardData": "Tafel-Daten hier einfügen:",
+      "imported": "Importiert"
     },
     "classes": {
       "title": "Meine Klassen",
@@ -831,6 +834,29 @@
         "longSleeves": "Lange Ärmel",
         "shortSleeves": "Kurze Ärmel"
       }
+    },
+    "clock": {
+      "format24": "24-Stunden-Format",
+      "showSeconds": "Sekunden anzeigen",
+      "typography": "Typografie",
+      "displayStyle": "Anzeigestil",
+      "colorPalette": "Farbpalette",
+      "glow": "Leuchten",
+      "fonts": {
+        "inherit": "Übernehmen",
+        "digital": "Digital",
+        "modern": "Modern",
+        "school": "Schule"
+      },
+      "styles": {
+        "default": "Standard",
+        "lcd": "LCD-Panel",
+        "minimal": "Minimal"
+      }
+    },
+    "schedule": {
+      "startTimer": "Timer starten",
+      "startTimerUntil": "Countdown-Timer bis {{time}} starten"
     }
   },
   "boardBreadcrumb": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -874,6 +874,10 @@
     "dashboard": {
       "emptyBoardHint": "Arrastra herramientas desde el Dock para empezar",
       "switchBoardsHint": "Usa los controles de navegación en la parte inferior izquierda para cambiar de tablero"
+    },
+    "schedule": {
+      "startTimer": "Iniciar Temporizador",
+      "startTimerUntil": "Iniciar cuenta regresiva hasta {{time}}"
     }
   },
   "boardBreadcrumb": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -90,7 +90,10 @@
       "boardName": "Nom du tableau",
       "activeCollection": "Active Collection",
       "rootBoards": "Boards",
-      "manageAll": "Manage all boards"
+      "manageAll": "Manage all boards",
+      "create": "Créer",
+      "enterBoardData": "Collez vos données de tableau ici :",
+      "imported": "Importé"
     },
     "classes": {
       "title": "Mes Classes",
@@ -831,6 +834,29 @@
         "longSleeves": "Manches longues",
         "shortSleeves": "Manches courtes"
       }
+    },
+    "clock": {
+      "format24": "Format 24H",
+      "showSeconds": "Afficher les secondes",
+      "typography": "Typographie",
+      "displayStyle": "Style d'affichage",
+      "colorPalette": "Palette de couleurs",
+      "glow": "Lueur",
+      "fonts": {
+        "inherit": "Hériter",
+        "digital": "Digital",
+        "modern": "Moderne",
+        "school": "École"
+      },
+      "styles": {
+        "default": "Par défaut",
+        "lcd": "Panneau LCD",
+        "minimal": "Minimal"
+      }
+    },
+    "schedule": {
+      "startTimer": "Démarrer le minuteur",
+      "startTimerUntil": "Démarrer le compte à rebours jusqu'à {{time}}"
     }
   },
   "boardBreadcrumb": {

--- a/tests/i18n/widgetClockScheduleLocales.test.ts
+++ b/tests/i18n/widgetClockScheduleLocales.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Regression test for missing widgets.clock and widgets.schedule namespaces
+ * in DE, ES, and FR locales, and for missing sidebar.boards keys in DE and FR.
+ *
+ * GAPS FOUND (pre-fix):
+ *   - `widgets.clock` (11 leaf keys incl. nested fonts/styles): entirely absent
+ *     from DE and FR; ES had full parity.
+ *   - `widgets.schedule` (2 keys): absent from ALL non-EN locales (DE, ES, FR).
+ *   - `sidebar.boards.create`, `sidebar.boards.enterBoardData`,
+ *     `sidebar.boards.imported`: missing from DE and FR; ES had full parity.
+ *
+ * AFFECTED COMPONENTS (no `defaultValue` fallback — loud bugs):
+ *
+ *   components/widgets/ClockWidget/Settings.tsx:
+ *     t('widgets.clock.format24')          — line 26
+ *     t('widgets.clock.showSeconds')       — line 36
+ *     t('widgets.clock.fonts.inherit')     — line 51
+ *     t('widgets.clock.fonts.digital')     — line 52
+ *     t('widgets.clock.fonts.modern')      — line 53
+ *     t('widgets.clock.fonts.school')      — line 56
+ *     t('widgets.clock.styles.default')    — line 64
+ *     t('widgets.clock.styles.lcd')        — line 65
+ *     t('widgets.clock.styles.minimal')    — line 66
+ *     t('widgets.clock.typography')        — line 74
+ *     t('widgets.clock.displayStyle')      — line 99
+ *     t('widgets.clock.colorPalette')      — line 122
+ *     t('widgets.clock.glow')              — line 151
+ *
+ *   components/widgets/Schedule/components/ScheduleRow.tsx:
+ *     t('widgets.schedule.startTimerUntil', { time }) — lines 233, 236
+ *
+ *   (sidebar.boards keys are used in components/layout/Sidebar.tsx without
+ *   defaultValue — teachers see raw key paths when importing boards)
+ *
+ * This test loads locale JSON files directly so assertions fire before the
+ * i18next runtime attempts (and silently skips) any fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+// ─── widgets.clock keys ───────────────────────────────────────────────────────
+
+/** Top-level string keys within widgets.clock */
+const REQUIRED_CLOCK_TOP_KEYS = [
+  'format24',
+  'showSeconds',
+  'typography',
+  'displayStyle',
+  'colorPalette',
+  'glow',
+] as const;
+
+/** Keys within widgets.clock.fonts */
+const REQUIRED_CLOCK_FONT_KEYS = [
+  'inherit',
+  'digital',
+  'modern',
+  'school',
+] as const;
+
+/** Keys within widgets.clock.styles */
+const REQUIRED_CLOCK_STYLE_KEYS = ['default', 'lcd', 'minimal'] as const;
+
+// ─── widgets.schedule keys ────────────────────────────────────────────────────
+
+const REQUIRED_SCHEDULE_KEYS = ['startTimer', 'startTimerUntil'] as const;
+
+// ─── sidebar.boards keys ─────────────────────────────────────────────────────
+
+const REQUIRED_BOARDS_KEYS = ['create', 'enterBoardData', 'imported'] as const;
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — widgets.clock baseline', () => {
+  it('has a widgets.clock section', () => {
+    expect(en).toHaveProperty(['widgets', 'clock']);
+  });
+
+  it('has all required top-level clock keys', () => {
+    for (const key of REQUIRED_CLOCK_TOP_KEYS) {
+      expect(
+        en.widgets.clock,
+        `en.widgets.clock.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has a widgets.clock.fonts sub-section', () => {
+    expect(
+      en.widgets.clock,
+      'en.widgets.clock.fonts is missing'
+    ).toHaveProperty('fonts');
+  });
+
+  it('has all required widgets.clock.fonts keys', () => {
+    for (const key of REQUIRED_CLOCK_FONT_KEYS) {
+      expect(
+        en.widgets.clock.fonts,
+        `en.widgets.clock.fonts.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+
+  it('has a widgets.clock.styles sub-section', () => {
+    expect(
+      en.widgets.clock,
+      'en.widgets.clock.styles is missing'
+    ).toHaveProperty('styles');
+  });
+
+  it('has all required widgets.clock.styles keys', () => {
+    for (const key of REQUIRED_CLOCK_STYLE_KEYS) {
+      expect(
+        en.widgets.clock.styles,
+        `en.widgets.clock.styles.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+describe('EN locale — widgets.schedule baseline', () => {
+  it('has a widgets.schedule section', () => {
+    expect(en).toHaveProperty(['widgets', 'schedule']);
+  });
+
+  it('has all required schedule keys', () => {
+    for (const key of REQUIRED_SCHEDULE_KEYS) {
+      expect(
+        en.widgets.schedule,
+        `en.widgets.schedule.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+describe('EN locale — sidebar.boards baseline', () => {
+  it('has all required sidebar.boards keys', () => {
+    for (const key of REQUIRED_BOARDS_KEYS) {
+      expect(
+        en.sidebar.boards,
+        `en.sidebar.boards.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity: widgets.clock ─────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
+])('$code locale — widgets.clock parity with EN', ({ code, locale }) => {
+  it(`${code}: has a widgets.clock section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.clock section is entirely missing — LOUD bug (no defaultValue fallback)`
+    ).toHaveProperty(['widgets', 'clock']);
+  });
+
+  it(`${code}: has all required top-level clock keys (no defaultValue — loud bugs)`, () => {
+    for (const key of REQUIRED_CLOCK_TOP_KEYS) {
+      expect(
+        locale,
+        `${code}.widgets.clock.${key} is missing — LOUD bug (no defaultValue fallback)`
+      ).toHaveProperty(['widgets', 'clock', key]);
+    }
+  });
+
+  it(`${code}: has a widgets.clock.fonts sub-section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.clock.fonts sub-section is missing`
+    ).toHaveProperty(['widgets', 'clock', 'fonts']);
+  });
+
+  it(`${code}: has all required widgets.clock.fonts keys`, () => {
+    for (const key of REQUIRED_CLOCK_FONT_KEYS) {
+      expect(
+        locale,
+        `${code}.widgets.clock.fonts.${key} is missing`
+      ).toHaveProperty(['widgets', 'clock', 'fonts', key]);
+    }
+  });
+
+  it(`${code}: has a widgets.clock.styles sub-section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.clock.styles sub-section is missing`
+    ).toHaveProperty(['widgets', 'clock', 'styles']);
+  });
+
+  it(`${code}: has all required widgets.clock.styles keys`, () => {
+    for (const key of REQUIRED_CLOCK_STYLE_KEYS) {
+      expect(
+        locale,
+        `${code}.widgets.clock.styles.${key} is missing`
+      ).toHaveProperty(['widgets', 'clock', 'styles', key]);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity: widgets.schedule ───────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
+])('$code locale — widgets.schedule parity with EN', ({ code, locale }) => {
+  it(`${code}: has a widgets.schedule section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.schedule section is entirely missing — LOUD bug (no defaultValue fallback)`
+    ).toHaveProperty(['widgets', 'schedule']);
+  });
+
+  it(`${code}: has all required schedule keys (no defaultValue — loud bugs)`, () => {
+    for (const key of REQUIRED_SCHEDULE_KEYS) {
+      expect(
+        locale,
+        `${code}.widgets.schedule.${key} is missing — LOUD bug (no defaultValue fallback)`
+      ).toHaveProperty(['widgets', 'schedule', key]);
+    }
+  });
+});
+
+// ─── DE / FR parity: sidebar.boards ─────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'fr', locale: fr },
+])('$code locale — sidebar.boards missing keys', ({ code, locale }) => {
+  it(`${code}: has all required sidebar.boards keys`, () => {
+    for (const key of REQUIRED_BOARDS_KEYS) {
+      expect(locale, `${code}.sidebar.boards.${key} is missing`).toHaveProperty(
+        ['sidebar', 'boards', key]
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Root Cause

Three i18n namespaces were added to `locales/en.json` but never propagated to non-English locales. All affected call sites use `t()` without a `defaultValue` fallback, so German and French teachers see raw i18next key paths (e.g. `widgets.clock.typography`, `sidebar.boards.create`) rendered directly in the UI.

| Namespace / Key | DE | ES | FR | Component |
|---|---|---|---|---|
| `widgets.clock` (13 leaf keys incl. `fonts.*`, `styles.*`) | MISSING | present | MISSING | `ClockWidget/Settings.tsx` |
| `widgets.schedule.startTimer` + `startTimerUntil` | MISSING | MISSING | MISSING | `Schedule/components/ScheduleRow.tsx` |
| `sidebar.boards.create` | MISSING | present | MISSING | `Sidebar.tsx` |
| `sidebar.boards.enterBoardData` | MISSING | present | MISSING | `Sidebar.tsx` |
| `sidebar.boards.imported` | MISSING | present | MISSING | `Sidebar.tsx` |

## Fix

- **`locales/de.json`**: Added full `widgets.clock` namespace (13 leaf keys with `fonts` and `styles` sub-objects), `widgets.schedule` (2 keys), and `sidebar.boards.create/enterBoardData/imported`
- **`locales/es.json`**: Added `widgets.schedule` (2 keys — only gap for ES)
- **`locales/fr.json`**: Added full `widgets.clock` namespace, `widgets.schedule` (2 keys), and `sidebar.boards.create/enterBoardData/imported`

Translations follow tone of adjacent keys (German: informal du-form matching existing sidebar entries; French: formal vous-form matching existing entries).

## Band-Aid Rejected

Adding `defaultValue` fallbacks to the `t()` call sites in the components would hide the missing translations from developers and i18n tests, silently displaying English for non-EN users instead of surfacing the gap. The correct fix is propagating the translations.

## Regression Test

`tests/i18n/widgetClockScheduleLocales.test.ts` — 35 tests:
- EN baseline assertions for all three namespaces
- DE/ES/FR parity for `widgets.clock` (top-level keys + `fonts.*` + `styles.*`)
- DE/ES/FR parity for `widgets.schedule`
- DE/FR parity for the three `sidebar.boards` keys

**Before fix**: 20/35 tests fail on dev-paul (DE and FR missing entire namespaces)  
**After fix**: 35/35 pass

## Evidence

- TypeScript: exit 0
- ESLint (changed files): no warnings/errors
- Prettier: all locale JSON files formatted correctly
- i18n tests (216 total across 15 test files): all pass

## Risk

**contained** — locale JSON additions only; no TypeScript, no component logic, no Firestore interaction touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01US1gVX7fL5buF5eLJoxqvv)_