### PR TITLE
fix(functions): add maxRedirects:0 to checkUrlCompatibility to prevent SSRF redirect bypass

### DIFF
--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -787,6 +787,29 @@ describe('checkUrlCompatibility', () => {
     ).rejects.toThrow(/private or reserved/i);
     expect(mockHead).not.toHaveBeenCalled();
   });
+
+  // Regression: checkUrlCompatibility called axios.head() without maxRedirects:0,
+  // so a public URL that 302-redirected to a private/internal IP (e.g. the GCP
+  // metadata endpoint at 169.254.169.254) would bypass the blocklist entirely —
+  // the same SSRF redirect bypass that was already fixed in fetchExternalProxy.
+  it('disables axios redirects so the SSRF blocklist stays load-bearing under 3xx', async () => {
+    const mockHead = vi.mocked(axios.head);
+    mockHead.mockResolvedValue({ headers: {} });
+
+    const handler = checkUrlCompatibility as unknown as (
+      req: unknown,
+      context: unknown
+    ) => Promise<unknown>;
+    await handler(
+      { url: 'https://example.com/embed-test' },
+      { auth: { uid: '123' } }
+    );
+
+    expect(mockHead).toHaveBeenCalledWith(
+      'https://example.com/embed-test',
+      expect.objectContaining({ maxRedirects: 0 })
+    );
+  });
 });
 
 describe('adminAnalytics', () => {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1536,6 +1536,12 @@ export const checkUrlCompatibility = onCall(
     try {
       const response = await axios.head(data.url, {
         timeout: 10000,
+        // SSRF guard: the blocklist check above only validates the initial URL.
+        // Without this, axios would follow up to 5 redirects by default, so a
+        // public host could 302 to a private/internal IP (e.g. the GCP metadata
+        // endpoint at 169.254.169.254) and bypass the check entirely — the same
+        // vulnerability that was already fixed in fetchExternalProxy.
+        maxRedirects: 0,
         headers: {
           'User-Agent':
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',


### PR DESCRIPTION
## Root cause

`checkUrlCompatibility` (`functions/src/index.ts`) calls `axios.head(data.url, { timeout: 10000, headers: {...} })` without `maxRedirects: 0`. The private-IP SSRF blocklist check runs **only on the initial URL**. Since `axios` follows up to 5 redirects by default, an attacker who can point the function at a public URL that 302-redirects to a private/internal address (e.g. the GCP metadata endpoint at `169.254.169.254`, or any VPC-internal service) bypasses the blocklist entirely.

This is the identical vulnerability that was already fixed in `fetchExternalProxy` — which explicitly sets `maxRedirects: 0` with a comment explaining exactly why. `checkUrlCompatibility` was missed in that fix.

**Attack scenario:** Authenticated teacher calls `checkUrlCompatibility({ url: "https://attacker.example/redirect-to-metadata" })`. The blocklist accepts `attacker.example`. Axios follows the 302 to `http://169.254.169.254/computeMetadata/v1/...`. The function receives a response from the internal endpoint, potentially leaking service account credentials or internal network topology.

## Fix

Added `maxRedirects: 0` to the `axios.head()` call in `checkUrlCompatibility`, with a comment mirroring the rationale already documented in `fetchExternalProxy`. A 3xx response from a SSRF-probing redirect will now surface as an axios error rather than silently following the chain.

## Rejected band-aid

Expanding the blocklist to cover more IP ranges would not help — the attacker controls the redirect target and can pick any private IP not yet blocked. The only correct fix is to refuse to follow redirects at all, same as `fetchExternalProxy`.

## Regression test

`functions/src/index.test.ts` — new test in the `checkUrlCompatibility` describe block: "disables axios redirects so the SSRF blocklist stays load-bearing under 3xx." Verifies `axios.head` is called with `expect.objectContaining({ maxRedirects: 0 })`. Mirrors the analogous test already passing for `fetchExternalProxy`. Fails on baseline (no `maxRedirects` arg), passes after fix.

## Risk

**Contained** — one-line addition to a single Cloud Function's HTTP call. No logic change; a 3xx response was already surfaced as an error to the client (the function returns `{ compatible: false }` on any axios error). Teachers will no longer receive `compatible: true` for URLs that redirect to private IPs, which is the correct behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFyLtu7LW1CDaoHMTjcgfS)_