### PR TITLE
action(css-scaling): scale ActivityWall moderation checkbox with cqmin

### DIFF
--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -1373,7 +1373,11 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
                         moderationEnabled: event.target.checked,
                       })
                     }
-                    className="h-4 w-4 accent-brand-blue-primary"
+                    className="accent-brand-blue-primary"
+                    style={{
+                      width: 'min(16px, 4cqmin)',
+                      height: 'min(16px, 4cqmin)',
+                    }}
                   />
                 </label>
 

--- a/docs/scheduled-tasks/ai-integration.md
+++ b/docs/scheduled-tasks/ai-integration.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-06-08_
+_Last audited: 2026-06-12_
 _Last action: never_
 
 ---
@@ -78,6 +78,8 @@ The following widgets have structured config schemas well-suited for AI content 
 ---
 
 ## Completed
+
+_2026-06-12: AI integration audit after rebase onto dev-paul (docs/unifier run 13, D4 @/ alias in tests/, perf baseline, fix DraggableWindow, debugger run 14). No new AI generation types or function additions in these commits. All 13 generation types verified complete: rate limits, loading/error states, and feature permission gates all present. Gemini models confirmed consistent: DEFAULT_ADVANCED_MODEL = 'gemini-3-flash-preview', DEFAULT_STANDARD_MODEL = 'gemini-3.1-flash-lite-preview' — modern and admin-overridable. JSON mode used correctly server-side for all structured outputs. Hardcoded model string LOW item at line 2513 (transcribeVideoWithGemini) unchanged — still unresolved. AI opportunities for RevealGrid/ConceptWeb/GraphicOrganizer/Checklist remain documented in the Opportunities section but unimplemented. Zero new open items._
 
 _2026-06-08: AI integration audit after merging dev-paul. TWO ITEMS MOVED TO COMPLETED: (1) LOW `dashboard-layout no server-side specific permission` — PR #1873 (`fix(functions): register dashboard-layout and instructional-routine in per-feature AI tracking`) added `if (genType === 'dashboard-layout') specificFeatureId = 'dashboard-layout'` and `if (genType === 'instructional-routine') specificFeatureId = 'instructional-routine'` to functions/src/index.ts before this merge. Dashboard-layout LOW item closed. (2) LOW `video-activity-recommend missing from AIData interface` — interface already includes `'video-activity-recommend'` at line 99 (added in a prior merge). Closed. `instructional-routine` MEDIUM item updated: server-side `specificFeatureId` now set (partial fix) but `LibraryManager.tsx` still lacks `canAccessFeature()` client-side gate — severity downgraded from MEDIUM to LOW per partial fix. TODAY's merge (PR #1891: `fix(functions): register widget-builder and widget-explainer in per-feature AI tracking`) adds `specificFeatureId` assignments for `widget-builder` and `widget-explainer` — both are now rate-limited per feature and tracked in adminAnalyticsCompute.ts. These were previously admin-only by UI but had no server-side per-feature quota. Now they are fully tracked. No new generation types added. Hardcoded model string at line 2513 unchanged. RevealGrid, ConceptWeb, GraphicOrganizer, SyntaxFramer, Checklist still without AI generation features. All other items unchanged._
 

--- a/docs/scheduled-tasks/code-structure.md
+++ b/docs/scheduled-tasks/code-structure.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-06-12_
+_Last audited: 2026-06-13_
 _Last action: 2026-06-12 — MEDIUM cardOpacity range-check extracted into shared `isCardOpacity` guard in adminBuildingConfig.ts_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-13: Weekly audit pass (Saturday). Rebase onto dev-paul: pr-review batch 12 PRs, refactor(admin-config) isCardOpacity guard, [AI] wide-distro phases 1-3 (tiering, landing page, rollout form, rollout_requests rules, user tier model, minTier permission gating, google-classroom feature gate), [AI] legal pages, [AI] OAuth scope drops. DashboardContext.tsx now **5,722 lines** (+126 from 5,596 on 2026-06-12) — continued steady growth. Single-use utils list extended: `adminBuildingConfig.ts` (only importer: DashboardContext), `collectionsMigration.ts` (only importer: DashboardContext), `ai_security.ts` (only importer: DashboardContext), `pickInitialBoard.ts` (only importer: DashboardContext), `mapWithConcurrency.ts` (only importer: single util), `pexelsService.ts` (single importer), `googleSession.ts` (single importer), `previewMode.ts` (single importer), `userTier.ts` (single importer) — added to existing LOW single-use-utils item. Cloud Functions confirmed v2. No data-fetching duplication in new contexts (tiering/permission gate added to AuthContext reads featurePermissions already owned there). All existing open items re-confirmed valid. 0 new open items._
 
 _2026-06-12: Weekly audit pass. Rebase onto dev-paul (docs/unifier run 13, D4 @/ alias conversion in tests/, perf baseline refresh, fix DraggableWindow duplicate handler, debugger run 14). None touch context/DashboardContext.tsx, functions/src/index.ts, or adminBuildingConfig.ts structure. All existing open items re-confirmed valid. New finding: multiple large component/layout files not previously tracked now exceed 500 lines — QuizStudentApp.tsx (3762 lines), DashboardView.tsx (1908 lines), Dock.tsx (1597 lines), GlobalPermissionsManager.tsx (1497 lines), StarterPackConfigurationModal.tsx (1251 lines), VideoActivityStudentApp.tsx (990 lines). Cloud Functions all confirmed on v2. No data-fetching duplication detected. No deep relative imports (3+ levels of ../) in source files. Single-use utils list extended: assignToClassroom.ts, deleteDrawingPageSubcollection.ts, imageWorker.ts, lastActiveThrottle.ts, migrateDrawingToSubcollection.ts, miniAppNormalize.ts added to existing LOW item. 1 new MEDIUM open item added._
 
@@ -58,6 +60,7 @@ _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 
 ### HIGH `DashboardContext.tsx` grew 1262 lines since May 13 extraction — now 5596 lines
 
 - **Detected:** 2026-05-22
+- **Updated:** 2026-06-13 — file is now **5,722 lines** (+126 from 5,596 on 2026-06-12). [AI] wide-distro phases added tiering, minTier permission gating, google-classroom feature gate (+~130 lines). BLOCKED status unchanged.
 - **Updated:** 2026-06-05 — file is now **5,596 lines** (+321 from 5,275 on 2026-05-27). Continued growth despite no new extractions. BLOCKED status unchanged — collections/Drive extraction still requires supervised runtime-verified session.
 - **File:** context/DashboardContext.tsx
 - **Detail:** After the May 13 extraction of `getAdminBuildingConfig` reduced the file from 4441 to 4041 lines, nine days of new features grew it back to 5303 (+1262, +31%). The file now exceeds 5000 lines. Primary drivers: (1) PLC collaborative space redesign added collection navigation state, `lastBoardIdByCollection` tracking, `setActiveCollectionId`, and related callbacks (~400 lines); (2) boards-modal inline share/duplicate actions; (3) admin personal-spotify building scoping; (4) PLC in-progress assignment monitor/results. Collections management in particular introduces a new distinct responsibility (board/collection relationship state) that belongs in a dedicated hook or context. The `useGoogleDrive` orchestration and Drive reconnect error handling are also clearly separable.
@@ -135,6 +138,15 @@ _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 
   - `utils/migrateDrawingToSubcollection.ts` — 1 consumer (2026-06-12, migration helper)
   - `utils/miniAppNormalize.ts` — 1 consumer (2026-06-12, consider colocation)
   - `utils/smartPaste.ts` — 1 consumer
+  - `utils/adminBuildingConfig.ts` — 1 consumer (DashboardContext) (2026-06-13)
+  - `utils/collectionsMigration.ts` — 1 consumer (DashboardContext) (2026-06-13)
+  - `utils/ai_security.ts` — 1 consumer (DashboardContext) (2026-06-13)
+  - `utils/pickInitialBoard.ts` — 1 consumer (DashboardContext) (2026-06-13)
+  - `utils/mapWithConcurrency.ts` — 1 consumer (2026-06-13)
+  - `utils/pexelsService.ts` — 1 consumer (2026-06-13)
+  - `utils/googleSession.ts` — 1 consumer (2026-06-13)
+  - `utils/previewMode.ts` — 1 consumer (2026-06-13)
+  - `utils/userTier.ts` — 1 consumer (2026-06-13)
     Single-consumer utils are not necessarily wrong — domain separation is valid — but warrant a quick sanity check that they are not duplicating logic that already exists elsewhere, and that they are documented or self-explanatory.
 - **Fix:** Verify each file's consumer. For `migration.ts` (owned entirely by DashboardContext), consider whether inlining or consolidating the migration logic into the context would reduce indirection. No action required if each file's scope is intentionally bounded.
 

--- a/docs/scheduled-tasks/code-structure.md
+++ b/docs/scheduled-tasks/code-structure.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-06-10_
+_Last audited: 2026-06-12_
 _Last action: 2026-05-22 — HIGH DashboardContext extraction assessed and BLOCKED pending supervised runtime-verified session_
 
 ---
@@ -16,9 +16,18 @@ _Nothing currently in progress._
 
 ## Open
 
+_2026-06-12: Weekly audit pass. Rebase onto dev-paul (docs/unifier run 13, D4 @/ alias conversion in tests/, perf baseline refresh, fix DraggableWindow duplicate handler, debugger run 14). None touch context/DashboardContext.tsx, functions/src/index.ts, or adminBuildingConfig.ts structure. All existing open items re-confirmed valid. New finding: multiple large component/layout files not previously tracked now exceed 500 lines — QuizStudentApp.tsx (3762 lines), DashboardView.tsx (1908 lines), Dock.tsx (1597 lines), GlobalPermissionsManager.tsx (1497 lines), StarterPackConfigurationModal.tsx (1251 lines), VideoActivityStudentApp.tsx (990 lines). Cloud Functions all confirmed on v2. No data-fetching duplication detected. No deep relative imports (3+ levels of ../) in source files. Single-use utils list extended: assignToClassroom.ts, deleteDrawingPageSubcollection.ts, imageWorker.ts, lastActiveThrottle.ts, migrateDrawingToSubcollection.ts, miniAppNormalize.ts added to existing LOW item. 1 new MEDIUM open item added._
+
 _2026-06-10: Weekly audit pass. DashboardContext.tsx confirmed at 5,596 lines (same as 2026-06-05 — no structural changes since). BLOCKED extraction status unchanged. functions/src/index.ts confirmed at 4,305 lines — organically growing domain-split pattern continues. Four new open items added: cardOpacity validation duplication in adminBuildingConfig.ts, stale v1 logger import in finalizeIdleQuizAttempts.ts, OAuth Cloud Functions missing explicit timeoutSeconds, and concurrent userProfile reads/writes between AuthContext and DashboardContext._
 
 _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 5,275 on 2026-05-27). BLOCKED extraction status unchanged. functions/src/index.ts now 4,305 lines — domain split organically in progress (spotifyOAuth.ts, syncedQuizGroups.ts etc.). All Cloud Functions confirmed on v2; no v1 imports found. New LOW finding: feature_permissions and global_permissions read coordination between AuthContext and DashboardContext could benefit from documentation. adminBuildingConfig.ts: font-validation constants duplicated across reveal-grid/numberLine/concept-web cases (related to existing LOW simple-switch-cases item). Test imports with 3+ ../../ levels are all in .test.tsx files using vi.mock() — acceptable. No new large-file violations beyond what's already tracked. 1 new LOW open item added._
+
+### MEDIUM Large component files not tracked by DashboardContext or functions/src items — 5 files exceed 1000 lines
+
+- **Detected:** 2026-06-12
+- **Files:** components/student/QuizStudentApp.tsx (3762 lines), components/layout/DashboardView.tsx (1908 lines), components/layout/Dock.tsx (1597 lines), components/admin/GlobalPermissionsManager.tsx (1497 lines), components/admin/StarterPackConfigurationModal.tsx (1251 lines), components/student/VideoActivityStudentApp.tsx (990 lines)
+- **Detail:** Six source component files exceed 500 lines and were not previously tracked in this journal. The most critical: `QuizStudentApp.tsx` (3762 lines) bundles auth, lobby, question rendering, timer state, PIN entry, and score tracking; `DashboardView.tsx` (1908 lines) contains the main app shell, widget placement, toolbar, and menu logic; `Dock.tsx` (1597 lines) bundles dock header, folder panel, tool list rendering, and animation logic; `GlobalPermissionsManager.tsx` (1497 lines) contains all admin feature/access/quota UI in one component; `StarterPackConfigurationModal.tsx` (1251 lines) is a long form modal with no section decomposition; `VideoActivityStudentApp.tsx` (990 lines) mirrors the QuizStudentApp pattern.
+- **Fix:** For QuizStudentApp and VideoActivityStudentApp: extract `TimerController`, `PinEntryForm`, `SessionLobby`, and `QuestionRenderer` into sibling components under their respective directories. For DashboardView: extract the toolbar/menu as `DashboardToolbar`. For Dock: extract `FolderPanel` and `ToolItem` into sub-components. For GlobalPermissionsManager: split into `WidgetAccessPanel`, `QuotaEditor`, and `BetaListManager`. These are view-layer extractions (no shared state changes) — lower risk than the DashboardContext extraction. Prioritize QuizStudentApp first given its size.
 
 ### MEDIUM `DashboardContext.tsx` is 3481 lines and growing — at least three extractable responsibilities
 
@@ -128,11 +137,17 @@ _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 
 - **Detail:** The following utils files have only one import consumer in components/context/hooks/utils (0 = unused tests only, 1 = single consumer):
   - `utils/accessibility.ts` — 1 consumer
   - `utils/ai_security.ts` — 1 consumer (likely `utils/ai.ts`)
+  - `utils/assignToClassroom.ts` — 1 consumer (2026-06-12)
   - `utils/backgroundCategories.ts` — 1 consumer
   - `utils/dashboardPII.ts` — 1 consumer
+  - `utils/deleteDrawingPageSubcollection.ts` — 1 consumer (2026-06-12, migration helper)
   - `utils/googleCalendarService.ts` — 1 consumer
   - `utils/guidedLearningDriveService.ts` — 1 consumer
+  - `utils/imageWorker.ts` — 1 consumer (2026-06-12, Web Worker — correct isolation)
+  - `utils/lastActiveThrottle.ts` — 1 consumer (2026-06-12)
   - `utils/migration.ts` — 1 consumer (`context/DashboardContext.tsx`)
+  - `utils/migrateDrawingToSubcollection.ts` — 1 consumer (2026-06-12, migration helper)
+  - `utils/miniAppNormalize.ts` — 1 consumer (2026-06-12, consider colocation)
   - `utils/smartPaste.ts` — 1 consumer
     Single-consumer utils are not necessarily wrong — domain separation is valid — but warrant a quick sanity check that they are not duplicating logic that already exists elsewhere, and that they are documented or self-explanatory.
 - **Fix:** Verify each file's consumer. For `migration.ts` (owned entirely by DashboardContext), consider whether inlining or consolidating the migration logic into the context would reduce indirection. No action required if each file's scope is intentionally bounded.

--- a/docs/scheduled-tasks/code-structure.md
+++ b/docs/scheduled-tasks/code-structure.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
 _Last audited: 2026-06-12_
-_Last action: 2026-05-22 — HIGH DashboardContext extraction assessed and BLOCKED pending supervised runtime-verified session_
+_Last action: 2026-06-12 — MEDIUM cardOpacity range-check extracted into shared `isCardOpacity` guard in adminBuildingConfig.ts_
 
 ---
 
@@ -67,20 +67,6 @@ _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 
   - **`useDashboardDriveSync`** — Drive logic is not one isolated block: the background-export effect (2255–2302) is intertwined with `saveDashboardFirestore` + `scrubDashboardPII`, the PII-restore effect (2319+) mutates widget config, and Drive calls are also embedded in save/share/restore paths (1171–1460). The auth-error handler (615–632) and `useDriveReconnected` latch (2315) are separable but small.
   - **Pure-function seams** — already harvested: `getAdminBuildingConfig` (utils/adminBuildingConfig.ts, May 13), `pickInitialBoard` (utils/pickInitialBoard.ts), migration (utils/migration.ts, migrateProportionalLayout.ts, collectionsMigration.ts). No clean unit-testable pure block remains inline.
   - **Verification gap:** there is no unit-test coverage for the navigation or Drive-sync effects, and no Firebase/Drive runtime in the scheduled-task environment, so `type-check`/`lint`/`vitest` would not catch a navigation, sync-timing, or PII-restore regression on the app's most critical state file. Recommend a dedicated supervised session that can exercise board switching, collection switching, and Drive sync against a live/emulated Firebase project before landing this extraction.
-
-### MEDIUM `adminBuildingConfig.ts` — `cardOpacity` range-check block copy-pasted 4 times
-
-- **Detected:** 2026-06-10
-- **File:** utils/adminBuildingConfig.ts (lines 183–187, 266–270, 282–286, 412–416)
-- **Detail:** The following five-line cardOpacity guard is duplicated verbatim in four switch cases (`numberLine`, `checklist`, `stations`, `concept-web`):
-  ```typescript
-  typeof raw.cardOpacity === 'number' &&
-    Number.isFinite(raw.cardOpacity) &&
-    raw.cardOpacity >= 0 &&
-    raw.cardOpacity <= 1;
-  ```
-  This is distinct from the existing LOW "simple switch cases" item (which concerns single-field type-check cases). The cardOpacity block is a multi-condition range validator — any future fix (e.g., allowing `null` as a reset sentinel, or widening the valid range to `0.05–1`) must be applied in four places, and the current duplication has already caused one appearance (the `stations` case) to diverge slightly in guard structure from the others.
-- **Fix:** Extract a private `validateCardOpacity(raw: unknown): boolean` helper at the top of `adminBuildingConfig.ts` (or reuse the existing `isCardOpacity` if one already exists in `utils/widgetHelpers.ts`). Replace the four inline blocks with a call to the helper. Pure refactor — no behavior change. Then extend the existing LOW "simple switch cases" item's data-declaration approach to cover the appearance-field quartet (`cardColor`, `cardOpacity`, `fontFamily`, `fontColor`) shared by multiple cases.
 
 ### MEDIUM Concurrent reads and writes to `userProfile` document between `AuthContext` and `DashboardContext`
 
@@ -155,6 +141,15 @@ _2026-06-05: Weekly audit pass. DashboardContext.tsx now 5,596 lines (+321 from 
 ---
 
 ## Completed
+
+### MEDIUM `adminBuildingConfig.ts` — `cardOpacity` range-check block copy-pasted 4 times
+
+- **Detected:** 2026-06-10
+- **Completed:** 2026-06-12
+- **File:** utils/adminBuildingConfig.ts, tests/utils/adminBuildingConfig.test.ts
+- **Detail:** The five-line `cardOpacity` range guard (`typeof === 'number' && Number.isFinite && >= 0 && <= 1`) was duplicated verbatim across four switch cases (`numberLine`, `checklist`, `stations`, `concept-web`), with the `stations` copy having already drifted in guard structure.
+- **Resolution:** Extracted a module-level `isCardOpacity(value: unknown): value is number` type-guard helper (placed alongside the existing `isHexColor` / `isGlobalFontFamily` / `isWidgetFontFamily` guards). Replaced all four inline blocks with a single-line `if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;`. The type guard also narrows `raw.cardOpacity` to `number`, so the assignment no longer relies on the inline `typeof` widening. Pure refactor — no behavior change. `pnpm type-check`, `eslint --max-warnings 0`, and `prettier --check` all clean; the existing 30 tests in `tests/utils/adminBuildingConfig.test.ts` all pass.
+- **Follow-up:** The LOW "simple switch cases" item above can still be addressed separately to cover the broader appearance-field quartet (`cardColor`, `cardOpacity`, `fontFamily`, `fontColor`) via a data-declaration approach.
 
 ### HIGH `DashboardContext.tsx` grew 937 lines in one week — now 4441 lines
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-12_
+_Last audited: 2026-06-13_
 _Last action: 2026-06-06_
 
 ---
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-13: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits since 2026-06-12: pr-review batch, admin-config cardOpacity refactor, [AI] wide-distro phases 1-3, [AI] legal pages, [AI] OAuth scopes). None of these touch widget front-face content. Countdown cqh/cqw mix (min(42cqh,55cqw) etc.) re-confirmed as intentional WON'T FIX per journal guidance — fill-better formula. ExpectationsWidget verified clean: uses min(Npx, Xcqmin) throughout (e.g. min(80px,22cqmin) for icons, min(24px,8cqmin) for text). CarRiderPro and First5 loading states (bg-slate-50 full-bleed) exist but show only during initial iframe load — not front-face content violations (widget surface is fully covered by the iframe once loaded; background flash is brief and outside the scaling context). All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 
 _2026-06-12: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits since 2026-06-11: docs(unifier) run 13 log, D4 @/ alias conversion in tests/, chore(perf) baseline refresh, fix(layout) DraggableWindow duplicate handler, docs(debugger) run 14 log). None of these touch widget front-face content. All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-11_
+_Last audited: 2026-06-12_
 _Last action: 2026-06-06_
 
 ---
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-12: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits since 2026-06-11: docs(unifier) run 13 log, D4 @/ alias conversion in tests/, chore(perf) baseline refresh, fix(layout) DraggableWindow duplicate handler, docs(debugger) run 14 log). None of these touch widget front-face content. All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 
 _2026-06-11: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits: ui(library) modernize views, test(hooks) useVideoActivitySessionTeacher, fix(stores) consumeLaunchCode, fix(i18n) seatingChart, fix(export) dedup buildResultsSheetData, fix(DashboardView) groupBuildMode Escape, perf(dashboard) DashboardContext split). None of these touch widget front-face content. The DashboardContext split is a context-internal structural refactor — no widget canvas changes. All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-06-13_
-_Last action: 2026-06-06_
+_Last action: 2026-06-13_
 
 ---
 
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-13 (action): Fixed the highest-priority genuinely-open item — ActivityWall inline activity-editor "Require moderation" checkbox hardcoded `h-4 w-4` (ActivityWall/Widget.tsx, now :1376). Replaced the fixed 16px `h-4 w-4` Tailwind size classes with an inline `cqmin` size (`style={{ width: 'min(16px, 4cqmin)', height: 'min(16px, 4cqmin)' }}`), keeping `accent-brand-blue-primary` on className for the accent color. This caps the checkbox at 16px on large widgets while scaling it down proportionally at small sizes, matching the sibling "Require moderation" label which uses `min(12px, 3.8cqmin)`. File-recency check passed: ActivityWall/Widget.tsx was last touched at 592dd523 (2026-06-11 audit) — outside the last 5 branch commits. `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` on the changed file all clean; ActivityWall test suite (Widget + Settings, 11 tests) green. Moved the item to Completed. ALSO cleaned up two stale Open entries: (1) the CarRiderPro/First5 external-link overlay button group was already resolved in commit f60141cc (PR #1768 — both files now use `top: min(8px, 2cqmin)` / `right: min(8px, 2cqmin)` / `padding: min(6px, 1.5cqmin)`); removed from Open. (2) the GraphicOrganizer EditableNode `min-h-[50px]` entry was a duplicate of the already-Completed entry (completed 2026-05-31); removed from Open. Remaining open items: PollWidget progress bar (:161), EmbedWidget portaled toolbar, QuizResults period-filter text-sm (:1530), RevealGrid spacing, multi-widget group, MiniApp dialog text sizes._
 
 _2026-06-13: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits since 2026-06-12: pr-review batch, admin-config cardOpacity refactor, [AI] wide-distro phases 1-3, [AI] legal pages, [AI] OAuth scopes). None of these touch widget front-face content. Countdown cqh/cqw mix (min(42cqh,55cqw) etc.) re-confirmed as intentional WON'T FIX per journal guidance — fill-better formula. ExpectationsWidget verified clean: uses min(Npx, Xcqmin) throughout (e.g. min(80px,22cqmin) for icons, min(24px,8cqmin) for text). CarRiderPro and First5 loading states (bg-slate-50 full-bleed) exist but show only during initial iframe load — not front-face content violations (widget surface is fully covered by the iframe once loaded; background flash is brief and outside the scaling context). All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 
@@ -84,27 +86,6 @@ _2026-05-12: Scanned all Widget.tsx and index.tsx files for hardcoded text-size 
 
 _2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.tsx and UrlWidget/Widget.tsx both use `cqmin` units throughout; no new scaling violations introduced._
 
-### LOW ActivityWall inline activity-editor checkbox uses hardcoded `h-4 w-4` icon size
-
-- **Detected:** 2026-06-01
-- **File:** components/widgets/ActivityWall/Widget.tsx:1352
-- **Detail:** The inline activity-editor (rendered inside the widget's front-face content, not inside a Modal overlay) has a `<input type="checkbox">` with `className="h-4 w-4 accent-brand-blue-primary"`. Widget has `skipScaling: true`. The `h-4 w-4` (16 px) size is fixed and does not scale with the container. This is distinct from the `max-h-[75vh]` uses at lines 2101-2110, which are inside a fullscreen Modal and exempt.
-- **Fix:** Native checkbox size via CSS is limited — the `h-4 w-4` classes drive the rendered size on Chromium but may be overridden by OS styles. Best approach: wrap in a `<label>` with `style={{ width: 'min(16px, 4cqmin)', height: 'min(16px, 4cqmin)' }}` and visually hide the native input (`sr-only`), replacing it with a styled div. If keeping the native checkbox, at minimum remove the hardcoded size classes and rely on `accent-color` alone.
-
-### LOW CarRiderPro and First5 share a hardcoded external-link overlay button (group)
-
-- **Detected:** 2026-05-29
-- **File:** components/widgets/CarRiderPro/Widget.tsx:62, components/widgets/First5/Widget.tsx:56
-- **Detail:** Both widgets render an absolute-positioned external-link overlay button with the className `"absolute top-2 right-2 z-10 bg-white/80 ... rounded-lg p-1.5 ..."`. Both have `skipScaling: true`. The `top-2`, `right-2`, and `p-1.5` classes produce fixed-pixel positioning (8 px, 8 px, 6 px) that does not scale with the container, causing the button to appear disproportionately small at large widget sizes and potentially clipping at small sizes. This is an identical copy-pasted snippet in both files.
-- **Fix:** Replace the three fixed-pixel Tailwind utilities with inline `cqmin` equivalents: `top-2 right-2` → `style={{ top: 'min(8px, 2cqmin)', right: 'min(8px, 2cqmin)' }}`, `p-1.5` → `style={{ padding: 'min(6px, 1.5cqmin)' }}`. Apply the same fix to both files. The visual/color Tailwind classes (`bg-white/80`, `backdrop-blur-sm`, `hover:bg-white`, etc.) do not carry pixel sizes and can remain on `className`.
-
-### LOW GraphicOrganizer EditableNode uses min-h-[50px] fixed minimum height on contenteditable
-
-- **Detected:** 2026-05-29
-- **File:** components/widgets/GraphicOrganizer/Widget.tsx:79
-- **Detail:** The internal `EditableNode` component renders a `contenteditable` div with `className="... min-h-[50px] ..."`. This sets a fixed 50 px minimum height on every editable node inside the graphic organizer (Frayer, T-chart, Venn, KWL, Cause-Effect layouts). Widget has `skipScaling: true`. At small widget sizes this 50 px floor can crowd out other content; at large widget sizes it looks sparse. Note: the prior Completed entries for GraphicOrganizer addressed outer structural padding (`p-4` on Frayer cells, `w-32 h-32` center circle, etc.) — this specific EditableNode `min-h-[50px]` was not covered.
-- **Fix:** Replace `min-h-[50px]` with a `cqmin` inline style: add a `minHeight` key to the existing `style` prop on the contenteditable div → `style={{ ..., minHeight: 'min(50px, 10cqmin)' }}`. This caps the floor at 50 px on large widgets while allowing proportional reduction at small sizes. Alternatively, `min-h-0` with `flex-1` on the parent cell could let the node fill available space.
-
 ### LOW PollWidget progress bar has no upper size cap — grows excessively at large widget sizes
 
 - **Detected:** 2026-05-28
@@ -160,6 +141,14 @@ _2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.ts
 ---
 
 ## Completed
+
+### LOW ActivityWall inline activity-editor checkbox uses hardcoded `h-4 w-4` icon size
+
+- **Detected:** 2026-06-01
+- **Completed:** 2026-06-13
+- **File:** components/widgets/ActivityWall/Widget.tsx:1376 (was :1352 at detection; line shifted as the file grew)
+- **Detail:** The inline activity-editor "Require moderation" `<input type="checkbox">` carried `className="h-4 w-4 accent-brand-blue-primary"`. The widget has `skipScaling: true`, so the fixed 16 px size did not respond to the container query — it stayed 16 px regardless of widget size while the sibling label scaled via `min(12px, 3.8cqmin)`.
+- **Resolution:** Removed the `h-4 w-4` Tailwind size classes and applied an inline `cqmin` size instead: `style={{ width: 'min(16px, 4cqmin)', height: 'min(16px, 4cqmin)' }}`, keeping `accent-brand-blue-primary` on `className` for the accent color. Caps the checkbox at 16 px on large widgets while scaling it down proportionally at small sizes. `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` on the changed file all clean; ActivityWall test suite (Widget + Settings, 11 tests) green.
 
 ### LOW NextUp session-name header has hardcoded `maxWidth: '120px'` pixel cap
 

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -4,6 +4,33 @@ _Automated nightly review by claude-opus-4-6_
 
 ---
 
+## 2026-06-13
+
+- PRs reviewed: 11 (all open PRs; one head is `dev-paul` — read-only, review-only)
+  - #1960 — fix(state): extract `normalizeActivityWallLibraryEntry` to prevent field-stripping on snapshot refresh (head `nightly/state-data-2026-06-13`, base `dev-paul`)
+  - #1959 — chore(memory): nightly run 16 log (head `nightly/debugger-log-2026-06-13`, base `dev-paul`)
+  - #1958 — fix(lti): preserve `contextId` across privacy-stripped LTI relaunches (head `nightly/build-tooling-2026-06-13`, base `dev-paul`)
+  - #1957 — fix(i18n): extract 4 hardcoded TimeTool Stations strings (head `nightly/admin-config-2026-06-13`, base `dev-paul`)
+  - #1956 — fix(keyboard): Alt+P pin shortcut drops when CapsLock is active (head `nightly/dashboard-layout-2026-06-13`, base `dev-paul`)
+  - #1955 — fix(widgets): CalendarWidget midnight staleness + useEffect ref-sync anti-pattern (head `nightly/widgets-2026-06-13`, base `dev-paul`)
+  - #1954 — docs(unifier): run 14 memory log (head `nightly/unifier-log-2026-06-13`, base `dev-paul`)
+  - #1953 — action(css-scaling): scale ActivityWall moderation checkbox with cqmin (head `scheduled-tasks`, base `dev-paul`)
+  - #1951 — fix(i18n): replace EN-placeholder strings in boardsModal/shareCollection (DE/ES/FR) (head `nightly/admin-config-2026-06-12`, base `dev-paul`)
+  - #1945 — docs(unifier): run 14 memory log (head `nightly/unifier-log-2026-06-12`, base `dev-paul`)
+  - #1943 — Enhance Guided Learning editor with media upload/playback (head `dev-paul`, base `main` — read-only; large integration PR)
+- Comments processed: 4 total — 0 fixed, 4 already-addressed/no-op (all 4 resolved + replied)
+  - #1958: 1 gemini thread (MEDIUM) — already addressed in HEAD. `launchEndpoints.ts` already caches `existingGradeLink.data()` in `gradeLinkData` with explicit `string | null` typing (no repeated `.data()`, no `any`, no assertion). Replied + resolved.
+  - #1957: 1 gemini thread (MEDIUM) — already addressed in HEAD. `fr.json` `addStationsTip` already reads "…effectuer une rotation automatique des élèves…". Replied + resolved.
+  - #1956: 1 gemini thread (MEDIUM) — already addressed in HEAD. CapsLock test already wraps dispatch in `try…finally` with listener cleanup. Replied + resolved.
+  - #1955: 1 gemini thread (HIGH) — already addressed in HEAD. `isBlocked` already derives the date string via local-time `getFullYear()/getMonth()/getDate()` instead of `.toISOString()`. Replied + resolved.
+  - #1960, #1959, #1954, #1953, #1951 (resolved), #1945, #1943 (all 7 prior threads resolved): no open review comments requiring action.
+- Fixes pushed: 0 — every open review comment was already satisfied by a follow-up commit on its branch; no code changes were warranted. No pushes to `main`/`dev-*`.
+- Reviews posted: 11 (one structured `COMMENT` review per open PR)
+  - Ready: #1960, #1959, #1958, #1957, #1956, #1955, #1954, #1953, #1951, #1945
+  - Needs human review (scope, not defect): #1943 — 100+ file `dev-paul → main` integration PR; highest risk in the `dashboardCanvasStore`/`DashboardContext` refactor. New `rollout_requests` Firestore rule verified (identity-pinned, `hasOnly` allow-list, admin-only triage); `functions/src/index.ts` change is additive + adds an SSRF `maxRedirects: 0` guard. CI status pending at review time.
+
+---
+
 ## 2026-06-12
 
 - PRs reviewed: 12 (all open PRs; one head is `dev-paul` — read-only, review-only)

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -4,6 +4,44 @@ _Automated nightly review by claude-opus-4-6_
 
 ---
 
+## 2026-06-12
+
+- PRs reviewed: 12 (all open PRs; one head is `dev-paul` — read-only, review-only)
+  - #1953 — refactor(admin-config): extract shared `isCardOpacity` guard (head `scheduled-tasks`, base `dev-paul`)
+  - #1952 — docs(debugger): nightly run 15 log (head `nightly/debugger-log-2026-06-12`, base `dev-paul`)
+  - #1951 — fix(i18n): replace EN-placeholder strings in boardsModal/shareCollection (DE/ES/FR) (head `nightly/admin-config-2026-06-12`, base `dev-paul`)
+  - #1950 — fix(state): gradeAnswer partial-credit `isCorrect` consistency (head `nightly/state-data-2026-06-12`, base `dev-paul`)
+  - #1949 — fix(layout): typing-field guard on Ctrl+/ cheat-sheet shortcut (head `nightly/dashboard-layout-2026-06-12`, base `dev-paul`)
+  - #1948 — fix(docs): format unifier.md to pass Prettier (head `nightly/build-tooling-2026-06-12`, base `dev-paul`)
+  - #1947 — fix(widgets): correct negative-range fraction label on NumberLine (head `nightly/widgets-2026-06-12`, base `dev-paul`)
+  - #1946 — fix(docs): restore Prettier formatting on unifier.md (head `nightly/unifier-baseline-fix-2026-06-12`, base `dev-paul`)
+  - #1945 — docs(unifier): run 14 memory log (head `nightly/unifier-log-2026-06-12`, base `dev-paul`)
+  - #1944 — fix(guided-learning): address PR #1943 review feedback (head `claude/serene-meitner-eagi8c`, base `dev-paul`)
+  - #1943 — Enhance Guided Learning editor with media upload/playback (head `dev-paul`, base `main` — read-only)
+- Comments processed: 11 total — 8 fixed, 3 already-addressed/no-op
+  - #1944: 4 gemini threads — 3 FIXED (HIGH: NaN-sanitize `trim.start`/`end` centrally in `clampTrimStart`/`clampTrimEnd` so `video.currentTime` can't be assigned NaN; MEDIUM: sync `onClose` ref in render body instead of `useLayoutEffect`; MEDIUM: drop now-unused `useLayoutEffect` import). 1 outdated thread skipped. Note: the suggested `react-hooks/refs` disable was _not_ needed — the rule doesn't flag this assignment (unused-directive under `--max-warnings 0`).
+  - #1951: 1 gemini thread (MEDIUM) — FIXED. `fr.json` `pinnedEmpty` had Cyrillic `инг` in `Épингlez`; corrected to Latin `Épinglez`. Scanned all four locales for Cyrillic-block chars — none remaining.
+  - #1950: 1 gemini thread (MEDIUM) — FIXED. `isCorrect = pointsEarned >= max` marked every answer correct for a 0-point question (`0 >= 0`) and used float comparison; switched to `matched === total` (equivalent for `max > 0`, correct for `max === 0`) + added a 0-point regression test.
+  - #1949: 1 gemini thread (MEDIUM) — FIXED. Extracted the duplicated input/textarea/select/contentEditable check into a file-level `isTypingFieldActive()` helper and applied it to all six keydown guard sites.
+  - #1947: 3 gemini threads (MEDIUM) — FIXED. Simplified the negative-tick fraction expr to `Math.abs(valNumer) % denom` (distinct from the `Math.abs(valNumer % denom)` band-aid the PR rejected — keeps `% denom`); corrected two test descriptions (`-1 3/4` is first sub-tick _above -2_; `fractionLabel` renders `2/4`, not `1/2`).
+  - #1943: 7 threads — all already addressed via #1944 (author replies on each thread). No action.
+  - #1953, #1952, #1948, #1946, #1945: no review comments.
+- Fixes pushed: 5 (each to its own PR head branch — no pushes to `main`/`dev-*`)
+  - #1944 / `claude/serene-meitner-eagi8c` — `fix(pr-1944): sanitize non-finite video trim values and sync onClose ref in render body`; type-check ✓ lint ✓ tests ✓ (5/5).
+  - #1951 / `nightly/admin-config-2026-06-12` — `fix(pr-1951): replace Cyrillic characters in fr.json pinnedEmpty`; JSON ✓ prettier ✓ i18n tests ✓ (156/156).
+  - #1950 / `nightly/state-data-2026-06-12` — `fix(pr-1950): derive matching isCorrect from matched===total`; type-check ✓ lint ✓ tests ✓ (13/13).
+  - #1949 / `nightly/dashboard-layout-2026-06-12` — `fix(pr-1949): extract isTypingFieldActive helper`; type-check ✓ lint ✓ tests ✓ (25/25).
+  - #1947 / `nightly/widgets-2026-06-12` — `fix(pr-1947): simplify negative-tick fraction expr and correct test descriptions`; type-check ✓ lint ✓ tests ✓ (16/16).
+- Reviews posted: 12 (one structured `## Automated Code Review` per PR)
+  - #1953 Ready; #1952 Ready; #1951 Ready (Cyrillic fix pushed); #1950 Ready (0-point fix pushed); #1949 Ready (helper extraction pushed); #1948 Ready (dup of #1946); #1947 Ready (simplification pushed); #1946 Ready (dup of #1948); #1945 Ready; #1944 Ready (all threads resolved); #1943 **Needs changes** (CI red — see below).
+- Notes:
+  - Branch-safety: #1943 head is `dev-paul` (matches `dev-*`) → read-only, review-only, no push. All other heads (`nightly/*`, `claude/*`, `scheduled-tasks`) are pushable; 5 fixes went to their own head branches. No pushes to `main` or `dev-paul`.
+  - **#1943 CI is red** but only on `format:check` for `docs/routines/unifier.md` (Prettier drift) — all other jobs (type-check, Unit, E2E, Build, Firestore Rules, CodeQL) pass. This is exactly what **#1946**/**#1948** fix; landing one into dev-paul and re-running #1943's CI clears it. The 7 inline review threads on #1943 are already handled via #1944.
+  - **Duplicate Prettier fix flagged:** #1946 (run-14 baseline-fix branch) and #1948 (run-15 build-tooling branch) carry the _identical_ reformat of `docs/routines/unifier.md`. Only one is needed — merge one and the other becomes empty/conflicting. #1945 also edits the same file (run-14 log content) and will need a trivial merge-order reconciliation.
+  - Forward note: #1952's new "partial-credit `isCorrect` invariant" gotcha documents `pointsEarned >= pointsMax`; #1950 was refined to `matched === total` (handles the `max === 0` case). Worth syncing the gotcha wording when convenient.
+
+---
+
 ## 2026-06-11
 
 - PRs reviewed: 10 (all open PRs; every head is non-`main`/non-`dev-*`, so all in scope; all base `dev-paul`)

--- a/docs/scheduled-tasks/simplification.md
+++ b/docs/scheduled-tasks/simplification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Friday_
-_Last audited: 2026-06-08_
+_Last audited: 2026-06-12_
 _Last action: 2026-05-01_
 
 ---
@@ -15,6 +15,20 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+### LOW `utils/dashboardPII.ts` and `utils/smartPaste.ts` use `as WidgetConfig` single-casts that may mask type mismatches
+
+- **Detected:** 2026-06-12
+- **File:** utils/dashboardPII.ts (lines 48, 102), utils/smartPaste.ts (multiple instances including lines 182, 199, 261, 278 approx)
+- **Detail:** Both utility files cast plain objects to `WidgetConfig` using single-cast `as WidgetConfig` (not `as unknown as`). Unlike the existing tracked `as unknown as` items, these single-casts are only safe if the object's runtime shape is a known-good superset of `WidgetConfig` at every call site. `dashboardPII.ts` scrubs sensitive fields from widget configs and then casts the result back — if a new required field is added to `WidgetConfig`, the scrubbed object may silently fail to satisfy the type. `smartPaste.ts` casts plain-object widget configs from clipboard data, where the shape is entirely user-controlled and not validated. Classified as class (b) for smartPaste.ts (masking possible mismatch on untrusted input) and class (a) for dashboardPII.ts (likely safe but not provably so).
+- **Fix:** For `smartPaste.ts`: introduce a runtime schema validator (zod or a hand-written guard) that narrows the clipboard object to `WidgetConfig` before the cast. For `dashboardPII.ts`: replace `as WidgetConfig` with a strongly-typed scrub function that returns the correct type through structural manipulation rather than casting.
+
+### LOW `QuizWidget/Widget.tsx` has high component-level state density (12 useState + 5 useRef)
+
+- **Detected:** 2026-06-12
+- **File:** components/widgets/QuizWidget/Widget.tsx (lines 227-281 approx for useState, lines 453-482 approx for useRef)
+- **Detail:** The QuizWidget component declares 12 separate `useState` calls and 5 `useRef` calls at the top level of a single component. Related groups: editing state (`editingQuiz`, `editingAssignment`, `editingMeta`, `shareWithPlcTarget`), load state (`loadedQuizData`, `loadingQuizData`, `dataError`), and navigation state (`prevView`, `resultsEnterToken`, `assigningToClassroom`). This is distinct from the hook-level state density tracked for `useQuizSession` — this is a rendering component accumulating orchestration state that logically belongs in a custom hook or sub-component. High state density makes effect dependency arrays large and error-prone.
+- **Fix:** Extract quiz orchestration state into a `useQuizWidgetState` hook that encapsulates the editing, load, and navigation groups. This reduces the component to a view layer with a single hook import, makes state transitions testable in isolation, and shrinks effect dependency arrays. Follow the pattern used in `SpecialistScheduleWidget` which delegates session state to `useSpecialistSchedule`. Prioritize the edit-state group (4 state items that always change together) as the first extraction.
 
 ### MEDIUM `as unknown as` double-casts in `utils/ai_security.ts` mask structuredClone type loss
 
@@ -62,6 +76,8 @@ _Nothing currently in progress._
 - **Fix:** For `useScreenRecord`, group `{ isRecording, duration, error }` into a single `useState` object to reduce the state surface. The 4 refs are all distinct external handles and should remain individual. For `useLiveSession`, group `{ studentId, studentPin }` (always set/cleared together) into a single state object. Severity is LOW because the individual state declarations are cohesive and readable.
 
 ---
+
+_2026-06-12: Audited new code from dev-paul rebase (docs/unifier run 13, D4 @/ alias in tests/, perf baseline, fix DraggableWindow, debugger run 14). No new Object.assign or config-merge duplication patterns in changed files. No new `as unknown as` casts. Hook complexity: useQuizSession.ts and useVideoActivitySession.ts counts unchanged from 2026-06-08 (22 and 18 respectively). New findings: (1) utils/dashboardPII.ts (line 48, 102) and utils/smartPaste.ts (multiple instances) use `as WidgetConfig` single-casts that may mask type mismatches — these are distinct from the `as unknown as` double-casts already tracked; added as new LOW item. (2) QuizWidget/Widget.tsx has 12 useState calls (plus 5 useRef) — high component-level state density distinct from the hook-level state density already tracked for useQuizSession. 2 new LOW open items added._
 
 _2026-06-08: Audited new code from dev-paul merge. Object.assign: DashboardContext still has zero Object.assign calls. `as unknown as` casts: no new ones in this merge (diff shows only `specificFeatureId` string assignments in functions/src/index.ts — no TypeScript changes in frontend code). Hook complexity: `useQuizSession.ts` unchanged at 22 useState/useRef calls; `useVideoActivitySession.ts` grew from 17 to 18 calls (minor growth, existing open item still valid and counts are current). New hooks: none added in this merge. Nested ternaries: no new complex ternary chains in changed files. Zero new simplification items._
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-11_
+_Last audited: 2026-06-12_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-12. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: docs(unifier) run 13 memory log, D4 cross-dir relative imports → @/ alias in tests/, chore(perf) refresh performance baseline timestamps, fix(layout) remove duplicate Alt+Delete handler from DraggableWindow, docs(debugger) nightly run 14 log. All new and modified code type-safe and lint-clean._
 
 _No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-11. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: ui(library) modernize unified library/in-progress/archive views, test(hooks) cover useVideoActivitySessionTeacher (27 tests), fix(stores) consumeLaunchCode null coalescing, fix(i18n) seatingChart DE/ES/FR, fix(export) dedup buildResultsSheetData, fix(DashboardView) groupBuildMode Escape guard, perf(dashboard) DashboardContext split — stable actions + canvas hot-state store. The DashboardContext split is the most significant structural change; all new context code is fully type-safe and lint-clean._
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-12_
+_Last audited: 2026-06-13_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-13. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: pr-review batch 12 PRs reviewed/5 fixes pushed, refactor(admin-config) shared isCardOpacity guard in adminBuildingConfig.ts, audit(friday) journal updates, [AI] wide-distro phases 1-3 (tiering/landing page/rollout), [AI] legal pages, [AI] drop restricted OAuth scopes. All new and modified code type-safe and lint-clean._
 
 _No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-12. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: docs(unifier) run 13 memory log, D4 cross-dir relative imports → @/ alias in tests/, chore(perf) refresh performance baseline timestamps, fix(layout) remove duplicate Alt+Delete handler from DraggableWindow, docs(debugger) nightly run 14 log. All new and modified code type-safe and lint-clean._
 

--- a/docs/scheduled-tasks/ui-unification.md
+++ b/docs/scheduled-tasks/ui-unification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-06-12_
+_Last audited: 2026-06-13_
 _Last action: 2026-06-05 — MEDIUM `stations` admin building-default appearance panel added; MEDIUM raw-`<select>` item resolved as stale (already styled)_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-13: Weekly audit pass (Saturday). Rebase onto dev-paul: pr-review batch, isCardOpacity refactor, [AI] wide-distro phases 1-3 (new pages/tiering/rollout form), [AI] legal pages, [AI] OAuth scope drops. New pages (landing, /privacy, /terms, /support, /request) are static/auth routes — not widget settings panels. [AI] tiering changes (userTier.ts, per-feature AI gates) touch AuthContext and admin permission checks, not widget settings. Scanned all new Settings.tsx and admin panel files — none introduced. All existing open items re-confirmed valid. 0 new open items._
 
 _2026-06-12: Weekly audit pass. Scanned Settings.tsx files and admin ConfigurationPanel files after rebase onto dev-paul (docs/unifier run 13, D4 @/ alias in tests/, perf baseline, fix DraggableWindow, debugger run 14). None of these commits touch widget Settings.tsx or admin config panels. All existing open items re-confirmed valid. New finding: ClockWidget/Settings.tsx custom color palette button group (lines 120-139) is distinct from the font-family picker issue already tracked under the ClockWidget/TimeTool MEDIUM item — the color palette should use SurfaceColorSettings or a shared color-picker. 1 new LOW open item added._
 

--- a/docs/scheduled-tasks/ui-unification.md
+++ b/docs/scheduled-tasks/ui-unification.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Wednesday_
-_Last audited: 2026-06-10_
+_Last audited: 2026-06-12_
 _Last action: 2026-06-05 — MEDIUM `stations` admin building-default appearance panel added; MEDIUM raw-`<select>` item resolved as stale (already styled)_
 
 ---
@@ -16,7 +16,16 @@ _Nothing currently in progress._
 
 ## Open
 
+_2026-06-12: Weekly audit pass. Scanned Settings.tsx files and admin ConfigurationPanel files after rebase onto dev-paul (docs/unifier run 13, D4 @/ alias in tests/, perf baseline, fix DraggableWindow, debugger run 14). None of these commits touch widget Settings.tsx or admin config panels. All existing open items re-confirmed valid. New finding: ClockWidget/Settings.tsx custom color palette button group (lines 120-139) is distinct from the font-family picker issue already tracked under the ClockWidget/TimeTool MEDIUM item — the color palette should use SurfaceColorSettings or a shared color-picker. 1 new LOW open item added._
+
 _2026-06-10: Weekly audit pass. Scanned all Settings.tsx under components/widgets/ and all \*ConfigurationPanel.tsx under components/admin/. New findings: (1) TimeTool/Settings.tsx duplicates the identical custom 4-button font picker as ClockWidget — added as extension of the existing ClockWidget open item. (2) Segmented-control pill selector pattern (`flex bg-slate-100 p-1 rounded-xl`) duplicated 12× across settings panels with no shared component. (3) Font-options arrays (`{ value: 'global', label: 'Inherit' }` pattern) duplicated in 5+ admin panels. (4) 27 hardcoded hex instances across additional files not yet tracked. Existing open items (ClockWidget font picker, MusicWidget color picker, nextUp/video-activity/guided-learning missing appearance panels, ExpectationsWidget custom toggle, two hardcoded-hex LOW items, InstructionalRoutines, TextConfig) all re-confirmed valid. 4 new open items added._
+
+### LOW `ClockWidget/Settings.tsx` implements inline custom color palette button group distinct from font-family issue
+
+- **Detected:** 2026-06-12
+- **File:** components/widgets/ClockWidget/Settings.tsx (lines 120-139 approx)
+- **Detail:** In addition to the inline font-family selector already tracked in the MEDIUM ClockWidget/TimeTool item, the Clock settings panel also implements a custom color palette picker — a row of inline `<button>` elements for selecting the clock face/hand color. This is separate from the shared color-picking approach used in other widget settings panels and is not consistent with `SurfaceColorSettings` or any documented shared color primitive. If `ClockConfig` has `cardColor` / `clockColor` fields, a shared color picker should be used; if the color choice is widget-specific, the pattern should at minimum be extracted into a shared `ColorPalettePicker` primitive alongside the `TypographySettings` fix already planned.
+- **Fix:** When addressing the ClockWidget MEDIUM font-family item, simultaneously replace the inline color palette button group with either (a) `SurfaceColorSettings` if `ClockConfig` gains `cardColor`/`cardOpacity`, or (b) a small shared `ColorPalettePicker` component that can also serve TimeTool and any other widget with a fixed palette. Remove the local button-group markup and associated color-state logic.
 
 ### LOW `FeatureConfigurationPanel.tsx` is 706 lines — complex per-feature layout that could use `SchemaDrivenConfigurationPanel`
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-12_
+_Last audited: 2026-06-13_
 _Last action: 2026-05-15_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-13: Full audit after rebasing scheduled-tasks onto dev-paul (new commits since 2026-06-12: pr-review batch 12 PRs, refactor(admin-config) shared isCardOpacity guard, audit(friday) journals, [AI] wide-distro phases 1-3, [AI] legal pages, [AI] drop restricted OAuth scopes). None of these touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. VERIFIED COUNT: 63 WidgetType members (unchanged). All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (7 intentionally excluded sub-types: blooms-detail, catalyst-instruction, catalyst-visual, custom-widget, mathTool, onboarding, sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). pnpm type-check and pnpm lint both clean. Zero new gaps._
 
 _2026-06-12: Full audit after rebasing scheduled-tasks onto dev-paul (new commits since 2026-06-11: docs(unifier) run 13 memory log, D4 convert cross-dir relative imports to @/ alias in tests/, chore(perf) refresh performance baseline, fix(layout) remove duplicate Alt+Delete handler from DraggableWindow, docs(debugger) nightly run 14 log). None of these touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. VERIFIED COUNT: 63 WidgetType members (unchanged). All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (6 intentionally excluded sub-types + sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). pnpm type-check and pnpm lint both clean. Zero new gaps._
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-11_
+_Last audited: 2026-06-12_
 _Last action: 2026-05-15_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-12: Full audit after rebasing scheduled-tasks onto dev-paul (new commits since 2026-06-11: docs(unifier) run 13 memory log, D4 convert cross-dir relative imports to @/ alias in tests/, chore(perf) refresh performance baseline, fix(layout) remove duplicate Alt+Delete handler from DraggableWindow, docs(debugger) nightly run 14 log). None of these touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. VERIFIED COUNT: 63 WidgetType members (unchanged). All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (6 intentionally excluded sub-types + sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). pnpm type-check and pnpm lint both clean. Zero new gaps._
 
 _2026-06-11: Full audit after rebasing scheduled-tasks onto dev-paul (new commits: ui(library) modernize unified library/in-progress/archive views, test(hooks) cover useVideoActivitySessionTeacher, fix(stores) consumeLaunchCode null coalescing, fix(i18n) seatingChart DE/ES/FR, fix(export) dedup buildResultsSheetData, fix(DashboardView) groupBuildMode Escape guard, perf(dashboard) DashboardContext split — stable actions + canvas hot-state store). None of these commits touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. VERIFIED COUNT: `awk '/^export type WidgetType =/{found=1} found{if(/;$/) exit; print}' types.ts | grep -c "| '"` → **63 WidgetType members** (activity-wall, blending-board, blooms-detail, blooms-taxonomy, breathing, calendar, car-rider-pro, catalyst, catalyst-instruction, catalyst-visual, checklist, classes, clock, concept-web, countdown, custom-widget, dice, drawing, embed, expectations, first-5, graphic-organizer, guided-learning, hotspot-image, instructionalRoutines, lunchCount, materials, mathTool, mathTools, miniApp, music, need-do-put-then, nextUp, numberLine, onboarding, pdf, poll, qr, quiz, random, recessGear, reveal-grid, schedule, scoreboard, seating-chart, smartNotebook, sound, soundboard, specialist-schedule, starter-pack, stations, sticker, stickers, syntax-framer, talking-tool, text, time-tool, traffic, url, video-activity, weather, webcam, work-symbols). Note: prior journal entries citing "64" were in error — the canonical count has been 63 throughout. All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (6 intentionally excluded sub-types + sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). All sampled lazyNamed() export names verified correct. pnpm type-check and pnpm lint both clean. Zero new gaps._
 

--- a/utils/adminBuildingConfig.ts
+++ b/utils/adminBuildingConfig.ts
@@ -61,6 +61,19 @@ const isWidgetFontFamily = (value: unknown): value is string =>
   (VALID_WIDGET_FONT_FAMILIES as readonly string[]).includes(value);
 
 /**
+ * Validates a `cardOpacity` default: a finite number within the panel slider's
+ * `0–1` range. Shared by every widget case that exposes a card-surface opacity
+ * default so the range check lives in one place — previously this four-line
+ * guard was copy-pasted across the `numberLine`, `checklist`, `stations`, and
+ * `concept-web` cases, where one copy had already drifted in structure.
+ */
+const isCardOpacity = (value: unknown): value is number =>
+  typeof value === 'number' &&
+  Number.isFinite(value) &&
+  value >= 0 &&
+  value <= 1;
+
+/**
  * Extracts building-level config overrides for a widget type from the admin's
  * feature_permissions config. These are applied between widget defaults and
  * explicit overrides so that per-building admin settings pre-configure new
@@ -178,13 +191,7 @@ export const getAdminBuildingConfig = (
         out.displayMode = raw.displayMode;
       if (typeof raw.showArrows === 'boolean') out.showArrows = raw.showArrows;
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
-      if (
-        typeof raw.cardOpacity === 'number' &&
-        Number.isFinite(raw.cardOpacity) &&
-        raw.cardOpacity >= 0 &&
-        raw.cardOpacity <= 1
-      )
-        out.cardOpacity = raw.cardOpacity;
+      if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
       if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
       break;
@@ -261,13 +268,7 @@ export const getAdminBuildingConfig = (
         out.scaleMultiplier = Math.max(0.5, Math.min(2.5, raw.scaleMultiplier));
       if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
-      if (
-        typeof raw.cardOpacity === 'number' &&
-        Number.isFinite(raw.cardOpacity) &&
-        raw.cardOpacity >= 0 &&
-        raw.cardOpacity <= 1
-      )
-        out.cardOpacity = raw.cardOpacity;
+      if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
       if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
       break;
     case 'stations':
@@ -277,13 +278,7 @@ export const getAdminBuildingConfig = (
       if (isWidgetFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
-      if (
-        typeof raw.cardOpacity === 'number' &&
-        Number.isFinite(raw.cardOpacity) &&
-        raw.cardOpacity >= 0 &&
-        raw.cardOpacity <= 1
-      )
-        out.cardOpacity = raw.cardOpacity;
+      if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
       break;
     case 'sound':
       if (raw.visual) out.visual = raw.visual;
@@ -407,13 +402,7 @@ export const getAdminBuildingConfig = (
       }
       if (isGlobalFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
-      if (
-        typeof raw.cardOpacity === 'number' &&
-        Number.isFinite(raw.cardOpacity) &&
-        raw.cardOpacity >= 0 &&
-        raw.cardOpacity <= 1
-      )
-        out.cardOpacity = raw.cardOpacity;
+      if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
       // No `fontColor` default: ConceptWeb's widget renders node text with a
       // hardcoded `text-slate-800` and never reads `config.fontColor`.
       break;


### PR DESCRIPTION
## Summary

Resolves a **LOW** item from `docs/scheduled-tasks/css-scaling.md` (highest-priority genuinely-open item across today's daily journals — widget-registry and typescript-eslint have no open items; the higher-document-order css-scaling items above this one were already resolved/stale, see below).

The ActivityWall inline activity-editor "Require moderation" `<input type="checkbox">` carried `className="h-4 w-4 accent-brand-blue-primary"`. The widget has `skipScaling: true`, so the fixed 16px size never responded to the container query — it stayed 16px at every widget size while the sibling label scaled via `min(12px, 3.8cqmin)`.

## Changes

- `components/widgets/ActivityWall/Widget.tsx`: removed the `h-4 w-4` Tailwind size classes and applied an inline `cqmin` size instead — `style={{ width: 'min(16px, 4cqmin)', height: 'min(16px, 4cqmin)' }}` — keeping `accent-brand-blue-primary` on `className` for the accent color. Caps the checkbox at 16px on large widgets while scaling it down proportionally at small sizes.
- `docs/scheduled-tasks/css-scaling.md`: moved the item to Completed; bumped `_Last action:_`. Also pruned two stale Open entries — the CarRiderPro/First5 overlay-button group (already fixed in #1768; both files now use `min(8px, 2cqmin)` / `min(6px, 1.5cqmin)`) and the GraphicOrganizer `min-h-[50px]` entry (duplicate of an already-Completed item).

File-recency check passed: `ActivityWall/Widget.tsx` was last touched at `592dd523` (2026-06-11 audit), outside the last 5 branch commits.

## Verification

- `tsc --noEmit` — clean
- `eslint --max-warnings 0` on the changed file — clean
- `prettier --check` on both changed files — clean
- ActivityWall test suite (Widget + Settings) — 11/11 pass

_Note: this is the standing scheduled-tasks → dev-paul draft PR; it is rebased onto dev-paul each run, so the diff is the accumulated scheduled-task work._