### PR TITLE
fix(D4): library/ Modal imports → @/ alias

### DIFF
--- a/components/common/library/AssignModal.tsx
+++ b/components/common/library/AssignModal.tsx
@@ -21,7 +21,7 @@
 
 import React, { useCallback, useState } from 'react';
 import { Loader2, Rocket } from 'lucide-react';
-import { Modal } from '../Modal';
+import { Modal } from '@/components/common/Modal';
 import type { AssignModalProps, AssignModeOption } from './types';
 
 const MODAL_LABEL_ID = 'assign-modal-title';

--- a/components/common/library/ViewOnlyShareModal.tsx
+++ b/components/common/library/ViewOnlyShareModal.tsx
@@ -35,7 +35,7 @@ import {
   ExternalLink,
   X,
 } from 'lucide-react';
-import { Modal } from '../Modal';
+import { Modal } from '@/components/common/Modal';
 
 export interface ViewOnlyShareModalProps {
   /** The thing being shared (quiz title, set title, activity title). */

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -27,7 +27,7 @@ import {
   Sparkles,
   X,
 } from 'lucide-react';
-import { Modal } from '../../Modal';
+import { Modal } from '@/components/common/Modal';
 import type {
   ImportAdapter,
   ImportSourceKind,


### PR DESCRIPTION
## Canonical form

`import { Modal } from '@/components/common/Modal'`

The `@/` alias maps to the repo root, so this resolves identically to `'../Modal'` (from `library/`) and `'../../Modal'` (from `library/importer/`).

## Instances unified

| File | Old import | New import |
|---|---|---|
| `components/common/library/ViewOnlyShareModal.tsx` | `'../Modal'` | `'@/components/common/Modal'` |
| `components/common/library/AssignModal.tsx` | `'../Modal'` | `'@/components/common/Modal'` |
| `components/common/library/importer/ImportWizard.tsx` | `'../../Modal'` | `'@/components/common/Modal'` |

The within-feature `import { ... } from '../types'` in ImportWizard.tsx (D4-E2) was intentionally left alone — it resolves to `library/types.ts` within the same feature subdirectory.

## Enforcement

D4 canon is the enforcement layer. All known anti-patterns in `components/common/library/` are now resolved. The existing ESLint import alias configuration already catches new cross-directory relative imports on new code.

## Behavior preservation evidence

Pure alias substitution — `@/components/common/Modal` resolves to the identical file as the relative paths. No runtime behavior, API surface, or component behavior changes. tsc + eslint both clean.

**Risk tag: mechanical** (pure equivalence — alias resolution only)

---

_Nightly unifier run 11 · 2026-06-09 · D4 Import Path Convention_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WN84M2ZFM958jrh19H8uDP)_