### PR TITLE
fix(nrpsStore): preserve contextTitle when privacy-configured LTI relaunch omits it

### DIFF
--- a/functions/src/lti/nrpsStore.test.ts
+++ b/functions/src/lti/nrpsStore.test.ts
@@ -322,6 +322,48 @@ describe('persistLtiLaunchContext — quiz', () => {
     expect(writeAt('users/teacher-1/lti_seen_sections/')).toBeUndefined();
   });
 
+  it('does not clobber the context membership doc title when a relaunch omits it', async () => {
+    // Regression: a privacy-configured Schoology relaunch (contextTitle: null)
+    // was overwriting the previously-stored contextTitle in the membership doc
+    // with null, clearing the section name shown in the linking UI. The fix
+    // applies the same "prefer stored title" logic that the seen-section
+    // inventory already uses (args.contextTitle ?? storedTitle).
+    quizSessions = [
+      {
+        id: 'sess-1',
+        data: {
+          code: 'ABC123',
+          status: 'active',
+          startedAt: 100,
+          teacherUid: 'teacher-1',
+          periodNames: ['Math 7'],
+          classPeriodByClassId: { 'schoology:ctx-1': 'Math 7' },
+          ltiAttachment: { resourceLinkId: 'rl-1', contextId: 'ctx-1' },
+          ltiNrps: true,
+        },
+      },
+    ];
+    contextDocs.set(
+      `${LTI_SESSION_MEMBERSHIPS_COLLECTION}/sess-1/contexts/ctx-1`,
+      { contextMembershipsUrl: QUIZ_ARGS.membershipUrl, contextTitle: 'Math 7' }
+    );
+    seenDocs.set('users/teacher-1/lti_seen_sections/ctx-1', {
+      contextId: 'ctx-1',
+      contextTitle: 'Math 7',
+      sessionId: 'sess-1',
+      kind: 'quiz',
+    });
+    // A relaunch with no title should produce ZERO writes: the membership URL
+    // is unchanged, the stored title is preserved (not clobbered to null), and
+    // the seen-section inventory is already current.
+    await persistLtiLaunchContext(db(), { ...QUIZ_ARGS, contextTitle: null });
+    // Neither the context membership doc nor anything else should be rewritten.
+    expect(
+      writeAt(`${LTI_SESSION_MEMBERSHIPS_COLLECTION}/sess-1/contexts/`)
+    ).toBeUndefined();
+    expect(writes).toHaveLength(0);
+  });
+
   it('skips the archive mirror when the session has no teacherUid', async () => {
     quizSessions = [
       {

--- a/functions/src/lti/nrpsStore.ts
+++ b/functions/src/lti/nrpsStore.ts
@@ -176,17 +176,26 @@ export async function persistLtiLaunchContext(
       .doc(contextId);
     const existing = await ctxRef.get();
     const ex = existing.data();
+    // Prefer the stored title over a null from a privacy-configured relaunch:
+    // some Schoology deployments omit the context title on relaunches (privacy
+    // config). Overwriting a previously-captured title with null would clear
+    // the section name shown in the linking UI permanently until a titled
+    // launch occurs again — the same preservation logic the seen-section
+    // inventory (below) already applies to its own copy.
+    const storedCtxTitle =
+      typeof ex?.contextTitle === 'string' ? ex.contextTitle : null;
+    const nextCtxTitle = args.contextTitle ?? storedCtxTitle;
     // Only write when new or changed — bounds writes to actual changes.
     if (
       !existing.exists ||
       ex?.contextMembershipsUrl !== membershipUrl ||
-      ex?.contextTitle !== (args.contextTitle ?? null)
+      ex?.contextTitle !== nextCtxTitle
     ) {
       batch.set(
         ctxRef,
         {
           contextMembershipsUrl: membershipUrl,
-          contextTitle: args.contextTitle ?? null,
+          contextTitle: nextCtxTitle,
           deploymentId: args.deploymentId,
           updatedAt: Date.now(),
         },


### PR DESCRIPTION
## Root Cause

`persistLtiLaunchContext` (`functions/src/lti/nrpsStore.ts`) wrote the context membership document with:

```typescript
contextTitle: args.contextTitle ?? null
```

Some Schoology deployments with privacy settings configured omit `contextTitle` on relaunches — `args.contextTitle` is `null`. On any such relaunch, the previously-stored section name was overwritten with `null`, permanently clearing the section name displayed in the LTI class linking UI until a full titled launch occurred again.

The seen-section inventory written by the same function already applied the correct preservation logic (`args.contextTitle ?? storedTitle`) — the context membership doc path simply missed it.

## Fix

Before writing, load the stored title as a fallback:

```typescript
const storedCtxTitle =
  typeof ex?.contextTitle === 'string' ? ex.contextTitle : null;
const nextCtxTitle = args.contextTitle ?? storedCtxTitle;
```

Then use `nextCtxTitle` in both the change-detection guard and the write payload. As a bonus, a no-change privacy relaunch (URL unchanged, title preserved) now correctly produces **zero Firestore writes** instead of an unnecessary overwrite.

## Band-Aid Rejected

Adding `contextTitle: args.contextTitle ?? ex?.contextTitle ?? null` only in the write payload, without updating the change-detection guard — rejected because the guard would still see `'Math 7' !== null` and trigger a write when the effective value is unchanged, wasting a Firestore write and resetting `updatedAt` unnecessarily.

## Regression Test

New test in `functions/src/lti/nrpsStore.test.ts`:

**"does not clobber the context membership doc title when a relaunch omits it"**

- Sets up an existing context doc (`contextTitle: 'Math 7'`, URL unchanged)
- Calls `persistLtiLaunchContext` with `contextTitle: null`
- Asserts `writes.length === 0` (no Firestore writes occurred)

**Before fix**: 1 test fails — the relaunch triggers a write that sets `contextTitle: null` (write count = 1, not 0)  
**After fix**: 12/12 tests pass

## Evidence

- TypeScript: exit 0
- ESLint: clean
- Prettier: no changes needed
- Functions tests: 27/27 files, 516/516 tests pass (1 new test vs 515 baseline)

## Risk

**contained** — change is in a single Cloud Function helper. Only affects the LTI context membership doc write path; no student data, auth, or other collections touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01US1gVX7fL5buF5eLJoxqvv)_