### PR TITLE
fix(DashboardView): Alt+Arrow and Alt+P shortcuts swallow events in focused text fields

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1296,11 +1296,11 @@ export const DashboardView: React.FC = () => {
       if (e.altKey && e.key === 'p') {
         // Guard: don't intercept Alt shortcuts while the user is typing in a
         // form field (mirrors the Escape / Delete guards above).
-        const activeElP = document.activeElement as HTMLElement;
-        const isTypingFieldP =
-          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeElP?.tagName || '') ||
-          activeElP?.isContentEditable;
-        if (isTypingFieldP) return;
+        const activeEl = document.activeElement as HTMLElement;
+        const isTypingField =
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeEl?.tagName || '') ||
+          activeEl?.isContentEditable;
+        if (isTypingField) return;
 
         e.preventDefault();
         if (activeDashboard && activeDashboard.widgets.length > 0) {
@@ -1327,12 +1327,11 @@ export const DashboardView: React.FC = () => {
       // Guard: Alt + ArrowLeft/Right is word-navigation in text fields on
       // macOS and many Linux keyboard layouts. Don't intercept it there.
       if (e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
-        const activeElNav = document.activeElement as HTMLElement;
-        const isTypingFieldNav =
-          ['INPUT', 'TEXTAREA', 'SELECT'].includes(
-            activeElNav?.tagName || ''
-          ) || activeElNav?.isContentEditable;
-        if (isTypingFieldNav) return;
+        const activeEl = document.activeElement as HTMLElement;
+        const isTypingField =
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeEl?.tagName || '') ||
+          activeEl?.isContentEditable;
+        if (isTypingField) return;
 
         e.preventDefault();
         if (dashboards.length > 1) {

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1294,6 +1294,14 @@ export const DashboardView: React.FC = () => {
 
       // Alt + P: Pin/Unpin top or focused widget
       if (e.altKey && e.key === 'p') {
+        // Guard: don't intercept Alt shortcuts while the user is typing in a
+        // form field (mirrors the Escape / Delete guards above).
+        const activeElP = document.activeElement as HTMLElement;
+        const isTypingFieldP =
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeElP?.tagName || '') ||
+          activeElP?.isContentEditable;
+        if (isTypingFieldP) return;
+
         e.preventDefault();
         if (activeDashboard && activeDashboard.widgets.length > 0) {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
@@ -1316,17 +1324,22 @@ export const DashboardView: React.FC = () => {
       }
 
       // Alt + Left/Right: Navigate boards (with wrap-around)
-      if (e.altKey && e.key === 'ArrowLeft') {
+      // Guard: Alt + ArrowLeft/Right is word-navigation in text fields on
+      // macOS and many Linux keyboard layouts. Don't intercept it there.
+      if (e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+        const activeElNav = document.activeElement as HTMLElement;
+        const isTypingFieldNav =
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(
+            activeElNav?.tagName || ''
+          ) || activeElNav?.isContentEditable;
+        if (isTypingFieldNav) return;
+
         e.preventDefault();
         if (dashboards.length > 1) {
           const nextIdx =
-            (currentIndex - 1 + dashboards.length) % dashboards.length;
-          loadDashboard(dashboards[nextIdx].id);
-        }
-      } else if (e.altKey && e.key === 'ArrowRight') {
-        e.preventDefault();
-        if (dashboards.length > 1) {
-          const nextIdx = (currentIndex + 1) % dashboards.length;
+            e.key === 'ArrowLeft'
+              ? (currentIndex - 1 + dashboards.length) % dashboards.length
+              : (currentIndex + 1) % dashboards.length;
           loadDashboard(dashboards[nextIdx].id);
         }
       }

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -499,4 +499,186 @@ describe('Global Escape Interaction', () => {
       })
     );
   });
+
+  /**
+   * Regression: the global Alt+ArrowLeft / Alt+ArrowRight board-navigation
+   * shortcuts called e.preventDefault() before checking whether a text field
+   * was focused. Alt+Arrow is the standard macOS / Linux shortcut for
+   * word-by-word cursor navigation inside text inputs. When a teacher pressed
+   * Alt+ArrowLeft to move the cursor back one word in a widget settings input,
+   * the global handler swallowed the event and switched to the previous board
+   * instead of performing text navigation.
+   *
+   * Fix: added an `isTypingField` guard (matching the Escape / Delete handlers)
+   * that returns early — without calling preventDefault — when either
+   * Alt+ArrowLeft or Alt+ArrowRight is fired while a form field has focus.
+   */
+  it('does not call preventDefault on Alt+ArrowLeft when a text input is focused', () => {
+    const dashboard = createMockDashboard([]);
+    const mockDashboards: Dashboard[] = [
+      createMockDashboard([]),
+      createMockDashboard([]),
+    ];
+    mockDashboards[0].id = 'dash-a';
+    mockDashboards[1].id = 'dash-b';
+    const mockLoadDashboard = vi.fn();
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: dashboard,
+            dashboards: mockDashboards,
+            loadDashboard: mockLoadDashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+        <input data-testid="nav-input" />
+      </DashboardContext.Provider>
+    );
+
+    const input = screen.getByTestId('nav-input');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const altLeftEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      window.dispatchEvent(altLeftEvent);
+    });
+
+    // Must NOT preventDefault (would block word-navigation in the input).
+    expect(altLeftEvent.defaultPrevented).toBe(false);
+    // Must NOT navigate to a different board.
+    expect(mockLoadDashboard).not.toHaveBeenCalled();
+  });
+
+  it('does not call preventDefault on Alt+ArrowRight when a text input is focused', () => {
+    const dashboard = createMockDashboard([]);
+    const mockDashboards: Dashboard[] = [
+      createMockDashboard([]),
+      createMockDashboard([]),
+    ];
+    mockDashboards[0].id = 'dash-a';
+    mockDashboards[1].id = 'dash-b';
+    const mockLoadDashboard = vi.fn();
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: dashboard,
+            dashboards: mockDashboards,
+            loadDashboard: mockLoadDashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+        <input data-testid="nav-input-right" />
+      </DashboardContext.Provider>
+    );
+
+    const input = screen.getByTestId('nav-input-right');
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const altRightEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      window.dispatchEvent(altRightEvent);
+    });
+
+    // Must NOT preventDefault (would block word-navigation in the input).
+    expect(altRightEvent.defaultPrevented).toBe(false);
+    // Must NOT navigate to a different board.
+    expect(mockLoadDashboard).not.toHaveBeenCalled();
+  });
+
+  it('does call preventDefault and loadDashboard on Alt+ArrowLeft when no text input is focused', () => {
+    const mockDashboards: Dashboard[] = [
+      createMockDashboard([]),
+      createMockDashboard([]),
+    ];
+    mockDashboards[0].id = 'dash-a';
+    mockDashboards[1].id = 'dash-b';
+    const mockLoadDashboard = vi.fn();
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: mockDashboards[1],
+            dashboards: mockDashboards,
+            loadDashboard: mockLoadDashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+      </DashboardContext.Provider>
+    );
+
+    // No input focused.
+    expect(document.activeElement).toBe(document.body);
+
+    const altLeftEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      window.dispatchEvent(altLeftEvent);
+    });
+
+    // Should prevent default and navigate to the previous board.
+    expect(altLeftEvent.defaultPrevented).toBe(true);
+    expect(mockLoadDashboard).toHaveBeenCalledWith('dash-a');
+  });
+
+  it('does not call preventDefault on Alt+P when a textarea is focused', () => {
+    const dashboard = createMockDashboard([]);
+
+    render(
+      <DashboardContext.Provider
+        value={
+          {
+            ...mockContextValue,
+            activeDashboard: dashboard,
+          } as DashboardContextValue
+        }
+      >
+        <DashboardView />
+        <textarea data-testid="pin-textarea" />
+      </DashboardContext.Provider>
+    );
+
+    const textarea = screen.getByTestId('pin-textarea');
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    const altPEvent = new KeyboardEvent('keydown', {
+      key: 'p',
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      window.dispatchEvent(altPEvent);
+    });
+
+    // Must NOT preventDefault (let the browser handle the key in the textarea).
+    expect(altPEvent.defaultPrevented).toBe(false);
+  });
 });


### PR DESCRIPTION
## Root Cause

`DashboardView.tsx`'s global `keydown` handler registers shortcuts for:
- `Alt+ArrowLeft` / `Alt+ArrowRight` — board navigation
- `Alt+P` — widget pin

All three shortcuts called `e.preventDefault()` **before** checking whether a form field was focused. `Alt+ArrowLeft/Right` is the standard macOS / Linux word-by-word cursor navigation shortcut inside text inputs. When a teacher pressed `Alt+ArrowLeft` while typing in any widget settings input, the browser default was suppressed and the dashboard switched boards instead of moving the cursor — a silent, disruptive action during live classroom use.

The same class of bug was previously fixed for `Delete` (PR #1877 added the `isTypingField` guard). The `Alt+Arrow` and `Alt+P` handlers simply weren't updated at the same time.

## Fix

Added the standard `isTypingField` guard (`['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName) || isContentEditable`) at the top of each shortcut block, returning early **before** `e.preventDefault()`. The separate `ArrowLeft` and `ArrowRight` branches were also collapsed into one `if/else` to reduce duplication.

## Band-Aid Rejected

Wrapping only `loadDashboard(...)` in an `if (!isTypingField)` block while leaving `e.preventDefault()` unconditional — this would still suppress the browser's word-navigation behaviour even though the board switch wouldn't happen. The text cursor would be stuck, silently broken.

## Regression Tests

4 new tests in `tests/escapeInteraction.test.tsx`:

| Test | Before fix | After fix |
|---|---|---|
| `Alt+ArrowLeft` does not `preventDefault` / navigate when input focused | **FAIL** | PASS |
| `Alt+ArrowRight` does not `preventDefault` / navigate when input focused | **FAIL** | PASS |
| `Alt+ArrowLeft` DOES `preventDefault` + navigate when no input focused | PASS | PASS |
| `Alt+P` does not `preventDefault` when textarea focused | **FAIL** | PASS |

10/10 tests pass after fix (was 7/10).

## Evidence

- TypeScript: exit 0
- ESLint (layout + common): no warnings/errors
- Prettier: clean
- `tests/escapeInteraction.test.tsx`: 10/10 pass

## Risk

**contained** — guard added to two shortcut blocks in one handler function in `DashboardView.tsx`. No state, no Firestore, no component hierarchy changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01US1gVX7fL5buF5eLJoxqvv)_