### PR TITLE
fix(keyboard): Alt+P pin shortcut drops when CapsLock is active

### DIFF
--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -1334,7 +1334,7 @@ export const DashboardView: React.FC = () => {
       }
 
       // Alt + P: Pin/Unpin top or focused widget
-      if (e.altKey && e.key === 'p') {
+      if (e.altKey && e.key.toLowerCase() === 'p') {
         // Guard: don't intercept Alt shortcuts while the user is typing in a
         // form field (mirrors the Escape / Delete guards above).
         if (isTypingFieldActive()) return;

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -833,6 +833,34 @@ describe('DashboardView Gestures & Navigation', () => {
       expect(detail2.widgetId).toBe(WIDGET_ID);
       expect(detail2.key).toBe('Pin');
     });
+
+    // Regression: Alt+P must fire even when CapsLock is active (e.key === 'P').
+    // Previously the guard used a case-sensitive `e.key === 'p'` comparison, so
+    // the shortcut was silently swallowed whenever CapsLock was on and no widget
+    // held keyboard focus (the DraggableWindow path was unaffected because it
+    // uses e.key.toLowerCase()).  Fix: normalize the key with .toLowerCase()
+    // before comparing.
+    it('dispatches Pin action with correct widgetId when Alt+P is pressed with CapsLock active (e.key === "P")', () => {
+      renderView();
+
+      const dispatched: CustomEvent[] = [];
+      const handler = (e: Event) => dispatched.push(e as CustomEvent);
+      window.addEventListener('widget-keyboard-action', handler);
+
+      expect(document.activeElement).toBe(childButton);
+
+      // Simulate CapsLock-active Alt+P: browsers produce key === 'P' (uppercase).
+      fireEvent.keyDown(window, { key: 'P', altKey: true });
+
+      window.removeEventListener('widget-keyboard-action', handler);
+
+      expect(dispatched).toHaveLength(1);
+      const detail = (
+        dispatched[0] as CustomEvent<{ widgetId: string; key: string }>
+      ).detail;
+      expect(detail.widgetId).toBe(WIDGET_ID);
+      expect(detail.key).toBe('Pin');
+    });
   });
 
   // Toast accessibility: the ToastContainer must expose live-region roles so

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -847,12 +847,14 @@ describe('DashboardView Gestures & Navigation', () => {
       const handler = (e: Event) => dispatched.push(e as CustomEvent);
       window.addEventListener('widget-keyboard-action', handler);
 
-      expect(document.activeElement).toBe(childButton);
+      try {
+        expect(document.activeElement).toBe(childButton);
 
-      // Simulate CapsLock-active Alt+P: browsers produce key === 'P' (uppercase).
-      fireEvent.keyDown(window, { key: 'P', altKey: true });
-
-      window.removeEventListener('widget-keyboard-action', handler);
+        // Simulate CapsLock-active Alt+P: browsers produce key === 'P' (uppercase).
+        fireEvent.keyDown(window, { key: 'P', altKey: true });
+      } finally {
+        window.removeEventListener('widget-keyboard-action', handler);
+      }
 
       expect(dispatched).toHaveLength(1);
       const detail = (


### PR DESCRIPTION
## Bug

The global `window` keydown handler's `Alt+P` guard compared `e.key === 'p'` (case-sensitive). When CapsLock is active the browser produces `e.key === 'P'` — the comparison fails and the shortcut does nothing.

The widget-level handler in `DraggableWindow.tsx` already uses `e.key.toLowerCase()` correctly, so the gap only affects the global path (topmost widget, no explicit focus).

## Fix

`components/layout/DashboardView.tsx` line 1337:

```diff
-      if (e.altKey && e.key === 'p') {
+      if (e.altKey && e.key.toLowerCase() === 'p') {
```

## Regression test

Added to `tests/components/layout/DashboardView.test.tsx` inside the existing keyboard-action describe block:

> `dispatches Pin action with correct widgetId when Alt+P is pressed with CapsLock active (e.key === "P")`

Fires `keyDown(window, { key: 'P', altKey: true })` — asserts one `widget-keyboard-action` with `{ key: 'Pin' }`.

- **FAILS on unpatched code**: 0 events dispatched
- **PASSES after fix**: 1 event with correct payload

## Validation

| Check | Result |
|---|---|
| type-check | ✓ |
| eslint (layout + test files) | ✓ 0 warnings |
| format:check | ✓ |
| vitest (137 component test files, 1153 tests) | ✓ all pass |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWuzsxj5f2JoQPhfJEDGnU)_