### PR TITLE
fix(export): deduplicate duplicate answers by first-occurrence in buildResultsSheetData

### DIFF
--- a/tests/utils/assignmentExportShared.test.ts
+++ b/tests/utils/assignmentExportShared.test.ts
@@ -166,6 +166,40 @@ describe('buildResultsSheetData', () => {
     expect(dataRows[1][3]).toBe('Zara');
   });
 
+  // Regression: Firestore arrayUnion races / Drive-sync double-writes can
+  // produce duplicate answer entries for the same questionId. The original
+  // `new Map(r.answers.map(...))` constructor kept the LAST duplicate, but
+  // `getEarnedPoints` (used for the published score) kept the FIRST (by
+  // chronological sort). When the last duplicate is wrong and the first is
+  // correct, the exported score would be 0% even though the student's
+  // published score is 100%. Fix: discard every answer after the first
+  // occurrence per questionId, matching the "first-wins" semantics of the
+  // scoring path.
+  it('deduplicates duplicate answers per question by first-occurrence', () => {
+    // Grader that awards full credit for 'correct' and zero for anything else.
+    const gradeFn = (_q: ExportableQuestion, answer: string): GradeResult => ({
+      isCorrect: answer === 'correct',
+      pointsEarned: answer === 'correct' ? 1 : 0,
+      pointsMax: 1,
+    });
+
+    const response = r({
+      answers: [
+        { questionId: 'q1', answer: 'correct' }, // first — should win
+        { questionId: 'q1', answer: 'wrong' }, // duplicate — should be ignored
+      ],
+    });
+
+    const { dataRows } = buildResultsSheetData([response], [q()], gradeFn);
+
+    // Score column index 6: should be 100% (first answer correct), not 0%
+    expect(dataRows[0][6]).toBe('100%');
+    // Points Earned column index 7: should be 1
+    expect(dataRows[0][7]).toBe('1');
+    // Q1 column (index 11): should show the first answer's earned points
+    expect(dataRows[0][11]).toBe('1');
+  });
+
   it('handles empty questions and responses without crashing', () => {
     const empty = buildResultsSheetData([], [], ALWAYS_FULL);
     expect(empty.headers).toHaveLength(11); // 11 fixed cols + 0 question cols

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -144,7 +144,22 @@ export function buildResultsSheetData<
       ? new Date(r.submittedAt).toLocaleString()
       : '';
     const warnings = r.tabSwitchWarnings?.toString() ?? '0';
-    const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
+    // Deduplicate by questionId, keeping the FIRST occurrence in the array.
+    // Firestore arrayUnion races and Drive-sync double-writes can produce
+    // duplicate answer entries; `new Map([...entries])` would silently keep
+    // the LAST duplicate, but the scoring path (`getEarnedPoints`) keeps the
+    // first chronologically-sorted entry. Mismatching the two would produce an
+    // export score that contradicts the student's published grade — same root
+    // cause as #1827. Using a for-loop with a prior-seen guard preserves
+    // array insertion order (= natural arrival order) as the tiebreak, which
+    // matches what happens in practice when no `answeredAt` field is present
+    // on the ExportableResponse interface.
+    const answerMap = new Map<string, (typeof r.answers)[number]>();
+    for (const a of r.answers) {
+      if (!answerMap.has(a.questionId)) {
+        answerMap.set(a.questionId, a);
+      }
+    }
     // Grade once per question per response, cached by question id. The
     // previous shape called `gradeFn` twice (once for the answer column,
     // once for the row sum) which doubled normalization/regex work on

--- a/utils/assignmentExportShared.ts
+++ b/utils/assignmentExportShared.ts
@@ -154,8 +154,9 @@ export function buildResultsSheetData<
     // array insertion order (= natural arrival order) as the tiebreak, which
     // matches what happens in practice when no `answeredAt` field is present
     // on the ExportableResponse interface.
-    const answerMap = new Map<string, (typeof r.answers)[number]>();
-    for (const a of r.answers) {
+    const answerMap = new Map<string, R['answers'][number]>();
+    const answers = r.answers ?? [];
+    for (const a of answers) {
       if (!answerMap.has(a.questionId)) {
         answerMap.set(a.questionId, a);
       }


### PR DESCRIPTION
## Root Cause

`buildResultsSheetData` in `utils/assignmentExportShared.ts` built the per-response answer map with:

```ts
const answerMap = new Map(r.answers.map((a) => [a.questionId, a]));
```

`Map` constructor iterates all entries and on duplicate keys the **last entry wins**. Firestore `arrayUnion` races and Drive-sync double-writes (the same failure mode fixed in `getEarnedPoints` #1827, `publishAssignmentScores` #1787/#1803/#1855, `buildContributionDoc` #1777) can produce duplicate answer entries for the same `questionId`.

When the first answer is correct and the second (duplicate) is wrong, the exported sheet graded zero — while `getEarnedPoints` (the published score already shown to students) uses the **first chronological entry** and returns full credit. A teacher could publish 100% and export a sheet showing 0% for the same student on the same question.

## Fix

Replaced the `Map` constructor with an explicit first-wins loop:

```ts
const answerMap = new Map<string, (typeof r.answers)[number]>();
for (const a of r.answers) {
  if (!answerMap.has(a.questionId)) answerMap.set(a.questionId, a);
}
```

## Band-Aid Rejected

Sorting `r.answers` by `answeredAt` before constructing the Map. Rejected because `ExportableResponse.answers` is typed as `{ questionId: string; answer: string }[]` — `answeredAt` is not in the shared interface. A sort on a field not guaranteed to exist would be fragile and could silently degrade to arbitrary ordering on legacy data.

## Regression Test

`tests/utils/assignmentExportShared.test.ts` — 1 new test:
- Response with `[{q1, correct}, {q1, wrong}]` (duplicate q1): score must be 100%, not 0%.

**Before:** 1 failed / 16 passed | **After:** 17 passed

## Risk

**contained** — same dedup pattern (#1827/#1787/#1803) already applied across 5 other scoring paths. This is the export path for the same data.

https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS

---
_Generated by [Claude Code](https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS)_