### PR TITLE
perf(gl): eliminate double-commit-per-keystroke in Guided Learning editor

### DIFF
--- a/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
@@ -373,8 +373,8 @@ interface PaneProps {
 /**
  * Slice comparator for the context pane. The controller object from
  * `useGuidedLearningEditorState` is rebuilt on every render (and the modal
- * re-renders on every `onStateChange` flush), so the pane memoizes on the
- * slices it actually consumes. The setters / step callbacks it uses are
+ * hosts the hook, so it re-renders on every editor state change), so the
+ * pane memoizes on the slices it actually consumes. The setters / step callbacks it uses are
  * referentially stable. The upload callbacks are intentionally NOT compared:
  * `useStorage` returns fresh function identities on every render, so they
  * never compare equal, but they are functionally equivalent for the

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.test.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Focused regression tests for GuidedLearningEditorModal's dirty-state and
+ * save-payload computation. As of the double-commit-per-keystroke perf fix,
+ * the modal reads the editor controller's fields directly (the hook lives
+ * inside the modal) instead of mirroring them via an onStateChange echo, so
+ * these tests pin the behavior that must not drift:
+ *   - isDirty is equality-based (reverting an edit makes the modal clean
+ *     again), which drives the unsaved-changes guard on close
+ *   - the saved set is built field-for-field from the live draft, with
+ *     default-valued optional fields omitted from the payload
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GuidedLearningSet } from '@/types';
+import { GuidedLearningEditorModal } from './GuidedLearningEditorModal';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { uid: 'test-user', displayName: 'Test Teacher' },
+    isAdmin: false,
+    canAccessFeature: () => false,
+  }),
+}));
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useStorage', () => ({
+  useStorage: () => ({
+    uploading: false,
+    uploadHotspotImage: vi.fn(),
+    uploadGuidedLearningMedia: vi.fn(),
+  }),
+}));
+
+// The panes are exercised elsewhere (GuidedLearningPlayer.test.tsx and the
+// perf harness); here we only test the modal's own dirty/save logic.
+vi.mock('./GuidedLearningEditor', () => ({
+  GuidedLearningEditorContextPane: () => null,
+  GuidedLearningEditorDetailPane: () => null,
+}));
+
+// Override the global useDialog mock with a controllable showConfirm so the
+// unsaved-changes guard is observable (default global mock auto-confirms).
+const { showConfirmMock } = vi.hoisted(() => ({
+  showConfirmMock: vi.fn(),
+}));
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({
+    showAlert: vi.fn().mockResolvedValue(undefined),
+    showConfirm: showConfirmMock,
+    showPrompt: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function buildSet(): GuidedLearningSet {
+  return {
+    id: 'set-1',
+    title: 'Original Title',
+    imageUrls: ['https://example.com/slide-1.png'],
+    steps: [
+      {
+        id: 'step-1',
+        xPct: 10,
+        yPct: 20,
+        imageIndex: 0,
+        interactionType: 'text-popover',
+        showOverlay: 'none',
+        text: 'Step text',
+      },
+    ],
+    mode: 'structured',
+    createdAt: 1000,
+    updatedAt: 2000,
+  };
+}
+
+function renderModal(set: GuidedLearningSet) {
+  const onClose = vi.fn();
+  const onSave = vi.fn().mockResolvedValue(undefined);
+  render(
+    <GuidedLearningEditorModal
+      isOpen
+      set={set}
+      meta={null}
+      onClose={onClose}
+      onSave={onSave}
+    />
+  );
+  return { onClose, onSave };
+}
+
+beforeEach(() => {
+  showConfirmMock.mockReset().mockResolvedValue(false);
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('GuidedLearningEditorModal dirty state', () => {
+  it('closes without a discard prompt when nothing was edited', async () => {
+    const { onClose } = renderModal(buildSet());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(showConfirmMock).not.toHaveBeenCalled();
+  });
+
+  it('prompts on close after an edit, and is clean again after reverting it', async () => {
+    const { onClose } = renderModal(buildSet());
+    const titleInput = screen.getByLabelText('Title');
+
+    // Edit → dirty → close is guarded (showConfirm resolves false = keep editing).
+    fireEvent.change(titleInput, { target: { value: 'Original Title!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(showConfirmMock).toHaveBeenCalledTimes(1));
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Revert to the original value → equality-based isDirty goes clean →
+    // close proceeds without another prompt.
+    fireEvent.change(titleInput, { target: { value: 'Original Title' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(showConfirmMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GuidedLearningEditorModal save payload', () => {
+  it('builds the saved set from the draft, omitting default-valued optional fields', async () => {
+    const set = buildSet();
+    const { onSave, onClose } = renderModal(set);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Set' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+
+    const [saved, driveFileId] = onSave.mock.calls[0] as [
+      GuidedLearningSet,
+      string | undefined,
+    ];
+    expect(driveFileId).toBeUndefined();
+    // Optional fields at their defaults (imageKinds, videoTrims,
+    // hotspotPulse, imageTransition, welcome*) must NOT appear at all.
+    expect(Object.keys(saved).sort()).toEqual(
+      [
+        'authorUid',
+        'createdAt',
+        'description',
+        'id',
+        'imageUrls',
+        'isBuilding',
+        'mode',
+        'steps',
+        'title',
+        'updatedAt',
+      ].sort()
+    );
+    expect(saved).toMatchObject({
+      id: 'set-1',
+      title: 'Original Title',
+      description: undefined,
+      imageUrls: set.imageUrls,
+      steps: set.steps,
+      mode: 'structured',
+      createdAt: 1000,
+    });
+    expect(typeof saved.updatedAt).toBe('number');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves the live (trimmed) title after an edit', async () => {
+    const { onSave } = renderModal(buildSet());
+
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: '  Renamed Set  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Set' }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+    const [saved] = onSave.mock.calls[0] as [GuidedLearningSet];
+    expect(saved.title).toBe('Renamed Set');
+  });
+});

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditorModal.tsx
@@ -6,7 +6,7 @@
  * for the currently-selected hotspot.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { Folder as FolderIcon, Inbox, Sparkles } from 'lucide-react';
 import {
   GuidedLearningMode,
@@ -24,10 +24,7 @@ import {
   GuidedLearningEditorContextPane,
   GuidedLearningEditorDetailPane,
 } from './GuidedLearningEditor';
-import {
-  GuidedLearningEditorState,
-  useGuidedLearningEditorState,
-} from './useGuidedLearningEditorState';
+import { useGuidedLearningEditorState } from './useGuidedLearningEditorState';
 import { GuidedLearningAIGenerator } from './GuidedLearningAIGenerator';
 
 interface GuidedLearningEditorModalProps {
@@ -155,9 +152,6 @@ export const GuidedLearningEditorModal: React.FC<
   onFolderChange,
 }) => {
   const { isAdmin, canAccessFeature } = useAuth();
-  const [liveState, setLiveState] = useState<GuidedLearningEditorState | null>(
-    null
-  );
   const [saving, setSaving] = useState(false);
   const [showAiGen, setShowAiGen] = useState(false);
 
@@ -196,45 +190,52 @@ export const GuidedLearningEditorModal: React.FC<
     [set]
   );
 
-  // Reset live state when set prop identity changes
+  // Reset modal-local state when set prop identity changes (the editor hook
+  // resets its own draft state on the same identity change).
   const [prevSet, setPrevSet] = useState<GuidedLearningSet | null>(set);
   if (set !== prevSet) {
     setPrevSet(set);
-    setLiveState(null);
     setSaving(false);
     setShowAiGen(false);
   }
 
-  const handleStateChange = useCallback((state: GuidedLearningEditorState) => {
-    setLiveState(state);
-  }, []);
-
+  // The hook is called inside this component, so the modal already re-renders
+  // on every editor state change — dirty state and the save payload read the
+  // controller's fields directly (no mirrored "live state" copy).
   const editorState = useGuidedLearningEditorState({
     existingSet: set,
     existingMeta: meta,
-    onStateChange: handleStateChange,
     folders,
     folderId,
     onFolderChange,
   });
 
   const isDirty = useMemo(() => {
-    if (!liveState) return false;
     return (
-      liveState.title !== originalTitle ||
-      liveState.description !== originalDescription ||
-      liveState.mode !== originalMode ||
-      liveState.hotspotPulse !== originalHotspotPulse ||
-      liveState.imageTransition !== originalImageTransition ||
-      liveState.welcomeEnabled !== originalWelcomeEnabled ||
-      liveState.welcomeMessage !== originalWelcomeMessage ||
-      !arraysEqual(liveState.imageUrls, originalImageUrls) ||
-      !arraysEqual(liveState.imageKinds, originalImageKinds) ||
-      !trimsEqual(liveState.videoTrims, originalVideoTrims) ||
-      !stepsEqual(liveState.steps, originalSteps)
+      editorState.title !== originalTitle ||
+      editorState.description !== originalDescription ||
+      editorState.mode !== originalMode ||
+      editorState.hotspotPulse !== originalHotspotPulse ||
+      editorState.imageTransition !== originalImageTransition ||
+      editorState.welcomeEnabled !== originalWelcomeEnabled ||
+      editorState.welcomeMessage !== originalWelcomeMessage ||
+      !arraysEqual(editorState.imageUrls, originalImageUrls) ||
+      !arraysEqual(editorState.imageKinds, originalImageKinds) ||
+      !trimsEqual(editorState.videoTrims, originalVideoTrims) ||
+      !stepsEqual(editorState.steps, originalSteps)
     );
   }, [
-    liveState,
+    editorState.title,
+    editorState.description,
+    editorState.mode,
+    editorState.hotspotPulse,
+    editorState.imageTransition,
+    editorState.welcomeEnabled,
+    editorState.welcomeMessage,
+    editorState.imageUrls,
+    editorState.imageKinds,
+    editorState.videoTrims,
+    editorState.steps,
     originalTitle,
     originalDescription,
     originalMode,
@@ -249,47 +250,47 @@ export const GuidedLearningEditorModal: React.FC<
   ]);
 
   const handleSave = async () => {
-    if (!set || !liveState) return;
+    if (!set) return;
     setSaving(true);
     try {
       const now = Date.now();
       const builtSet: GuidedLearningSet = {
         id: set.id,
-        title: liveState.title.trim(),
-        description: liveState.description.trim() || undefined,
-        imageUrls: liveState.imageUrls,
+        title: editorState.title.trim(),
+        description: editorState.description.trim() || undefined,
+        imageUrls: editorState.imageUrls,
         // Only persist kinds when at least one slide is a video — keeps
         // image-only (and legacy) sets free of the new field.
-        ...(liveState.imageKinds.some((k) => k === 'video')
-          ? { imageKinds: liveState.imageKinds }
+        ...(editorState.imageKinds.some((k) => k === 'video')
+          ? { imageKinds: editorState.imageKinds }
           : {}),
         // Only persist trims when at least one slide actually has one —
         // keeps untrimmed (and legacy) sets free of the new field.
-        ...(liveState.videoTrims.some(Boolean)
-          ? { videoTrims: liveState.videoTrims }
+        ...(editorState.videoTrims.some(Boolean)
+          ? { videoTrims: editorState.videoTrims }
           : {}),
-        steps: liveState.steps,
-        mode: liveState.mode,
+        steps: editorState.steps,
+        mode: editorState.mode,
         createdAt: set.createdAt,
         updatedAt: now,
         isBuilding: set.isBuilding,
         authorUid: set.authorUid,
         // Only persist a hotspotPulse value when it differs from the default
         // ('consistent') — keeps untouched legacy sets clean of new fields.
-        ...(liveState.hotspotPulse !== 'consistent'
-          ? { hotspotPulse: liveState.hotspotPulse }
+        ...(editorState.hotspotPulse !== 'consistent'
+          ? { hotspotPulse: editorState.hotspotPulse }
           : {}),
-        ...(liveState.imageTransition !== 'none'
-          ? { imageTransition: liveState.imageTransition }
+        ...(editorState.imageTransition !== 'none'
+          ? { imageTransition: editorState.imageTransition }
           : {}),
         // Welcome screen — only persist when actually enabled WITH content.
         // Toggle-on-but-empty falls back to default behavior at render time
         // anyway, so don't write the field; this also avoids cluttering
         // legacy sets that have never touched welcome settings.
-        ...(liveState.welcomeEnabled && liveState.welcomeMessage.trim()
+        ...(editorState.welcomeEnabled && editorState.welcomeMessage.trim()
           ? {
               welcomeEnabled: true,
-              welcomeMessage: liveState.welcomeMessage,
+              welcomeMessage: editorState.welcomeMessage,
             }
           : {}),
       };
@@ -303,10 +304,10 @@ export const GuidedLearningEditorModal: React.FC<
   // The header now hosts the editable title input directly. Pass through
   // the live value so users see what they're typing; placeholder kicks in
   // for empty strings.
-  const headerTitleValue = liveState?.title ?? originalTitle ?? '';
+  const headerTitleValue = editorState.title;
   const titlePlaceholder = originalTitle ? 'Edit Set' : 'Set title…';
 
-  const stepCount = liveState?.steps.length ?? set?.steps.length ?? 0;
+  const stepCount = editorState.steps.length;
 
   // Folder picker — surfaced as a compact icon button in the header so
   // it doesn't take a full row in the body. Anchored popover renders
@@ -393,10 +394,9 @@ export const GuidedLearningEditorModal: React.FC<
         onClose={onClose}
         saveLabel="Save Set"
         saveDisabled={
-          !liveState ||
-          !liveState.title.trim() ||
-          liveState.imageUrls.length === 0 ||
-          liveState.uploading
+          !editorState.title.trim() ||
+          editorState.imageUrls.length === 0 ||
+          editorState.uploading
         }
         footerExtras={footerExtras}
         className="h-[90vh]"

--- a/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
+++ b/components/widgets/GuidedLearning/components/useGuidedLearningEditorState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   GuidedLearningSet,
   GuidedLearningMode,
@@ -17,22 +17,6 @@ import {
   type GuidedLearningMediaKind,
 } from '@/utils/guidedLearningMedia';
 
-/** State emitted by `onStateChange` so a parent modal can track dirty state. */
-export interface GuidedLearningEditorState {
-  title: string;
-  description: string;
-  mode: GuidedLearningMode;
-  imageUrls: string[];
-  imageKinds: GuidedLearningMediaKind[];
-  videoTrims: (GuidedLearningVideoTrim | null)[];
-  steps: GuidedLearningStep[];
-  uploading: boolean;
-  hotspotPulse: 'consistent' | 'reminder' | 'off';
-  imageTransition: 'none' | 'slide' | 'fade';
-  welcomeEnabled: boolean;
-  welcomeMessage: string;
-}
-
 /** Live progress for the slide-upload pipeline (null when idle). */
 export interface SlideUploadProgress {
   /** 1-based index of the file currently uploading. */
@@ -46,7 +30,6 @@ export interface SlideUploadProgress {
 interface UseGuidedLearningEditorStateProps {
   existingSet: GuidedLearningSet | null;
   existingMeta: GuidedLearningSetMetadata | null;
-  onStateChange?: (state: GuidedLearningEditorState) => void;
   folders?: LibraryFolder[];
   folderId?: string | null;
   onFolderChange?: (folderId: string | null) => void;
@@ -131,7 +114,6 @@ function trimsForSet(
  */
 export function useGuidedLearningEditorState({
   existingSet,
-  onStateChange,
   folders,
   folderId,
   onFolderChange,
@@ -202,37 +184,6 @@ export function useGuidedLearningEditorState({
     setWelcomeEnabled(Boolean(existingSet?.welcomeEnabled));
     setWelcomeMessage(existingSet?.welcomeMessage ?? '');
   }
-
-  useEffect(() => {
-    onStateChange?.({
-      title,
-      description,
-      mode,
-      imageUrls,
-      imageKinds,
-      videoTrims,
-      steps,
-      uploading,
-      hotspotPulse,
-      imageTransition,
-      welcomeEnabled,
-      welcomeMessage,
-    });
-  }, [
-    title,
-    description,
-    mode,
-    imageUrls,
-    imageKinds,
-    videoTrims,
-    steps,
-    uploading,
-    hotspotPulse,
-    imageTransition,
-    welcomeEnabled,
-    welcomeMessage,
-    onStateChange,
-  ]);
 
   // Render-synced mirror of imageUrls.length so the sequential upload loop
   // (which awaits between appends, letting renders flush) can compute the

--- a/tests/perf/results/after.json
+++ b/tests/perf/results/after.json
@@ -1,67 +1,79 @@
 {
-  "generatedAt": "2026-06-09T21:44:48.946Z",
+  "generatedAt": "2026-06-09T23:39:27.011Z",
   "runCommand": "pnpm exec vitest run tests/perf/editorPerf.test.tsx",
-  "note": "Median of 3 runs post-change. Commit counts identical across all 3 runs.",
+  "note": "POST-CHANGE results: medianDurationMs = median of 3 runs; commits identical across all 3 runs.",
   "scenarios": [
     {
       "scenario": "quiz.mount",
       "commits": 3,
-      "medianDurationMs": 46.606
+      "medianDurationMs": 45.763,
+      "runDurationsMs": [45.767, 45.372, 45.763]
     },
     {
       "scenario": "quiz.type25",
       "commits": 25,
-      "medianDurationMs": 82.286
+      "medianDurationMs": 83.143,
+      "runDurationsMs": [82.862, 83.95, 83.143]
     },
     {
       "scenario": "quiz.switchSelection10",
       "commits": 18,
-      "medianDurationMs": 57.107
+      "medianDurationMs": 57.128,
+      "runDurationsMs": [56.411, 58.153, 57.128]
     },
     {
       "scenario": "quiz.addQuestion",
       "commits": 2,
-      "medianDurationMs": 2.153
+      "medianDurationMs": 2.258,
+      "runDurationsMs": [2.258, 2.177, 2.349]
     },
     {
       "scenario": "va.mount",
       "commits": 4,
-      "medianDurationMs": 14.091
+      "medianDurationMs": 14.427,
+      "runDurationsMs": [14.602, 14.077, 14.427]
     },
     {
       "scenario": "va.type25",
       "commits": 25,
-      "medianDurationMs": 20.063
+      "medianDurationMs": 20.35,
+      "runDurationsMs": [20.606, 19.738, 20.35]
     },
     {
       "scenario": "va.switchSelection10",
       "commits": 10,
-      "medianDurationMs": 27.382
+      "medianDurationMs": 26.911,
+      "runDurationsMs": [25.85, 34.166, 26.911]
     },
     {
       "scenario": "va.addTask",
       "commits": 2,
-      "medianDurationMs": 9.598
+      "medianDurationMs": 9.423,
+      "runDurationsMs": [9.016, 9.459, 9.423]
     },
     {
       "scenario": "gl.mount",
       "commits": 3,
-      "medianDurationMs": 14.73
+      "medianDurationMs": 13.856,
+      "runDurationsMs": [13.563, 13.856, 14.151]
     },
     {
       "scenario": "gl.type25",
-      "commits": 50,
-      "medianDurationMs": 103.408
+      "commits": 25,
+      "medianDurationMs": 98.674,
+      "runDurationsMs": [98.674, 94.721, 99.188]
     },
     {
       "scenario": "gl.switchSlide10",
       "commits": 10,
-      "medianDurationMs": 52.188
+      "medianDurationMs": 44.53,
+      "runDurationsMs": [44.53, 58.698, 44.153]
     },
     {
       "scenario": "gl.addStep",
       "commits": 3,
-      "medianDurationMs": 17.01
+      "medianDurationMs": 16.299,
+      "runDurationsMs": [16.299, 17.795, 16.291]
     }
   ]
 }

--- a/tests/perf/results/baseline.json
+++ b/tests/perf/results/baseline.json
@@ -1,79 +1,79 @@
 {
-  "generatedAt": "2026-06-09T20:56:59.362Z",
+  "generatedAt": "2026-06-09T23:21:11.984Z",
   "runCommand": "pnpm exec vitest run tests/perf/editorPerf.test.tsx",
-  "note": "PRE-CHANGE baseline for the unified quiz/VA/GL editor perf pass. commits = Profiler commit count (deterministic primary metric, identical across 3 runs). medianDurationMs = median summed actualDuration over 3 suite runs (machine-dependent, indicative). NOTE: re-running the harness overwrites this file with a single-run snapshot (actualDurationMs per scenario); to reproduce this shape, run 3x and take per-scenario medians.",
+  "note": "PRE-CHANGE baseline for the GL editor double-commit-per-keystroke pass (pass 2, post-#1920 HEAD). commits = Profiler commit count (deterministic primary metric, identical across 3 runs). medianDurationMs = median summed actualDuration over 3 suite runs (machine-dependent, indicative). NOTE: re-running the harness overwrites this file with a single-run snapshot (actualDurationMs per scenario); to reproduce this shape, run 3x and take per-scenario medians.",
   "scenarios": [
     {
       "scenario": "quiz.mount",
       "commits": 3,
-      "medianDurationMs": 51.927,
-      "runDurationsMs": [51.927, 53.336, 51.058]
+      "medianDurationMs": 45.159,
+      "runDurationsMs": [45.063, 45.159, 48.726]
     },
     {
       "scenario": "quiz.type25",
       "commits": 25,
-      "medianDurationMs": 162.801,
-      "runDurationsMs": [162.801, 161.302, 165.855]
+      "medianDurationMs": 93.92,
+      "runDurationsMs": [93.92, 84.663, 94.895]
     },
     {
       "scenario": "quiz.switchSelection10",
       "commits": 18,
-      "medianDurationMs": 44.275,
-      "runDurationsMs": [44.275, 42.259, 49.067]
+      "medianDurationMs": 64.586,
+      "runDurationsMs": [64.586, 63.636, 65.17]
     },
     {
       "scenario": "quiz.addQuestion",
       "commits": 2,
-      "medianDurationMs": 4.805,
-      "runDurationsMs": [4.884, 4.558, 4.805]
+      "medianDurationMs": 2.372,
+      "runDurationsMs": [2.184, 2.372, 2.493]
     },
     {
       "scenario": "va.mount",
       "commits": 4,
-      "medianDurationMs": 16.978,
-      "runDurationsMs": [16.697, 17.922, 16.978]
+      "medianDurationMs": 14.712,
+      "runDurationsMs": [14.712, 13.842, 15.788]
     },
     {
       "scenario": "va.type25",
       "commits": 25,
-      "medianDurationMs": 37.427,
-      "runDurationsMs": [37.182, 37.565, 37.427]
+      "medianDurationMs": 20.438,
+      "runDurationsMs": [20.438, 18.973, 24.057]
     },
     {
       "scenario": "va.switchSelection10",
       "commits": 10,
-      "medianDurationMs": 85.08,
-      "runDurationsMs": [85.08, 83.683, 87.12]
+      "medianDurationMs": 30.386,
+      "runDurationsMs": [30.386, 29.402, 34.405]
     },
     {
       "scenario": "va.addTask",
       "commits": 2,
-      "medianDurationMs": 14.978,
-      "runDurationsMs": [15.112, 14.467, 14.978]
+      "medianDurationMs": 9.868,
+      "runDurationsMs": [9.342, 9.868, 12.512]
     },
     {
       "scenario": "gl.mount",
       "commits": 3,
-      "medianDurationMs": 20.113,
-      "runDurationsMs": [20.113, 24.705, 19.745]
+      "medianDurationMs": 14.581,
+      "runDurationsMs": [14.436, 14.581, 17.436]
     },
     {
       "scenario": "gl.type25",
       "commits": 50,
-      "medianDurationMs": 294.098,
-      "runDurationsMs": [294.098, 290.561, 294.696]
+      "medianDurationMs": 119.305,
+      "runDurationsMs": [132.349, 108.515, 119.305]
     },
     {
       "scenario": "gl.switchSlide10",
       "commits": 10,
-      "medianDurationMs": 33.313,
-      "runDurationsMs": [34.706, 32.323, 33.313]
+      "medianDurationMs": 71.707,
+      "runDurationsMs": [71.707, 59.072, 75.731]
     },
     {
       "scenario": "gl.addStep",
       "commits": 3,
-      "medianDurationMs": 29.036,
-      "runDurationsMs": [31.31, 28.807, 29.036]
+      "medianDurationMs": 18.369,
+      "runDurationsMs": [18.369, 17.831, 19.393]
     }
   ]
 }

--- a/tests/perf/results/bundle-after.json
+++ b/tests/perf/results/bundle-after.json
@@ -2,20 +2,20 @@
   "chunks": [
     {
       "name": "EditorModalShell.js",
-      "gzipKb": 1.4
+      "gzipKb": 1.36
     },
     {
       "name": "QuizResults.js",
-      "gzipKb": 33.78
+      "gzipKb": 32.83
     },
     {
       "name": "index-guidedLearningEditor.js",
-      "gzipKb": 34.53
+      "gzipKb": 33.58
     },
     {
       "name": "VideoActivityEditorModal.js",
-      "gzipKb": 18.09
+      "gzipKb": 17.66
     }
   ],
-  "totalGzipKb": 87.8
+  "totalGzipKb": 85.43
 }


### PR DESCRIPTION
## Summary

Pass 2 of the measured `perf-ux-pass` workflow, scoped to the Guided Learning editor — fixes the one architectural item deferred from #1920.

**Root cause:** `useGuidedLearningEditorState` is called *inside* `GuidedLearningEditorModal`, yet it echoed its entire state object back to the modal via an `onStateChange` effect → `setLiveState`, producing a **second render commit on every keystroke**. The `liveState` mirror was provably redundant state.

**Fix:** delete the echo entirely — the modal computes `isDirty`, the save payload, header title, step count, and `saveDisabled` directly from the controller, using the same equality helpers. Dirty semantics and the persisted `GuidedLearningSet` shape (including field-omission rules for `imageKinds`/`videoTrims`/`hotspotPulse`/`imageTransition`/`welcome*`) are pinned byte-identical by a new colocated test suite.

## Measured results (unchanged committed harness, fresh post-#1920 baseline in first commit)

| Scenario | Before | After |
|---|---|---|
| gl.type25 | **50 commits** / 119.3ms | **25 commits** / 98.7ms |
| gl.switchSlide10 | 10 commits / 71.7ms | 10 commits / 44.5ms |
| other 10 scenarios | — | commit counts identical, no regressions |

GL typing is now 1 commit/keystroke, matching the quiz and VA editors. Bundle: GL editor chunk −0.44 KB gzip.

## Cost audit

Cost-neutral: zero new Firestore reads/writes/listeners, Storage ops, or AI calls. Save still writes exactly once per explicit Save click with an identical payload contract.

## Verification

- `pnpm run validate` fully green locally (4391 root + 517 functions tests)
- Workflow quality gates (type-check / lint zero-warnings / format / targeted vitest) pass
- Harness re-run 3×: commit counts stable across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)