### PR TITLE
perf(dashboard): DashboardContext split — stable actions + canvas hot-state store (measured)

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -51,7 +51,11 @@ import { calculateSnapBounds, SNAP_LAYOUT_CONSTANTS } from '@/utils/layoutMath';
 import { clampWidgetToWorld, getWorldBounds } from '@/utils/zoomPanMath';
 import { useScreenshot } from '@/hooks/useScreenshot';
 import { useWindowSize } from '@/hooks/useWindowSize';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useDashboardCanvasSelector,
+  useDashboardCanvasStateGetter,
+} from '@/context/dashboardCanvasStore';
 import { GlassCard } from './GlassCard';
 import { SettingsPanel } from './SettingsPanel';
 import { useClickOutside } from '@/hooks/useClickOutside';
@@ -183,6 +187,8 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   globalStyle,
 }) => {
   const { t } = useTranslation();
+  // Mount-stable actions surface — identities never change, so dep arrays
+  // listing them are trivially satisfied and never re-fire.
   const {
     updateWidget,
     removeWidget,
@@ -191,18 +197,25 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     addToast,
     resetWidgetSize,
     deleteAllWidgets,
-    selectedWidgetId,
     setSelectedWidgetId,
-    activeDashboard,
     updateWidgets,
     ungroupWidgets,
-    groupBuildMode,
     setGroupBuildMode,
-    selectedWidgetIds,
     setSelectedWidgetIds,
-    zoom,
-    isActiveBoardReadOnly,
-  } = useDashboard();
+  } = useDashboardActions();
+  // Narrow primitive-returning subscriptions — foreign widget mutations
+  // (another widget's selection, z-order, config) bail out via Object.is
+  // instead of re-rendering every shell on the board.
+  const isSelectedWidget = useDashboardCanvasSelector(
+    (s) => s.selectedWidgetId === widget.id
+  );
+  const isActiveBoardReadOnly = useDashboardCanvasSelector(
+    (s) => s.isActiveBoardReadOnly
+  );
+  const zoom = useDashboardCanvasSelector((s) => s.zoom);
+  const groupBuildMode = useDashboardCanvasSelector((s) => s.groupBuildMode);
+  // Event-handler-time canvas reads (no render subscription).
+  const getCanvasState = useDashboardCanvasStateGetter();
   const { showConfirm: showConfirmDialog } = useDialog();
 
   const [isDragging, setIsDragging] = useState(false);
@@ -219,18 +232,23 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   // close, duplicate, lock, pin, etc.) are valid for a read-only viewer,
   // and the toolbar's "Settings" gear has no per-button isLocked gate of
   // its own — suppressing showTools at the root is the safest gap-fill.
-  const showTools =
-    selectedWidgetId === widget.id && !hasOpenModal && !isActiveBoardReadOnly;
+  const showTools = isSelectedWidget && !hasOpenModal && !isActiveBoardReadOnly;
 
-  // Group visual state
+  // Group visual state. Both selectors return booleans, so foreign
+  // selection/dashboard churn bails out; the O(n) widget scan runs inside
+  // the selector (per store notify), not in a render.
   const isInGroup = !!widget.groupId;
-  const isGroupActive =
-    isInGroup &&
-    activeDashboard?.widgets.some(
-      (w) => w.groupId === widget.groupId && w.id === selectedWidgetId
-    );
-  const isGroupBuildSelected =
-    groupBuildMode && selectedWidgetIds.includes(widget.id);
+  const isGroupActive = useDashboardCanvasSelector(
+    (s) =>
+      !!widget.groupId &&
+      (s.activeDashboard?.widgets.some(
+        (w) => w.groupId === widget.groupId && w.id === s.selectedWidgetId
+      ) ??
+        false)
+  );
+  const isGroupBuildSelected = useDashboardCanvasSelector(
+    (s) => s.groupBuildMode && s.selectedWidgetIds.includes(widget.id)
+  );
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [tempTitle, setTempTitle] = useState(widget.customTitle ?? title);
   const [shouldRenderSettings, setShouldRenderSettings] = useState(
@@ -253,18 +271,24 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const customGridRef = useRef(customGrid);
   // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md: "assign refs directly in render body"); react-hooks/refs v7 incorrectly cascades this as an error when any setState is called during render
   customGridRef.current = customGrid;
+  // Only subscribe to the dashboard while the snap menu is OPEN: the selector
+  // returns null (stable) when closed, so board mutations don't re-render the
+  // shell; open, it tracks dashboard changes exactly as before.
+  const snapMenuDashboard = useDashboardCanvasSelector((s) =>
+    showSnapMenu ? s.activeDashboard : null
+  );
   const occupiedCells = useMemo(() => {
-    // Short-circuit before any per-widget work: activeDashboard is a dep, so
+    // Short-circuit before any per-widget work: snapMenuDashboard is a dep, so
     // without this guard every widget mutation across the board would pay the
     // O(n) grid-occupancy scan even with the snap menu closed.
-    if (!showSnapMenu || !activeDashboard) return EMPTY_OCCUPIED_CELLS;
+    if (!snapMenuDashboard) return EMPTY_OCCUPIED_CELLS;
     const set = new Set<string>();
 
     const { PADDING } = SNAP_LAYOUT_CONSTANTS;
     const safeWidth = Math.max(1, windowSize.width - PADDING * 2);
     const safeHeight = Math.max(1, windowSize.height - PADDING * 2);
 
-    for (const w of activeDashboard.widgets) {
+    for (const w of snapMenuDashboard.widgets) {
       if (w.id === widget.id) continue; // ignore self
       if (w.minimized || w.maximized) continue; // not visible on canvas
 
@@ -295,7 +319,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
       }
     }
     return set;
-  }, [showSnapMenu, activeDashboard, widget.id, windowSize]);
+  }, [snapMenuDashboard, widget.id, windowSize]);
 
   // Pre-cached zones for edge detection optimization
   const splitLayout = useMemo(
@@ -978,10 +1002,12 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
     dragState.current = { x: widget.x, y: widget.y, w: widget.w, h: widget.h };
     dragDistanceRef.current = 0;
 
-    // Collect group siblings for coordinated drag
+    // Collect group siblings for coordinated drag. Read the dashboard at
+    // event time via the getter — this shell no longer subscribes to it.
     const hasGroup = !!widget.groupId;
-    if (hasGroup && activeDashboard) {
-      groupSiblingsRef.current = activeDashboard.widgets
+    const dashboardAtPointerDown = getCanvasState().activeDashboard;
+    if (hasGroup && dashboardAtPointerDown) {
+      groupSiblingsRef.current = dashboardAtPointerDown.widgets
         .filter(
           (w) =>
             w.groupId === widget.groupId &&

--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -11,6 +11,7 @@ import type {
 import { DEFAULT_GLOBAL_STYLE } from '@/types';
 import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { GroupBoundingBox } from '@/components/common/GroupBoundingBox';
+import { useDashboardCanvasSelector } from '@/context/dashboardCanvasStore';
 
 export interface BoardCanvasProps {
   dashboard: Dashboard;
@@ -21,8 +22,6 @@ export interface BoardCanvasProps {
   session: LiveSession | null;
   students: LiveStudent[];
   emptyStudents: LiveStudent[];
-  selectedWidgetId: string | null;
-  zoom: number;
   // Pass-through callbacks: same shape WidgetRenderer expects.
   updateSessionConfig: (config: WidgetConfig) => Promise<void>;
   updateSessionBackground: (background: string) => Promise<void>;
@@ -48,6 +47,36 @@ export interface BoardCanvasProps {
 }
 
 /**
+ * Group bounding-box overlay, isolated so selection/zoom changes re-render
+ * only this layer (and the affected DraggableWindows via their own
+ * selectors) — memo(BoardCanvas) bails entirely, skipping the widget
+ * mapping loop and its 15 WidgetRenderer memo comparisons.
+ */
+const GroupBoundingBoxLayer: FC<{ dashboard: Dashboard }> = ({ dashboard }) => {
+  const selectedWidgetId = useDashboardCanvasSelector(
+    (s) => s.selectedWidgetId
+  );
+  const zoom = useDashboardCanvasSelector((s) => s.zoom);
+
+  const selectedGroupId = selectedWidgetId
+    ? dashboard.widgets.find((w) => w.id === selectedWidgetId)?.groupId
+    : undefined;
+
+  const groupMembers = selectedGroupId
+    ? dashboard.widgets.filter(
+        (w) =>
+          w.groupId === selectedGroupId &&
+          !w.minimized &&
+          !w.isLocked &&
+          !w.isPinned
+      )
+    : [];
+
+  if (!selectedGroupId || groupMembers.length === 0) return null;
+  return <GroupBoundingBox groupWidgets={groupMembers} zoom={zoom} />;
+};
+
+/**
  * Renders a single Board's widget canvas. Visibility is controlled by the
  * `isActive` flag: inactive boards render with `display: none` so React
  * state (timer counts, drawings in flight, video positions) is preserved
@@ -66,8 +95,6 @@ export const BoardCanvas: FC<BoardCanvasProps> = memo(
     session,
     students,
     emptyStudents,
-    selectedWidgetId,
-    zoom,
     updateSessionConfig,
     updateSessionBackground,
     startSession,
@@ -85,20 +112,6 @@ export const BoardCanvas: FC<BoardCanvasProps> = memo(
     // Each Board resolves its own globalStyle so hidden boards don't inherit
     // the active Board's styling when widget memoization is evaluated.
     const globalStyle = dashboard.globalStyle ?? DEFAULT_GLOBAL_STYLE;
-
-    const selectedGroupId = selectedWidgetId
-      ? dashboard.widgets.find((w) => w.id === selectedWidgetId)?.groupId
-      : undefined;
-
-    const groupMembers = selectedGroupId
-      ? dashboard.widgets.filter(
-          (w) =>
-            w.groupId === selectedGroupId &&
-            !w.minimized &&
-            !w.isLocked &&
-            !w.isPinned
-        )
-      : [];
 
     return (
       <div
@@ -148,9 +161,7 @@ export const BoardCanvas: FC<BoardCanvasProps> = memo(
           );
         })}
         {/* Group Bounding Box — rendered when a grouped widget is selected */}
-        {selectedGroupId && groupMembers.length > 0 && (
-          <GroupBoundingBox groupWidgets={groupMembers} zoom={zoom} />
-        )}
+        <GroupBoundingBoxLayer dashboard={dashboard} />
       </div>
     );
   }

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -199,7 +199,6 @@ export const DashboardView: React.FC = () => {
     setGroupBuildMode,
     selectedWidgetIds,
     setSelectedWidgetIds,
-    selectedWidgetId,
     annotationActive,
     isActiveBoardReadOnly,
   } = useDashboard();
@@ -1724,8 +1723,6 @@ export const DashboardView: React.FC = () => {
           sessions={sessions}
           students={students}
           emptyStudents={EMPTY_STUDENTS}
-          selectedWidgetId={selectedWidgetId}
-          zoom={zoom}
           updateSessionConfig={updateSessionConfig}
           updateSessionBackground={updateSessionBackground}
           startSession={startSession}

--- a/components/layout/MountedBoardsLayer.tsx
+++ b/components/layout/MountedBoardsLayer.tsx
@@ -15,8 +15,6 @@ export interface MountedBoardsLayerProps {
   sessions?: Map<string, LiveSession>;
   students: LiveStudent[];
   emptyStudents: LiveStudent[];
-  selectedWidgetId: string | null;
-  zoom: number;
   // Pass-through callbacks (typed via BoardCanvasProps at the call site)
   updateSessionConfig: BoardCanvasProps['updateSessionConfig'];
   updateSessionBackground: BoardCanvasProps['updateSessionBackground'];
@@ -41,8 +39,6 @@ export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
   sessions,
   students,
   emptyStudents,
-  selectedWidgetId,
-  zoom,
   updateSessionConfig,
   updateSessionBackground,
   startSession,
@@ -79,8 +75,6 @@ export const MountedBoardsLayer: FC<MountedBoardsLayerProps> = ({
           session={sessions?.get(db.id) ?? null}
           students={students}
           emptyStudents={emptyStudents}
-          selectedWidgetId={selectedWidgetId}
-          zoom={zoom}
           updateSessionConfig={updateSessionConfig}
           updateSessionBackground={updateSessionBackground}
           startSession={startSession}

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -18,7 +18,7 @@ import { ScalableWidget } from '@/components/common/ScalableWidget';
 import { WidgetLayoutWrapper } from '@/components/widgets/WidgetLayout';
 import { useWindowSize } from '@/hooks/useWindowSize';
 import { useAuth } from '@/context/useAuth';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardCanvasSelector } from '@/context/dashboardCanvasStore';
 import { UI_CONSTANTS } from '@/config/layout';
 import {
   WIDGET_SETTINGS_COMPONENTS,
@@ -111,7 +111,11 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
     featurePermissions,
     disableCloseConfirmation: accountDisableCloseConfirmation,
   } = useAuth();
-  const { isActiveBoardReadOnly } = useDashboard();
+  // Narrow subscription: foreign widget mutations no longer pierce the
+  // memo() bailout below — only the read-only flag flipping re-renders here.
+  const isActiveBoardReadOnly = useDashboardCanvasSelector(
+    (s) => s.isActiveBoardReadOnly
+  );
 
   const handleToggleLive = useCallback(async () => {
     try {

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -1,6 +1,7 @@
 import React, {
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useRef,
   useMemo,
@@ -86,6 +87,12 @@ import {
   SubstituteShareInput,
   SubstituteShareResult,
 } from './DashboardContextValue';
+import {
+  createDashboardCanvasStore,
+  DashboardActionsContext,
+  DashboardCanvasStoreContext,
+  type DashboardActions,
+} from './dashboardCanvasStore';
 import { validateGridConfig, sanitizeAIConfig } from '@/utils/ai_security';
 import { getAdminBuildingConfig as getAdminBuildingConfigPure } from '@/utils/adminBuildingConfig';
 import { AnnotationState } from './DashboardContextValue';
@@ -5349,6 +5356,106 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     [annotationLocalState, activeDashboard?.annotationOverlay?.objects]
   );
 
+  // ---- Canvas hot-path surfaces (whole-board re-render fix, Stage 1) ----
+  // Latest-ref delegation: the ref is reassigned with the freshest action
+  // closures on every render (same render-body-assignment pattern as
+  // `isActiveBoardReadOnlyRef` above), and `stableActions` below exposes
+  // thin wrappers with a fixed identity. Consumers of the actions context
+  // therefore never re-render on provider state changes, yet every call
+  // dispatches to the freshest closure — no stale-closure hazard even for
+  // actions whose useCallback deps churn.
+  const liveActions: DashboardActions = {
+    updateWidget,
+    updateWidgets,
+    removeWidget,
+    duplicateWidget,
+    bringToFront,
+    moveWidgetLayer,
+    addToast,
+    resetWidgetSize,
+    deleteAllWidgets,
+    ungroupWidgets,
+    groupWidgets,
+    setSelectedWidgetId,
+    setSelectedWidgetIds,
+    setGroupBuildMode,
+    setZoom,
+  };
+  const liveActionsRef = useRef(liveActions);
+  liveActionsRef.current = liveActions;
+  // Empty deps is the point: identity fixed for the provider's lifetime.
+  const stableActions = useMemo<DashboardActions>(
+    () => ({
+      updateWidget: (id, updates) =>
+        liveActionsRef.current.updateWidget(id, updates),
+      updateWidgets: (updates) => liveActionsRef.current.updateWidgets(updates),
+      removeWidget: (id) => liveActionsRef.current.removeWidget(id),
+      duplicateWidget: (id) => liveActionsRef.current.duplicateWidget(id),
+      bringToFront: (id) => liveActionsRef.current.bringToFront(id),
+      moveWidgetLayer: (id, direction) =>
+        liveActionsRef.current.moveWidgetLayer(id, direction),
+      addToast: (message, type, action) =>
+        liveActionsRef.current.addToast(message, type, action),
+      resetWidgetSize: (id) => liveActionsRef.current.resetWidgetSize(id),
+      deleteAllWidgets: () => liveActionsRef.current.deleteAllWidgets(),
+      ungroupWidgets: (groupId) =>
+        liveActionsRef.current.ungroupWidgets(groupId),
+      groupWidgets: (widgetIds) =>
+        liveActionsRef.current.groupWidgets(widgetIds),
+      setSelectedWidgetId: (id) =>
+        liveActionsRef.current.setSelectedWidgetId(id),
+      setSelectedWidgetIds: (ids) =>
+        liveActionsRef.current.setSelectedWidgetIds(ids),
+      setGroupBuildMode: (active) =>
+        liveActionsRef.current.setGroupBuildMode(active),
+      setZoom: (value) => liveActionsRef.current.setZoom(value),
+    }),
+    []
+  );
+
+  // Derived mirror of the canvas hot slice. The provider stays the single
+  // source of truth: the store is only ever written here, during render,
+  // and `setStateFromRender` keeps object identity when nothing changed.
+  const [canvasStore] = useState(() =>
+    createDashboardCanvasStore({
+      activeDashboard,
+      selectedWidgetId,
+      selectedWidgetIds,
+      groupBuildMode,
+      zoom,
+      isActiveBoardReadOnly,
+    })
+  );
+  canvasStore.setStateFromRender({
+    activeDashboard,
+    selectedWidgetId,
+    selectedWidgetIds,
+    groupBuildMode,
+    zoom,
+    isActiveBoardReadOnly,
+  });
+  // Post-commit notification (sync-with-external-store effect). Deliberately
+  // NO dependency array: it must run after EVERY provider commit so no
+  // hot-slice change is ever missed; subscribers bail via Object.is on their
+  // cached selections, so the blanket notify costs ~nothing. StrictMode
+  // double-invocation is safe: setStateFromRender is idempotent and a
+  // duplicate notify finds unchanged snapshots.
+  //
+  // useLayoutEffect is LOAD-BEARING here — do not "simplify" to useEffect.
+  // Passive effects only flush pre-paint for discrete-event updates (clicks);
+  // continuous-priority updates (Ctrl+wheel zoom via DashboardView's onWheel
+  // -> setZoom) and async updates (Firestore listeners flipping
+  // isActiveBoardReadOnly) paint BEFORE a passive effect runs, so store
+  // subscribers (e.g. GroupBoundingBoxLayer's zoom selector) would trail the
+  // prop-driven surface transform by one painted frame per wheel tick. A
+  // layout effect runs pre-paint and subscriber setState inside it flushes
+  // synchronously, so store-subscribed components always paint in the same
+  // frame as prop-driven ones — preserving DashboardView's "zoom + pan flush
+  // together, no mismatched intermediate frame" invariant.
+  useLayoutEffect(() => {
+    canvasStore.notify();
+  });
+
   const contextValue = useMemo(
     () => ({
       driveService,
@@ -5605,7 +5712,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   return (
     <DashboardContext.Provider value={contextValue}>
-      {children}
+      <DashboardActionsContext.Provider value={stableActions}>
+        <DashboardCanvasStoreContext.Provider value={canvasStore}>
+          {children}
+        </DashboardCanvasStoreContext.Provider>
+      </DashboardActionsContext.Provider>
     </DashboardContext.Provider>
   );
 };

--- a/context/dashboardCanvasStore.test.tsx
+++ b/context/dashboardCanvasStore.test.tsx
@@ -1,0 +1,492 @@
+/**
+ * Contract tests for the canvas hot-path store + stable actions surface
+ * (context/dashboardCanvasStore.ts) against the REAL DashboardProvider.
+ *
+ * These pin the four guarantees the hot-path shells (DraggableWindow /
+ * WidgetRenderer / BoardCanvas) were migrated onto:
+ *
+ *   1. Actions identity stability — `useDashboardActions()` returns the same
+ *      object (and same methods) across every provider commit after mount.
+ *   2. Latest-closure dispatch — a method captured at mount still executes
+ *      the freshest provider closure (no stale-closure hazard).
+ *   3. Untouched-subscriber isolation — a component subscribed via
+ *      `useDashboardCanvasSelector` re-renders ONLY when its own selection
+ *      changes, not on foreign widget mutations. (The parent-driven half of
+ *      this metric is asserted in tests/perf/dashboardPerf.test.tsx.)
+ *   4. Legacy fallback — under a bare DashboardContext.Provider (the
+ *      subs/student/test hosts), all three hooks resolve off the legacy
+ *      value without throwing.
+ *
+ * Plus StrictMode safety for (1) and (3a).
+ */
+
+import React, { useEffect } from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DashboardProvider } from './DashboardContext';
+import { useDashboard } from './useDashboard';
+import {
+  useDashboardActions,
+  useDashboardCanvasSelector,
+  useDashboardCanvasStateGetter,
+  type DashboardActions,
+  type DashboardCanvasState,
+} from './dashboardCanvasStore';
+import {
+  DashboardContext,
+  type DashboardContextValue,
+} from './DashboardContextValue';
+import { Dashboard, WidgetData } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors context/DashboardContext.bringToFront.test.tsx)
+// ---------------------------------------------------------------------------
+
+vi.mock('./useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      uid: 'test-user',
+      displayName: 'Test User',
+      email: 'test@example.com',
+    },
+    isAdmin: false,
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    refreshGoogleToken: vi.fn(),
+    remoteControlEnabled: true,
+    profileLoaded: true,
+  }),
+}));
+
+type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+let capturedSnapshotCb: SnapshotCb | null = null;
+
+vi.mock('../hooks/useFirestore', () => ({
+  useFirestore: () => ({
+    saveDashboard: vi.fn().mockResolvedValue(Date.now()),
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboards: vi.fn((cb: SnapshotCb) => {
+      capturedSnapshotCb = cb;
+      return () => {
+        // cleanup
+      };
+    }),
+    shareDashboard: vi.fn(),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+    rosters: [],
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    activeRosterId: null,
+  }),
+}));
+
+vi.mock('../hooks/useRosters', () => ({
+  useRosters: () => ({
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Probes
+// ---------------------------------------------------------------------------
+
+/** Captures the actions object on EVERY render so identity can be compared. */
+const ActionsProbe: React.FC<{ captured: DashboardActions[] }> = ({
+  captured,
+}) => {
+  const actions = useDashboardActions();
+  captured.push(actions);
+  return null;
+};
+
+/** Captures the full legacy context (to drive addWidget and read state). */
+interface ContextSnapshot {
+  activeDashboard: Dashboard | null;
+  addWidget: ReturnType<typeof useDashboard>['addWidget'];
+}
+
+const ContextProbe: React.FC<{
+  stateRef: { current: ContextSnapshot | null };
+}> = ({ stateRef }) => {
+  const ctx = useDashboard();
+  useEffect(() => {
+    stateRef.current = {
+      activeDashboard: ctx.activeDashboard,
+      addWidget: ctx.addWidget,
+    };
+  });
+  return null;
+};
+
+/**
+ * Replicates the DraggableWindow shell subscription: a per-widget selection
+ * flag plus the read-only flag, with a render counter in the body. In
+ * StrictMode the body runs twice per actual render — the assertions below
+ * therefore check for ZERO delta (0 is 0 doubled) on untouched probes.
+ */
+const shellProbeRenders = new Map<string, number>();
+
+const ShellProbe: React.FC<{ id: string }> = ({ id }) => {
+  const isSelected = useDashboardCanvasSelector(
+    (s) => s.selectedWidgetId === id
+  );
+  const isReadOnly = useDashboardCanvasSelector((s) => s.isActiveBoardReadOnly);
+  shellProbeRenders.set(id, (shellProbeRenders.get(id) ?? 0) + 1);
+  return <span data-selected={isSelected} data-readonly={isReadOnly} />;
+};
+
+function probeRenderDelta(
+  baseline: ReadonlyMap<string, number>,
+  id: string
+): number {
+  return (shellProbeRenders.get(id) ?? 0) - (baseline.get(id) ?? 0);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWidget(
+  id: string,
+  z: number,
+  extra: Partial<WidgetData> = {}
+): WidgetData {
+  return {
+    id,
+    type: 'text',
+    x: 0,
+    y: 0,
+    w: 1,
+    h: 1,
+    z,
+    flipped: false,
+    config: { text: 'test' } as WidgetData['config'],
+    ...extra,
+  };
+}
+
+function makeDashboard(widgets: WidgetData[]): Dashboard {
+  return {
+    id: 'dash-1',
+    name: 'Test Board',
+    background: 'bg-slate-900',
+    widgets,
+    createdAt: 1000,
+    updatedAt: 1000,
+  };
+}
+
+async function pushSnapshot(dashboards: Dashboard[]): Promise<void> {
+  if (!capturedSnapshotCb) throw new Error('Provider not mounted');
+  const cb = capturedSnapshotCb;
+  await act(async () => {
+    cb(dashboards, false);
+    await Promise.resolve();
+  });
+}
+
+function getWidget(
+  stateRef: { current: ContextSnapshot | null },
+  id: string
+): WidgetData {
+  const w = stateRef.current?.activeDashboard?.widgets.find((w) => w.id === id);
+  if (!w) throw new Error(`widget ${id} not found`);
+  return w;
+}
+
+interface Harness {
+  captured: DashboardActions[];
+  stateRef: { current: ContextSnapshot | null };
+}
+
+function setup(opts: { strictMode?: boolean } = {}): Harness {
+  const captured: DashboardActions[] = [];
+  const stateRef: { current: ContextSnapshot | null } = { current: null };
+  const tree = (
+    <DashboardProvider>
+      <ActionsProbe captured={captured} />
+      <ContextProbe stateRef={stateRef} />
+      <ShellProbe id="w-1" />
+      <ShellProbe id="w-2" />
+      <ShellProbe id="w-3" />
+    </DashboardProvider>
+  );
+  render(opts.strictMode ? <React.StrictMode>{tree}</React.StrictMode> : tree);
+  return { captured, stateRef };
+}
+
+function latestActions(captured: DashboardActions[]): DashboardActions {
+  const last = captured[captured.length - 1];
+  if (!last) throw new Error('Actions never captured');
+  return last;
+}
+
+const THREE_WIDGETS = (): WidgetData[] => [
+  makeWidget('w-1', 1),
+  makeWidget('w-2', 2),
+  makeWidget('w-3', 3),
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedSnapshotCb = null;
+  shellProbeRenders.clear();
+});
+
+describe('useDashboardActions identity stability', () => {
+  it('returns the same actions object and methods across all mutations', async () => {
+    const { captured, stateRef } = setup();
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    const first = captured[0];
+    if (!first) throw new Error('Actions never captured');
+
+    act(() => {
+      stateRef.current?.addWidget('text');
+    });
+    act(() => {
+      latestActions(captured).bringToFront('w-1');
+    });
+    act(() => {
+      latestActions(captured).updateWidget('w-2', {
+        config: { text: 'edited' } as WidgetData['config'],
+      });
+    });
+    act(() => {
+      latestActions(captured).setSelectedWidgetId('w-3');
+    });
+
+    await waitFor(() => {
+      const config = getWidget(stateRef, 'w-2').config as { text?: string };
+      expect(config.text).toBe('edited');
+    });
+
+    // The OBJECT identity never changed across any of the four mutations…
+    for (const snapshot of captured) {
+      expect(Object.is(snapshot, first)).toBe(true);
+    }
+    // …and neither did the individual methods.
+    const last = latestActions(captured);
+    expect(Object.is(last.updateWidget, first.updateWidget)).toBe(true);
+    expect(Object.is(last.bringToFront, first.bringToFront)).toBe(true);
+    expect(Object.is(last.removeWidget, first.removeWidget)).toBe(true);
+    expect(Object.is(last.setSelectedWidgetId, first.setSelectedWidgetId)).toBe(
+      true
+    );
+  });
+
+  it('dispatches to the LATEST closure, not the mount-time one', async () => {
+    const { captured, stateRef } = setup();
+
+    // Capture bringToFront BEFORE any board exists — the mount-time closure
+    // sees no active dashboard, so a stale-closure wrapper would no-op.
+    const earlyBringToFront = captured[0]?.bringToFront;
+    if (!earlyBringToFront) throw new Error('Actions never captured');
+
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    act(() => {
+      earlyBringToFront('w-1');
+    });
+
+    await waitFor(() => {
+      // maxZ was 3, so the raise proves the live closure ran.
+      expect(getWidget(stateRef, 'w-1').z).toBe(4);
+    });
+  });
+});
+
+describe('useDashboardCanvasSelector untouched-subscriber isolation', () => {
+  it('does not re-render foreign probes on bringToFront', async () => {
+    const { captured } = setup();
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    const baseline = new Map(shellProbeRenders);
+    act(() => {
+      latestActions(captured).bringToFront('w-2');
+    });
+
+    expect(probeRenderDelta(baseline, 'w-1')).toBe(0);
+    expect(probeRenderDelta(baseline, 'w-3')).toBe(0);
+  });
+
+  it('re-renders only the shedding and gaining probes on selection change', async () => {
+    const { captured } = setup();
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    act(() => {
+      latestActions(captured).setSelectedWidgetId('w-1');
+    });
+
+    const baseline = new Map(shellProbeRenders);
+    act(() => {
+      latestActions(captured).setSelectedWidgetId('w-3');
+    });
+
+    // w-1 sheds the selection, w-3 gains it — w-2 must stay untouched.
+    expect(probeRenderDelta(baseline, 'w-1')).toBeGreaterThan(0);
+    expect(probeRenderDelta(baseline, 'w-3')).toBeGreaterThan(0);
+    expect(probeRenderDelta(baseline, 'w-2')).toBe(0);
+  });
+
+  it('does not re-render foreign probes on a widget config mutation', async () => {
+    const { captured } = setup();
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    const baseline = new Map(shellProbeRenders);
+    act(() => {
+      latestActions(captured).updateWidget('w-2', { minimized: true });
+    });
+
+    expect(probeRenderDelta(baseline, 'w-1')).toBe(0);
+    expect(probeRenderDelta(baseline, 'w-3')).toBe(0);
+  });
+});
+
+describe('legacy fallback mode (subs/student/test hosts)', () => {
+  it('resolves all three hooks off a bare DashboardContext.Provider', () => {
+    const dashboard = makeDashboard(THREE_WIDGETS());
+    // Minimal legacy value covering exactly what the hooks read. Alternate
+    // hosts (SubsDashboardProvider, StudentContexts) supply the full value;
+    // structurally the hooks only touch the hot slice + action fields.
+    const legacyValue = {
+      activeDashboard: dashboard,
+      selectedWidgetId: 'w-2',
+      selectedWidgetIds: [],
+      groupBuildMode: false,
+      zoom: 1.5,
+      isActiveBoardReadOnly: true,
+      updateWidget: vi.fn(),
+      bringToFront: vi.fn(),
+      removeWidget: vi.fn(),
+      setSelectedWidgetId: vi.fn(),
+    } as unknown as DashboardContextValue;
+
+    const result: {
+      actions?: DashboardActions;
+      isSelected?: boolean;
+      slice?: DashboardCanvasState;
+    } = {};
+
+    const FallbackProbe: React.FC = () => {
+      const actions = useDashboardActions();
+      const isSelected = useDashboardCanvasSelector(
+        (s) => s.selectedWidgetId === 'w-2'
+      );
+      const getState = useDashboardCanvasStateGetter();
+      useEffect(() => {
+        result.actions = actions;
+        result.isSelected = isSelected;
+        result.slice = getState();
+      });
+      return null;
+    };
+
+    expect(() =>
+      render(
+        <DashboardContext.Provider value={legacyValue}>
+          <FallbackProbe />
+        </DashboardContext.Provider>
+      )
+    ).not.toThrow();
+
+    // The legacy value structurally satisfies DashboardActions — the hook
+    // hands it back as-is (no wrapping, no casts).
+    expect(result.actions).toBe(legacyValue);
+    expect(result.isSelected).toBe(true);
+    expect(result.slice?.activeDashboard).toBe(dashboard);
+    expect(result.slice?.zoom).toBe(1.5);
+    expect(result.slice?.isActiveBoardReadOnly).toBe(true);
+  });
+});
+
+describe('StrictMode safety', () => {
+  it('keeps actions identity stable and untouched probes isolated', async () => {
+    const { captured } = setup({ strictMode: true });
+    await pushSnapshot([makeDashboard(THREE_WIDGETS())]);
+
+    const first = captured[0];
+    if (!first) throw new Error('Actions never captured');
+
+    const baseline = new Map(shellProbeRenders);
+    act(() => {
+      latestActions(captured).bringToFront('w-2');
+    });
+
+    // (1) Identity stability holds through StrictMode's double rendering.
+    for (const snapshot of captured) {
+      expect(Object.is(snapshot, first)).toBe(true);
+    }
+    // (3a) Untouched probes did not re-render (double-notify from the
+    // doubled post-commit effect bails on the unchanged snapshot).
+    expect(probeRenderDelta(baseline, 'w-1')).toBe(0);
+    expect(probeRenderDelta(baseline, 'w-3')).toBe(0);
+  });
+});

--- a/context/dashboardCanvasStore.ts
+++ b/context/dashboardCanvasStore.ts
@@ -1,0 +1,268 @@
+/**
+ * Canvas hot-path store + stable actions surface for DashboardProvider.
+ *
+ * `DashboardContext` exposes one value object (~100 properties) whose
+ * identity changes on every provider commit, so every `useDashboard()`
+ * consumer re-renders on every state mutation. The canvas hot path
+ * (BoardCanvas → WidgetRenderer → DraggableWindow) only needs a 6-field
+ * state slice plus a fixed set of action callbacks, so this module exposes
+ * two narrower, mount-stable surfaces:
+ *
+ * - `DashboardActionsContext`: an actions object whose identity NEVER
+ *   changes after mount (thin wrappers delegating to a latest-ref inside
+ *   the provider), so action-only consumers never re-render.
+ * - `DashboardCanvasStoreContext`: a `useSyncExternalStore`-backed mirror
+ *   of the 6 hot state fields. The provider assigns the slice during its
+ *   own render body and notifies subscribers post-commit, so subscribers
+ *   always read commit-consistent values. Selector hooks bail out via
+ *   `Object.is`, collapsing e.g. a selection change from "all shells
+ *   re-render" to "only the two affected shells re-render".
+ *
+ * The store is a derived MIRROR of DashboardProvider state — the provider
+ * remains the single source of truth; nothing writes to the store except
+ * the provider's render-body mirror. The render-body mirror assumes
+ * DashboardProvider's subtree never renders inside a transition
+ * (startTransition/useDeferredValue); if concurrent rendering of this
+ * subtree is ever introduced, move the mirror into the same useLayoutEffect
+ * that notifies, since a discarded render would otherwise leave
+ * never-committed values readable via `getState`.
+ *
+ * Back-compat: every hook here falls back to the legacy DashboardContext
+ * when the new contexts are absent, because DashboardContext has alternate
+ * value hosts that never mount these providers (SubsDashboardProvider,
+ * StudentContexts, and unit tests mounting `DashboardContext.Provider`
+ * directly). The fallback reads via React 19's conditional `use` — NOT an
+ * unconditional useContext, which would subscribe every store-mode
+ * component to the churning legacy value and pierce memo() on every
+ * provider commit. In fallback mode consumers subscribe to the full legacy
+ * context — exactly their pre-refactor behavior in those hosts.
+ *
+ * Listener/snapshot mechanics modeled on `components/common/modalStore.ts`.
+ */
+
+import {
+  createContext,
+  use,
+  useCallback,
+  useContext,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import type { Dashboard } from '@/types';
+import {
+  DashboardContext,
+  type DashboardContextValue,
+} from './DashboardContextValue';
+
+/**
+ * The narrow state slice the canvas hot path subscribes to. Mirrored from
+ * DashboardProvider on every provider render via `setStateFromRender`.
+ */
+export interface DashboardCanvasState {
+  activeDashboard: Dashboard | null;
+  selectedWidgetId: string | null;
+  selectedWidgetIds: string[];
+  groupBuildMode: boolean;
+  zoom: number;
+  isActiveBoardReadOnly: boolean;
+}
+
+/**
+ * Minimal external-store contract for the canvas hot slice.
+ *
+ * `setStateFromRender` and `notify` are internal — only DashboardProvider
+ * calls them (assignment during render, notification post-commit).
+ */
+export interface DashboardCanvasStore {
+  getState: () => DashboardCanvasState;
+  subscribe: (listener: () => void) => () => void;
+  /**
+   * Internal: provider render-body mirror. Keeps the previous state OBJECT
+   * identity when all 6 fields are `Object.is`-equal (so `getSnapshot`
+   * stays referentially stable across unrelated provider commits). MUST
+   * NOT call listeners — it runs during render.
+   */
+  setStateFromRender: (next: DashboardCanvasState) => void;
+  /** Internal: provider post-commit notifier. */
+  notify: () => void;
+}
+
+export function createDashboardCanvasStore(
+  initial: DashboardCanvasState
+): DashboardCanvasStore {
+  let state = initial;
+  const listeners = new Set<() => void>();
+
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setStateFromRender: (next) => {
+      // Field-wise Object.is so untouched slices keep object identity.
+      // `selectedWidgetIds` compares by reference — the provider replaces
+      // the array on change.
+      if (
+        Object.is(state.activeDashboard, next.activeDashboard) &&
+        Object.is(state.selectedWidgetId, next.selectedWidgetId) &&
+        Object.is(state.selectedWidgetIds, next.selectedWidgetIds) &&
+        Object.is(state.groupBuildMode, next.groupBuildMode) &&
+        Object.is(state.zoom, next.zoom) &&
+        Object.is(state.isActiveBoardReadOnly, next.isActiveBoardReadOnly)
+      ) {
+        return;
+      }
+      state = next;
+    },
+    notify: () => {
+      for (const listener of listeners) listener();
+    },
+  };
+}
+
+/**
+ * The action subset the canvas hot path needs. A `Pick` of the legacy
+ * context value, so a `DashboardContextValue` structurally satisfies it —
+ * that's what makes the legacy fallback in `useDashboardActions` cast-free.
+ */
+export type DashboardActions = Pick<
+  DashboardContextValue,
+  | 'updateWidget'
+  | 'updateWidgets'
+  | 'removeWidget'
+  | 'duplicateWidget'
+  | 'bringToFront'
+  | 'moveWidgetLayer'
+  | 'addToast'
+  | 'resetWidgetSize'
+  | 'deleteAllWidgets'
+  | 'ungroupWidgets'
+  | 'groupWidgets'
+  | 'setSelectedWidgetId'
+  | 'setSelectedWidgetIds'
+  | 'setGroupBuildMode'
+  | 'setZoom'
+>;
+
+/** Mount-stable actions surface provided by DashboardProvider. */
+export const DashboardActionsContext = createContext<DashboardActions | null>(
+  null
+);
+
+/** Canvas hot-slice store provided by DashboardProvider. */
+export const DashboardCanvasStoreContext =
+  createContext<DashboardCanvasStore | null>(null);
+
+/** Picks the 6 hot fields off the full legacy context value (fallback mode). */
+const sliceFromLegacy = (
+  value: DashboardContextValue
+): DashboardCanvasState => ({
+  activeDashboard: value.activeDashboard,
+  selectedWidgetId: value.selectedWidgetId,
+  selectedWidgetIds: value.selectedWidgetIds,
+  groupBuildMode: value.groupBuildMode,
+  zoom: value.zoom,
+  isActiveBoardReadOnly: value.isActiveBoardReadOnly,
+});
+
+/** No-op subscribe used when no store is mounted (legacy fallback hosts). */
+const noopSubscribe = (): (() => void) => () => undefined;
+
+/** Constant snapshot for the unused store slot in fallback mode. */
+const getNullSnapshot = (): null => null;
+
+/**
+ * Actions hook for the canvas hot path. With DashboardProvider mounted the
+ * returned object's identity never changes after mount; in alternate hosts
+ * it falls back to the full legacy context value (which structurally
+ * satisfies `DashboardActions`).
+ */
+export function useDashboardActions(): DashboardActions {
+  const actions = useContext(DashboardActionsContext);
+  if (actions) return actions;
+  // Fallback hosts only. React 19's `use` may be called conditionally, and
+  // that's load-bearing here: an unconditional useContext(DashboardContext)
+  // would subscribe every hot-path component to the legacy value (a new
+  // identity on every provider commit), and context updates pierce memo() —
+  // defeating the whole point of the stable actions surface.
+  const legacy = use(DashboardContext);
+  if (!legacy)
+    throw new Error('useDashboard must be used within DashboardProvider');
+  return legacy;
+}
+
+/**
+ * Selector hook over the canvas hot slice. With a store mounted, the
+ * component re-renders ONLY when its selection changes (`Object.is`);
+ * without one (subs/student/test hosts) it reads the slice off the legacy
+ * context and re-renders with every legacy context change — exactly the
+ * pre-refactor behavior there.
+ *
+ * Selectors MUST return primitives or identity-stable objects (fields of
+ * the slice, not freshly-built objects/arrays): the cached snapshot only
+ * dedupes `Object.is`-equal selections, so a selector that allocates a new
+ * object each call would re-render on every notify and can trip
+ * `useSyncExternalStore`'s render-loop guard.
+ */
+export function useDashboardCanvasSelector<T>(
+  selector: (s: DashboardCanvasState) => T
+): T {
+  const store = useContext(DashboardCanvasStoreContext);
+
+  // Cache the last selection so Object.is-equal results return the SAME
+  // reference — useSyncExternalStore treats a changed snapshot reference
+  // as "store changed" and would otherwise loop. getSnapshot is rebuilt
+  // each render (closing over the freshest selector), which uSES supports
+  // without re-subscribing; only `subscribe` identity drives resubscription.
+  const lastSnapshotRef = useRef<{ value: T } | null>(null);
+
+  // Always called (hook order); fed inert arguments in fallback mode.
+  const subscribed = useSyncExternalStore<T | null>(
+    store ? store.subscribe : noopSubscribe,
+    store
+      ? () => {
+          const next = selector(store.getState());
+          const cached = lastSnapshotRef.current;
+          if (cached && Object.is(cached.value, next)) return cached.value;
+          lastSnapshotRef.current = { value: next };
+          return next;
+        }
+      : getNullSnapshot
+  );
+
+  if (store) return subscribed as T;
+  // Fallback hosts only — conditional `use` (see useDashboardActions) so
+  // store-mode components never subscribe to the churning legacy context.
+  const legacy = use(DashboardContext);
+  if (!legacy)
+    throw new Error('useDashboard must be used within DashboardProvider');
+  return selector(sliceFromLegacy(legacy));
+}
+
+/**
+ * Returns a STABLE function for event-handler-time reads of the canvas hot
+ * slice (e.g. pointer-down group-sibling capture) without subscribing the
+ * component to any of it.
+ */
+export function useDashboardCanvasStateGetter(): () => DashboardCanvasState {
+  const store = useContext(DashboardCanvasStoreContext);
+
+  // With a store the getter only depends on the store object (created once
+  // per provider mount), so its identity is fixed — and the conditional
+  // `use` (see useDashboardActions) keeps store-mode components from
+  // subscribing to the churning legacy context at all. In fallback mode the
+  // getter depends on the legacy value — those hosts re-render on every
+  // legacy context change anyway, so a per-commit getter identity matches
+  // today's behavior there.
+  const legacyForFallback = store ? null : (use(DashboardContext) ?? null);
+
+  return useCallback(() => {
+    if (store) return store.getState();
+    if (!legacyForFallback)
+      throw new Error('useDashboard must be used within DashboardProvider');
+    return sliceFromLegacy(legacyForFallback);
+  }, [store, legacyForFallback]);
+}

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -3,8 +3,33 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardView } from '@/components/layout/DashboardView';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import {
+  DashboardContext,
+  type DashboardContextValue,
+} from '@/context/DashboardContextValue';
 import { useLiveSession } from '@/hooks/useLiveSession';
 import { Dashboard } from '@/types';
+
+// The canvas hot path (BoardCanvas's group overlay, DraggableWindow) reads
+// the hot slice via useDashboardCanvasSelector, which without
+// DashboardProvider's store falls back to the legacy DashboardContext — so
+// every render mounts under a bare provider, the same alternate-host
+// pattern as SubsDashboardProvider/StudentContexts.
+const legacyCtxValue = {
+  activeDashboard: null,
+  selectedWidgetId: null,
+  selectedWidgetIds: [],
+  groupBuildMode: false,
+  zoom: 1,
+  isActiveBoardReadOnly: false,
+} as unknown as DashboardContextValue;
+
+const renderView = () =>
+  render(
+    <DashboardContext.Provider value={legacyCtxValue}>
+      <DashboardView />
+    </DashboardContext.Provider>
+  );
 
 type DashboardGestureHandlers = {
   onDrag?: (state: {
@@ -212,13 +237,13 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('renders correctly', () => {
-    render(<DashboardView />);
+    renderView();
     expect(screen.getByTestId('sidebar')).toBeInTheDocument();
     expect(screen.getByTestId('dock')).toBeInTheDocument();
   });
 
   it('does NOT toggle minimize on Alt + M (now handled by widgets)', () => {
-    render(<DashboardView />);
+    renderView();
 
     // Fire Alt+M
     fireEvent.keyDown(window, { key: 'm', altKey: true });
@@ -228,13 +253,13 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('navigates to previous board on Alt + Left', () => {
-    render(<DashboardView />);
+    renderView();
     fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
     expect(mockLoadDashboard).toHaveBeenCalledWith('db-1');
   });
 
   it('navigates to next board on Alt + Right', () => {
-    render(<DashboardView />);
+    renderView();
     fireEvent.keyDown(window, { key: 'ArrowRight', altKey: true });
     expect(mockLoadDashboard).toHaveBeenCalledWith('db-3');
   });
@@ -264,7 +289,7 @@ describe('DashboardView Gestures & Navigation', () => {
       },
     });
 
-    render(<DashboardView />);
+    renderView();
     fireEvent.keyDown(window, { key: 'Escape', shiftKey: true });
     expect(mockMinimizeAll).toHaveBeenCalled();
   });
@@ -293,7 +318,7 @@ describe('DashboardView Gestures & Navigation', () => {
       },
     });
 
-    render(<DashboardView />);
+    renderView();
     fireEvent.keyDown(window, { key: 'Delete', shiftKey: true });
     await waitFor(() => expect(mockDeleteAll).toHaveBeenCalled());
   });
@@ -327,7 +352,7 @@ describe('DashboardView Gestures & Navigation', () => {
       collectionsApi: collectionsStub,
     });
 
-    const { unmount } = render(<DashboardView />);
+    const { unmount } = renderView();
     fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
     expect(mockLoadDashboard).toHaveBeenCalledWith('db-3');
     unmount();
@@ -349,13 +374,13 @@ describe('DashboardView Gestures & Navigation', () => {
       collectionsApi: collectionsStub,
     });
 
-    render(<DashboardView />);
+    renderView();
     fireEvent.keyDown(window, { key: 'ArrowRight', altKey: true });
     expect(mockLoadDashboard).toHaveBeenCalledWith('db-1');
   });
 
   it('calls addWidget with correct config when spart-sticker with url is dropped', () => {
-    const { container } = render(<DashboardView />);
+    const { container } = renderView();
 
     const dashboardRoot = container.querySelector('#dashboard-root');
     if (!dashboardRoot) throw new Error('Dashboard root not found');
@@ -394,7 +419,7 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('calls addWidget with icon when spart-sticker WITHOUT url is dropped', () => {
-    const { container } = render(<DashboardView />);
+    const { container } = renderView();
 
     const dashboardRoot = container.querySelector('#dashboard-root');
     if (!dashboardRoot) throw new Error('Dashboard root not found');
@@ -432,7 +457,7 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('calls addWidget with correct config when application/sticker is dropped with valid ratio', () => {
-    render(<DashboardView />);
+    renderView();
     const root = document.getElementById('dashboard-root');
     if (!root) throw new Error('Root not found');
     expect(root).toBeInTheDocument();
@@ -473,7 +498,7 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('calls addWidget with fallback ratio when application/sticker is dropped with missing/null ratio', () => {
-    render(<DashboardView />);
+    renderView();
     const root = document.getElementById('dashboard-root');
     if (!root) throw new Error('Root not found');
 
@@ -513,7 +538,7 @@ describe('DashboardView Gestures & Navigation', () => {
   });
 
   it('calls addWidget with fallback ratio when application/sticker is dropped with invalid ratio (e.g. 0)', () => {
-    render(<DashboardView />);
+    renderView();
     const root = document.getElementById('dashboard-root');
     if (!root) throw new Error('Root not found');
 
@@ -599,7 +624,7 @@ describe('DashboardView Gestures & Navigation', () => {
       },
     });
 
-    render(<DashboardView />);
+    renderView();
     mockUpdateWidget.mockClear();
     mockMinimizeAllWidgets.mockClear();
     mockLoadDashboard.mockClear();
@@ -741,7 +766,7 @@ describe('DashboardView Gestures & Navigation', () => {
     });
 
     it('dispatches Escape action with correct widgetId when child is focused', () => {
-      render(<DashboardView />);
+      renderView();
 
       const dispatched: CustomEvent[] = [];
       const handler = (e: Event) => dispatched.push(e as CustomEvent);
@@ -766,7 +791,7 @@ describe('DashboardView Gestures & Navigation', () => {
     });
 
     it('dispatches Delete action with correct widgetId when child is focused', () => {
-      render(<DashboardView />);
+      renderView();
 
       const dispatched: CustomEvent[] = [];
       const handler = (e: Event) => dispatched.push(e as CustomEvent);
@@ -788,7 +813,7 @@ describe('DashboardView Gestures & Navigation', () => {
     });
 
     it('dispatches Pin action with correct widgetId when child is focused (Alt+P)', () => {
-      render(<DashboardView />);
+      renderView();
 
       const dispatched: CustomEvent[] = [];
       const handler = (e: Event) => dispatched.push(e as CustomEvent);
@@ -843,7 +868,7 @@ describe('DashboardView Gestures & Navigation', () => {
         collectionsApi: collectionsStub,
       });
 
-      render(<DashboardView />);
+      renderView();
 
       // Normal toast announces politely via its own role="status".
       const statusToast = screen.getByText('Saved').closest('[role="status"]');
@@ -870,7 +895,7 @@ describe('DashboardView Gestures & Navigation', () => {
         collectionsApi: collectionsStub,
       });
 
-      render(<DashboardView />);
+      renderView();
 
       const dismiss = screen.getByRole('button', { name: 'Dismiss' });
       fireEvent.click(dismiss);

--- a/tests/components/layout/MountedBoardsLayer.test.tsx
+++ b/tests/components/layout/MountedBoardsLayer.test.tsx
@@ -37,8 +37,6 @@ const noopProps = {
   animationClass: '',
   students: [],
   emptyStudents: [],
-  selectedWidgetId: null,
-  zoom: 1,
   globalStyle: {},
   updateSessionConfig: () => undefined,
   updateSessionBackground: () => undefined,

--- a/tests/components/widgets/WidgetRenderer.test.tsx
+++ b/tests/components/widgets/WidgetRenderer.test.tsx
@@ -5,6 +5,10 @@ import { WidgetRenderer } from '@/components/widgets/WidgetRenderer';
 import { WidgetData, GlobalStyle } from '@/types';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import {
+  DashboardContext,
+  type DashboardContextValue,
+} from '@/context/DashboardContextValue';
 import { useWindowSize } from '@/hooks/useWindowSize';
 
 // Mock dependencies
@@ -113,6 +117,20 @@ describe('WidgetRenderer', () => {
     } as unknown as GlobalStyle,
   };
 
+  // WidgetRenderer reads the canvas hot slice via useDashboardCanvasSelector,
+  // which (without DashboardProvider's store mounted) falls back to the
+  // legacy DashboardContext — so mount under a bare provider, the same
+  // alternate-host pattern as SubsDashboardProvider/StudentContexts.
+  const legacyCtxValue = {
+    isActiveBoardReadOnly: false,
+  } as unknown as DashboardContextValue;
+
+  const withCtx = (ui: React.ReactElement) => (
+    <DashboardContext.Provider value={legacyCtxValue}>
+      {ui}
+    </DashboardContext.Provider>
+  );
+
   beforeEach(() => {
     vi.clearAllMocks();
     (useAuth as unknown as Mock).mockReturnValue({
@@ -128,13 +146,13 @@ describe('WidgetRenderer', () => {
   });
 
   it('renders content correctly', () => {
-    render(<WidgetRenderer {...mockProps} />);
+    render(withCtx(<WidgetRenderer {...mockProps} />));
     expect(screen.getByTestId('draggable-window')).toBeInTheDocument();
     expect(screen.getByTestId('widget-content')).toBeInTheDocument();
   });
 
   it('passes stable children callback to ScalableWidget across re-renders', () => {
-    const { rerender } = render(<WidgetRenderer {...mockProps} />);
+    const { rerender } = render(withCtx(<WidgetRenderer {...mockProps} />));
 
     expect(mockScalableWidget).toHaveBeenCalledTimes(1);
     const firstRenderProps = mockScalableWidget.mock
@@ -142,7 +160,7 @@ describe('WidgetRenderer', () => {
 
     // Rerender with CHANGED prop that forces WidgetRenderer to update
     // but should NOT change the ScalableWidget children callback
-    rerender(<WidgetRenderer {...mockProps} isLive={true} />);
+    rerender(withCtx(<WidgetRenderer {...mockProps} isLive={true} />));
 
     expect(mockScalableWidget).toHaveBeenCalledTimes(2);
     const secondRenderProps = mockScalableWidget.mock
@@ -157,7 +175,7 @@ describe('WidgetRenderer', () => {
       ...mockProps,
       dashboardSettings: { spotlightWidgetId: 'w1' },
     };
-    render(<WidgetRenderer {...spotlightProps} />);
+    render(withCtx(<WidgetRenderer {...spotlightProps} />));
 
     expect(mockDraggableWindow).toHaveBeenCalled();
     const props = mockDraggableWindow.mock.calls[0][0] as {

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -24,8 +24,14 @@
  *   - PER-SHELL RENDER COUNTS: every DraggableWindow render invocation is
  *     counted per widget id (via a counting wrapper around the real
  *     component), recorded as totalShellRenders + a per-widget breakdown.
- *     This is the ruler for the context-split refactor: a single-widget
- *     mutation should render only the affected shell(s), not all 15.
+ *     This is the ruler for the context-split refactor, and the contract is
+ *     now ASSERTED: a single-widget mutation (bringToFront / add / remove /
+ *     minimize / restore) must parent-drive renders of ONLY the affected
+ *     shell(s) — untouched shells must show 0 in the per-scenario diff.
+ *     The wrapper observes parent-driven (WidgetRenderer-driven) renders;
+ *     selector-driven internal re-renders inside DraggableWindow are pinned
+ *     separately by context/dashboardCanvasStore.test.tsx, so together the
+ *     two layers cover the whole metric.
  *
  * Results are written to tests/perf/results/dashboard-baseline.json. The
  * test asserts only that metrics were produced and that the gestures had
@@ -117,8 +123,14 @@ const { STUB_WIDGET_TYPES, shellRenderCounts, countShellRender } = vi.hoisted(
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
-vi.mock('@/context/useAuth', () => ({
-  useAuth: () => ({
+vi.mock('@/context/useAuth', () => {
+  // ONE stable value object, mirroring the real AuthContext where the
+  // callbacks are useCallbacks and the value is memoized. A fresh object per
+  // call would hand DashboardContext an unstable `saveWidgetConfig`, making
+  // `updateWidget` (deps: [saveWidgetConfig]) churn identity every provider
+  // render and pierce every shell's memo() — a mock artifact, not production
+  // behavior — which would mask the per-shell render metric below.
+  const stableAuthValue = {
     user: {
       uid: 'perf-user',
       displayName: 'Perf Teacher',
@@ -141,8 +153,9 @@ vi.mock('@/context/useAuth', () => ({
     canAccessFeature: () => false,
     canAccessWidget: () => true,
     disableCloseConfirmation: false,
-  }),
-}));
+  };
+  return { useAuth: () => stableAuthValue };
+});
 
 type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
 let capturedSnapshotCb: SnapshotCb | null = null;
@@ -490,7 +503,8 @@ function getCtx(): ReturnType<typeof useDashboard> {
 /**
  * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
  * BoardCanvas: context state and callbacks flow down as props, while
- * DraggableWindow additionally reads useDashboard() directly.
+ * DraggableWindow/WidgetRenderer read the stable actions context and the
+ * canvas hot-slice selectors directly (context/dashboardCanvasStore.ts).
  */
 const BoardHarness: React.FC = () => {
   const ctx = useDashboard();
@@ -507,8 +521,6 @@ const BoardHarness: React.FC = () => {
       session={null}
       students={EMPTY_STUDENTS}
       emptyStudents={EMPTY_STUDENTS}
-      selectedWidgetId={ctx.selectedWidgetId}
-      zoom={ctx.zoom}
       updateSessionConfig={noopAsync}
       updateSessionBackground={noopAsync}
       startSession={startSessionStub}
@@ -725,6 +737,33 @@ describe('dashboard canvas performance baseline', () => {
     // The mount must have rendered all 15 shells at least once each.
     const mount = metrics.find((m) => m.scenario === 'mount15');
     expect(Object.keys(mount?.shellRendersByWidget ?? {})).toHaveLength(15);
+
+    // Context-split contract (deterministic render-count facts, not
+    // durations): a single-widget mutation parent-drives renders of ONLY
+    // the affected shell(s). An untouched shell appearing in a scenario's
+    // per-widget diff means something re-introduced a board-wide
+    // subscription (or broke widget identity preservation) — exactly the
+    // regression this ruler exists to catch.
+    const shellDiff = (scenario: string): string[] => {
+      const m = metrics.find((x) => x.scenario === scenario);
+      if (!m) throw new Error(`scenario ${scenario} not recorded`);
+      return Object.keys(m.shellRendersByWidget).sort();
+    };
+    // Each pointer-down raised one widget; only those five shells rendered.
+    expect(shellDiff('bringToFront5')).toEqual([
+      'w-1',
+      'w-2',
+      'w-3',
+      'w-4',
+      'w-6',
+    ]);
+    // Adding mounts only the new shell; removal unmounts without rendering
+    // any surviving shell.
+    expect(shellDiff('addWidget')).toEqual(['added-widget']);
+    expect(shellDiff('removeWidget')).toEqual([]);
+    // Minimize/restore touch only the targeted widget's shell.
+    expect(shellDiff('minimize')).toEqual(['w-3']);
+    expect(shellDiff('restore')).toEqual(['w-3']);
   });
 });
 

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -21,6 +21,11 @@
  * For each scenario we record:
  *   - Profiler commit COUNT (primary metric — must be identical run-to-run)
  *   - summed actualDuration (indicative only; machine-dependent)
+ *   - PER-SHELL RENDER COUNTS: every DraggableWindow render invocation is
+ *     counted per widget id (via a counting wrapper around the real
+ *     component), recorded as totalShellRenders + a per-widget breakdown.
+ *     This is the ruler for the context-split refactor: a single-widget
+ *     mutation should render only the affected shell(s), not all 15.
  *
  * Results are written to tests/perf/results/dashboard-baseline.json. The
  * test asserts only that metrics were produced and that the gestures had
@@ -73,29 +78,42 @@ import type {
 
 // ─── Shared fixtures (hoisted so vi.mock factories can use them) ────────────
 
-const { STUB_WIDGET_TYPES } = vi.hoisted(() => ({
-  // 15 widgets across 8 distinct types — all on the standard (non-position-
-  // aware) drag path, which is what every widget except the 3 catalyst types
-  // uses. All are registered skipScaling so the container-query branch of
-  // WidgetRenderer is exercised (the majority path per WidgetRegistry).
-  STUB_WIDGET_TYPES: [
-    'clock',
-    'text',
-    'checklist',
-    'poll',
-    'weather',
-    'schedule',
-    'dice',
-    'scoreboard',
-    'clock',
-    'text',
-    'checklist',
-    'poll',
-    'weather',
-    'schedule',
-    'dice',
-  ] as const,
-}));
+const { STUB_WIDGET_TYPES, shellRenderCounts, countShellRender } = vi.hoisted(
+  () => {
+    // Render-invocation counts of the DraggableWindow shell, keyed by widget
+    // id. Widgets added mid-test get random UUIDs, so those are normalized to
+    // a stable label to keep the results JSON identical run-to-run.
+    const counts = new Map<string, number>();
+    return {
+      shellRenderCounts: counts,
+      countShellRender: (widgetId: string) => {
+        const key = /^w-\d+$/.test(widgetId) ? widgetId : 'added-widget';
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      },
+      // 15 widgets across 8 distinct types — all on the standard (non-position-
+      // aware) drag path, which is what every widget except the 3 catalyst types
+      // uses. All are registered skipScaling so the container-query branch of
+      // WidgetRenderer is exercised (the majority path per WidgetRegistry).
+      STUB_WIDGET_TYPES: [
+        'clock',
+        'text',
+        'checklist',
+        'poll',
+        'weather',
+        'schedule',
+        'dice',
+        'scoreboard',
+        'clock',
+        'text',
+        'checklist',
+        'poll',
+        'weather',
+        'schedule',
+        'dice',
+      ] as const,
+    };
+  }
+);
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -246,6 +264,26 @@ vi.mock('@/components/widgets/WidgetRegistry', () => {
   };
 });
 
+// Per-shell render counter: re-export the REAL DraggableWindow wrapped in a
+// component that bumps a per-widget-id counter on every render invocation.
+// The wrapper renders exactly when WidgetRenderer re-creates the shell's
+// element, so its count is the "did this untouched shell re-render?" ruler —
+// it stays put when the canvas bails out above the shell and drops to ~0 for
+// untouched widgets once the context split lands.
+vi.mock('@/components/common/DraggableWindow', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/components/common/DraggableWindow')
+    >();
+  const ReactActual = await import('react');
+  const RealDraggableWindow = actual.DraggableWindow;
+  const CountingDraggableWindow: typeof actual.DraggableWindow = (props) => {
+    countShellRender(props.widget.id);
+    return ReactActual.createElement(RealDraggableWindow, props);
+  };
+  return { ...actual, DraggableWindow: CountingDraggableWindow };
+});
+
 vi.mock('@/components/widgets/LiveControl', () => ({
   LiveControl: () => null,
 }));
@@ -313,13 +351,28 @@ interface ScenarioMetric {
   scenario: string;
   commits: number;
   actualDurationMs: number;
+  totalShellRenders: number;
+  shellRendersByWidget: Record<string, number>;
 }
 
 const metrics: ScenarioMetric[] = [];
 
+/** Per-widget delta of shellRenderCounts since the given baseline snapshot. */
+function shellRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...shellRenderCounts.keys()].sort()) {
+    const delta = (shellRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
 function createRecorder() {
   let commits = 0;
   let duration = 0;
+  let shellBaseline: ReadonlyMap<string, number> = new Map();
   const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
     commits += 1;
     duration += actualDuration;
@@ -329,12 +382,19 @@ function createRecorder() {
     start() {
       commits = 0;
       duration = 0;
+      shellBaseline = new Map(shellRenderCounts);
     },
     record(scenario: string) {
+      const shellRendersByWidget = shellRenderDeltas(shellBaseline);
       metrics.push({
         scenario,
         commits,
         actualDurationMs: Number(duration.toFixed(3)),
+        totalShellRenders: Object.values(shellRendersByWidget).reduce(
+          (sum, n) => sum + n,
+          0
+        ),
+        shellRendersByWidget,
       });
     },
   };
@@ -660,7 +720,11 @@ describe('dashboard canvas performance baseline', () => {
     for (const m of metrics) {
       expect(m.commits).toBeGreaterThanOrEqual(0);
       expect(m.actualDurationMs).toBeGreaterThanOrEqual(0);
+      expect(m.totalShellRenders).toBeGreaterThanOrEqual(0);
     }
+    // The mount must have rendered all 15 shells at least once each.
+    const mount = metrics.find((m) => m.scenario === 'mount15');
+    expect(Object.keys(mount?.shellRendersByWidget ?? {})).toHaveLength(15);
   });
 });
 
@@ -678,9 +742,13 @@ afterAll(() => {
         generatedAt: new Date().toISOString(),
         runCommand: 'pnpm exec vitest run tests/perf/dashboardPerf.test.tsx',
         note:
-          'Profiler commit counts are the deterministic primary metric and ' +
-          'must be identical across runs. actualDurationMs is machine-' +
-          'dependent and indicative only — compare medians of 3 runs.',
+          'Profiler commit counts and per-shell render counts are the ' +
+          'deterministic primary metrics and must be identical across runs. ' +
+          'totalShellRenders sums DraggableWindow render invocations across ' +
+          'all widgets per scenario; shellRendersByWidget shows which shells ' +
+          'rendered (widgets added mid-test are keyed "added-widget"). ' +
+          'actualDurationMs is machine-dependent and indicative only — ' +
+          'compare medians of 3 runs.',
         skipped:
           'Snap-overlay edge snapping and the snap-layout menu need real ' +
           'viewport geometry, so they are not exercised in jsdom; the drag ' +

--- a/tests/perf/results/dashboard-after.json
+++ b/tests/perf/results/dashboard-after.json
@@ -1,19 +1,126 @@
 {
-  "generatedAt": "2026-06-10T02:31:00.000Z",
+  "generatedAt": "2026-06-10T05:55:43.834Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Median of 3 runs. Profiler commit counts were identical across all 3 runs (deterministic primary metric); actualDurationMs is the median of the 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
-    { "scenario": "mount15", "commits": 4, "actualDurationMs": 92.891 },
-    { "scenario": "drag.press", "commits": 2, "actualDurationMs": 10.647 },
-    { "scenario": "drag.move30", "commits": 0, "actualDurationMs": 0 },
-    { "scenario": "drag.release", "commits": 2, "actualDurationMs": 10.108 },
-    { "scenario": "resize.press", "commits": 1, "actualDurationMs": 0.606 },
-    { "scenario": "resize.move30", "commits": 0, "actualDurationMs": 0 },
-    { "scenario": "resize.release", "commits": 2, "actualDurationMs": 11.368 },
-    { "scenario": "bringToFront5", "commits": 10, "actualDurationMs": 50.677 },
-    { "scenario": "addWidget", "commits": 2, "actualDurationMs": 13.826 },
-    { "scenario": "removeWidget", "commits": 2, "actualDurationMs": 10.682 },
-    { "scenario": "minimize", "commits": 2, "actualDurationMs": 10.519 },
-    { "scenario": "restore", "commits": 2, "actualDurationMs": 10.307 }
+    {
+      "scenario": "mount15",
+      "commits": 4,
+      "actualDurationMs": 96.772,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
+    },
+    {
+      "scenario": "drag.press",
+      "commits": 2,
+      "actualDurationMs": 1.459,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-5": 1
+      }
+    },
+    {
+      "scenario": "drag.move30",
+      "commits": 0,
+      "actualDurationMs": 0,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
+    },
+    {
+      "scenario": "drag.release",
+      "commits": 2,
+      "actualDurationMs": 2.043,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-5": 1
+      }
+    },
+    {
+      "scenario": "resize.press",
+      "commits": 1,
+      "actualDurationMs": 0.655,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
+    },
+    {
+      "scenario": "resize.move30",
+      "commits": 0,
+      "actualDurationMs": 0,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
+    },
+    {
+      "scenario": "resize.release",
+      "commits": 2,
+      "actualDurationMs": 2.018,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-7": 1
+      }
+    },
+    {
+      "scenario": "bringToFront5",
+      "commits": 10,
+      "actualDurationMs": 6.04,
+      "totalShellRenders": 5,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-6": 1
+      }
+    },
+    {
+      "scenario": "addWidget",
+      "commits": 2,
+      "actualDurationMs": 3.733,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "added-widget": 1
+      }
+    },
+    {
+      "scenario": "removeWidget",
+      "commits": 2,
+      "actualDurationMs": 0.627,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
+    },
+    {
+      "scenario": "minimize",
+      "commits": 2,
+      "actualDurationMs": 1.277,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-3": 1
+      }
+    },
+    {
+      "scenario": "restore",
+      "commits": 2,
+      "actualDurationMs": 1.287,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-3": 1
+      }
+    }
   ]
 }

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,68 +1,237 @@
 {
-  "generatedAt": "2026-06-10T02:14:31.171Z",
+  "generatedAt": "2026-06-10T04:07:23.423Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts are the deterministic primary metric and must be identical across runs. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
       "commits": 4,
-      "actualDurationMs": 92.154
+      "actualDurationMs": 90.573,
+      "totalShellRenders": 30,
+      "shellRendersByWidget": {
+        "w-1": 2,
+        "w-10": 2,
+        "w-11": 2,
+        "w-12": 2,
+        "w-13": 2,
+        "w-14": 2,
+        "w-15": 2,
+        "w-2": 2,
+        "w-3": 2,
+        "w-4": 2,
+        "w-5": 2,
+        "w-6": 2,
+        "w-7": 2,
+        "w-8": 2,
+        "w-9": 2
+      }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 10.695
+      "actualDurationMs": 10.669,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "drag.move30",
       "commits": 0,
-      "actualDurationMs": 0
+      "actualDurationMs": 0,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
     },
     {
       "scenario": "drag.release",
       "commits": 2,
-      "actualDurationMs": 10.174
+      "actualDurationMs": 10.431,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 0.611
+      "actualDurationMs": 0.609,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
     },
     {
       "scenario": "resize.move30",
       "commits": 0,
-      "actualDurationMs": 0
+      "actualDurationMs": 0,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
     },
     {
       "scenario": "resize.release",
       "commits": 2,
-      "actualDurationMs": 10.523
+      "actualDurationMs": 11.011,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 50.93
+      "actualDurationMs": 52.636,
+      "totalShellRenders": 75,
+      "shellRendersByWidget": {
+        "w-1": 5,
+        "w-10": 5,
+        "w-11": 5,
+        "w-12": 5,
+        "w-13": 5,
+        "w-14": 5,
+        "w-15": 5,
+        "w-2": 5,
+        "w-3": 5,
+        "w-4": 5,
+        "w-5": 5,
+        "w-6": 5,
+        "w-7": 5,
+        "w-8": 5,
+        "w-9": 5
+      }
     },
     {
       "scenario": "addWidget",
       "commits": 2,
-      "actualDurationMs": 13.708
+      "actualDurationMs": 14.135,
+      "totalShellRenders": 16,
+      "shellRendersByWidget": {
+        "added-widget": 1,
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 10.532
+      "actualDurationMs": 10.664,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 10.445
+      "actualDurationMs": 10.675,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 10.308
+      "actualDurationMs": 10.574,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      }
     }
   ]
 }

--- a/tests/perf/results/dashboard-bundle-after.json
+++ b/tests/perf/results/dashboard-bundle-after.json
@@ -2,16 +2,16 @@
   "chunks": [
     {
       "name": "WidgetRenderer.js",
-      "gzipKb": 34.56
+      "gzipKb": 34.6
     },
     {
       "name": "DashboardView.js",
-      "gzipKb": 383.65
+      "gzipKb": 383.69
     },
     {
       "name": "index.js",
-      "gzipKb": 368.09
+      "gzipKb": 368.94
     }
   ],
-  "totalGzipKb": 786.3
+  "totalGzipKb": 787.23
 }


### PR DESCRIPTION
## What

The deferred root fix from #1923: eliminates whole-board re-renders on single-widget context mutations. Stacked on `perf/dashboard-canvas-pass` (#1923) — **merge that first, then this will be rebased onto dev-paul.**

### Mechanism (hybrid, zero new deps)

- **`DashboardActionsContext`** — mount-stable object of action callbacks via the latest-ref delegation pattern (`actionsRef` assigned in the provider render body + `useMemo(..., [])` thin wrappers). Identity never changes; every call executes the freshest closure — no stale-state hazard.
- **Canvas hot-state store** (`context/dashboardCanvasStore.ts`) — a `useSyncExternalStore`-based derived *mirror* of the 6-field hot slice (activeDashboard, selectedWidgetId, selectedWidgetIds, groupBuildMode, zoom, isActiveBoardReadOnly), written from the provider's render body and notified post-commit via `useLayoutEffect`. Per-widget primitive selectors with `Object.is` bailout mean a selection click re-renders exactly the 2 affected shells, not all 15.
- **Back-compat**: `useDashboard()` and its ~185 consumers are untouched. New hooks fall back to the legacy context for alternate value hosts (subs portal, student view, direct-Provider tests). DashboardProvider remains single source of truth; the direct-DOM drag/resize fast path is untouched.

### Measured (committed per-shell ruler, deterministic across 3 runs; commit counts unchanged in all 12 scenarios)

| Scenario | Shell renders before → after | Duration |
|---|---|---|
| bringToFront ×5 | 75 → **5** | 52.6 → 6.0ms |
| addWidget | 16 → **1** | 14.1 → 3.7ms |
| removeWidget | 15 → **0** | 10.7 → 0.6ms |
| minimize / restore | 15 → **1** | 10.7 → 1.2ms |
| drag/resize press+release | 15 → **1** each | ~10.7 → ~1.8ms |
| drag/resize move ×30 | 0 → 0 (fast path untouched) | — |

First commit extends the ruler with per-shell render counts and records the pre-split baseline; the contract (`untouched shells render 0 on foreign mutations`) is now *asserted* in the harness, so regressions fail CI.

### Verification

- Designed → implemented in 4 staged subagents → 3 adversarial reviewers (stale-state/subscription correctness, behavior preservation across 5 traced consumers, standards/coverage) → blocker fixed (notify moved to `useLayoutEffect`) → re-review clean.
- Full gates green: type-check, lint (zero warnings), format, **entire unit suite**.
- New contract tests: actions identity stability across mutations, store mirroring/fallback, per-shell render assertions.
- **Cost audit: NEUTRAL** — pure render-layer; zero Firestore reads/writes/listeners added, no listener duplication, debounce semantics unchanged. Bundle delta ~noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)