### PR TITLE
fix(BreathingWidget): use phase==='ready' sentinel for Reset disabled logic

### DIFF
--- a/components/widgets/Breathing/BreathingWidget.test.tsx
+++ b/components/widgets/Breathing/BreathingWidget.test.tsx
@@ -86,4 +86,40 @@ describe('BreathingWidget', () => {
     expect(screen.getByText('Ready')).toBeInTheDocument();
     expect(screen.getByLabelText('Start')).toBeInTheDocument();
   });
+
+  /**
+   * Regression test for the Reset button disable logic.
+   *
+   * Bug: the disable condition is `!isActive && progress === 0`.
+   * At a phase boundary (e.g. inhale → hold1), `setProgress(0)` fires.
+   * If the user pauses immediately after the transition, the state is:
+   *   isActive=false, phase='hold1', progress=0.
+   * The condition evaluates `!false && 0===0` → true → button incorrectly
+   * disabled, even though the user is mid-session.
+   *
+   * Fix: use `phase === 'ready'` as the quiescent-state sentinel instead of
+   * `progress === 0`, because 'ready' is the only state where reset is a
+   * genuine no-op.
+   */
+  it('Reset button stays enabled when paused at the exact start of a phase (progress=0, phase!=ready)', () => {
+    render(<BreathingWidget widget={mockWidget} />);
+
+    // Start the 4-4-4-4 sequence (inhale=4s, hold1=4s, exhale=4s, hold2=4s).
+    // Then pause immediately before any progress advances — this leaves the
+    // hook in the state isActive=false, phase='inhale', progress=0, which is
+    // the same shape as the phase-boundary case (phase!='ready', progress=0).
+    fireEvent.click(screen.getByLabelText('Start'));
+    expect(screen.getByText('Inhale')).toBeInTheDocument();
+
+    // Pause without letting any RAF ticks fire so progress stays at exactly 0.
+    // isActive=false, phase='inhale', progress=0.
+    // With the bug: `!isActive && progress===0` → true → Reset is DISABLED (wrong).
+    // With the fix: `!isActive && phase==='ready'` → false → Reset is enabled (correct).
+    fireEvent.click(screen.getByLabelText('Pause'));
+    expect(screen.getByLabelText('Start')).toBeInTheDocument(); // confirm paused
+
+    // The Reset button MUST be enabled — the session has started (phase!='ready')
+    // even though progress happens to be 0 right at the phase start.
+    expect(screen.getByLabelText('Reset')).not.toBeDisabled();
+  });
 });

--- a/components/widgets/Breathing/BreathingWidget.tsx
+++ b/components/widgets/Breathing/BreathingWidget.tsx
@@ -113,7 +113,7 @@ export const BreathingWidget: React.FC<{ widget: WidgetData }> = ({
             </button>
             <button
               onClick={reset}
-              disabled={!isActive && progress === 0}
+              disabled={!isActive && phase === 'ready'}
               className="flex items-center justify-center rounded-2xl bg-slate-100 text-slate-500 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-slate-700 transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
               style={{
                 width: 'min(56px, 18cqmin)',


### PR DESCRIPTION
## Root cause

`BreathingWidget.tsx` used `disabled={!isActive && progress === 0}` to guard the Reset button. This is a false proxy for "no session in progress." At every phase boundary (e.g. inhale → hold1 → exhale → hold2), `setProgress(0)` fires in `useBreathing`. If the teacher pauses *immediately after* a phase transition, the state is `isActive=false, phase='hold1', progress=0` — which satisfies the condition and wrongly disables Reset mid-session. The teacher sees a greyed-out button and cannot reset an in-flight breathing exercise.

## Fix

Changed to `disabled={!isActive && phase === 'ready'}`. The `'ready'` phase is the only true quiescent state; it is the only time Reset is a genuine no-op. All other phases — even paused at progress=0 — represent an active or mid-session state.

## Rejected band-aid

Could have added a `hasStarted` boolean to track "session has been touched." That adds state to work around the symptom (a bad disabled condition) without fixing the root check. Using `phase === 'ready'` directly expresses the semantic intent.

## Regression test

`BreathingWidget.test.tsx` — new test: "Reset button is enabled when paused at a phase boundary (isActive=false, phase=inhale, progress=0)." Starts the session, pauses before any RAF tick fires, asserts `Reset` is enabled. Fails on current code (`disabled={!isActive && progress === 0}`), passes after fix.

## Evidence

- Before: `disabled={!isActive && progress === 0}` → test reports `disabled=""` on Reset button
- After: `disabled={!isActive && phase === 'ready'}` → all 4 tests pass

## Risk

**Contained** — one-line change to a single widget's JSX prop. No shared utilities, no context, no hooks changed. Existing tests continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFyLtu7LW1CDaoHMTjcgfS)_