### PR TITLE
Guided Learning: media pipeline overhaul, GIF/MP4 slides, and screen capture studio

### DIFF
--- a/components/guidedLearning/GuidedLearningStudentApp.tsx
+++ b/components/guidedLearning/GuidedLearningStudentApp.tsx
@@ -362,6 +362,7 @@ const StudentExperience: React.FC<{ anonymousUid: string }> = ({
     id: session.id,
     title: session.title,
     imageUrls: session.imageUrls,
+    imageKinds: session.imageKinds,
     steps: session.publicSteps,
     mode: session.mode,
     createdAt: session.createdAt,

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
@@ -19,13 +19,19 @@ import {
   Activity,
   ArrowLeftRight,
   MessageSquare,
+  Camera,
+  Circle,
+  Film,
+  MonitorUp,
   type LucideIcon,
 } from 'lucide-react';
 import { GuidedLearningMode } from '@/types';
 import { SortableList } from '@/components/common/SortableList';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { Z_INDEX } from '@/config/zIndex';
+import { GL_MEDIA_ACCEPT } from '@/utils/guidedLearningMedia';
 import { GuidedLearningStepEditor } from './GuidedLearningStepEditor';
+import { ScreenCaptureModal, type CaptureMode } from './ScreenCaptureModal';
 import { calculateImageFootprint } from '../utils/imageUtils';
 import type { GuidedLearningEditorController } from './useGuidedLearningEditorState';
 
@@ -364,6 +370,7 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const imageContainerRef = useRef<HTMLDivElement>(null);
   const imageRef = useRef<HTMLImageElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   // Title + folder are owned by the modal shell now (editable header
   // input + header folder icon button), so the body destructures only
@@ -382,11 +389,14 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
     welcomeMessage,
     setWelcomeMessage,
     imageUrls,
+    imageKinds,
     currentImageIndex,
     setCurrentImageIndex,
     uploading,
+    uploadProgress,
     uploadFromFiles,
     uploadFromClipboard,
+    addCapturedMedia,
     deleteImage,
     moveImage,
     imageError,
@@ -401,6 +411,9 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
   } = state;
 
   const currentImageUrl = imageUrls[currentImageIndex] ?? '';
+  const currentKind = imageKinds[currentImageIndex] ?? 'image';
+  const [dragActive, setDragActive] = useState(false);
+  const [captureMode, setCaptureMode] = useState<CaptureMode | null>(null);
 
   const [imgBounds, setImgBounds] = useState<{
     offsetLeft: number;
@@ -410,13 +423,22 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
   } | null>(null);
 
   const measureImage = useCallback(() => {
-    if (!imageRef.current || !imageContainerRef.current) {
+    // Measure whichever media element is currently rendered. Video slides
+    // expose their natural size via videoWidth/videoHeight instead.
+    const media = imageRef.current ?? videoRef.current;
+    if (!media || !imageContainerRef.current) {
       setImgBounds(null);
       return;
     }
+    const naturalW =
+      media instanceof HTMLVideoElement ? media.videoWidth : media.naturalWidth;
+    const naturalH =
+      media instanceof HTMLVideoElement
+        ? media.videoHeight
+        : media.naturalHeight;
     const footprint = calculateImageFootprint(
-      imageRef.current.naturalWidth,
-      imageRef.current.naturalHeight,
+      naturalW,
+      naturalH,
       imageContainerRef.current.getBoundingClientRect().width,
       imageContainerRef.current.getBoundingClientRect().height
     );
@@ -435,6 +457,58 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
     if (files.length === 0) return;
     await uploadFromFiles(files);
     e.target.value = '';
+  };
+
+  // Native paste support — Ctrl/Cmd+V anywhere in the editor adds the
+  // clipboard image as a slide (more reliable than the async Clipboard API
+  // behind the Paste button, which needs a permission prompt). Skips events
+  // that originate in inputs so pasting text into fields still works.
+  useEffect(() => {
+    const onPaste = (e: ClipboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const files = Array.from(e.clipboardData?.files ?? []).filter((f) =>
+        f.type.startsWith('image/')
+      );
+      if (files.length === 0) return;
+      e.preventDefault();
+      void uploadFromFiles(files);
+    };
+    window.addEventListener('paste', onPaste);
+    return () => window.removeEventListener('paste', onPaste);
+  }, [uploadFromFiles]);
+
+  // Drag-and-drop — the entire canvas column is a drop target. The counter
+  // ref avoids flicker from dragenter/dragleave firing on child elements.
+  const dragDepthRef = useRef(0);
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+    dragDepthRef.current += 1;
+    setDragActive(true);
+  };
+  const handleDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setDragActive(false);
+  };
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('Files')) return;
+    e.preventDefault();
+  };
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    dragDepthRef.current = 0;
+    setDragActive(false);
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length > 0) void uploadFromFiles(files);
   };
 
   const handleImageClick = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -528,24 +602,42 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
       </div>
 
       {/* Canvas */}
-      <div className="flex-1 min-h-0 px-5 py-4 flex flex-col gap-3 bg-slate-50">
+      <div
+        className="flex-1 min-h-0 px-5 py-4 flex flex-col gap-3 bg-slate-50 relative"
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
+        {dragActive && (
+          <div className="absolute inset-2 z-40 rounded-xl border-2 border-dashed border-brand-blue-primary bg-brand-blue-primary/10 backdrop-blur-[2px] flex items-center justify-center pointer-events-none">
+            <span className="bg-brand-blue-primary text-white text-sm font-bold rounded-lg shadow-lg px-4 py-2 flex items-center gap-2">
+              <Upload className="w-4 h-4" />
+              Drop images, GIFs, or videos to add slides
+            </span>
+          </div>
+        )}
         {imageUrls.length > 0 ? (
           <>
             {imageUrls.length > 1 && (
               <div className="flex flex-wrap gap-1.5 shrink-0">
-                {imageUrls.map((url, idx) => (
-                  <button
-                    key={url}
-                    onClick={() => setCurrentImageIndex(idx)}
-                    className={`px-2.5 py-1 rounded-md text-xs font-bold border transition-colors ${
-                      idx === currentImageIndex
-                        ? 'border-brand-blue-primary bg-brand-blue-primary text-white'
-                        : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400'
-                    }`}
-                  >
-                    Image {idx + 1}
-                  </button>
-                ))}
+                {imageUrls.map((url, idx) => {
+                  const isVideo = (imageKinds[idx] ?? 'image') === 'video';
+                  return (
+                    <button
+                      key={url}
+                      onClick={() => setCurrentImageIndex(idx)}
+                      className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-bold border transition-colors ${
+                        idx === currentImageIndex
+                          ? 'border-brand-blue-primary bg-brand-blue-primary text-white'
+                          : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400'
+                      }`}
+                    >
+                      {isVideo && <Film className="w-3 h-3" aria-hidden />}
+                      Slide {idx + 1}
+                    </button>
+                  );
+                })}
               </div>
             )}
 
@@ -555,14 +647,28 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
               onClick={handleImageClick}
               data-no-drag={addingStep ? 'true' : undefined}
             >
-              <img
-                ref={imageRef}
-                src={currentImageUrl}
-                alt="Current step image"
-                className="w-full h-full object-contain"
-                draggable={false}
-                onLoad={measureImage}
-              />
+              {currentKind === 'video' ? (
+                <video
+                  key={currentImageUrl}
+                  ref={videoRef}
+                  src={currentImageUrl}
+                  muted
+                  loop
+                  autoPlay
+                  playsInline
+                  className="w-full h-full object-contain"
+                  onLoadedMetadata={measureImage}
+                />
+              ) : (
+                <img
+                  ref={imageRef}
+                  src={currentImageUrl}
+                  alt="Current step image"
+                  className="w-full h-full object-contain"
+                  draggable={false}
+                  onLoad={measureImage}
+                />
+              )}
               {currentImageSteps.map((s) => {
                 const globalIndex = steps.findIndex((x) => x.id === s.id);
                 return (
@@ -608,13 +714,36 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
                 <p className="font-medium">Uploading…</p>
               </div>
             ) : (
-              <div className="flex flex-col items-center gap-2 text-slate-500">
+              <div className="flex flex-col items-center gap-2 text-slate-500 px-6">
                 <ImageIcon className="w-10 h-10" />
-                <p className="font-medium">Add an image to get started</p>
+                <p className="font-medium">Add media to get started</p>
                 <p className="text-xs">
-                  PNG, JPG, GIF, or paste from clipboard
+                  Drag &amp; drop or paste (Ctrl+V) screenshots, GIFs, or MP4
+                  clips — or capture your screen below.
                 </p>
               </div>
+            )}
+          </div>
+        )}
+
+        {uploadProgress && (
+          <div className="flex items-center gap-2 text-xs font-bold text-brand-blue-primary shrink-0">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            <span className="truncate">
+              Uploading {uploadProgress.fileName} ({uploadProgress.current} of{' '}
+              {uploadProgress.total}
+              {uploadProgress.percent !== null
+                ? ` · ${uploadProgress.percent}%`
+                : ''}
+              )
+            </span>
+            {uploadProgress.percent !== null && (
+              <span className="flex-1 max-w-[160px] h-1.5 rounded-full bg-slate-200 overflow-hidden">
+                <span
+                  className="block h-full bg-brand-blue-primary rounded-full transition-all"
+                  style={{ width: `${uploadProgress.percent}%` }}
+                />
+              </span>
             )}
           </div>
         )}
@@ -626,7 +755,7 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
         <input
           ref={fileInputRef}
           type="file"
-          accept="image/*"
+          accept={GL_MEDIA_ACCEPT}
           multiple
           className="hidden"
           onChange={handleFileSelect}
@@ -639,11 +768,13 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
             className="flex items-center gap-1.5 px-3 py-1.5 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg transition-colors text-sm"
           >
             <Upload className="w-4 h-4" />
-            Add image
+            Add media
           </button>
+          <CaptureMenuButton onPick={setCaptureMode} />
           <button
             onClick={() => void uploadFromClipboard()}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-300 hover:border-slate-400 text-slate-700 font-bold rounded-lg transition-colors text-sm"
+            title="Paste an image from your clipboard (or press Ctrl+V anywhere)"
           >
             <Clipboard className="w-4 h-4" />
             Paste
@@ -667,7 +798,7 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
                     onClick={() => moveImage(currentImageIndex, -1)}
                     disabled={currentImageIndex === 0}
                     className="p-1.5 text-slate-500 disabled:opacity-30 hover:bg-slate-200 rounded transition-colors"
-                    aria-label="Move image earlier"
+                    aria-label="Move slide earlier"
                   >
                     <ChevronUp className="w-4 h-4" />
                   </button>
@@ -675,7 +806,7 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
                     onClick={() => moveImage(currentImageIndex, 1)}
                     disabled={currentImageIndex === imageUrls.length - 1}
                     className="p-1.5 text-slate-500 disabled:opacity-30 hover:bg-slate-200 rounded transition-colors"
-                    aria-label="Move image later"
+                    aria-label="Move slide later"
                   >
                     <ChevronDown className="w-4 h-4" />
                   </button>
@@ -684,15 +815,125 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
               <button
                 onClick={() => deleteImage(currentImageIndex)}
                 className={`flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-300 hover:border-red-300 hover:bg-red-50 text-slate-600 hover:text-red-600 font-bold rounded-lg transition-colors text-sm ${imageUrls.length > 1 ? '' : 'ml-auto'}`}
-                aria-label="Delete current image"
+                aria-label="Delete current slide"
               >
                 <Trash2 className="w-4 h-4" />
-                Delete image
+                Delete slide
               </button>
             </>
           )}
         </div>
       </div>
+
+      {captureMode && (
+        <ScreenCaptureModal
+          mode={captureMode}
+          onAddMedia={addCapturedMedia}
+          onClose={() => setCaptureMode(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+// ─── Capture menu (Snap / Record / From video) ───────────────────────────────
+
+const CAPTURE_OPTIONS: {
+  value: CaptureMode;
+  label: string;
+  desc: string;
+  icon: LucideIcon;
+}[] = [
+  {
+    value: 'snap',
+    label: 'Snap screen frames',
+    desc: 'Share your screen and snap a still for each step of a workflow.',
+    icon: Camera,
+  },
+  {
+    value: 'record',
+    label: 'Record your screen',
+    desc: 'Capture the workflow as a video slide.',
+    icon: Circle,
+  },
+  {
+    value: 'video-file',
+    label: 'Slides from a video',
+    desc: 'Extract frames from an MP4/WebM, or add the whole clip.',
+    icon: Film,
+  },
+];
+
+const CAPTURE_MENU_WIDTH = 260;
+
+const CaptureMenuButton: React.FC<{
+  onPick: (mode: CaptureMode) => void;
+}> = ({ onPick }) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  useClickOutside(containerRef, () => setOpen(false), [popoverRef]);
+  const pos = usePopoverPosition(open, triggerRef, CAPTURE_MENU_WIDTH);
+
+  return (
+    <div ref={containerRef} className="relative shrink-0">
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={`flex items-center gap-1.5 px-3 py-1.5 font-bold rounded-lg transition-colors text-sm border ${
+          open
+            ? 'bg-brand-blue-primary/10 border-brand-blue-primary text-brand-blue-primary'
+            : 'bg-white border-slate-300 hover:border-slate-400 text-slate-700'
+        }`}
+      >
+        <MonitorUp className="w-4 h-4" />
+        Capture screen
+        <ChevronDown className="w-3 h-3 text-slate-400" />
+      </button>
+      {open &&
+        pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            role="menu"
+            data-click-outside-ignore="true"
+            className="overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+            style={{
+              position: 'fixed',
+              top: pos.top,
+              left: pos.left,
+              width: CAPTURE_MENU_WIDTH,
+              zIndex: Z_INDEX.modalContent,
+            }}
+          >
+            {CAPTURE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                role="menuitem"
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  onPick(opt.value);
+                }}
+                className="flex w-full items-start gap-2.5 px-3 py-2 text-left text-slate-700 transition-colors hover:bg-slate-100"
+              >
+                <opt.icon className="w-4 h-4 mt-0.5 shrink-0 text-brand-blue-primary" />
+                <span>
+                  <span className="block font-bold text-xs">{opt.label}</span>
+                  <span className="block text-xxs text-slate-500 leading-snug">
+                    {opt.desc}
+                  </span>
+                </span>
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
     </div>
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
@@ -478,11 +478,15 @@ export const GuidedLearningEditorContextPane: React.FC<PaneProps> = ({
         f.type.startsWith('image/')
       );
       if (files.length === 0) return;
+      // preventDefault + capture phase: Dock's global smart-paste handler
+      // respects `e.defaultPrevented`, and capture guarantees this listener
+      // runs first — otherwise a single paste would both add a slide here
+      // and open Dock's image-paste modal.
       e.preventDefault();
       void uploadFromFiles(files);
     };
-    window.addEventListener('paste', onPaste);
-    return () => window.removeEventListener('paste', onPaste);
+    window.addEventListener('paste', onPaste, true);
+    return () => window.removeEventListener('paste', onPaste, true);
   }, [uploadFromFiles]);
 
   // Drag-and-drop — the entire canvas column is a drop target. The counter

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -155,6 +155,13 @@ export const GuidedLearningEditorModal: React.FC<
     () => (set ? [...set.imageUrls] : []),
     [set]
   );
+  // Normalized per-slide kinds (missing entries = 'image') so dirty
+  // comparison is stable for legacy sets without the field.
+  const originalImageKinds = useMemo(
+    () =>
+      set ? set.imageUrls.map((_, i) => set.imageKinds?.[i] ?? 'image') : [],
+    [set]
+  );
   const originalSteps = useMemo(
     () => (set ? structuredClone(set.steps) : []),
     [set]
@@ -193,6 +200,7 @@ export const GuidedLearningEditorModal: React.FC<
       liveState.welcomeEnabled !== originalWelcomeEnabled ||
       liveState.welcomeMessage !== originalWelcomeMessage ||
       !arraysEqual(liveState.imageUrls, originalImageUrls) ||
+      !arraysEqual(liveState.imageKinds, originalImageKinds) ||
       !stepsEqual(liveState.steps, originalSteps)
     );
   }, [
@@ -205,6 +213,7 @@ export const GuidedLearningEditorModal: React.FC<
     originalWelcomeEnabled,
     originalWelcomeMessage,
     originalImageUrls,
+    originalImageKinds,
     originalSteps,
   ]);
 
@@ -218,6 +227,11 @@ export const GuidedLearningEditorModal: React.FC<
         title: liveState.title.trim(),
         description: liveState.description.trim() || undefined,
         imageUrls: liveState.imageUrls,
+        // Only persist kinds when at least one slide is a video — keeps
+        // image-only (and legacy) sets free of the new field.
+        ...(liveState.imageKinds.some((k) => k === 'video')
+          ? { imageKinds: liveState.imageKinds }
+          : {}),
         steps: liveState.steps,
         mode: liveState.mode,
         createdAt: set.createdAt,

--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -44,6 +44,7 @@ import type {
   GuidedLearningSet,
   GuidedLearningSetMetadata,
 } from '@/types';
+import { pickThumbnailUrl } from '@/utils/guidedLearningMedia';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
@@ -306,7 +307,7 @@ const buildLibraryEntries = (
     description: set.description,
     stepCount: set.steps.length,
     mode: set.mode,
-    imageUrl: set.imageUrls[0],
+    imageUrl: pickThumbnailUrl(set),
     updatedAt: set.updatedAt,
     createdAt: set.createdAt,
     buildingSet: set,

--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.test.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.test.tsx
@@ -299,4 +299,54 @@ describe('GuidedLearningPlayer', () => {
       'Second image banner'
     );
   });
+
+  it('renders video slides in a <video> element and skips them when preloading', () => {
+    // Record every Image preload by spying on the prototype src setter.
+    // Not forwarding to the real setter — jsdom would try (and fail) to
+    // fetch the URL; recording it is all the test needs.
+    const imageConstructed: string[] = [];
+    const srcSpy = vi
+      .spyOn(HTMLImageElement.prototype, 'src', 'set')
+      .mockImplementation(function (this: HTMLImageElement, value: string) {
+        imageConstructed.push(value);
+      });
+    try {
+      const set: GuidedLearningSet = {
+        id: 'set-3',
+        title: 'Video Slide Test',
+        imageUrls: [
+          'https://example.com/clip.mp4',
+          'https://example.com/image-1.png',
+        ],
+        imageKinds: ['video', 'image'],
+        steps: [
+          {
+            id: 'step-1',
+            xPct: 50,
+            yPct: 50,
+            imageIndex: 0,
+            interactionType: 'tooltip',
+            text: 'On the video',
+          },
+        ],
+        mode: 'structured',
+        createdAt: 0,
+        updatedAt: 0,
+      };
+
+      const { container } = render(<GuidedLearningPlayer set={set} />);
+
+      // The current slide is a video — rendered via <video>, not <img>.
+      const video = container.querySelector('video');
+      expect(video).not.toBeNull();
+      expect(video?.src).toContain('clip.mp4');
+      expect(screen.queryByAltText('Video Slide Test')).not.toBeInTheDocument();
+
+      // Preloading warms only the image slide; the MP4 streams on demand.
+      expect(imageConstructed).toContain('https://example.com/image-1.png');
+      expect(imageConstructed).not.toContain('https://example.com/clip.mp4');
+    } finally {
+      srcSpy.mockRestore();
+    }
+  });
 });

--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.test.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.test.tsx
@@ -290,7 +290,7 @@ describe('GuidedLearningPlayer', () => {
       screen.queryByRole('button', { name: /step 2/i })
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: /show image 2/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show slide 2/i }));
     expect(image.src).toContain('image-2.png');
 
     fireEvent.click(screen.getByRole('button', { name: /step 2/i }));

--- a/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningPlayer.tsx
@@ -105,6 +105,7 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
+  const videoElRef = useRef<HTMLVideoElement>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const progressRef = useRef(0);
 
@@ -116,15 +117,20 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
   } | null>(null);
 
   const measureImg = useCallback(() => {
-    if (!imgRef.current || !containerRef.current) {
+    // Whichever media element is mounted for the current slide — <img> for
+    // image slides, <video> for video slides.
+    const media = imgRef.current ?? videoElRef.current;
+    if (!media || !containerRef.current) {
       setImgOffset(null);
       return;
     }
 
     const rect = containerRef.current.getBoundingClientRect();
     const footprint = calculateImageFootprint(
-      imgRef.current.naturalWidth,
-      imgRef.current.naturalHeight,
+      media instanceof HTMLVideoElement ? media.videoWidth : media.naturalWidth,
+      media instanceof HTMLVideoElement
+        ? media.videoHeight
+        : media.naturalHeight,
       rect.width,
       rect.height
     );
@@ -160,6 +166,11 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
           Math.max(set.imageUrls.length - 1, 0)
         );
   const currentImageUrl = set.imageUrls[currentImageIndex] ?? set.imageUrls[0];
+  // Per-slide media kind — 'video' slides (uploaded MP4/WebM or screen
+  // recordings) render in a muted looping <video>; missing entries are
+  // images (legacy sets/sessions have no imageKinds field at all).
+  const slideKind: 'image' | 'video' =
+    set.imageKinds?.[currentImageIndex] ?? 'image';
 
   // Image-transition bookkeeping — when `currentImageIndex` changes and a
   // transition is enabled, we briefly render the previous image as an
@@ -181,8 +192,14 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
     const id = setTimeout(() => setPrevImageIndex(null), 500);
     return () => clearTimeout(id);
   }, [prevImageIndex]);
+  // Skip the exit layer when the previous slide was a video — an <img>
+  // can't render a video URL, so the transition falls back to an instant
+  // swap for that case.
   const previousImageUrl =
-    prevImageIndex !== null ? (set.imageUrls[prevImageIndex] ?? null) : null;
+    prevImageIndex !== null &&
+    (set.imageKinds?.[prevImageIndex] ?? 'image') !== 'video'
+      ? (set.imageUrls[prevImageIndex] ?? null)
+      : null;
 
   const toContainerStep = useCallback(
     (step: GuidedLearningPublicStep | null) => {
@@ -206,11 +223,15 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
       : null;
 
   useEffect(() => {
-    for (const url of set.imageUrls) {
+    // Warm the browser cache for image slides so step navigation doesn't
+    // flash. Video slides are intentionally skipped — preloading every MP4
+    // up front would burn bandwidth; the <video> element streams on demand.
+    set.imageUrls.forEach((url, i) => {
+      if ((set.imageKinds?.[i] ?? 'image') === 'video') return;
       const image = new Image();
       image.src = url;
-    }
-  }, [set.imageUrls]);
+    });
+  }, [set.imageUrls, set.imageKinds]);
 
   const goNext = useCallback(() => {
     if (steps.length === 0) return;
@@ -622,9 +643,9 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
                       padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
                       fontSize: 'min(10px, 2.6cqmin)',
                     }}
-                    aria-label={`Show image ${imageIndex + 1}`}
+                    aria-label={`Show slide ${imageIndex + 1}`}
                   >
-                    Image {imageIndex + 1}
+                    Slide {imageIndex + 1}
                   </button>
                 ))}
               </div>
@@ -661,8 +682,23 @@ export const GuidedLearningPlayer: React.FC<Props> = ({
             {/* Current image is always mounted — kept stable across image
                 changes so React doesn't re-create the <img> node, which
                 would invalidate refs held by callers/tests and force a
-                fresh load even when the URL is unchanged. */}
-            {currentImageUrl && (
+                fresh load even when the URL is unchanged. Video slides swap
+                in a muted looping <video> (keyed by URL so the element
+                reloads when the slide changes). */}
+            {currentImageUrl && slideKind === 'video' && (
+              <video
+                key={currentImageUrl}
+                ref={videoElRef}
+                src={currentImageUrl}
+                muted
+                loop
+                autoPlay
+                playsInline
+                className="absolute inset-0 w-full h-full object-contain pointer-events-none"
+                onLoadedMetadata={measureImg}
+              />
+            )}
+            {currentImageUrl && slideKind !== 'video' && (
               <img
                 ref={imgRef}
                 src={currentImageUrl}

--- a/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import React, { useRef, useState } from 'react';
+import { Loader2, Plus, Trash2, Upload } from 'lucide-react';
 import {
   GuidedLearningStep,
   GuidedLearningInteractionType,
   GuidedLearningQuestionType,
 } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { useStorage } from '@/hooks/useStorage';
 
 interface Props {
   step: GuidedLearningStep;
@@ -133,7 +135,7 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
 
         {imageCount >= 2 && (
           <div>
-            <label className={labelClass}>Image</label>
+            <label className={labelClass}>Slide</label>
             <select
               value={step.imageIndex}
               onChange={(e) =>
@@ -143,7 +145,7 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
             >
               {Array.from({ length: imageCount }, (_, i) => (
                 <option key={i} value={i}>
-                  Image {i + 1}
+                  Slide {i + 1}
                 </option>
               ))}
             </select>
@@ -224,33 +226,54 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
           </div>
         )}
 
-        {/* Audio URL */}
+        {/* Audio: upload or external URL */}
         {step.interactionType === 'audio' && (
           <div>
-            <label className={labelClass}>Audio URL</label>
+            <label className={labelClass}>Audio</label>
             <input
               type="url"
               value={step.audioUrl ?? ''}
-              onChange={(e) => update({ audioUrl: e.target.value })}
-              placeholder="Firebase Storage or external audio URL"
+              onChange={(e) =>
+                update({
+                  audioUrl: e.target.value,
+                  audioStoragePath: undefined,
+                })
+              }
+              placeholder="Paste an audio URL (.mp3, .wav, .ogg)…"
               className={inputClass}
             />
-            <p className="text-slate-500 text-xs mt-1">
-              Paste a direct URL to an audio file (.mp3, .wav, .ogg)
-            </p>
+            <StepMediaUpload
+              accept="audio/*"
+              buttonLabel="…or upload an audio file"
+              onUploaded={(url, storagePath) =>
+                update({ audioUrl: url, audioStoragePath: storagePath })
+              }
+            />
           </div>
         )}
 
-        {/* Video URL */}
+        {/* Video: upload or YouTube/external URL */}
         {step.interactionType === 'video' && (
           <div>
-            <label className={labelClass}>Video URL</label>
+            <label className={labelClass}>Video</label>
             <input
               type="url"
               value={step.videoUrl ?? ''}
-              onChange={(e) => update({ videoUrl: e.target.value })}
-              placeholder="YouTube URL or direct video URL"
+              onChange={(e) =>
+                update({
+                  videoUrl: e.target.value,
+                  videoStoragePath: undefined,
+                })
+              }
+              placeholder="Paste a YouTube or direct video URL…"
               className={inputClass}
+            />
+            <StepMediaUpload
+              accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+              buttonLabel="…or upload an MP4/WebM file"
+              onUploaded={(url, storagePath) =>
+                update({ videoUrl: url, videoStoragePath: storagePath })
+              }
             />
           </div>
         )}
@@ -421,6 +444,79 @@ export const GuidedLearningStepEditor: React.FC<Props> = ({
           />
         </div>
       </div>
+    </div>
+  );
+};
+
+/**
+ * Inline file-upload row for a step's audio/video media. Uploads to the
+ * user's media path in Firebase Storage (Drive image links can't stream
+ * AV files) and hands back the download URL + storage path.
+ */
+const StepMediaUpload: React.FC<{
+  accept: string;
+  buttonLabel: string;
+  onUploaded: (url: string, storagePath: string) => void;
+}> = ({ accept, buttonLabel, onUploaded }) => {
+  const { user } = useAuth();
+  const { uploadGuidedLearningVideo } = useStorage();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [progress, setProgress] = useState<number | null>(null);
+  const [error, setError] = useState('');
+
+  const handleFile = async (file: File) => {
+    if (!user) return;
+    setError('');
+    setProgress(0);
+    try {
+      const { url, storagePath } = await uploadGuidedLearningVideo(
+        user.uid,
+        file,
+        file.name.replace(/[^\w.-]+/g, '_'),
+        setProgress
+      );
+      onUploaded(url, storagePath);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed.');
+    } finally {
+      setProgress(null);
+    }
+  };
+
+  return (
+    <div className="mt-1.5">
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFile(file);
+          e.target.value = '';
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={progress !== null}
+        className="flex items-center gap-1.5 text-xs font-bold text-brand-blue-primary hover:text-brand-blue-dark disabled:opacity-60 transition-colors"
+      >
+        {progress !== null ? (
+          <>
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Uploading… {progress}%
+          </>
+        ) : (
+          <>
+            <Upload className="w-3.5 h-3.5" />
+            {buttonLabel}
+          </>
+        )}
+      </button>
+      {error && (
+        <p className="text-red-600 text-xs font-medium mt-1">{error}</p>
+      )}
     </div>
   );
 };

--- a/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningStepEditor.tsx
@@ -459,7 +459,7 @@ const StepMediaUpload: React.FC<{
   onUploaded: (url: string, storagePath: string) => void;
 }> = ({ accept, buttonLabel, onUploaded }) => {
   const { user } = useAuth();
-  const { uploadGuidedLearningVideo } = useStorage();
+  const { uploadGuidedLearningMedia } = useStorage();
   const inputRef = useRef<HTMLInputElement>(null);
   const [progress, setProgress] = useState<number | null>(null);
   const [error, setError] = useState('');
@@ -469,7 +469,7 @@ const StepMediaUpload: React.FC<{
     setError('');
     setProgress(0);
     try {
-      const { url, storagePath } = await uploadGuidedLearningVideo(
+      const { url, storagePath } = await uploadGuidedLearningMedia(
         user.uid,
         file,
         file.name.replace(/[^\w.-]+/g, '_'),

--- a/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
+++ b/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
@@ -1,0 +1,439 @@
+/**
+ * ScreenCaptureModal — the Guided Learning "capture studio".
+ *
+ * Three ways to turn a real on-screen workflow into walkthrough slides
+ * without leaving the editor:
+ *   - Snap frames: share a screen/window/tab, then snap a still per step
+ *     of the workflow. Each snap becomes a slide immediately, so a teacher
+ *     can click through a website and capture every state in one pass.
+ *   - Record screen: capture the workflow as a WebM screen recording and
+ *     add it as a single video slide.
+ *   - From a video file: load a local MP4/WebM, scrub to any moment and
+ *     extract it as an image slide — or add the whole clip as a video slide.
+ *
+ * All output funnels through `onAddMedia`, which uploads via the editor
+ * state's normal slide pipeline (compression, progress, kinds tracking).
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Camera,
+  Circle,
+  Film,
+  Loader2,
+  MonitorUp,
+  Square,
+  Upload,
+  X,
+} from 'lucide-react';
+import { Z_INDEX } from '@/config/zIndex';
+import type { GuidedLearningMediaKind } from '@/utils/guidedLearningMedia';
+
+export type CaptureMode = 'snap' | 'record' | 'video-file';
+
+interface Props {
+  mode: CaptureMode;
+  onAddMedia: (
+    blob: Blob,
+    kind: GuidedLearningMediaKind,
+    baseName: string
+  ) => Promise<void>;
+  onClose: () => void;
+}
+
+const MODE_TITLES: Record<CaptureMode, string> = {
+  snap: 'Snap screen frames',
+  record: 'Record your screen',
+  'video-file': 'Slides from a video',
+};
+
+const MODE_HINTS: Record<CaptureMode, string> = {
+  snap: 'Share a window or tab, walk through your workflow, and snap a frame for each step. Every snap becomes a slide.',
+  record:
+    'Share a window or tab and record the workflow. The recording is added as a single video slide.',
+  'video-file':
+    'Open a video file, scrub to a moment, and extract it as an image slide — or add the whole clip as a video slide.',
+};
+
+function formatDuration(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = Math.floor(totalSeconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** Draw the current frame of a <video> element to a PNG blob. */
+async function grabFrame(video: HTMLVideoElement): Promise<Blob | null> {
+  const w = video.videoWidth;
+  const h = video.videoHeight;
+  if (w === 0 || h === 0) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.drawImage(video, 0, 0, w, h);
+  return new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+}
+
+export const ScreenCaptureModal: React.FC<Props> = ({
+  mode,
+  onAddMedia,
+  onClose,
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const fileUrlRef = useRef<string | null>(null);
+
+  const [sharing, setSharing] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [recordSeconds, setRecordSeconds] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [addedCount, setAddedCount] = useState(0);
+  const [error, setError] = useState('');
+  const [videoFile, setVideoFile] = useState<File | null>(null);
+  const [snapFlash, setSnapFlash] = useState(false);
+
+  const stopStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    setSharing(false);
+  }, []);
+
+  // Tear down screen share / recording / object URLs when the modal closes.
+  useEffect(() => {
+    return () => {
+      if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+        recorderRef.current.stop();
+      }
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      if (fileUrlRef.current) URL.revokeObjectURL(fileUrlRef.current);
+    };
+  }, []);
+
+  // Recording duration ticker.
+  useEffect(() => {
+    if (!recording) return;
+    const id = window.setInterval(
+      () => setRecordSeconds((prev) => prev + 1),
+      1000
+    );
+    return () => window.clearInterval(id);
+  }, [recording]);
+
+  const startShare = useCallback(async () => {
+    setError('');
+    try {
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        // Audio only matters for recordings; harmless for snaps if denied.
+        audio: mode === 'record',
+      });
+      streamRef.current = stream;
+      setSharing(true);
+      stream.getVideoTracks()[0].onended = () => {
+        // User stopped sharing from the browser UI.
+        if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+          recorderRef.current.stop();
+        }
+        stopStream();
+      };
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play().catch(() => undefined);
+      }
+    } catch {
+      setError(
+        'Screen sharing was cancelled or blocked. Allow screen sharing and try again.'
+      );
+    }
+  }, [mode, stopStream]);
+
+  const handleSnap = useCallback(async () => {
+    if (!videoRef.current || busy) return;
+    setBusy(true);
+    setError('');
+    try {
+      const blob = await grabFrame(videoRef.current);
+      if (!blob) {
+        setError('Could not capture a frame — try sharing again.');
+        return;
+      }
+      setSnapFlash(true);
+      window.setTimeout(() => setSnapFlash(false), 250);
+      await onAddMedia(blob, 'image', `screen-step-${Date.now()}`);
+      setAddedCount((prev) => prev + 1);
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, onAddMedia]);
+
+  const startRecording = useCallback(() => {
+    const stream = streamRef.current;
+    if (!stream) return;
+    setError('');
+    chunksRef.current = [];
+    const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9')
+      ? 'video/webm;codecs=vp9'
+      : 'video/webm';
+    const recorder = new MediaRecorder(stream, { mimeType });
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunksRef.current.push(e.data);
+    };
+    recorder.onstop = () => {
+      const blob = new Blob(chunksRef.current, { type: 'video/webm' });
+      chunksRef.current = [];
+      setRecording(false);
+      stopStream();
+      if (blob.size === 0) {
+        setError('The recording came back empty — try again.');
+        return;
+      }
+      setBusy(true);
+      void onAddMedia(blob, 'video', `screen-recording-${Date.now()}`)
+        .then(() => setAddedCount((prev) => prev + 1))
+        .finally(() => setBusy(false));
+    };
+    recorderRef.current = recorder;
+    recorder.start();
+    setRecordSeconds(0);
+    setRecording(true);
+  }, [onAddMedia, stopStream]);
+
+  const stopRecording = useCallback(() => {
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      recorderRef.current.stop();
+    }
+  }, []);
+
+  const handleVideoFile = useCallback((file: File) => {
+    setError('');
+    if (fileUrlRef.current) URL.revokeObjectURL(fileUrlRef.current);
+    const url = URL.createObjectURL(file);
+    fileUrlRef.current = url;
+    setVideoFile(file);
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+      videoRef.current.src = url;
+    }
+  }, []);
+
+  const handleAddWholeVideo = useCallback(async () => {
+    if (!videoFile || busy) return;
+    setBusy(true);
+    try {
+      await onAddMedia(
+        videoFile,
+        'video',
+        videoFile.name.replace(/\.[^.]+$/, '') || 'video-slide'
+      );
+      setAddedCount((prev) => prev + 1);
+    } finally {
+      setBusy(false);
+    }
+  }, [videoFile, busy, onAddMedia]);
+
+  const showPreview = sharing || videoFile !== null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 bg-slate-950/70 backdrop-blur-sm flex items-center justify-center p-4"
+      style={{ zIndex: Z_INDEX.modalNested }}
+      role="dialog"
+      aria-modal="true"
+      aria-label={MODE_TITLES[mode]}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden max-h-[90vh]">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-5 py-4 border-b border-slate-200">
+          <div className="min-w-0">
+            <h3 className="text-base font-bold text-slate-900 flex items-center gap-2">
+              {mode === 'snap' ? (
+                <Camera className="w-4 h-4 text-brand-blue-primary" />
+              ) : mode === 'record' ? (
+                <Circle className="w-4 h-4 text-brand-red-primary" />
+              ) : (
+                <Film className="w-4 h-4 text-brand-blue-primary" />
+              )}
+              {MODE_TITLES[mode]}
+            </h3>
+            <p className="text-xs text-slate-500 mt-1 leading-snug">
+              {MODE_HINTS[mode]}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="shrink-0 p-1.5 rounded-lg text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+            aria-label="Close capture"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Preview area */}
+        <div className="relative bg-slate-900 aspect-video shrink min-h-0">
+          <video
+            ref={videoRef}
+            muted={mode !== 'video-file'}
+            playsInline
+            controls={mode === 'video-file' && videoFile !== null}
+            className={`w-full h-full object-contain ${showPreview ? '' : 'hidden'}`}
+          />
+          {snapFlash && (
+            <div className="absolute inset-0 bg-white/80 pointer-events-none" />
+          )}
+          {recording && (
+            <div className="absolute top-3 left-3 flex items-center gap-2 bg-black/70 text-white text-xs font-bold rounded-full px-3 py-1.5">
+              <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse motion-reduce:animate-none" />
+              REC {formatDuration(recordSeconds)}
+            </div>
+          )}
+          {!showPreview && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-slate-400">
+              {mode === 'video-file' ? (
+                <>
+                  <Film className="w-10 h-10" />
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg text-sm transition-colors"
+                  >
+                    <Upload className="w-4 h-4" />
+                    Open video file
+                  </button>
+                  <p className="text-xs">MP4 or WebM</p>
+                </>
+              ) : (
+                <>
+                  <MonitorUp className="w-10 h-10" />
+                  <button
+                    onClick={() => void startShare()}
+                    className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-lg text-sm transition-colors"
+                  >
+                    <MonitorUp className="w-4 h-4" />
+                    Share your screen
+                  </button>
+                  <p className="text-xs">
+                    Pick the window or tab with your workflow
+                  </p>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer controls */}
+        <div className="px-5 py-4 border-t border-slate-200 flex flex-wrap items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleVideoFile(file);
+              e.target.value = '';
+            }}
+          />
+
+          {mode === 'snap' && sharing && (
+            <button
+              onClick={() => void handleSnap()}
+              disabled={busy}
+              className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 text-white font-bold rounded-lg text-sm transition-colors"
+            >
+              {busy ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Camera className="w-4 h-4" />
+              )}
+              Snap frame
+            </button>
+          )}
+
+          {mode === 'record' && sharing && !recording && (
+            <button
+              onClick={startRecording}
+              className="flex items-center gap-2 px-4 py-2 bg-brand-red-primary hover:bg-brand-red-dark text-white font-bold rounded-lg text-sm transition-colors"
+            >
+              <Circle className="w-4 h-4 fill-current" />
+              Start recording
+            </button>
+          )}
+          {mode === 'record' && recording && (
+            <button
+              onClick={stopRecording}
+              className="flex items-center gap-2 px-4 py-2 bg-slate-800 hover:bg-slate-700 text-white font-bold rounded-lg text-sm transition-colors"
+            >
+              <Square className="w-4 h-4 fill-current" />
+              Stop &amp; add slide
+            </button>
+          )}
+
+          {mode === 'video-file' && videoFile && (
+            <>
+              <button
+                onClick={() => {
+                  videoRef.current?.pause();
+                  void handleSnap();
+                }}
+                disabled={busy}
+                className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 text-white font-bold rounded-lg text-sm transition-colors"
+              >
+                {busy ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Camera className="w-4 h-4" />
+                )}
+                Add this frame as a slide
+              </button>
+              <button
+                onClick={() => void handleAddWholeVideo()}
+                disabled={busy}
+                className="flex items-center gap-2 px-4 py-2 bg-white border border-slate-300 hover:border-slate-400 disabled:opacity-50 text-slate-700 font-bold rounded-lg text-sm transition-colors"
+              >
+                <Film className="w-4 h-4" />
+                Add whole video as a slide
+              </button>
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                className="text-xs font-bold text-slate-500 hover:text-slate-700 transition-colors px-2 py-2"
+              >
+                Open a different file
+              </button>
+            </>
+          )}
+
+          {(mode === 'snap' || mode === 'record') && sharing && !recording && (
+            <button
+              onClick={stopStream}
+              className="text-xs font-bold text-slate-500 hover:text-slate-700 transition-colors px-2 py-2"
+            >
+              Stop sharing
+            </button>
+          )}
+
+          <div className="ml-auto flex items-center gap-3">
+            {error && (
+              <span className="text-xs font-medium text-red-600">{error}</span>
+            )}
+            {addedCount > 0 && !error && (
+              <span className="text-xs font-bold text-emerald-700">
+                {addedCount} {addedCount === 1 ? 'slide' : 'slides'} added
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-slate-100 hover:bg-slate-200 text-slate-700 font-bold rounded-lg text-sm transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
+++ b/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
@@ -126,6 +126,12 @@ export const ScreenCaptureModal: React.FC<Props> = ({
 
   const startShare = useCallback(async () => {
     setError('');
+    // getDisplayMedia is absent in insecure contexts (plain HTTP) and some
+    // embedded/mobile browsers — fail with a message instead of a TypeError.
+    if (!navigator.mediaDevices?.getDisplayMedia) {
+      setError('Screen sharing is not supported in this browser or context.');
+      return;
+    }
     try {
       const stream = await navigator.mediaDevices.getDisplayMedia({
         video: true,
@@ -175,6 +181,10 @@ export const ScreenCaptureModal: React.FC<Props> = ({
     const stream = streamRef.current;
     if (!stream) return;
     setError('');
+    if (typeof MediaRecorder === 'undefined') {
+      setError('Screen recording is not supported in this browser.');
+      return;
+    }
     chunksRef.current = [];
     const mimeType = MediaRecorder.isTypeSupported('video/webm;codecs=vp9')
       ? 'video/webm;codecs=vp9'
@@ -237,6 +247,9 @@ export const ScreenCaptureModal: React.FC<Props> = ({
   }, [videoFile, busy, onAddMedia]);
 
   const showPreview = sharing || videoFile !== null;
+
+  // SSR guard — matches the portal pattern used elsewhere in the editor.
+  if (typeof document === 'undefined') return null;
 
   return createPortal(
     <div

--- a/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
+++ b/components/widgets/GuidedLearning/components/ScreenCaptureModal.tsx
@@ -114,6 +114,18 @@ export const ScreenCaptureModal: React.FC<Props> = ({
     };
   }, []);
 
+  // Escape closes the modal (standard modal affordance). Skipped while a
+  // recording is in flight so a stray Escape can't silently discard it.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || recording) return;
+      e.stopPropagation();
+      onClose();
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [recording, onClose]);
+
   // Recording duration ticker.
   useEffect(() => {
     if (!recording) return;

--- a/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
+++ b/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
@@ -124,7 +124,7 @@ export function useGuidedLearningEditorState({
   onFolderChange,
 }: UseGuidedLearningEditorStateProps): GuidedLearningEditorController {
   const { user } = useAuth();
-  const { uploading, uploadHotspotImage, uploadGuidedLearningVideo } =
+  const { uploading, uploadHotspotImage, uploadGuidedLearningMedia } =
     useStorage();
 
   const [title, setTitle] = useState(existingSet?.title ?? '');
@@ -263,7 +263,7 @@ export function useGuidedLearningEditorState({
           });
           try {
             if (kind === 'video') {
-              const { url } = await uploadGuidedLearningVideo(
+              const { url } = await uploadGuidedLearningMedia(
                 user.uid,
                 file,
                 file.name.replace(/[^\w.-]+/g, '_'),
@@ -291,7 +291,7 @@ export function useGuidedLearningEditorState({
       }
       if (errors.length > 0) setImageError(errors.join(' '));
     },
-    [user, uploadHotspotImage, uploadGuidedLearningVideo, appendSlides]
+    [user, uploadHotspotImage, uploadGuidedLearningMedia, appendSlides]
   );
 
   const uploadFromClipboard = useCallback(async () => {

--- a/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
+++ b/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   GuidedLearningSet,
   GuidedLearningMode,
@@ -8,6 +8,13 @@ import {
 } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useStorage } from '@/hooks/useStorage';
+import {
+  getMediaKind,
+  prepareImageForUpload,
+  validateSlideFile,
+  videoExtensionForMime,
+  type GuidedLearningMediaKind,
+} from '@/utils/guidedLearningMedia';
 
 /** State emitted by `onStateChange` so a parent modal can track dirty state. */
 export interface GuidedLearningEditorState {
@@ -15,12 +22,23 @@ export interface GuidedLearningEditorState {
   description: string;
   mode: GuidedLearningMode;
   imageUrls: string[];
+  imageKinds: GuidedLearningMediaKind[];
   steps: GuidedLearningStep[];
   uploading: boolean;
   hotspotPulse: 'consistent' | 'reminder' | 'off';
   imageTransition: 'none' | 'slide' | 'fade';
   welcomeEnabled: boolean;
   welcomeMessage: string;
+}
+
+/** Live progress for the slide-upload pipeline (null when idle). */
+export interface SlideUploadProgress {
+  /** 1-based index of the file currently uploading. */
+  current: number;
+  total: number;
+  fileName: string;
+  /** 0–100 within the current file; null when the backend can't report. */
+  percent: number | null;
 }
 
 interface UseGuidedLearningEditorStateProps {
@@ -49,13 +67,21 @@ export interface GuidedLearningEditorController {
   setWelcomeEnabled: (next: boolean) => void;
   welcomeMessage: string;
   setWelcomeMessage: (next: string) => void;
-  // Images
+  // Slides (images, GIFs, and uploaded/recorded videos)
   imageUrls: string[];
+  imageKinds: GuidedLearningMediaKind[];
   currentImageIndex: number;
   setCurrentImageIndex: (next: number) => void;
   uploading: boolean;
+  uploadProgress: SlideUploadProgress | null;
   uploadFromFiles: (files: File[]) => Promise<void>;
   uploadFromClipboard: () => Promise<void>;
+  /** Add an editor-captured blob (screen snap / recording) as a new slide. */
+  addCapturedMedia: (
+    blob: Blob,
+    kind: GuidedLearningMediaKind,
+    baseName: string
+  ) => Promise<void>;
   deleteImage: (index: number) => void;
   moveImage: (fromIndex: number, direction: -1 | 1) => void;
   imageError: string;
@@ -80,6 +106,12 @@ export interface GuidedLearningEditorController {
   currentImageSteps: GuidedLearningStep[];
 }
 
+/** Normalize a set's persisted kinds array to align with its imageUrls. */
+function kindsForSet(set: GuidedLearningSet | null): GuidedLearningMediaKind[] {
+  if (!set) return [];
+  return set.imageUrls.map((_, i) => set.imageKinds?.[i] ?? 'image');
+}
+
 /**
  * Owns all state for the Guided Learning editor. Returned as a controller
  * object that the modal hands to the context + detail pane components.
@@ -92,7 +124,8 @@ export function useGuidedLearningEditorState({
   onFolderChange,
 }: UseGuidedLearningEditorStateProps): GuidedLearningEditorController {
   const { user } = useAuth();
-  const { uploading, uploadHotspotImage } = useStorage();
+  const { uploading, uploadHotspotImage, uploadGuidedLearningVideo } =
+    useStorage();
 
   const [title, setTitle] = useState(existingSet?.title ?? '');
   const [description, setDescription] = useState(
@@ -104,6 +137,9 @@ export function useGuidedLearningEditorState({
   const [imageUrls, setImageUrls] = useState<string[]>(
     existingSet?.imageUrls ?? []
   );
+  const [imageKinds, setImageKinds] = useState<GuidedLearningMediaKind[]>(() =>
+    kindsForSet(existingSet)
+  );
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
   const [steps, setSteps] = useState<GuidedLearningStep[]>(
     existingSet?.steps ?? []
@@ -111,6 +147,8 @@ export function useGuidedLearningEditorState({
   const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
   const [imageError, setImageError] = useState('');
   const [addingStep, setAddingStep] = useState(false);
+  const [uploadProgress, setUploadProgress] =
+    useState<SlideUploadProgress | null>(null);
   const [hotspotPulse, setHotspotPulse] = useState<
     'consistent' | 'reminder' | 'off'
   >(existingSet?.hotspotPulse ?? 'consistent');
@@ -135,11 +173,13 @@ export function useGuidedLearningEditorState({
     setDescription(existingSet?.description ?? '');
     setMode(existingSet?.mode ?? 'structured');
     setImageUrls(existingSet?.imageUrls ?? []);
+    setImageKinds(kindsForSet(existingSet));
     setCurrentImageIndex(0);
     setSteps(existingSet?.steps ?? []);
     setSelectedStepId(null);
     setImageError('');
     setAddingStep(false);
+    setUploadProgress(null);
     setHotspotPulse(existingSet?.hotspotPulse ?? 'consistent');
     setImageTransition(existingSet?.imageTransition ?? 'none');
     setWelcomeEnabled(Boolean(existingSet?.welcomeEnabled));
@@ -152,6 +192,7 @@ export function useGuidedLearningEditorState({
       description,
       mode,
       imageUrls,
+      imageKinds,
       steps,
       uploading,
       hotspotPulse,
@@ -164,6 +205,7 @@ export function useGuidedLearningEditorState({
     description,
     mode,
     imageUrls,
+    imageKinds,
     steps,
     uploading,
     hotspotPulse,
@@ -173,26 +215,83 @@ export function useGuidedLearningEditorState({
     onStateChange,
   ]);
 
+  // Render-synced mirror of imageUrls.length so the sequential upload loop
+  // (which awaits between appends, letting renders flush) can compute the
+  // new last index without putting a side effect inside a state updater.
+  const slideCountRef = useRef(imageUrls.length);
+  slideCountRef.current = imageUrls.length;
+
+  const appendSlides = useCallback(
+    (urls: string[], kinds: GuidedLearningMediaKind[]) => {
+      if (urls.length === 0) return;
+      setImageUrls((prev) => [...prev, ...urls]);
+      setImageKinds((prev) => [...prev, ...kinds]);
+      // Jump the canvas to the last newly added slide so the teacher can
+      // immediately start placing hotspots on it.
+      setCurrentImageIndex(slideCountRef.current + urls.length - 1);
+    },
+    []
+  );
+
+  /**
+   * Validate, compress, and upload a batch of slide files (images, GIFs,
+   * MP4/WebM videos). Files upload sequentially so the progress indicator
+   * reads "2 of 5" instead of racing five spinners; each successful file is
+   * appended immediately so one bad file doesn't discard the others.
+   */
   const uploadFromFiles = useCallback(
     async (files: File[]) => {
       if (!user || files.length === 0) return;
       setImageError('');
+
+      const errors: string[] = [];
+      const accepted = files.filter((file) => {
+        const error = validateSlideFile(file);
+        if (error) errors.push(error);
+        return !error;
+      });
+
       try {
-        const uploadedUrls = await Promise.all(
-          files.map((file) => uploadHotspotImage(user.uid, file))
-        );
-        if (uploadedUrls.length > 0) {
-          setImageUrls((prev) => [...prev, ...uploadedUrls]);
-          setCurrentImageIndex((prev) =>
-            Math.max(prev, imageUrls.length + uploadedUrls.length - 1)
-          );
+        for (let i = 0; i < accepted.length; i++) {
+          const file = accepted[i];
+          const kind = getMediaKind(file) ?? 'image';
+          setUploadProgress({
+            current: i + 1,
+            total: accepted.length,
+            fileName: file.name,
+            percent: kind === 'video' ? 0 : null,
+          });
+          try {
+            if (kind === 'video') {
+              const { url } = await uploadGuidedLearningVideo(
+                user.uid,
+                file,
+                file.name.replace(/[^\w.-]+/g, '_'),
+                (percent) =>
+                  setUploadProgress((prev) =>
+                    prev ? { ...prev, percent } : prev
+                  )
+              );
+              appendSlides([url], ['video']);
+            } else {
+              const prepared = await prepareImageForUpload(file);
+              const url = await uploadHotspotImage(user.uid, prepared);
+              appendSlides([url], ['image']);
+            }
+          } catch (err) {
+            errors.push(
+              err instanceof Error
+                ? `"${file.name}": ${err.message}`
+                : `"${file.name}" failed to upload.`
+            );
+          }
         }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : 'Upload failed';
-        setImageError(msg);
+      } finally {
+        setUploadProgress(null);
       }
+      if (errors.length > 0) setImageError(errors.join(' '));
     },
-    [user, uploadHotspotImage, imageUrls.length]
+    [user, uploadHotspotImage, uploadGuidedLearningVideo, appendSlides]
   );
 
   const uploadFromClipboard = useCallback(async () => {
@@ -211,10 +310,26 @@ export function useGuidedLearningEditorState({
       setImageError('No image found in clipboard.');
     } catch {
       setImageError(
-        'Could not read clipboard. Try using the file upload instead.'
+        'Could not read clipboard. Try Ctrl+V with the editor focused, or use Add media instead.'
       );
     }
   }, [uploadFromFiles]);
+
+  const addCapturedMedia = useCallback(
+    async (blob: Blob, kind: GuidedLearningMediaKind, baseName: string) => {
+      const ext =
+        kind === 'video'
+          ? videoExtensionForMime(blob.type)
+          : blob.type === 'image/png'
+            ? 'png'
+            : 'webp';
+      const file = new File([blob], `${baseName}.${ext}`, {
+        type: blob.type || (kind === 'video' ? 'video/webm' : 'image/png'),
+      });
+      await uploadFromFiles([file]);
+    },
+    [uploadFromFiles]
+  );
 
   const deleteImage = useCallback(
     (deleteIndex: number) => {
@@ -222,6 +337,7 @@ export function useGuidedLearningEditorState({
         (_, index) => index !== deleteIndex
       );
       setImageUrls(updatedImageUrls);
+      setImageKinds((prev) => prev.filter((_, index) => index !== deleteIndex));
       setCurrentImageIndex((curr) => {
         if (updatedImageUrls.length === 0) return 0;
         if (curr === deleteIndex)
@@ -248,14 +364,16 @@ export function useGuidedLearningEditorState({
     (fromIndex: number, direction: -1 | 1) => {
       const toIndex = fromIndex + direction;
       if (toIndex < 0 || toIndex >= imageUrls.length) return;
-      setImageUrls((prev) => {
+      const swap = <T>(prev: T[]): T[] => {
         const updated = [...prev];
         [updated[fromIndex], updated[toIndex]] = [
           updated[toIndex],
           updated[fromIndex],
         ];
         return updated;
-      });
+      };
+      setImageUrls(swap);
+      setImageKinds(swap);
       setSteps((prev) =>
         prev.map((step) => {
           if (step.imageIndex === fromIndex)
@@ -334,11 +452,14 @@ export function useGuidedLearningEditorState({
     welcomeMessage,
     setWelcomeMessage,
     imageUrls,
+    imageKinds,
     currentImageIndex,
     setCurrentImageIndex,
     uploading,
+    uploadProgress,
     uploadFromFiles,
     uploadFromClipboard,
+    addCapturedMedia,
     deleteImage,
     moveImage,
     imageError,

--- a/hooks/useGuidedLearning.ts
+++ b/hooks/useGuidedLearning.ts
@@ -19,6 +19,7 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
 import { useGoogleDrive } from './useGoogleDrive';
 import { GuidedLearningSet, GuidedLearningSetMetadata } from '@/types';
+import { pickThumbnailUrl } from '@/utils/guidedLearningMedia';
 import { GuidedLearningDriveService } from '@/utils/guidedLearningDriveService';
 import {
   GuidedLearningDriveLike,
@@ -184,7 +185,7 @@ export const useGuidedLearning = (
         description: set.description,
         stepCount: set.steps.length,
         mode: set.mode,
-        imageUrl: updatedSet.imageUrls[0] ?? '',
+        imageUrl: pickThumbnailUrl(updatedSet),
         driveFileId,
         createdAt: set.createdAt,
         updatedAt: updatedSet.updatedAt,
@@ -255,7 +256,7 @@ export const useGuidedLearning = (
           description: fresh.description,
           stepCount: fresh.steps.length,
           mode: fresh.mode,
-          imageUrl: fresh.imageUrls[0] ?? '',
+          imageUrl: pickThumbnailUrl(fresh),
           driveFileId: createdDriveFileId,
           createdAt: fresh.createdAt,
           updatedAt: fresh.updatedAt,

--- a/hooks/useGuidedLearningSession.ts
+++ b/hooks/useGuidedLearningSession.ts
@@ -205,6 +205,11 @@ export const useGuidedLearningSessionTeacher = (
         title: set.title,
         mode: set.mode,
         imageUrls: set.imageUrls,
+        // Mirror per-slide kinds so the student player renders video slides
+        // in a <video> element. Omitted for image-only sets.
+        ...(set.imageKinds?.some((k) => k === 'video')
+          ? { imageKinds: set.imageKinds.slice(0, set.imageUrls.length) }
+          : {}),
         publicSteps,
         teacherUid,
         createdAt: Date.now(),

--- a/hooks/useStorage.ts
+++ b/hooks/useStorage.ts
@@ -144,12 +144,13 @@ export const useStorage = () => {
   };
 
   /**
-   * Upload a guided-learning video slide / step recording. Always writes to
-   * Firebase Storage (never Drive): `lh3.googleusercontent.com` Drive links
-   * only serve images, so a Drive-hosted MP4 can't play in a `<video>` tag.
+   * Upload guided-learning AV media (video slides, screen recordings, and
+   * per-step audio/video files). Always writes to Firebase Storage (never
+   * Drive): `lh3.googleusercontent.com` Drive links only serve images, so a
+   * Drive-hosted MP4/MP3 can't stream in a `<video>`/`<audio>` tag.
    * Reuses the `hotspot_images` path so existing storage rules cover it.
    */
-  const uploadGuidedLearningVideo = async (
+  const uploadGuidedLearningMedia = async (
     userId: string,
     blob: Blob,
     fileName: string,
@@ -407,7 +408,7 @@ export const useStorage = () => {
     uploading,
     uploadFile,
     uploadFileWithProgress,
-    uploadGuidedLearningVideo,
+    uploadGuidedLearningMedia,
     uploadBackgroundImage,
     uploadSticker,
     uploadDisplayImage,

--- a/hooks/useStorage.ts
+++ b/hooks/useStorage.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   ref,
   uploadBytes,
+  uploadBytesResumable,
   getDownloadURL,
   deleteObject,
 } from 'firebase/storage';
@@ -104,6 +105,59 @@ export const useStorage = () => {
       `users/${userId}/display_images/${timestamp}-${file.name}`,
       file
     );
+  };
+
+  /**
+   * Resumable Firebase Storage upload with percent progress (0–100).
+   * Used for large guided-learning media (MP4 slides, screen recordings)
+   * where the binary `uploading` spinner isn't enough feedback.
+   */
+  const uploadFileWithProgress = async (
+    path: string,
+    blob: Blob,
+    onProgress?: (percent: number) => void
+  ): Promise<string> => {
+    setUploading(true);
+    try {
+      const storageRef = ref(storage, path);
+      const task = uploadBytesResumable(storageRef, blob);
+      await new Promise<void>((resolve, reject) => {
+        task.on(
+          'state_changed',
+          (snapshot) => {
+            if (snapshot.totalBytes > 0) {
+              onProgress?.(
+                Math.round(
+                  (snapshot.bytesTransferred / snapshot.totalBytes) * 100
+                )
+              );
+            }
+          },
+          reject,
+          resolve
+        );
+      });
+      return await getDownloadURL(task.snapshot.ref);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  /**
+   * Upload a guided-learning video slide / step recording. Always writes to
+   * Firebase Storage (never Drive): `lh3.googleusercontent.com` Drive links
+   * only serve images, so a Drive-hosted MP4 can't play in a `<video>` tag.
+   * Reuses the `hotspot_images` path so existing storage rules cover it.
+   */
+  const uploadGuidedLearningVideo = async (
+    userId: string,
+    blob: Blob,
+    fileName: string,
+    onProgress?: (percent: number) => void
+  ): Promise<{ url: string; storagePath: string }> => {
+    const storagePath = `users/${userId}/hotspot_images/${Date.now()}-${fileName}`;
+    const url = await uploadFileWithProgress(storagePath, blob, onProgress);
+    return { url, storagePath };
   };
 
   const uploadHotspotImage = async (
@@ -352,6 +406,8 @@ export const useStorage = () => {
   return {
     uploading,
     uploadFile,
+    uploadFileWithProgress,
+    uploadGuidedLearningVideo,
     uploadBackgroundImage,
     uploadSticker,
     uploadDisplayImage,

--- a/types.ts
+++ b/types.ts
@@ -4735,6 +4735,14 @@ export interface GuidedLearningSet {
   /** Firebase Storage URLs for one or more activity images */
   imageUrls: string[];
   imagePaths?: string[];
+  /**
+   * Per-slide media kind aligned by index with `imageUrls`. `'video'` slides
+   * (uploaded MP4/WebM or screen recordings) render in a muted looping
+   * `<video>` element; `'image'` covers static images and animated GIFs.
+   * Missing array or missing entries = `'image'`, so legacy sets need no
+   * migration. Only persisted when at least one slide is a video.
+   */
+  imageKinds?: ('image' | 'video')[];
   steps: GuidedLearningStep[];
   mode: GuidedLearningMode;
   createdAt: number;
@@ -4842,6 +4850,11 @@ export interface GuidedLearningSession {
   title: string;
   mode: GuidedLearningMode;
   imageUrls: string[];
+  /**
+   * Mirrors `GuidedLearningSet.imageKinds` so the student player knows which
+   * slides are videos. Missing = all slides are images (legacy sessions).
+   */
+  imageKinds?: ('image' | 'video')[];
   /** Student-safe steps (no answer keys) */
   publicSteps: GuidedLearningPublicStep[];
   teacherUid: string;

--- a/utils/guidedLearningMedia.ts
+++ b/utils/guidedLearningMedia.ts
@@ -1,0 +1,148 @@
+/**
+ * Media-intake helpers for the Guided Learning editor: file validation for
+ * the expanded image/GIF/video pipeline, and client-side downscaling so
+ * 4K screenshots don't ship multi-megabyte originals to every student.
+ */
+
+export type GuidedLearningMediaKind = 'image' | 'video';
+
+/** `accept` attribute for the slide file input / drop zone. */
+export const GL_MEDIA_ACCEPT =
+  'image/*,video/mp4,video/webm,video/quicktime,.mp4,.webm,.mov';
+
+/** Static images are re-encoded below this; GIFs upload as-is up to this cap. */
+export const GL_MAX_IMAGE_BYTES = 15 * 1024 * 1024; // 15MB
+export const GL_MAX_VIDEO_BYTES = 200 * 1024 * 1024; // 200MB
+
+/** Longest edge after downscaling — plenty for projector + student screens. */
+const MAX_IMAGE_DIMENSION = 2560;
+/** Skip re-encoding when the original is already small. */
+const REENCODE_THRESHOLD_BYTES = 600 * 1024;
+
+const VIDEO_MIME_PREFIX = /^video\//;
+
+export function getMediaKind(file: File): GuidedLearningMediaKind | null {
+  if (VIDEO_MIME_PREFIX.test(file.type)) return 'video';
+  if (file.type.startsWith('image/')) return 'image';
+  // Some OSes hand over screen recordings with an empty MIME type — fall
+  // back to the extension so drag-dropped .mov/.mp4 files still work.
+  if (/\.(mp4|webm|mov)$/i.test(file.name)) return 'video';
+  if (/\.(png|jpe?g|gif|webp|bmp|avif|svg)$/i.test(file.name)) return 'image';
+  return null;
+}
+
+/**
+ * Validate a slide upload. Returns an error string (for the editor's error
+ * strip) or null when the file is acceptable.
+ */
+export function validateSlideFile(file: File): string | null {
+  const kind = getMediaKind(file);
+  if (!kind) {
+    return `"${file.name}" isn't a supported file. Use PNG, JPG, GIF, WebP, MP4, or WebM.`;
+  }
+  if (kind === 'video' && file.size > GL_MAX_VIDEO_BYTES) {
+    return `"${file.name}" is too large (max ${Math.round(GL_MAX_VIDEO_BYTES / 1024 / 1024)}MB for video). Trim it or record a shorter clip.`;
+  }
+  if (kind === 'image' && file.size > GL_MAX_IMAGE_BYTES) {
+    return `"${file.name}" is too large (max ${Math.round(GL_MAX_IMAGE_BYTES / 1024 / 1024)}MB for images).`;
+  }
+  return null;
+}
+
+function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error(`Could not read "${file.name}" as an image.`));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality));
+}
+
+/**
+ * Downscale + re-encode a static image before upload. Animated GIFs and
+ * SVGs pass through untouched (re-encoding would flatten/rasterize them),
+ * as do images that are already small. Returns the original file whenever
+ * processing wouldn't actually shrink it.
+ */
+export async function prepareImageForUpload(file: File): Promise<File> {
+  if (
+    file.type === 'image/gif' ||
+    file.type === 'image/svg+xml' ||
+    typeof document === 'undefined'
+  ) {
+    return file;
+  }
+
+  let img: HTMLImageElement;
+  try {
+    img = await loadImageFromFile(file);
+  } catch {
+    // Unreadable as an image element (or a decode quirk) — let the raw
+    // file through; upload-side limits still apply.
+    return file;
+  }
+
+  const { naturalWidth: w, naturalHeight: h } = img;
+  if (w === 0 || h === 0) return file;
+
+  const needsResize = Math.max(w, h) > MAX_IMAGE_DIMENSION;
+  if (!needsResize && file.size <= REENCODE_THRESHOLD_BYTES) return file;
+
+  const scale = needsResize ? MAX_IMAGE_DIMENSION / Math.max(w, h) : 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(w * scale);
+  canvas.height = Math.round(h * scale);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return file;
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+  // WebP keeps alpha (screenshots with transparency) at far smaller sizes
+  // than PNG; fall back to JPEG if the browser can't encode WebP.
+  let blob = await canvasToBlob(canvas, 'image/webp', 0.85);
+  if (!blob || blob.type !== 'image/webp') {
+    blob = await canvasToBlob(canvas, 'image/jpeg', 0.85);
+  }
+  if (!blob || blob.size >= file.size) return file;
+
+  const ext = blob.type === 'image/webp' ? 'webp' : 'jpg';
+  const baseName = file.name.replace(/\.[^.]+$/, '') || 'image';
+  return new File([blob], `${baseName}.${ext}`, { type: blob.type });
+}
+
+/**
+ * Pick a thumbnail-safe URL for a set: the first slide whose kind is
+ * `'image'`. `<img>` tags can't render a video URL, so video-first sets
+ * would otherwise show a broken library card.
+ */
+export function pickThumbnailUrl(set: {
+  imageUrls: string[];
+  imageKinds?: ('image' | 'video')[];
+}): string {
+  const kinds = set.imageKinds ?? [];
+  const idx = set.imageUrls.findIndex(
+    (_, i) => (kinds[i] ?? 'image') !== 'video'
+  );
+  return idx >= 0 ? set.imageUrls[idx] : '';
+}
+
+/** File extension for an uploaded/recorded video blob's MIME type. */
+export function videoExtensionForMime(mime: string): string {
+  if (mime.includes('webm')) return 'webm';
+  if (mime.includes('quicktime')) return 'mov';
+  return 'mp4';
+}

--- a/utils/guidedLearningMedia.ts
+++ b/utils/guidedLearningMedia.ts
@@ -38,7 +38,7 @@ export function getMediaKind(file: File): GuidedLearningMediaKind | null {
 export function validateSlideFile(file: File): string | null {
   const kind = getMediaKind(file);
   if (!kind) {
-    return `"${file.name}" isn't a supported file. Use PNG, JPG, GIF, WebP, MP4, or WebM.`;
+    return `"${file.name}" isn't a supported file. Use an image (PNG, JPG, GIF, WebP…) or a video (MP4, WebM, MOV).`;
   }
   if (kind === 'video' && file.size > GL_MAX_VIDEO_BYTES) {
     return `"${file.name}" is too large (max ${Math.round(GL_MAX_VIDEO_BYTES / 1024 / 1024)}MB for video). Trim it or record a shorter clip.`;


### PR DESCRIPTION
## Summary

Upgrades the Guided Learning walkthrough builder into a high-end onboarding authoring experience: a much better upload/paste pipeline, GIF + MP4/WebM video slides end-to-end (editor → session → student player), and a new in-editor **screen capture studio** for turning real on-screen workflows into walkthrough slides.

> Note: the original request said "video activity", but everything described (image upload/paste, walkthrough media, screen capture) lives in **Guided Learning** — confirmed with the author before starting.

> **Ride-along CI commit:** this branch was cut from a baseline that includes `e93a45f` — *ci: restore auto preview deploy on every dev-`*` push* — which intentionally reverts the opt-in preview-deploy gating from `2261fea` and adds concurrency cancellation. That commit predates this session's work and is included here only because it isn't on `main` yet; the always-on preview behavior is its stated intent, not a side effect of this PR.

## Upload & paste improvements (creation UX/perf)

- **Drag-and-drop** files anywhere on the editor canvas, with a drop-zone highlight
- **Native Ctrl/Cmd+V paste** of clipboard images (the old Paste button used the permission-gated async Clipboard API; both now work). The listener runs in capture phase and calls `preventDefault`, so Dock's global smart-paste can't double-handle the same paste
- **Client-side compression**: images are downscaled to max 2560px and re-encoded (WebP, JPEG fallback) before upload, so 4K screenshots don't ship multi-MB originals to every student device. GIFs/SVGs pass through untouched; re-encoding is skipped when it wouldn't shrink the file
- **Validation + progress**: per-file type/size validation with friendly errors, sequential uploads with a "file N of M (· %)" progress strip; one bad file no longer discards the rest of the batch

## GIF + MP4/WebM walkthrough slides

- New optional `GuidedLearningSet.imageKinds` (`'image' | 'video'`) aligned with `imageUrls` — **no migration needed**; legacy sets/sessions without the field behave exactly as before
- Video slides render as muted looping `<video>` in both the editor canvas and the player; hotspots, tooltips, spotlights, and pan-zoom overlay them exactly like image slides
- Videos always upload to **Firebase Storage** with resumable progress (Drive `lh3.googleusercontent.com` links only serve images, so Drive-first routing is image-only); existing `hotspot_images` storage rules cover the path
- `imageKinds` is mirrored onto session docs so the student app plays video slides; library thumbnails skip video slides so cards don't render a broken `<img>`

## Screen capture studio (new `ScreenCaptureModal`)

Three ways to capture an actual workflow without leaving the editor:
- **Snap frames** — share a screen/window/tab via `getDisplayMedia`, then snap a still per step of the workflow; every snap becomes a slide instantly (the streamlined "capture each step" flow)
- **Record screen** — capture the workflow with `MediaRecorder` and add it as a single WebM video slide
- **From a video file** — open a local MP4/WebM, scrub to any moment and extract it as an image slide, or add the whole clip as a video slide

Guards added from review: `getDisplayMedia`/`MediaRecorder` availability checks with friendly errors, SSR portal guard, Escape-to-close (suppressed while recording).

## Step media + player polish

- Per-step **audio/video upload** (with percent progress) replaces the URL-only fields; YouTube/external URLs still work (`uploadGuidedLearningMedia` carries both)
- Player perf: only image slides are preloaded (videos stream on demand instead of being fetched eagerly); video slides are measured via `videoWidth/Height` so hotspot coordinates stay accurate
- "Image N" → "Slide N" naming across editor and player

## Validation

- `pnpm run type-check` ✅
- `pnpm run lint` (zero warnings) ✅
- `pnpm run format:check` ✅
- `pnpm run test` ✅ — includes a new player unit test asserting a `'video'` slide renders `<video>` (not `<img>`) and is skipped by the image preloader

Manual testing of `getDisplayMedia`/`MediaRecorder` flows needs a real browser session (dev preview), since they require user gestures + screen-share permission.

https://claude.ai/code/session_01XXyBAffsA7eG5wPRktTngj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXyBAffsA7eG5wPRktTngj)_