### PR TITLE
fix(DashboardView): guard groupBuildMode Escape against typing fields

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1205,12 +1205,20 @@ export const DashboardView: React.FC = () => {
   // Keyboard Navigation
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Escape: Exit group-build mode first (highest priority modal state)
+      // Escape: Exit group-build mode first (highest priority modal state).
+      // Guard: if focus is inside a typing field, let the second Escape branch
+      // handle it (blur the field) — don't exit group-build mode unexpectedly.
       if (e.key === 'Escape' && groupBuildMode) {
-        e.preventDefault();
-        setGroupBuildMode(false);
-        setSelectedWidgetIds([]);
-        return;
+        const activeEl = document.activeElement as HTMLElement;
+        const isTypingField =
+          ['INPUT', 'TEXTAREA', 'SELECT'].includes(activeEl?.tagName || '') ||
+          activeEl?.isContentEditable;
+        if (!isTypingField) {
+          e.preventDefault();
+          setGroupBuildMode(false);
+          setSelectedWidgetIds([]);
+          return;
+        }
       }
 
       // Escape: Close top-most widget or blur input

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -879,4 +879,128 @@ describe('DashboardView Gestures & Navigation', () => {
       expect(mockRemoveToast).toHaveBeenCalledWith('toast-1');
     });
   });
+
+  // Regression: groupBuildMode Escape handler lacked a typing-field guard.
+  //
+  // Bug: when groupBuildMode was active, the first `if (e.key === 'Escape' &&
+  // groupBuildMode)` branch ran unconditionally — it called e.preventDefault()
+  // and setGroupBuildMode(false) even when the user had an INPUT/TEXTAREA/SELECT
+  // focused and was pressing Escape intending only to dismiss/blur that field.
+  // The "blur the input" path in the second `if (e.key === 'Escape')` block was
+  // never reached because the first branch returned early, so the input kept
+  // focus and the user was left with group-build mode silently cancelled.
+  //
+  // Fix: add a typing-field guard at the top of the groupBuildMode branch so
+  // that Escape inside a form field blurs the field and leaves groupBuildMode
+  // active, consistent with all other keyboard shortcut branches.
+  describe('groupBuildMode Escape does not exit group-build when a typing field is focused', () => {
+    const collectionsStub = {
+      collections: [],
+      loading: false,
+      error: null,
+      createCollection: vi.fn(),
+      renameCollection: vi.fn(),
+      moveCollection: vi.fn(),
+      deleteCollection: vi.fn(),
+      reorderSiblings: vi.fn(),
+      setCollectionMetadata: vi.fn(),
+      setCollectionDefaultBoard: vi.fn(),
+    };
+
+    let inputEl: HTMLInputElement;
+    const mockSetGroupBuildMode = vi.fn();
+    const mockSetSelectedWidgetIds = vi.fn();
+
+    beforeEach(() => {
+      mockSetGroupBuildMode.mockClear();
+      mockSetSelectedWidgetIds.mockClear();
+
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: mockDashboards[1],
+        dashboards: mockDashboards,
+        toasts: [],
+        addWidget: mockAddWidget,
+        loadDashboard: mockLoadDashboard,
+        removeToast: vi.fn(),
+        updateWidget: vi.fn(),
+        removeWidget: vi.fn(),
+        duplicateWidget: vi.fn(),
+        bringToFront: vi.fn(),
+        addToast: vi.fn(),
+        minimizeAllWidgets: vi.fn(),
+        restoreAllWidgets: vi.fn(),
+        deleteAllWidgets: vi.fn(),
+        setSelectedWidgetId: vi.fn(),
+        zoom: 1,
+        setZoom: vi.fn(),
+        // group-build state
+        groupBuildMode: true,
+        setGroupBuildMode: mockSetGroupBuildMode,
+        selectedWidgetIds: [],
+        setSelectedWidgetIds: mockSetSelectedWidgetIds,
+        collectionsApi: collectionsStub,
+      });
+
+      // Create and focus an input element so document.activeElement is an INPUT.
+      inputEl = document.createElement('input');
+      inputEl.type = 'text';
+      document.body.appendChild(inputEl);
+      inputEl.focus();
+    });
+
+    afterEach(() => {
+      if (inputEl.parentNode) {
+        inputEl.parentNode.removeChild(inputEl);
+      }
+    });
+
+    it('should NOT call setGroupBuildMode when Escape is pressed inside an input', () => {
+      render(<DashboardView />);
+
+      // Sanity: the focused element is our input.
+      expect(document.activeElement).toBe(inputEl);
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      // The typing-field guard must prevent group-build exit.
+      expect(mockSetGroupBuildMode).not.toHaveBeenCalled();
+      expect(mockSetSelectedWidgetIds).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call setGroupBuildMode when Escape is pressed inside a textarea', () => {
+      // Replace the input with a textarea.
+      if (inputEl.parentNode) inputEl.parentNode.removeChild(inputEl);
+      const textarea = document.createElement('textarea');
+      document.body.appendChild(textarea);
+      textarea.focus();
+
+      render(<DashboardView />);
+
+      expect(document.activeElement).toBe(textarea);
+      fireEvent.keyDown(window, { key: 'Escape' });
+      expect(mockSetGroupBuildMode).not.toHaveBeenCalled();
+
+      if (textarea.parentNode) textarea.parentNode.removeChild(textarea);
+    });
+
+    it('DOES call setGroupBuildMode when Escape is pressed with no typing field focused', () => {
+      // Move focus away from the input (to body or a non-typing element).
+      inputEl.blur();
+
+      render(<DashboardView />);
+
+      // document.activeElement is now body (not a typing field).
+      expect(
+        ['INPUT', 'TEXTAREA', 'SELECT'].includes(
+          (document.activeElement as HTMLElement)?.tagName || ''
+        )
+      ).toBe(false);
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      // Without a focused typing field, group-build mode should exit.
+      expect(mockSetGroupBuildMode).toHaveBeenCalledWith(false);
+      expect(mockSetSelectedWidgetIds).toHaveBeenCalledWith([]);
+    });
+  });
 });


### PR DESCRIPTION
## Root Cause

In `components/layout/DashboardView.tsx`, the global `handleKeyDown` handler exits group-build mode on Escape unconditionally:

```js
if (e.key === 'Escape' && groupBuildMode) {
  e.preventDefault();
  setGroupBuildMode(false);
  setSelectedWidgetIds([]);
  return;
}
```

Every other shortcut branch in the same handler (`Delete`, `Alt+P`, `Alt+Arrow`) applies the standard `isTypingField` guard before acting. This branch did not. Pressing Escape while an `INPUT`, `TEXTAREA`, or `SELECT` was focused and group-build mode was active would:
1. Call `e.preventDefault()` — suppress native Escape handling in the field
2. Call `setGroupBuildMode(false)` — silently cancel the mode the user didn't intend to exit
3. Skip the second Escape branch that blurs the field — leaving the input still focused

## Fix

Added the standard `isTypingField` guard (`['INPUT', 'TEXTAREA', 'SELECT'].includes(tagName) || isContentEditable`) to the group-build-mode Escape branch. When a typing field is focused, the first branch is skipped and the second branch handles blur as normal.

## Band-Aid Rejected

Moving `activeElement.blur()` into the first branch would fix the blur side-effect but still cancel group-build mode without user intent. The correct fix is to skip the entire first branch.

## Regression Test

`tests/components/layout/DashboardView.test.tsx` — 3 new tests:
- Escape in `<input>` with `groupBuildMode` active: `setGroupBuildMode` NOT called
- Escape in `<textarea>` with `groupBuildMode` active: `setGroupBuildMode` NOT called
- Escape with no focused field and `groupBuildMode` active: `setGroupBuildMode` IS called (golden-path guard)

**Before:** 2 failed / 19 passed | **After:** 21 passed

## Risk

**contained** — one-line guard added to a single keyboard handler branch. Pattern already used at 4 other shortcut branches in the same handler.

https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS

---
_Generated by [Claude Code](https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS)_