### PR TITLE
fix(state): dedup questions in buildQuizClassroomGradeEntries currentTotal

### DIFF
--- a/tests/utils/classroomGradePush.test.ts
+++ b/tests/utils/classroomGradePush.test.ts
@@ -144,4 +144,28 @@ describe('buildQuizClassroomGradeEntries', () => {
     // must omit it so the gradebook grade reflects mastery, not answer speed.
     expect(getEarnedPointsMock.mock.calls[0][2]).toBeUndefined();
   });
+
+  it('deduplicates questions by id before summing currentTotal (Drive-sync duplicate guard)', () => {
+    // Drive-sync duplication or arrayUnion races can write the same question id
+    // twice into the quiz's questions array. Without a dedup guard, currentTotal
+    // inflates (10 + 10 = 20) while getEarnedPoints stays correct (it builds a
+    // Map that naturally deduplicates by id, so earned = 10 for a perfect answer).
+    // The scaling (earned / currentTotal) * maxPoints then understates the grade:
+    //   bugged:   (10 / 20) * 10 = 5  ← wrong (50% instead of 100%)
+    //   correct:  (10 / 10) * 10 = 10 ← correct
+    const dupQuestion: QuizQuestion = {
+      id: 'q-dup',
+      type: 'MC',
+      points: 10,
+    } as unknown as QuizQuestion;
+    // Two entries with the SAME id simulate the Drive-sync duplicate.
+    const questions = [dupQuestion, dupQuestion];
+    // The mock returns __earned; set it to the correct single-question earned
+    // value (10 pts) — matching what getEarnedPoints produces when its qMap
+    // deduplicates the question to one entry.
+    const response = resp('u1', 'completed', 10);
+    const grades = buildQuizClassroomGradeEntries([response], questions, 10);
+    // A student who earned 10/10 on the only real question should push 10/10.
+    expect(grades).toEqual([{ pseudonymUid: 'u1', pointsEarned: 10 }]);
+  });
 });

--- a/utils/classroomGradePush.ts
+++ b/utils/classroomGradePush.ts
@@ -66,7 +66,19 @@ export function buildQuizClassroomGradeEntries(
   questions: QuizQuestion[],
   maxPoints: number
 ): ClassroomGradeEntry[] {
-  const currentTotal = questions.reduce((s, q) => s + (q.points ?? 1), 0);
+  // Deduplicate by question id before summing — Drive-sync duplication and
+  // arrayUnion races can write the same question id twice into `questions`.
+  // Without this guard, `currentTotal` inflates while `getEarnedPoints`
+  // stays correct (it builds a Map that naturally deduplicates by id), so
+  // the scaling `(earned / currentTotal) * maxPoints` understates the grade.
+  // Mirrors the identical fence in `getResponseScore`, `buildResultsSheetData`,
+  // `buildContributionDoc`, and `publishAssignmentScores` (#1728–#1855).
+  const seenIds = new Set<string>();
+  const currentTotal = questions.reduce((s, q) => {
+    if (seenIds.has(q.id)) return s;
+    seenIds.add(q.id);
+    return s + (q.points ?? 1);
+  }, 0);
   return responses
     .filter(
       (r) =>


### PR DESCRIPTION
## Root cause

`utils/classroomGradePush.ts` `buildQuizClassroomGradeEntries` computes `currentTotal` (the denominator for Google Classroom grade scaling) via a raw `reduce` over the `questions` array:

```ts
const currentTotal = questions.reduce((s, q) => s + (q.points ?? 1), 0);
```

`getEarnedPoints` (the numerator) builds a `Map` from `questions.map(q => [q.id, q])`, which naturally deduplicates by ID. When Drive-sync or `arrayUnion` races write the same question ID twice:

- `earned` (numerator): correct — 10 pts for a perfect answer on a 10-pt question
- `currentTotal` (denominator): inflates — 10 + 10 = 20 instead of 10
- Scaling: `(10 / 20) * maxPoints = 5/10` pushed to Google Classroom instead of 10/10

A student with a perfect score receives a grade of 50% rather than 100%.

## Fix

Added a `seenIds: Set<string>` guard before the `reduce`, mirroring the identical fence already in `getResponseScore`, `buildResultsSheetData`, `buildContributionDoc`, and `publishAssignmentScores` (same bug pattern as #1728, #1777, #1787, #1803, #1827).

## Rejected band-aid

Could have filtered `questions` to unique IDs before passing into the function. That would hide duplicates from the caller too, potentially masking a future dedup issue elsewhere. The guard inside the accumulator is the established pattern for this codebase.

## Regression test

`tests/utils/classroomGradePush.test.ts` — new test: "deduplicates questions by id before summing currentTotal (Drive-sync duplicate guard)." Quiz with question `q1` written twice (10 pts each), student answers both correctly. Before fix: `pointsEarned: 5` (inflated denominator). After fix: `pointsEarned: 10`.

## Risk

**Contained** — single utility function, no context or hooks changed. Pattern is identical to 5+ prior fixes in this codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFyLtu7LW1CDaoHMTjcgfS)_