### PR TITLE
fix(i18n): add missing widgets.seatingChart translations to DE, ES, FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -854,6 +854,13 @@
         "minimal": "Minimal"
       }
     },
+    "seatingChart": {
+      "emptyStateAssignTitle": "Leeres Klassenzimmer",
+      "emptyStateAssignSubtitle": "Wechsle zu „Einrichten“, um Möbel anzuordnen.",
+      "emptyStateSetupTitle": "Keine Möbel",
+      "emptyStateFreeform": "Möbel über die Seitenleiste hinzufügen.",
+      "emptyStateTemplate": "Wähle eine Vorlage und klicke auf Layout anwenden."
+    },
     "schedule": {
       "startTimer": "Timer starten",
       "startTimerUntil": "Countdown-Timer bis {{time}} starten"

--- a/locales/es.json
+++ b/locales/es.json
@@ -891,6 +891,13 @@
       "emptyBoardHint": "Arrastra herramientas desde el Dock para empezar",
       "switchBoardsHint": "Usa los controles de navegación en la parte inferior izquierda para cambiar de tablero"
     },
+    "seatingChart": {
+      "emptyStateAssignTitle": "Aula vacía",
+      "emptyStateAssignSubtitle": "Cambia a «Configurar» para organizar el mobiliario.",
+      "emptyStateSetupTitle": "Sin mobiliario",
+      "emptyStateFreeform": "Añade mobiliario desde la barra lateral.",
+      "emptyStateTemplate": "Elige una plantilla y haz clic en Aplicar diseño."
+    },
     "schedule": {
       "startTimer": "Iniciar Temporizador",
       "startTimerUntil": "Iniciar cuenta regresiva hasta {{time}}"

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -854,6 +854,13 @@
         "minimal": "Minimal"
       }
     },
+    "seatingChart": {
+      "emptyStateAssignTitle": "Salle de classe vide",
+      "emptyStateAssignSubtitle": "Passez à « Configuration » pour disposer le mobilier.",
+      "emptyStateSetupTitle": "Aucun mobilier",
+      "emptyStateFreeform": "Ajoutez du mobilier depuis la barre latérale.",
+      "emptyStateTemplate": "Choisissez un modèle et cliquez sur Appliquer la mise en page."
+    },
     "schedule": {
       "startTimer": "Démarrer le minuteur",
       "startTimerUntil": "Démarrer le compte à rebours jusqu'à {{time}}"

--- a/tests/i18n/widgetSeatingChartLocales.test.ts
+++ b/tests/i18n/widgetSeatingChartLocales.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression test for missing widgets.seatingChart namespace in DE, ES, and FR.
+ *
+ * All 5 keys in widgets.seatingChart were absent from DE, ES, and FR — the
+ * entire sub-namespace did not exist in those files.  The call sites in
+ * components/widgets/SeatingChart/Widget.tsx use `defaultValue` fallbacks,
+ * which silently mask the bug at runtime (non-EN users see English text
+ * instead of translated text).
+ *
+ * The fix is to add proper translations to DE/ES/FR — NOT to rely on the
+ * defaultValue band-aid.
+ *
+ * AFFECTED CALL SITES (components/widgets/SeatingChart/Widget.tsx):
+ *   t('widgets.seatingChart.emptyStateAssignTitle',    { defaultValue: 'Empty Classroom' })          — line 967
+ *   t('widgets.seatingChart.emptyStateAssignSubtitle', { defaultValue: 'Switch to "Setup" to arrange furniture.' }) — line 970
+ *   t('widgets.seatingChart.emptyStateSetupTitle',     { defaultValue: 'No Furniture' })             — line 984
+ *   t('widgets.seatingChart.emptyStateFreeform',       { defaultValue: 'Add furniture from the sidebar.' }) — line 989
+ *   t('widgets.seatingChart.emptyStateTemplate',       { defaultValue: 'Pick a template and click Apply Layout.' }) — line 992
+ *
+ * These strings appear on the projected seating-chart widget face when the
+ * classroom has no furniture placed, so they are visible to the entire class.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+const REQUIRED_SEATING_CHART_KEYS = [
+  'emptyStateAssignTitle',
+  'emptyStateAssignSubtitle',
+  'emptyStateSetupTitle',
+  'emptyStateFreeform',
+  'emptyStateTemplate',
+] as const;
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — widgets.seatingChart baseline', () => {
+  it('has a widgets.seatingChart section', () => {
+    expect(en).toHaveProperty(['widgets', 'seatingChart']);
+  });
+
+  it('has all required widgets.seatingChart keys', () => {
+    for (const key of REQUIRED_SEATING_CHART_KEYS) {
+      expect(
+        en.widgets.seatingChart,
+        `en.widgets.seatingChart.${key} is missing from EN`
+      ).toHaveProperty(key);
+    }
+  });
+});
+
+// ─── DE / ES / FR parity ─────────────────────────────────────────────────────
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'es', locale: es },
+  { code: 'fr', locale: fr },
+])('$code locale — widgets.seatingChart parity with EN', ({ code, locale }) => {
+  it(`${code}: has a widgets.seatingChart section`, () => {
+    expect(
+      locale,
+      `${code}.widgets.seatingChart section is entirely missing`
+    ).toHaveProperty(['widgets', 'seatingChart']);
+  });
+
+  it(`${code}: has all required widgets.seatingChart keys`, () => {
+    for (const key of REQUIRED_SEATING_CHART_KEYS) {
+      expect(
+        (locale as typeof en).widgets.seatingChart,
+        `${code}.widgets.seatingChart.${key} is missing`
+      ).toHaveProperty(key);
+    }
+  });
+});


### PR DESCRIPTION
## Root Cause

The `widgets.seatingChart` sub-namespace (5 keys) was added to `locales/en.json` for empty-state messages on the projected seating-chart widget face but was never propagated to `locales/de.json`, `locales/es.json`, or `locales/fr.json`. The section key didn't exist in those files at all.

All 5 call sites in `SeatingChart/Widget.tsx` have `{ defaultValue: '...' }` fallbacks — so German, Spanish, and French users silently saw English text rather than raw key paths. The `defaultValue` masked the localization gap.

**Missing keys:**
- `emptyStateAssignTitle` — shown on the classroom projector when no furniture is placed
- `emptyStateAssignSubtitle`
- `emptyStateSetupTitle`
- `emptyStateFreeform`
- `emptyStateTemplate`

## Fix

Added the complete `widgets.seatingChart` section to `de.json`, `es.json`, and `fr.json` with accurate translations.

## Band-Aid Rejected

Adding nothing and relying on `defaultValue` fallbacks to serve English text. That's a localization failure, not a fix — non-EN teachers see English on projected classroom displays.

## Regression Test

`tests/i18n/widgetSeatingChartLocales.test.ts` — 8 tests verifying all 5 EN keys exist in DE, ES, and FR. Follows the established pattern of `widgetClockScheduleLocales.test.ts`.

**Before:** 6 failed / 2 passed | **After:** 8 passed

## Risk

**contained** — JSON locale files only, no source code changes.

https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS

---
_Generated by [Claude Code](https://claude.ai/code/session_012HeHu6hAQzhN4gGXg5Y4CS)_