### PR TITLE
chore(perf): refresh performance baseline timestamps (2026-06-11)

### DIFF
--- a/tests/perf/results/baseline.json
+++ b/tests/perf/results/baseline.json
@@ -1,67 +1,67 @@
 {
-  "generatedAt": "2026-06-10T03:09:28.190Z",
+  "generatedAt": "2026-06-11T05:28:05.595Z",
   "runCommand": "pnpm exec vitest run tests/perf/editorPerf.test.tsx",
   "note": "Profiler commit counts are the deterministic primary metric and must be identical across runs. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "scenarios": [
     {
       "scenario": "quiz.mount",
       "commits": 3,
-      "actualDurationMs": 168.354
+      "actualDurationMs": 153.474
     },
     {
       "scenario": "quiz.type25",
       "commits": 25,
-      "actualDurationMs": 228.172
+      "actualDurationMs": 261.366
     },
     {
       "scenario": "quiz.switchSelection10",
       "commits": 18,
-      "actualDurationMs": 158.477
+      "actualDurationMs": 184.848
     },
     {
       "scenario": "quiz.addQuestion",
       "commits": 2,
-      "actualDurationMs": 12.337
+      "actualDurationMs": 14.775
     },
     {
       "scenario": "va.mount",
       "commits": 4,
-      "actualDurationMs": 78.302
+      "actualDurationMs": 110.244
     },
     {
       "scenario": "va.type25",
       "commits": 25,
-      "actualDurationMs": 202.766
+      "actualDurationMs": 233.032
     },
     {
       "scenario": "va.switchSelection10",
       "commits": 10,
-      "actualDurationMs": 70.949
+      "actualDurationMs": 80.279
     },
     {
       "scenario": "va.addTask",
       "commits": 2,
-      "actualDurationMs": 21.235
+      "actualDurationMs": 18.54
     },
     {
       "scenario": "gl.mount",
       "commits": 3,
-      "actualDurationMs": 62.768
+      "actualDurationMs": 39.701
     },
     {
       "scenario": "gl.type25",
       "commits": 25,
-      "actualDurationMs": 242.69
+      "actualDurationMs": 330.819
     },
     {
       "scenario": "gl.switchSlide10",
       "commits": 10,
-      "actualDurationMs": 124.76
+      "actualDurationMs": 115.841
     },
     {
       "scenario": "gl.addStep",
       "commits": 3,
-      "actualDurationMs": 30.329
+      "actualDurationMs": 24.814
     }
   ]
 }

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-10T04:07:23.423Z",
+  "generatedAt": "2026-06-11T05:29:36.979Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
   "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
@@ -7,30 +7,7 @@
     {
       "scenario": "mount15",
       "commits": 4,
-      "actualDurationMs": 90.573,
-      "totalShellRenders": 30,
-      "shellRendersByWidget": {
-        "w-1": 2,
-        "w-10": 2,
-        "w-11": 2,
-        "w-12": 2,
-        "w-13": 2,
-        "w-14": 2,
-        "w-15": 2,
-        "w-2": 2,
-        "w-3": 2,
-        "w-4": 2,
-        "w-5": 2,
-        "w-6": 2,
-        "w-7": 2,
-        "w-8": 2,
-        "w-9": 2
-      }
-    },
-    {
-      "scenario": "drag.press",
-      "commits": 2,
-      "actualDurationMs": 10.669,
+      "actualDurationMs": 273.969,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -48,6 +25,15 @@
         "w-7": 1,
         "w-8": 1,
         "w-9": 1
+      }
+    },
+    {
+      "scenario": "drag.press",
+      "commits": 2,
+      "actualDurationMs": 2.87,
+      "totalShellRenders": 1,
+      "shellRendersByWidget": {
+        "w-5": 1
       }
     },
     {
@@ -60,30 +46,16 @@
     {
       "scenario": "drag.release",
       "commits": 2,
-      "actualDurationMs": 10.431,
-      "totalShellRenders": 15,
+      "actualDurationMs": 3.941,
+      "totalShellRenders": 1,
       "shellRendersByWidget": {
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
+        "w-5": 1
       }
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 0.609,
+      "actualDurationMs": 1.298,
       "totalShellRenders": 0,
       "shellRendersByWidget": {}
     },
@@ -97,140 +69,57 @@
     {
       "scenario": "resize.release",
       "commits": 2,
-      "actualDurationMs": 11.011,
-      "totalShellRenders": 15,
+      "actualDurationMs": 6.185,
+      "totalShellRenders": 1,
       "shellRendersByWidget": {
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
+        "w-7": 1
       }
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 52.636,
-      "totalShellRenders": 75,
+      "actualDurationMs": 15.158,
+      "totalShellRenders": 5,
       "shellRendersByWidget": {
-        "w-1": 5,
-        "w-10": 5,
-        "w-11": 5,
-        "w-12": 5,
-        "w-13": 5,
-        "w-14": 5,
-        "w-15": 5,
-        "w-2": 5,
-        "w-3": 5,
-        "w-4": 5,
-        "w-5": 5,
-        "w-6": 5,
-        "w-7": 5,
-        "w-8": 5,
-        "w-9": 5
+        "w-1": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-6": 1
       }
     },
     {
       "scenario": "addWidget",
       "commits": 2,
-      "actualDurationMs": 14.135,
-      "totalShellRenders": 16,
+      "actualDurationMs": 18.721,
+      "totalShellRenders": 1,
       "shellRendersByWidget": {
-        "added-widget": 1,
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
+        "added-widget": 1
       }
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 10.664,
-      "totalShellRenders": 15,
-      "shellRendersByWidget": {
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
-      }
+      "actualDurationMs": 1.88,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {}
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 10.675,
-      "totalShellRenders": 15,
+      "actualDurationMs": 3.219,
+      "totalShellRenders": 1,
       "shellRendersByWidget": {
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
+        "w-3": 1
       }
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 10.574,
-      "totalShellRenders": 15,
+      "actualDurationMs": 10.17,
+      "totalShellRenders": 1,
       "shellRendersByWidget": {
-        "w-1": 1,
-        "w-10": 1,
-        "w-11": 1,
-        "w-12": 1,
-        "w-13": 1,
-        "w-14": 1,
-        "w-15": 1,
-        "w-2": 1,
-        "w-3": 1,
-        "w-4": 1,
-        "w-5": 1,
-        "w-6": 1,
-        "w-7": 1,
-        "w-8": 1,
-        "w-9": 1
+        "w-3": 1
       }
     }
   ]


### PR DESCRIPTION
## Summary

Refreshes `tests/perf/results/baseline.json` and `tests/perf/results/dashboard-baseline.json` to reflect the current state of dev-paul after the DashboardContext split (PR #1931).

### What changed and why

**`baseline.json`** (editor perf harness): timing-only update — `actualDurationMs` values shifted due to machine variance; all deterministic commit counts are unchanged.

**`dashboard-baseline.json`** (canvas perf harness): two categories of change:

1. **Timing-only** — `actualDurationMs` values shifted due to machine variance (expected).

2. **Deterministic `totalShellRenders` drops (intentional perf win)** — widget shells no longer re-render on every canvas operation thanks to the stable-actions + hot-state-store split in #1931:

   | Scenario | Before | After |
   |---|---|---|
   | `bringToFront5` | 75 | 5 |
   | `addWidget` | 16 | 1 |
   | `mount15` | 30 | 15 |
   | `drag.press` | 15 | 1 |
   | `drag.release` | 15 | 1 |
   | `resize.release` | 15 | 1 |
   | `minimize` | 15 | 1 |
   | `restore` | 15 | 1 |
   | `removeWidget` | 15 | 0 |

   These are the measured wins from #1931. The baseline is updated to record the new correct values as the expected deterministic target for future runs.

One scenario (`drag.press`) was also reordered to match the natural execution order in the harness.