### PR TITLE
perf(dashboard): measured canvas perf pass — baseline ruler + low-risk identity/allocation fixes

### DIFF
--- a/.claude/workflows/perf-ux-pass.js
+++ b/.claude/workflows/perf-ux-pass.js
@@ -221,6 +221,9 @@ function groupByFileOverlap(items) {
 
 const ARGS = typeof args === 'string' ? (args.trim() ? JSON.parse(args) : {}) : (args ?? {});
 const TARGET = ARGS.target;
+// Optional filename prefix for tests/perf/results/* so a pass over a NEW
+// surface doesn't overwrite a previously committed ruler (e.g. 'dashboard-').
+const PREFIX = ARGS.resultsPrefix ?? '';
 if (!TARGET || !TARGET.name || !TARGET.files?.length || !TARGET.harnessSpec) {
   throw new Error(
     'perf-ux-pass requires args.target = { name, description, files: string[], harnessSpec }. ' +
@@ -277,7 +280,7 @@ ${TARGET.harnessSpec}
 REQUIREMENTS:
   - Mock Firebase/Firestore/context exactly the way neighboring tests do — the harness must run offline with zero network.
   - Mount each editor with REALISTIC data sizes (not 2 items — use the spec's sizes) so re-render cost is visible.
-  - Write results as pretty-printed JSON to tests/perf/results/baseline.json via node:fs INSIDE the test (mkdir recursive). The test itself must only assert that metrics were produced — NO duration thresholds (CI machines vary; this must never be flaky).
+  - Write results as pretty-printed JSON to tests/perf/results/${PREFIX}baseline.json via node:fs INSIDE the test (mkdir recursive). The test itself must only assert that metrics were produced — NO duration thresholds (CI machines vary; this must never be flaky).
   - The run command must be a single line, e.g.: pnpm exec vitest run tests/perf/editorPerf.test.tsx
   - Keep the harness lint/type/format clean (pnpm run lint touches it; zero warnings).
   - Do NOT modify any production source file. tests/perf/** is your only write surface.
@@ -290,7 +293,7 @@ Record the baseline numbers in your structured output AND in the JSON file.`,
 
 ${TARGET_BLOCK}
 
-You are recording the BUNDLE-SIZE BASELINE. Run "pnpm run build" once and identify which built chunks contain the target editor code (check dist/ output names and, if ambiguous, grep the chunk contents for distinctive editor strings). Record the gzip size of each relevant chunk plus the total. Write a pretty-printed JSON file to tests/perf/results/bundle-baseline.json with { chunks: [{name, gzipKb}], totalGzipKb } — strip any content-hash from chunk names so before/after names match. Do NOT modify any source file.`,
+You are recording the BUNDLE-SIZE BASELINE. Run "pnpm run build" once and identify which built chunks contain the target editor code (check dist/ output names and, if ambiguous, grep the chunk contents for distinctive editor strings). Record the gzip size of each relevant chunk plus the total. Write a pretty-printed JSON file to tests/perf/results/${PREFIX}bundle-baseline.json with { chunks: [{name, gzipKb}], totalGzipKb } — strip any content-hash from chunk names so before/after names match. Do NOT modify any source file.`,
       { label: 'baseline:bundle', phase: 'Baseline', schema: BUNDLE_SCHEMA }
     ),
   ...LENSES.map((l) => () =>
@@ -428,14 +431,14 @@ const [remeasure, bundleAfter, costAudit] = await parallel([
 Re-run the UNCHANGED performance harness and compare against the committed baseline.
   - Command: ${harnessBaseline.runCommand}
   - Baseline: ${harnessBaseline.resultsFile} → ${JSON.stringify(harnessBaseline.metrics)}
-Run it 3 times; commit counts must be stable, take median durations. The harness writes its JSON results file — copy/save the post-change numbers to tests/perf/results/after.json. Compare scenario by scenario: commits are the primary verdict (lower = improved), durations are corroborating. List ANY regression honestly. Do not modify the harness or any source file.`,
+Run it 3 times; commit counts must be stable, take median durations. The harness writes its JSON results file — copy/save the post-change numbers to tests/perf/results/${PREFIX}after.json. Compare scenario by scenario: commits are the primary verdict (lower = improved), durations are corroborating. List ANY regression honestly. Do not modify the harness or any source file.`,
       { label: 'remeasure', phase: 'Verify', schema: REMEASURE_SCHEMA }
     ),
   () =>
     agent(
       `${REPO}
 
-Re-run "pnpm run build" and record the gzip sizes of the SAME chunks as the bundle baseline (tests/perf/results/bundle-baseline.json — names are hash-stripped). Write tests/perf/results/bundle-after.json in the same shape. Note new/split/removed chunks explicitly. Do not modify any source file.`,
+Re-run "pnpm run build" and record the gzip sizes of the SAME chunks as the bundle baseline (tests/perf/results/${PREFIX}bundle-baseline.json — names are hash-stripped). Write tests/perf/results/${PREFIX}bundle-after.json in the same shape. Note new/split/removed chunks explicitly. Do not modify any source file.`,
       { label: 'bundle:after', phase: 'Verify', schema: BUNDLE_SCHEMA }
     ),
   () =>

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -46,6 +46,7 @@ import {
   DashboardSettings,
 } from '@/types';
 import { SNAP_LAYOUTS, SnapZone } from '@/config/snapLayouts';
+import { POSITION_AWARE_WIDGETS } from '@/config/widgetDefaults';
 import { calculateSnapBounds, SNAP_LAYOUT_CONSTANTS } from '@/utils/layoutMath';
 import { clampWidgetToWorld, getWorldBounds } from '@/utils/zoomPanMath';
 import { useScreenshot } from '@/hooks/useScreenshot';
@@ -74,12 +75,9 @@ const COLOR_HEX_TO_NAME: Record<string, string> = Object.fromEntries(
 const GRID_COLS = 10;
 const GRID_ROWS = 10;
 
-// Widgets that require real-time position updates for inter-widget functionality
-const POSITION_AWARE_WIDGETS: WidgetType[] = [
-  'catalyst',
-  'catalyst-instruction',
-  'catalyst-visual',
-];
+// Stable empty set returned by `occupiedCells` while the snap menu is closed
+// so the memo stays allocation-free and reference-stable on every render.
+const EMPTY_OCCUPIED_CELLS: ReadonlySet<string> = new Set();
 
 // Default min size all widgets shrink to during resize.
 const DEFAULT_MIN_W = 150;
@@ -256,8 +254,11 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md: "assign refs directly in render body"); react-hooks/refs v7 incorrectly cascades this as an error when any setState is called during render
   customGridRef.current = customGrid;
   const occupiedCells = useMemo(() => {
+    // Short-circuit before any per-widget work: activeDashboard is a dep, so
+    // without this guard every widget mutation across the board would pay the
+    // O(n) grid-occupancy scan even with the snap menu closed.
+    if (!showSnapMenu || !activeDashboard) return EMPTY_OCCUPIED_CELLS;
     const set = new Set<string>();
-    if (!showSnapMenu || !activeDashboard) return set;
 
     const { PADDING } = SNAP_LAYOUT_CONSTANTS;
     const safeWidth = Math.max(1, windowSize.width - PADDING * 2);
@@ -1133,10 +1134,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         );
 
         // OPTIMIZATION: If widget is not position-aware, update DOM directly and skip React render cycle
-        if (
-          !POSITION_AWARE_WIDGETS.includes(widget.type) &&
-          windowRef.current
-        ) {
+        if (!POSITION_AWARE_WIDGETS.has(widget.type) && windowRef.current) {
           windowRef.current.style.left = `${newX}px`;
           windowRef.current.style.top = `${newY}px`;
           if (dragState.current) {
@@ -1215,7 +1213,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       } else {
         // Commit final position if using direct DOM manipulation
         if (
-          !POSITION_AWARE_WIDGETS.includes(widget.type) &&
+          !POSITION_AWARE_WIDGETS.has(widget.type) &&
           dragState.current &&
           (dragState.current.x !== widget.x || dragState.current.y !== widget.y)
         ) {
@@ -1483,10 +1481,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         newH = Math.max(Math.min(minH, availableH), Math.min(newH, availableH));
 
         // OPTIMIZATION: If widget is not position-aware, update DOM directly and skip React render cycle
-        if (
-          !POSITION_AWARE_WIDGETS.includes(widget.type) &&
-          windowRef.current
-        ) {
+        if (!POSITION_AWARE_WIDGETS.has(widget.type) && windowRef.current) {
           windowRef.current.style.width = `${newW}px`;
           windowRef.current.style.height = `${newH}px`;
           windowRef.current.style.left = `${newX}px`;
@@ -1535,7 +1530,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
       // Commit final position/size if using direct DOM manipulation
       if (
-        !POSITION_AWARE_WIDGETS.includes(widget.type) &&
+        !POSITION_AWARE_WIDGETS.has(widget.type) &&
         dragState.current &&
         (dragState.current.w !== widget.w ||
           dragState.current.h !== widget.h ||
@@ -2008,7 +2003,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   /* eslint-disable react-hooks/refs */
   const shouldUseDragState =
     (isDragging || isResizing) &&
-    !POSITION_AWARE_WIDGETS.includes(widget.type) &&
+    !POSITION_AWARE_WIDGETS.has(widget.type) &&
     dragState.current;
 
   const UNIVERSAL_TEXT_SIZES: Record<string, string> = {

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -26,13 +26,7 @@ import {
   WIDGET_SCALING_CONFIG,
   DEFAULT_SCALING_CONFIG,
 } from './WidgetRegistry';
-
-// Widgets that require real-time position updates for inter-widget functionality
-const POSITION_AWARE_WIDGETS: WidgetType[] = [
-  'catalyst',
-  'catalyst-instruction',
-  'catalyst-visual',
-];
+import { POSITION_AWARE_WIDGETS } from '@/config/widgetDefaults';
 
 const LIVE_SESSION_UPDATE_DEBOUNCE_MS = 800; // Balance between real-time updates and reducing Firestore write costs
 
@@ -119,7 +113,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
   } = useAuth();
   const { isActiveBoardReadOnly } = useDashboard();
 
-  const handleToggleLive = async () => {
+  const handleToggleLive = useCallback(async () => {
     try {
       if (isLive) {
         await endSession();
@@ -134,7 +128,15 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
     } catch (error) {
       console.error('Failed to toggle live session:', error);
     }
-  };
+  }, [
+    isLive,
+    endSession,
+    startSession,
+    widget.id,
+    widget.type,
+    widget.config,
+    dashboardBackground,
+  ]);
 
   // Sync config changes to session when live
   // ⚡ BOLT OPTIMIZATION: Only serialize when config reference changes AND session is live to avoid expensive JSON.stringify on every drag/render
@@ -230,7 +232,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
 
   // Calculate a key that changes only when relevant position changes for position-aware widgets.
   // For standard widgets, this key is empty and doesn't trigger updates on drag.
-  const positionKey = POSITION_AWARE_WIDGETS.includes(widget.type)
+  const positionKey = POSITION_AWARE_WIDGETS.has(widget.type)
     ? `${widget.x},${widget.y}`
     : '';
 
@@ -428,13 +430,7 @@ const InnerWidgetRenderer = memo(
     if (pw.type !== nw.type) return false; // Defensive check for type change
 
     // If the widget type is position-aware, we MUST re-render if x or y changed.
-    const isPositionAware = [
-      'catalyst',
-      'catalyst-instruction',
-      'catalyst-visual',
-    ].includes(nw.type);
-
-    if (isPositionAware) {
+    if (POSITION_AWARE_WIDGETS.has(nw.type)) {
       if (pw.x !== nw.x) return false;
       if (pw.y !== nw.y) return false;
     }

--- a/config/widgetDefaults.ts
+++ b/config/widgetDefaults.ts
@@ -33,6 +33,19 @@ import {
  *
  * Widget types not listed here default to `'preserve-aspect'`.
  */
+/**
+ * Widgets that require real-time position updates for inter-widget
+ * functionality (Catalyst components read each other's positions). Shared by
+ * DraggableWindow's drag/resize hot path and WidgetRenderer's memo
+ * comparator — a Set so the per-frame lookup is O(1) and the list can't
+ * silently diverge between the two call sites.
+ */
+export const POSITION_AWARE_WIDGETS: ReadonlySet<WidgetType> = new Set([
+  'catalyst',
+  'catalyst-instruction',
+  'catalyst-visual',
+]);
+
 export const WIDGET_STRETCH_BEHAVIOR: Partial<
   Record<WidgetType, 'fill' | 'preserve-aspect'>
 > = {

--- a/context/DashboardContext.bringToFront.test.tsx
+++ b/context/DashboardContext.bringToFront.test.tsx
@@ -1,0 +1,344 @@
+import React, { useEffect } from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DashboardProvider } from './DashboardContext';
+import { useDashboard } from './useDashboard';
+import { Dashboard, WidgetData } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors tests/DashboardContext_removeWidgets.test.tsx)
+// ---------------------------------------------------------------------------
+
+vi.mock('./useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      uid: 'test-user',
+      displayName: 'Test User',
+      email: 'test@example.com',
+    },
+    isAdmin: false,
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    refreshGoogleToken: vi.fn(),
+    remoteControlEnabled: true,
+    profileLoaded: true,
+  }),
+}));
+
+type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+let capturedSnapshotCb: SnapshotCb | null = null;
+
+vi.mock('../hooks/useFirestore', () => ({
+  useFirestore: () => ({
+    saveDashboard: vi.fn().mockResolvedValue(Date.now()),
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboards: vi.fn((cb: SnapshotCb) => {
+      capturedSnapshotCb = cb;
+      return () => {
+        // cleanup
+      };
+    }),
+    shareDashboard: vi.fn(),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+    rosters: [],
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    activeRosterId: null,
+  }),
+}));
+
+vi.mock('../hooks/useRosters', () => ({
+  useRosters: () => ({
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test consumer
+// ---------------------------------------------------------------------------
+
+interface ContextSnapshot {
+  dashboards: Dashboard[];
+  activeDashboard: Dashboard | null;
+  bringToFront: (id: string) => void;
+  minimizeAllWidgets: () => void;
+  restoreAllWidgets: () => void;
+}
+
+const TestConsumer: React.FC<{
+  stateRef: { current: ContextSnapshot | null };
+}> = ({ stateRef }) => {
+  const ctx = useDashboard();
+  useEffect(() => {
+    stateRef.current = {
+      dashboards: ctx.dashboards,
+      activeDashboard: ctx.activeDashboard,
+      bringToFront: ctx.bringToFront,
+      minimizeAllWidgets: ctx.minimizeAllWidgets,
+      restoreAllWidgets: ctx.restoreAllWidgets,
+    };
+  });
+  return null;
+};
+
+function setup() {
+  const stateRef: { current: ContextSnapshot | null } = { current: null };
+  render(
+    <DashboardProvider>
+      <TestConsumer stateRef={stateRef} />
+    </DashboardProvider>
+  );
+  return stateRef;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWidget(
+  id: string,
+  z: number,
+  extra: Partial<WidgetData> = {}
+): WidgetData {
+  return {
+    id,
+    type: 'text',
+    x: 0,
+    y: 0,
+    w: 1,
+    h: 1,
+    z,
+    flipped: false,
+    config: { text: 'test' } as WidgetData['config'],
+    ...extra,
+  };
+}
+
+function makeDashboard(widgets: WidgetData[]): Dashboard {
+  return {
+    id: 'dash-1',
+    name: 'Test Board',
+    background: 'bg-slate-900',
+    widgets,
+    createdAt: 1000,
+    updatedAt: 1000,
+  };
+}
+
+async function pushSnapshot(dashboards: Dashboard[]): Promise<void> {
+  if (!capturedSnapshotCb) throw new Error('Provider not mounted');
+  const cb = capturedSnapshotCb;
+  await act(async () => {
+    cb(dashboards, false);
+    await Promise.resolve();
+  });
+}
+
+function getWidget(stateRef: ReturnType<typeof setup>, id: string) {
+  const w = stateRef.current?.activeDashboard?.widgets.find((w) => w.id === id);
+  if (!w) throw new Error(`widget ${id} not found`);
+  return w;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DashboardContext bringToFront', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSnapshotCb = null;
+  });
+
+  it('raises a non-frontmost widget to maxZ + 1 and preserves untouched widget identity', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([
+        makeWidget('w1', 1),
+        makeWidget('w2', 2),
+        makeWidget('w3', 3),
+      ]),
+    ]);
+
+    const w2Before = getWidget(stateRef, 'w2');
+    const w3Before = getWidget(stateRef, 'w3');
+
+    act(() => {
+      stateRef.current?.bringToFront('w1');
+    });
+
+    await waitFor(() => {
+      expect(getWidget(stateRef, 'w1').z).toBe(4);
+    });
+    // Untouched widgets keep the SAME object reference (memoization contract)
+    expect(getWidget(stateRef, 'w2')).toBe(w2Before);
+    expect(getWidget(stateRef, 'w3')).toBe(w3Before);
+  });
+
+  it('is a state no-op when the clicked widget is already frontmost', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([makeWidget('w1', 1), makeWidget('w2', 2)]),
+    ]);
+
+    const dashboardsBefore = stateRef.current?.dashboards;
+
+    act(() => {
+      stateRef.current?.bringToFront('w2');
+    });
+
+    // Returning the previous state object means the dashboards array
+    // identity is unchanged — no commit, no consumer re-render.
+    expect(stateRef.current?.dashboards).toBe(dashboardsBefore);
+  });
+
+  it('raises an entire group above the non-group max, preserving internal z-order', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([
+        makeWidget('g1', 1, { groupId: 'group-A' }),
+        makeWidget('g2', 3, { groupId: 'group-A' }),
+        makeWidget('solo', 5),
+      ]),
+    ]);
+
+    const soloBefore = getWidget(stateRef, 'solo');
+
+    act(() => {
+      stateRef.current?.bringToFront('g2');
+    });
+
+    await waitFor(() => {
+      // maxZ was 5; group members stack at 6, 7 in their original order
+      expect(getWidget(stateRef, 'g1').z).toBe(6);
+      expect(getWidget(stateRef, 'g2').z).toBe(7);
+    });
+    // Non-group widget object is untouched
+    expect(getWidget(stateRef, 'solo')).toBe(soloBefore);
+  });
+
+  it('is a state no-op when the entire group is already on top', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([
+        makeWidget('solo', 1),
+        makeWidget('g1', 2, { groupId: 'group-A' }),
+        makeWidget('g2', 3, { groupId: 'group-A' }),
+      ]),
+    ]);
+
+    const dashboardsBefore = stateRef.current?.dashboards;
+
+    act(() => {
+      stateRef.current?.bringToFront('g1');
+    });
+
+    expect(stateRef.current?.dashboards).toBe(dashboardsBefore);
+  });
+});
+
+describe('DashboardContext minimize/restore identity preservation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedSnapshotCb = null;
+  });
+
+  it('minimizeAllWidgets keeps object identity for already-minimized widgets', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([
+        makeWidget('open', 1),
+        makeWidget('mini', 2, { minimized: true }),
+      ]),
+    ]);
+
+    const miniBefore = getWidget(stateRef, 'mini');
+
+    act(() => {
+      stateRef.current?.minimizeAllWidgets();
+    });
+
+    await waitFor(() => {
+      expect(getWidget(stateRef, 'open').minimized).toBe(true);
+    });
+    expect(getWidget(stateRef, 'mini')).toBe(miniBefore);
+  });
+
+  it('restoreAllWidgets is a dashboard no-op when nothing is minimized/flipped/maximized', async () => {
+    const stateRef = setup();
+    await pushSnapshot([
+      makeDashboard([makeWidget('w1', 1), makeWidget('w2', 2)]),
+    ]);
+
+    const activeBefore = stateRef.current?.activeDashboard;
+
+    act(() => {
+      stateRef.current?.restoreAllWidgets();
+    });
+
+    expect(stateRef.current?.activeDashboard).toBe(activeBefore);
+  });
+});

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -4963,13 +4963,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   const minimizeAllWidgets = useCallback(() => {
-    if (!activeId) return;
+    if (!activeIdRef.current) return;
     if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
       prev.map((d) => {
-        if (d.id !== activeId) return d;
+        if (d.id !== activeIdRef.current) return d;
         // Keep object identity for widgets that are already minimized so
         // memoized renderers skip them; only rebuild when something changes.
         let changed = false;
@@ -4981,16 +4981,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         return changed ? { ...d, widgets } : d;
       })
     );
-  }, [activeId]);
+  }, []);
 
   const restoreAllWidgets = useCallback(() => {
-    if (!activeId) return;
+    if (!activeIdRef.current) return;
     if (isActiveBoardReadOnlyRef.current) return;
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
       prev.map((d) => {
-        if (d.id !== activeId) return d;
+        if (d.id !== activeIdRef.current) return d;
         // Same identity-preservation pattern as minimizeAllWidgets.
         let changed = false;
         const widgets = d.widgets.map((w) => {
@@ -5001,7 +5001,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         return changed ? { ...d, widgets } : d;
       })
     );
-  }, [activeId]);
+  }, []);
 
   const deleteAllWidgets = useCallback(() => {
     if (!activeId) return;

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -4705,9 +4705,13 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
             return w;
           });
 
+          // Widget id not on this board — keep the dashboard object identity
+          // so memoized consumers don't re-render on a no-op.
+          if (!widgetType) return d;
+
           // Save config globally so new instances inherit settings.
           // saveWidgetConfig handles transient-key stripping (including PII fields).
-          if (widgetType && updates.config) {
+          if (updates.config) {
             saveWidgetConfig(widgetType, updates.config);
           }
 
@@ -4842,22 +4846,37 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       const active = prev.find((d) => d.id === activeIdRef.current);
       if (!active) return prev;
 
-      const maxZ = active.widgets.reduce((max, w) => Math.max(max, w.z), 0);
-      const target = active.widgets.find((w) => w.id === id);
+      // Single pass: locate the target and the board-wide max z. Runs in the
+      // pointer-down handler, so avoid the reduce/filter/sort/spread chain
+      // and its transient array allocations.
+      let maxZ = 0;
+      let target: WidgetData | undefined;
+      for (const w of active.widgets) {
+        if (w.z > maxZ) maxZ = w.z;
+        if (w.id === id) target = w;
+      }
       if (!target) return prev;
 
       // If widget is in a group, bring the entire group to front
       if (target.groupId) {
-        const groupMembers = active.widgets
-          .filter((w) => w.groupId === target.groupId)
-          .sort((a, b) => a.z - b.z);
-        const groupIdSet = new Set(groupMembers.map((w) => w.id));
-        const groupMinZ = Math.min(...groupMembers.map((w) => w.z));
-        const nonGroupMaxZ = active.widgets.reduce((max, w) => {
-          if (groupIdSet.has(w.id)) return max;
-          return Math.max(max, w.z);
-        }, Number.NEGATIVE_INFINITY);
+        const groupId = target.groupId;
+        const groupMembers: WidgetData[] = [];
+        let groupMinZ = Number.POSITIVE_INFINITY;
+        let nonGroupMaxZ = Number.NEGATIVE_INFINITY;
+        for (const w of active.widgets) {
+          if (w.groupId === groupId) {
+            groupMembers.push(w);
+            if (w.z < groupMinZ) groupMinZ = w.z;
+          } else if (w.z > nonGroupMaxZ) {
+            nonGroupMaxZ = w.z;
+          }
+        }
         if (groupMinZ > nonGroupMaxZ) return prev; // entire group is already on top
+        // Preserve internal z-order within the group
+        groupMembers.sort((a, b) => a.z - b.z);
+        const newZById = new Map(
+          groupMembers.map((gw, idx) => [gw.id, maxZ + 1 + idx])
+        );
         lastLocalUpdateAt.current = Date.now();
         lastUpdateWasSettingsOnly.current = false;
         return prev.map((d) => {
@@ -4865,10 +4884,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
           return {
             ...d,
             widgets: d.widgets.map((w) => {
-              if (!groupIdSet.has(w.id)) return w;
-              // Preserve internal z-order within the group
-              const idx = groupMembers.findIndex((gw) => gw.id === w.id);
-              return { ...w, z: maxZ + 1 + idx };
+              const newZ = newZById.get(w.id);
+              return newZ === undefined ? w : { ...w, z: newZ };
             }),
           };
         });
@@ -4951,18 +4968,18 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
-      prev.map((d) =>
-        d.id === activeId
-          ? {
-              ...d,
-              widgets: d.widgets.map((w) => ({
-                ...w,
-                minimized: true,
-                flipped: false,
-              })),
-            }
-          : d
-      )
+      prev.map((d) => {
+        if (d.id !== activeId) return d;
+        // Keep object identity for widgets that are already minimized so
+        // memoized renderers skip them; only rebuild when something changes.
+        let changed = false;
+        const widgets = d.widgets.map((w) => {
+          if (w.minimized && !w.flipped) return w;
+          changed = true;
+          return { ...w, minimized: true, flipped: false };
+        });
+        return changed ? { ...d, widgets } : d;
+      })
     );
   }, [activeId]);
 
@@ -4972,19 +4989,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     lastLocalUpdateAt.current = Date.now();
     lastUpdateWasSettingsOnly.current = false;
     setDashboards((prev) =>
-      prev.map((d) =>
-        d.id === activeId
-          ? {
-              ...d,
-              widgets: d.widgets.map((w) => ({
-                ...w,
-                minimized: false,
-                flipped: false,
-                maximized: false,
-              })),
-            }
-          : d
-      )
+      prev.map((d) => {
+        if (d.id !== activeId) return d;
+        // Same identity-preservation pattern as minimizeAllWidgets.
+        let changed = false;
+        const widgets = d.widgets.map((w) => {
+          if (!w.minimized && !w.flipped && !w.maximized) return w;
+          changed = true;
+          return { ...w, minimized: false, flipped: false, maximized: false };
+        });
+        return changed ? { ...d, widgets } : d;
+      })
     );
   }, [activeId]);
 

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -1,0 +1,694 @@
+/**
+ * Performance baseline harness for the dashboard canvas
+ * (DashboardContext → BoardCanvas → WidgetRenderer → DraggableWindow).
+ *
+ * Mounts the REAL DashboardProvider (real reducer/callback surface, mocked
+ * Firestore transport) and the real BoardCanvas/WidgetRenderer/DraggableWindow
+ * stack inside a <React.Profiler>, seeds a board with 15 widgets of mixed
+ * types at realistic positions/sizes, and scripts the highest-frequency
+ * teacher interactions:
+ *
+ *   (1) mount15        — mount provider + board, push the 15-widget snapshot
+ *   (2) drag.press / drag.move30 / drag.release
+ *                      — pointer-drag one widget 30 × 5px (key metric:
+ *                        does every move commit the whole board, or zero?)
+ *   (3) resize.press / resize.move30 / resize.release
+ *                      — same gesture on the SE resize handle
+ *   (4) bringToFront5  — pointer-down on 5 different non-top widgets
+ *   (5) addWidget / removeWidget
+ *   (6) minimize / restore
+ *
+ * For each scenario we record:
+ *   - Profiler commit COUNT (primary metric — must be identical run-to-run)
+ *   - summed actualDuration (indicative only; machine-dependent)
+ *
+ * Results are written to tests/perf/results/dashboard-baseline.json. The
+ * test asserts only that metrics were produced and that the gestures had
+ * their expected behavioral outcome — NO duration thresholds, so this can
+ * never be flaky on slow CI machines.
+ *
+ * Run: pnpm exec vitest run tests/perf/dashboardPerf.test.tsx
+ *
+ * Mocking strategy (matches neighboring tests, e.g.
+ * tests/DashboardContext_removeWidgets.test.tsx and
+ * tests/components/common/DraggableWindow.test.tsx):
+ *   - useAuth / useFirestore / useRosters / useCollections /
+ *     useSharedCollection: stubbed hooks (no Firebase network).
+ *   - firebase/firestore: partial mock of the functions DashboardContext
+ *     calls outside the useFirestore abstraction (dock hydration path).
+ *   - useDialog + @/config/firebase: already mocked globally in tests/setup.ts.
+ *   - WidgetRegistry + WidgetLayout: lightweight synchronous stub widgets so
+ *     the harness measures the canvas machinery (DraggableWindow /
+ *     WidgetRenderer / context fan-out), not individual widget internals.
+ *   - useScreenshot: stubbed (html2canvas is irrelevant to canvas perf).
+ *   - Fake timers (incl. requestAnimationFrame + Date) so the provider's
+ *     debounced-save timers and DraggableWindow's rAF-coalesced pointermove
+ *     handling flush deterministically inside each scenario's window.
+ *   - PointerEvent / pointer capture / ResizeObserver / canvas getContext:
+ *     stubbed globally in tests/setup.ts; document.elementsFromPoint is
+ *     stubbed here (jsdom does not implement it).
+ *
+ * jsdom caveat (recorded as skipped in the results file): snap-overlay edge
+ * detection and the snap-layout menu need real viewport geometry, so the drag
+ * path deliberately stays >EDGE_THRESHOLD px away from every screen edge and
+ * the snap menu is never opened.
+ */
+
+import React, { Profiler, useEffect } from 'react';
+import type { ProfilerOnRenderCallback } from 'react';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { act, fireEvent, render } from '@testing-library/react';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { DashboardProvider } from '@/context/DashboardContext';
+import { useDashboard } from '@/context/useDashboard';
+import { BoardCanvas } from '@/components/layout/BoardCanvas';
+import type {
+  Dashboard,
+  LiveSession,
+  LiveStudent,
+  WidgetData,
+  WidgetType,
+} from '@/types';
+
+// ─── Shared fixtures (hoisted so vi.mock factories can use them) ────────────
+
+const { STUB_WIDGET_TYPES } = vi.hoisted(() => ({
+  // 15 widgets across 8 distinct types — all on the standard (non-position-
+  // aware) drag path, which is what every widget except the 3 catalyst types
+  // uses. All are registered skipScaling so the container-query branch of
+  // WidgetRenderer is exercised (the majority path per WidgetRegistry).
+  STUB_WIDGET_TYPES: [
+    'clock',
+    'text',
+    'checklist',
+    'poll',
+    'weather',
+    'schedule',
+    'dice',
+    'scoreboard',
+    'clock',
+    'text',
+    'checklist',
+    'poll',
+    'weather',
+    'schedule',
+    'dice',
+  ] as const,
+}));
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      uid: 'perf-user',
+      displayName: 'Perf Teacher',
+      email: 'perf@example.com',
+    },
+    isAdmin: false,
+    roleId: null,
+    isStudentRole: false,
+    roleResolved: true,
+    refreshGoogleToken: vi.fn(),
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    profileLoaded: true,
+    setupCompleted: true,
+    lastActiveCollectionId: null,
+    lastBoardIdByCollection: {},
+    remoteControlEnabled: true,
+    canAccessFeature: () => false,
+    canAccessWidget: () => true,
+    disableCloseConfirmation: false,
+  }),
+}));
+
+type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+let capturedSnapshotCb: SnapshotCb | null = null;
+
+vi.mock('@/hooks/useFirestore', () => ({
+  useFirestore: () => ({
+    saveDashboard: vi.fn().mockResolvedValue(Date.now()),
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboards: vi.fn((cb: SnapshotCb) => {
+      capturedSnapshotCb = cb;
+      return () => {
+        // cleanup
+      };
+    }),
+    shareDashboard: vi.fn(),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+  }),
+}));
+
+vi.mock('@/hooks/useRosters', () => ({
+  useRosters: () => ({
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  // Real module reference so any unmocked Firestore function still resolves
+  // to its real implementation. We override only the functions
+  // DashboardContext calls directly outside the useFirestore abstraction —
+  // primarily the dock-hydration path that reads userProfile via
+  // doc()/getDoc() and persists via setDoc().
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// Stub widget bodies: a synchronous div instead of the lazy-loaded real
+// widget, so the harness measures DraggableWindow/WidgetRenderer/context
+// machinery rather than individual widget internals.
+vi.mock('@/components/widgets/WidgetLayout', async () => {
+  const ReactActual = await import('react');
+  const Stub = ({ widget }: { widget: { id: string; type: string } }) =>
+    ReactActual.createElement(
+      'div',
+      { 'data-testid': `stub-widget-${widget.id}` },
+      widget.type
+    );
+  return { WidgetLayout: Stub, WidgetLayoutWrapper: Stub };
+});
+
+vi.mock('@/components/widgets/WidgetRegistry', () => {
+  const scaling: Record<string, { skipScaling: boolean }> = {};
+  for (const type of STUB_WIDGET_TYPES) {
+    scaling[type] = { skipScaling: true };
+  }
+  return {
+    WIDGET_COMPONENTS: {},
+    WIDGET_SETTINGS_COMPONENTS: {},
+    WIDGET_APPEARANCE_COMPONENTS: {},
+    DEFAULT_SCALING_CONFIG: {
+      baseWidth: 300,
+      baseHeight: 200,
+      canSpread: true,
+    },
+    WIDGET_SCALING_CONFIG: scaling,
+  };
+});
+
+vi.mock('@/components/widgets/LiveControl', () => ({
+  LiveControl: () => null,
+}));
+
+vi.mock('@/components/widgets/stickers/StickerItemWidget', () => ({
+  StickerItemWidget: () => null,
+}));
+
+vi.mock('@/hooks/useScreenshot', () => ({
+  useScreenshot: () => ({
+    takeScreenshot: vi.fn(),
+    isFlashing: false,
+    isCapturing: false,
+  }),
+}));
+
+// ─── jsdom environment stubs ─────────────────────────────────────────────────
+
+const originalElementsFromPointDescriptor = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  'elementsFromPoint'
+);
+
+beforeAll(() => {
+  // jsdom does not implement elementsFromPoint; DraggableWindow uses it for
+  // resize-handle / inner-edge pass-through checks. Returning [] means "no
+  // interactive element beneath", which keeps the gesture on the handle.
+  Object.defineProperty(Document.prototype, 'elementsFromPoint', {
+    configurable: true,
+    value: () => [],
+  });
+  // Fake timers (incl. rAF + Date) make the provider's debounced-save timers
+  // and the drag handlers' rAF coalescing flush deterministically inside each
+  // scenario window. performance/queueMicrotask stay real so Profiler
+  // durations remain meaningful and awaits flush naturally.
+  vi.useFakeTimers({
+    toFake: [
+      'setTimeout',
+      'clearTimeout',
+      'setInterval',
+      'clearInterval',
+      'Date',
+      'requestAnimationFrame',
+      'cancelAnimationFrame',
+    ],
+  });
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+  if (originalElementsFromPointDescriptor) {
+    Object.defineProperty(
+      Document.prototype,
+      'elementsFromPoint',
+      originalElementsFromPointDescriptor
+    );
+  } else {
+    Reflect.deleteProperty(Document.prototype, 'elementsFromPoint');
+  }
+});
+
+// ─── Profiler recorder ───────────────────────────────────────────────────────
+
+interface ScenarioMetric {
+  scenario: string;
+  commits: number;
+  actualDurationMs: number;
+}
+
+const metrics: ScenarioMetric[] = [];
+
+function createRecorder() {
+  let commits = 0;
+  let duration = 0;
+  const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
+    commits += 1;
+    duration += actualDuration;
+  };
+  return {
+    onRender,
+    start() {
+      commits = 0;
+      duration = 0;
+    },
+    record(scenario: string) {
+      metrics.push({
+        scenario,
+        commits,
+        actualDurationMs: Number(duration.toFixed(3)),
+      });
+    },
+  };
+}
+
+/**
+ * Flush everything the scenario scheduled — debounced Firestore saves
+ * (showSaving setTimeout(0) + 100–2500ms save debounces + post-save timers),
+ * pending rAF callbacks, and the promise chains they resolve — so commit
+ * attribution is identical run-to-run.
+ */
+const SETTLE_MS = 8000;
+async function settle(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+  });
+}
+
+/** Advance one rAF frame so DraggableWindow's coalesced pointermove runs. */
+async function frame(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(16);
+  });
+}
+
+function q<T extends Element>(selector: string): T {
+  const el = document.querySelector(selector);
+  if (!el) throw new Error(`Element not found: ${selector}`);
+  return el as T;
+}
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** 15 widgets of mixed stub types at realistic positions/sizes, z = 1..15. */
+function buildWidgets(): WidgetData[] {
+  return STUB_WIDGET_TYPES.map((type, i) => {
+    const n = i + 1;
+    return {
+      id: `w-${n}`,
+      type: type as WidgetType,
+      x: 40 + (i % 5) * 190,
+      y: 40 + Math.floor(i / 5) * 230,
+      w: 260 + (i % 3) * 40,
+      h: 180 + (i % 2) * 60,
+      z: n,
+      flipped: false,
+      config: {} as WidgetData['config'],
+    };
+  });
+}
+
+function buildDashboard(widgets: WidgetData[]): Dashboard {
+  return {
+    id: 'perf-dash',
+    name: 'Perf Baseline Board',
+    background: 'bg-slate-900',
+    widgets,
+    createdAt: 1000,
+    updatedAt: 1000,
+    // Match the jsdom viewport so the provider's proportional-migration
+    // hydration is an identity transform and the seeded geometry survives.
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+  };
+}
+
+async function pushSnapshot(dashboards: Dashboard[]): Promise<void> {
+  if (!capturedSnapshotCb) throw new Error('Provider not mounted');
+  const cb = capturedSnapshotCb;
+  await act(async () => {
+    cb(dashboards, false);
+    await Promise.resolve();
+  });
+}
+
+// ─── Harness component ───────────────────────────────────────────────────────
+
+const EMPTY_STUDENTS: LiveStudent[] = [];
+const noopAsync = (): Promise<void> => Promise.resolve();
+const startSessionStub = (): Promise<LiveSession> => {
+  throw new Error('startSession is not exercised by the perf harness');
+};
+
+const ctxRef: { current: ReturnType<typeof useDashboard> | null } = {
+  current: null,
+};
+
+function getCtx(): ReturnType<typeof useDashboard> {
+  if (!ctxRef.current) throw new Error('Dashboard context not captured');
+  return ctxRef.current;
+}
+
+/**
+ * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
+ * BoardCanvas: context state and callbacks flow down as props, while
+ * DraggableWindow additionally reads useDashboard() directly.
+ */
+const BoardHarness: React.FC = () => {
+  const ctx = useDashboard();
+  useEffect(() => {
+    ctxRef.current = ctx;
+  });
+  if (!ctx.activeDashboard) return null;
+  return (
+    <BoardCanvas
+      dashboard={ctx.activeDashboard}
+      isActive
+      isMinimized={false}
+      animationClass=""
+      session={null}
+      students={EMPTY_STUDENTS}
+      emptyStudents={EMPTY_STUDENTS}
+      selectedWidgetId={ctx.selectedWidgetId}
+      zoom={ctx.zoom}
+      updateSessionConfig={noopAsync}
+      updateSessionBackground={noopAsync}
+      startSession={startSessionStub}
+      endSession={noopAsync}
+      removeStudent={noopAsync}
+      toggleFreezeStudent={noopAsync}
+      toggleGlobalFreeze={noopAsync}
+      updateWidget={ctx.updateWidget}
+      removeWidget={ctx.removeWidget}
+      duplicateWidget={ctx.duplicateWidget}
+      bringToFront={ctx.bringToFront}
+      addToast={ctx.addToast}
+      updateDashboardSettings={ctx.updateDashboardSettings}
+    />
+  );
+};
+
+// ─── Scenarios ───────────────────────────────────────────────────────────────
+
+const MOUSE = { pointerType: 'mouse' } as const;
+
+describe('dashboard canvas performance baseline', () => {
+  it('mount15, drag30, resize30, bringToFront5, addRemove, minimizeRestore', async () => {
+    const rec = createRecorder();
+    const widgets = buildWidgets();
+
+    // (1) mount15 — mount the provider + board and push the 15-widget snapshot.
+    rec.start();
+    render(
+      <Profiler id="dashboard-canvas" onRender={rec.onRender}>
+        <DashboardProvider>
+          <BoardHarness />
+        </DashboardProvider>
+      </Profiler>
+    );
+    await pushSnapshot([buildDashboard(widgets)]);
+    await settle();
+    rec.record('mount15');
+    expect(document.querySelectorAll('[data-widget-id]')).toHaveLength(15);
+
+    // Post-mount geometry baselines (the provider's proportional-migration
+    // hydration may round pixel values slightly on load).
+    const mountedWidgets = getCtx().activeDashboard?.widgets ?? [];
+    const w5Start = mountedWidgets.find((w) => w.id === 'w-5');
+    const w7Start = mountedWidgets.find((w) => w.id === 'w-7');
+    if (!w5Start || !w7Start) throw new Error('seed widgets missing');
+
+    // (2) drag30 — press w-5's drag surface, 30 moves of 5px, release.
+    // Coordinates stay >EDGE_THRESHOLD px from every screen edge so the
+    // snap-zone preview never arms (see jsdom caveat in the header).
+    const dragSurface = q<HTMLElement>(
+      '[data-widget-id="w-5"] [data-testid="drag-surface"]'
+    );
+    rec.start();
+    fireEvent.pointerDown(dragSurface, {
+      ...MOUSE,
+      pointerId: 11,
+      clientX: 500,
+      clientY: 300,
+    });
+    await settle();
+    rec.record('drag.press');
+
+    rec.start();
+    for (let i = 1; i <= 30; i++) {
+      fireEvent.pointerMove(dragSurface, {
+        ...MOUSE,
+        pointerId: 11,
+        clientX: 500 + i * 5,
+        clientY: 300,
+      });
+      await frame();
+    }
+    rec.record('drag.move30');
+
+    rec.start();
+    fireEvent.pointerUp(dragSurface, {
+      ...MOUSE,
+      pointerId: 11,
+      clientX: 650,
+      clientY: 300,
+    });
+    await settle();
+    rec.record('drag.release');
+
+    // Behavioral validity: the drag committed a 150px x-translation.
+    const draggedW5 = getCtx().activeDashboard?.widgets.find(
+      (w) => w.id === 'w-5'
+    );
+    expect(draggedW5?.x).toBe(w5Start.x + 150);
+    expect(draggedW5?.y).toBe(w5Start.y);
+
+    // (3) resize30 — press w-7's SE resize handle, 30 moves of 5px, release.
+    const seHandle = q<HTMLElement>(
+      '[data-widget-id="w-7"] .resize-handle.cursor-se-resize'
+    );
+    rec.start();
+    fireEvent.pointerDown(seHandle, {
+      ...MOUSE,
+      pointerId: 22,
+      clientX: 600,
+      clientY: 500,
+    });
+    await settle();
+    rec.record('resize.press');
+
+    rec.start();
+    for (let i = 1; i <= 30; i++) {
+      fireEvent.pointerMove(seHandle, {
+        ...MOUSE,
+        pointerId: 22,
+        clientX: 600 + i * 5,
+        clientY: 500 + i * 5,
+      });
+      await frame();
+    }
+    rec.record('resize.move30');
+
+    rec.start();
+    fireEvent.pointerUp(seHandle, {
+      ...MOUSE,
+      pointerId: 22,
+      clientX: 750,
+      clientY: 650,
+    });
+    await settle();
+    rec.record('resize.release');
+
+    const resizedW7 = getCtx().activeDashboard?.widgets.find(
+      (w) => w.id === 'w-7'
+    );
+    expect(resizedW7?.w).toBe(w7Start.w + 150);
+    expect(resizedW7?.h).toBe(w7Start.h + 150);
+
+    // (4) bringToFront5 — pointer-down on 5 widgets that are each below the
+    // top of the z-stack at click time (w-5 holds the top z after the drag).
+    rec.start();
+    for (const id of ['w-1', 'w-2', 'w-3', 'w-4', 'w-6']) {
+      const root = q<HTMLElement>(`[data-widget-id="${id}"]`);
+      fireEvent.pointerDown(root, {
+        ...MOUSE,
+        pointerId: 33,
+        clientX: 100,
+        clientY: 100,
+      });
+      fireEvent.pointerUp(root, {
+        ...MOUSE,
+        pointerId: 33,
+        clientX: 100,
+        clientY: 100,
+      });
+      await settle();
+    }
+    rec.record('bringToFront5');
+    const zOfW6 = getCtx().activeDashboard?.widgets.find(
+      (w) => w.id === 'w-6'
+    )?.z;
+    const maxZ = Math.max(
+      ...(getCtx().activeDashboard?.widgets.map((w) => w.z) ?? [0])
+    );
+    expect(zOfW6).toBe(maxZ); // last-raised widget ends on top
+
+    // (5) addRemove — add one widget through the real context action, then
+    // remove it.
+    const seededIds = new Set(
+      getCtx().activeDashboard?.widgets.map((w) => w.id)
+    );
+    rec.start();
+    act(() => {
+      getCtx().addWidget('text');
+    });
+    await settle();
+    rec.record('addWidget');
+
+    const added = getCtx().activeDashboard?.widgets.find(
+      (w) => !seededIds.has(w.id)
+    );
+    if (!added) throw new Error('addWidget did not add a widget');
+    rec.start();
+    act(() => {
+      getCtx().removeWidget(added.id);
+    });
+    await settle();
+    rec.record('removeWidget');
+    expect(getCtx().activeDashboard?.widgets).toHaveLength(15);
+
+    // (6) minimizeRestore — same updateWidget payloads the Esc shortcut and
+    // the dock's minimized tray use.
+    rec.start();
+    act(() => {
+      getCtx().updateWidget('w-3', { minimized: true, flipped: false });
+    });
+    await settle();
+    rec.record('minimize');
+
+    rec.start();
+    act(() => {
+      getCtx().updateWidget('w-3', { minimized: false });
+    });
+    await settle();
+    rec.record('restore');
+    expect(
+      getCtx().activeDashboard?.widgets.find((w) => w.id === 'w-3')?.minimized
+    ).toBe(false);
+
+    // The harness only asserts that metrics were produced — no duration
+    // thresholds (CI machines vary; this must never be flaky).
+    expect(metrics).toHaveLength(12);
+    for (const m of metrics) {
+      expect(m.commits).toBeGreaterThanOrEqual(0);
+      expect(m.actualDurationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+// ─── Results file ────────────────────────────────────────────────────────────
+
+afterAll(() => {
+  // Vitest serves test modules over a non-file URL, so import.meta.url can't
+  // be used for paths — resolve from the repo root (vitest's cwd) instead.
+  const resultsDir = resolve(process.cwd(), 'tests/perf/results');
+  mkdirSync(resultsDir, { recursive: true });
+  writeFileSync(
+    join(resultsDir, 'dashboard-baseline.json'),
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        runCommand: 'pnpm exec vitest run tests/perf/dashboardPerf.test.tsx',
+        note:
+          'Profiler commit counts are the deterministic primary metric and ' +
+          'must be identical across runs. actualDurationMs is machine-' +
+          'dependent and indicative only — compare medians of 3 runs.',
+        skipped:
+          'Snap-overlay edge snapping and the snap-layout menu need real ' +
+          'viewport geometry, so they are not exercised in jsdom; the drag ' +
+          'path deliberately stays away from screen edges.',
+        scenarios: metrics,
+      },
+      null,
+      2
+    ) + '\n'
+  );
+});

--- a/tests/perf/results/dashboard-after.json
+++ b/tests/perf/results/dashboard-after.json
@@ -1,0 +1,19 @@
+{
+  "generatedAt": "2026-06-10T02:31:00.000Z",
+  "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
+  "note": "Median of 3 runs. Profiler commit counts were identical across all 3 runs (deterministic primary metric); actualDurationMs is the median of the 3 runs.",
+  "scenarios": [
+    { "scenario": "mount15", "commits": 4, "actualDurationMs": 92.891 },
+    { "scenario": "drag.press", "commits": 2, "actualDurationMs": 10.647 },
+    { "scenario": "drag.move30", "commits": 0, "actualDurationMs": 0 },
+    { "scenario": "drag.release", "commits": 2, "actualDurationMs": 10.108 },
+    { "scenario": "resize.press", "commits": 1, "actualDurationMs": 0.606 },
+    { "scenario": "resize.move30", "commits": 0, "actualDurationMs": 0 },
+    { "scenario": "resize.release", "commits": 2, "actualDurationMs": 11.368 },
+    { "scenario": "bringToFront5", "commits": 10, "actualDurationMs": 50.677 },
+    { "scenario": "addWidget", "commits": 2, "actualDurationMs": 13.826 },
+    { "scenario": "removeWidget", "commits": 2, "actualDurationMs": 10.682 },
+    { "scenario": "minimize", "commits": 2, "actualDurationMs": 10.519 },
+    { "scenario": "restore", "commits": 2, "actualDurationMs": 10.307 }
+  ]
+}

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,0 +1,68 @@
+{
+  "generatedAt": "2026-06-10T02:14:31.171Z",
+  "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
+  "note": "Profiler commit counts are the deterministic primary metric and must be identical across runs. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
+  "scenarios": [
+    {
+      "scenario": "mount15",
+      "commits": 4,
+      "actualDurationMs": 92.154
+    },
+    {
+      "scenario": "drag.press",
+      "commits": 2,
+      "actualDurationMs": 10.695
+    },
+    {
+      "scenario": "drag.move30",
+      "commits": 0,
+      "actualDurationMs": 0
+    },
+    {
+      "scenario": "drag.release",
+      "commits": 2,
+      "actualDurationMs": 10.174
+    },
+    {
+      "scenario": "resize.press",
+      "commits": 1,
+      "actualDurationMs": 0.611
+    },
+    {
+      "scenario": "resize.move30",
+      "commits": 0,
+      "actualDurationMs": 0
+    },
+    {
+      "scenario": "resize.release",
+      "commits": 2,
+      "actualDurationMs": 10.523
+    },
+    {
+      "scenario": "bringToFront5",
+      "commits": 10,
+      "actualDurationMs": 50.93
+    },
+    {
+      "scenario": "addWidget",
+      "commits": 2,
+      "actualDurationMs": 13.708
+    },
+    {
+      "scenario": "removeWidget",
+      "commits": 2,
+      "actualDurationMs": 10.532
+    },
+    {
+      "scenario": "minimize",
+      "commits": 2,
+      "actualDurationMs": 10.445
+    },
+    {
+      "scenario": "restore",
+      "commits": 2,
+      "actualDurationMs": 10.308
+    }
+  ]
+}

--- a/tests/perf/results/dashboard-bundle-after.json
+++ b/tests/perf/results/dashboard-bundle-after.json
@@ -1,0 +1,17 @@
+{
+  "chunks": [
+    {
+      "name": "WidgetRenderer.js",
+      "gzipKb": 34.56
+    },
+    {
+      "name": "DashboardView.js",
+      "gzipKb": 383.65
+    },
+    {
+      "name": "index.js",
+      "gzipKb": 368.09
+    }
+  ],
+  "totalGzipKb": 786.3
+}

--- a/tests/perf/results/dashboard-bundle-baseline.json
+++ b/tests/perf/results/dashboard-bundle-baseline.json
@@ -1,0 +1,17 @@
+{
+  "chunks": [
+    {
+      "name": "WidgetRenderer.js",
+      "gzipKb": 34.55
+    },
+    {
+      "name": "DashboardView.js",
+      "gzipKb": 383.66
+    },
+    {
+      "name": "index.js",
+      "gzipKb": 367.97
+    }
+  ],
+  "totalGzipKb": 786.18
+}


### PR DESCRIPTION
## Summary

Third run of the `perf-ux-pass` workflow, this time over the **dashboard canvas** (DraggableWindow / WidgetRenderer / DashboardContext) — the drag/resize/bring-to-front surface every teacher uses constantly, previously unmeasured.

### Headline baseline finding (good news)

The drag and resize **move paths already record 0 React commits** — DraggableWindow''s direct-DOM fast path works. The real cost center is **whole-board commits on every context mutation** (~2 commits × ~10ms with stub widget bodies per press/release/add/remove/minimize): every widget shell consumes `useDashboard()` directly, so any context-value recreation re-renders all of them. The root fix (context split / selector subscription) is **deferred as a high-risk refactor** of the 5,200-line context; this PR lands the low-risk slice.

### Changes

- `minimizeAllWidgets` / `restoreAllWidgets` now preserve object identity for unchanged widgets and return the same dashboard object when nothing changed (equal-or-fewer debounced Firestore saves)
- `updateWidget` returns the unmodified dashboard on widget-id miss
- `bringToFront` z-scan collapsed from reduce/filter/sort/map/spread to a single pass (byte-identical z assignments); the no-op identity contract is pinned by 6 new regression tests (`context/DashboardContext.bringToFront.test.tsx`)
- `occupiedCells` snap-grid memo short-circuits to a stable empty constant while the snap menu is closed (was O(widgets) on every DraggableWindow render)
- `POSITION_AWARE_WIDGETS` consolidated to one shared `ReadonlySet` (was duplicated in 2 files; `.includes()` → `.has()` on the drag hot path)
- `handleToggleLive` wrapped in `useCallback`
- New permanent ruler: `tests/perf/dashboardPerf.test.tsx` + `tests/perf/results/dashboard-*.json` (12 scenarios, commit counts deterministic across 3 runs); `perf-ux-pass.js` gains a `resultsPrefix` arg so new-surface passes don''t overwrite a prior pass''s ruler

### Honest measurement

All 12 harness scenarios are **commit-identical before/after** and durations are within noise — the wins here are off the commit path (allocations, skipped per-render work) or on no-op paths the harness doesn''t exercise, plus a mild Firestore write-volume reduction. Several findings the synthesis approved turned out to be already-fixed on audit (mappers already preserved identity for touched-path widgets; callbacks already stable) — the implementer narrowed scope rather than churning code.

Bundle: 786.18 → 786.30 KB gzip across tracked chunks (+0.015%, minifier noise).

### Gates

- type-check / lint (zero warnings) / format / tests: all green (workflow gates + local re-verification)
- **Cost audit: NEUTRAL, mildly write-reducing** — zero added Firestore reads/writes/listeners, Storage ops, or AI calls; two changes can only reduce write volume

### Deferred (recorded for future passes)

DashboardContext read/actions split (the real fan-out fix — revisit if canvas perf is felt), side-car z-order store, DOM-only drag for catalyst widgets, board-pan menu-style skip, snap-preview-before-threshold (behavior change), focus restoration after add/delete (separate UX PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)