### PR TITLE
fix(lti): preserve contextId across privacy-stripped LTI relaunches

### DIFF
--- a/functions/src/lti/launchEndpoints.test.ts
+++ b/functions/src/lti/launchEndpoints.test.ts
@@ -105,7 +105,14 @@ vi.mock('../classlinkShared', () => ({
 
 vi.mock('./config', async (orig) => ({
   ...(await orig<typeof import('./config')>()),
-  getLtiPlatformConfig: vi.fn().mockResolvedValue({ issuer: 'https://lms', clientId: 'c1', deploymentId: 'd1', authorizeUrl: 'https://lms/auth' }),
+  getLtiPlatformConfig: vi
+    .fn()
+    .mockResolvedValue({
+      issuer: 'https://lms',
+      clientId: 'c1',
+      deploymentId: 'd1',
+      authorizeUrl: 'https://lms/auth',
+    }),
   TOOL_ORIGIN: 'https://app.example',
   TOOL_LAUNCH_URL: 'https://app.example/lti/launch',
   MESSAGE_TYPE_DEEP_LINKING: 'LtiDeepLinkingRequest',
@@ -113,14 +120,21 @@ vi.mock('./config', async (orig) => ({
 
 import { ltiExchange } from './launchEndpoints';
 
-type Req = { auth?: { uid: string; token: Record<string, unknown> }; data: unknown };
-const callExchange = ltiExchange as unknown as (r: Req) => Promise<Record<string, unknown>>;
+type Req = {
+  auth?: { uid: string; token: Record<string, unknown> };
+  data: unknown;
+};
+const callExchange = ltiExchange as unknown as (
+  r: Req
+) => Promise<Record<string, unknown>>;
 
-function makeLaunch(overrides: Partial<{
-  contextId: string | null;
-  resourceLinkId: string | null;
-  ags: unknown;
-}> = {}) {
+function makeLaunch(
+  overrides: Partial<{
+    contextId: string | null;
+    resourceLinkId: string | null;
+    ags: unknown;
+  }> = {}
+) {
   return {
     role: 'student' as const,
     messageType: 'LtiResourceLinkRequest',
@@ -132,7 +146,10 @@ function makeLaunch(overrides: Partial<{
     ags: { lineitem: 'https://lms/lineitems/1', scope: [] } as unknown,
     nrps: null,
     deepLinking: null,
-    custom: { kind: 'quiz', quiz_code: 'ABC123' } as Record<string, unknown> | null,
+    custom: { kind: 'quiz', quiz_code: 'ABC123' } as Record<
+      string,
+      unknown
+    > | null,
     email: null,
     name: null,
     ...overrides,

--- a/functions/src/lti/launchEndpoints.test.ts
+++ b/functions/src/lti/launchEndpoints.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for ltiExchange — specifically the lti_grade_links write path.
+ *
+ * Regression (#1903-follow-up): ltiExchange wrote `contextId: launch.contextId`
+ * unconditionally into `lti_grade_links/{uid}/resources/{rlId}`. When a
+ * privacy-configured Schoology deployment relaunches without a context claim
+ * (contextId: null), the `{ merge: true }` set explicitly overwrote the
+ * previously-stored valid contextId with null — the same class of bug fixed
+ * for contextTitle in nrpsStore.ts. The fix reads the existing doc and uses
+ * `launch.contextId ?? storedDoc.contextId ?? null`.
+ *
+ * Only the lti_grade_links write path is exercised here; the full exchange flow
+ * (JWT validation, custom-token mint, persistLtiLaunchContext) is mocked away.
+ */
+
+/* eslint-disable @typescript-eslint/require-await -- mock async handlers mirror
+   the async Admin-SDK surface without awaiting anything. */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Lightweight Firestore mock ──────────────────────────────────────────────
+// Tracks the last write to lti_grade_links docs so we can assert preservation.
+interface GradeLinkDoc {
+  sub?: string;
+  contextId?: string | null;
+  resourceLinkId?: string;
+  ags?: unknown;
+  updatedAt?: number;
+}
+const gradeLinkStore = new Map<string, GradeLinkDoc>();
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  firestore: vi.fn(() => ({
+    doc: (path: string) => ({
+      path,
+      get: async () => {
+        const data = gradeLinkStore.get(path);
+        return { exists: !!data, data: () => data };
+      },
+      set: async (data: GradeLinkDoc) => {
+        // Emulate Firestore merge: merge stored doc with incoming fields.
+        const existing = gradeLinkStore.get(path) ?? {};
+        gradeLinkStore.set(path, { ...existing, ...data });
+      },
+    }),
+    collection: () => ({ where: () => ({ get: async () => ({ docs: [] }) }) }),
+    batch: () => ({ set: vi.fn(), commit: async () => {} }),
+  })),
+  auth: vi.fn(() => ({
+    createCustomToken: async () => 'custom-token',
+  })),
+}));
+
+vi.mock('firebase-functions/v2/https', () => {
+  class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+      this.name = 'HttpsError';
+    }
+  }
+  return {
+    onCall: (_o: unknown, handler: unknown) => handler,
+    onRequest: (_o: unknown, handler: unknown) => handler,
+    HttpsError,
+  };
+});
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: () => ({ value: () => 'test-secret' }),
+}));
+
+// Provide a real-enough launch code store: consumeLaunchCode returns the
+// launch we pre-seed via `nextLaunch`. The real stores.ts isn't needed here.
+let nextLaunch: ReturnType<typeof makeLaunch> | null = null;
+vi.mock('./stores', () => ({
+  putOidcState: vi.fn(),
+  consumeOidcState: vi.fn(),
+  mintLaunchCode: vi.fn(),
+  consumeLaunchCode: vi.fn(async () => nextLaunch),
+  newOpaqueId: vi.fn(() => 'opaque-id'),
+}));
+
+// Stub persistLtiLaunchContext so we only test the grade-link write path.
+vi.mock('./nrpsStore', () => ({
+  persistLtiLaunchContext: vi.fn(async () => 'sess-1'),
+  QUIZ_SESSIONS_COLLECTION: 'quiz_sessions',
+  VIDEO_ACTIVITY_SESSIONS_COLLECTION: 'video_activity_sessions',
+  LTI_SESSION_MEMBERSHIPS_COLLECTION: 'lti_session_memberships',
+  USERS_COLLECTION: 'users',
+  QUIZ_ASSIGNMENTS_SUBCOLLECTION: 'quiz_assignments',
+  LTI_SEEN_SECTIONS_SUBCOLLECTION: 'lti_seen_sections',
+}));
+
+vi.mock('./identity', () => ({ ltiStudentUid: () => 'uid-student' }));
+
+vi.mock('../classlinkShared', () => ({
+  ALLOWED_ORIGINS: [],
+  normalizeEmailDomain: () => 'school.edu',
+  resolveOrgIdForDomain: async () => null,
+}));
+
+vi.mock('./config', async (orig) => ({
+  ...(await orig<typeof import('./config')>()),
+  getLtiPlatformConfig: vi.fn().mockResolvedValue({ issuer: 'https://lms', clientId: 'c1', deploymentId: 'd1', authorizeUrl: 'https://lms/auth' }),
+  TOOL_ORIGIN: 'https://app.example',
+  TOOL_LAUNCH_URL: 'https://app.example/lti/launch',
+  MESSAGE_TYPE_DEEP_LINKING: 'LtiDeepLinkingRequest',
+}));
+
+import { ltiExchange } from './launchEndpoints';
+
+type Req = { auth?: { uid: string; token: Record<string, unknown> }; data: unknown };
+const callExchange = ltiExchange as unknown as (r: Req) => Promise<Record<string, unknown>>;
+
+function makeLaunch(overrides: Partial<{
+  contextId: string | null;
+  resourceLinkId: string | null;
+  ags: unknown;
+}> = {}) {
+  return {
+    role: 'student' as const,
+    messageType: 'LtiResourceLinkRequest',
+    sub: 'sub-1',
+    deploymentId: 'dep-1',
+    contextId: 'ctx-original' as string | null,
+    contextTitle: 'Math 7' as string | null,
+    resourceLinkId: 'rl-1' as string | null,
+    ags: { lineitem: 'https://lms/lineitems/1', scope: [] } as unknown,
+    nrps: null,
+    deepLinking: null,
+    custom: { kind: 'quiz', quiz_code: 'ABC123' } as Record<string, unknown> | null,
+    email: null,
+    name: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  gradeLinkStore.clear();
+  nextLaunch = null;
+});
+
+describe('ltiExchange — lti_grade_links null-clobber regression', () => {
+  it('REGRESSION: does not overwrite a stored contextId with null on privacy-stripped relaunch', async () => {
+    // First launch: student arrives with a full context (contextId = 'ctx-original').
+    nextLaunch = makeLaunch({ contextId: 'ctx-original' });
+    await callExchange({ data: { code: 'code-1' } });
+
+    const path = 'lti_grade_links/uid-student/resources/rl-1';
+    expect(gradeLinkStore.get(path)?.contextId).toBe('ctx-original');
+
+    // Second launch: same student, same assignment, but the platform omits the
+    // context claim (privacy-configured relaunch → contextId: null).
+    nextLaunch = makeLaunch({ contextId: null });
+    await callExchange({ data: { code: 'code-2' } });
+
+    // The stored contextId MUST be preserved — null must not clobber the valid value.
+    expect(gradeLinkStore.get(path)?.contextId).toBe('ctx-original');
+  });
+
+  it('writes the contextId on a fresh (first) launch', async () => {
+    nextLaunch = makeLaunch({ contextId: 'ctx-new' });
+    await callExchange({ data: { code: 'code-1' } });
+
+    const path = 'lti_grade_links/uid-student/resources/rl-1';
+    expect(gradeLinkStore.get(path)?.contextId).toBe('ctx-new');
+  });
+
+  it('accepts null contextId on a fresh launch (no stored value to preserve)', async () => {
+    nextLaunch = makeLaunch({ contextId: null });
+    await callExchange({ data: { code: 'code-1' } });
+
+    const path = 'lti_grade_links/uid-student/resources/rl-1';
+    // No stored value → null is the legitimate initial value.
+    expect(gradeLinkStore.get(path)?.contextId).toBeNull();
+  });
+});

--- a/functions/src/lti/launchEndpoints.test.ts
+++ b/functions/src/lti/launchEndpoints.test.ts
@@ -105,14 +105,12 @@ vi.mock('../classlinkShared', () => ({
 
 vi.mock('./config', async (orig) => ({
   ...(await orig<typeof import('./config')>()),
-  getLtiPlatformConfig: vi
-    .fn()
-    .mockResolvedValue({
-      issuer: 'https://lms',
-      clientId: 'c1',
-      deploymentId: 'd1',
-      authorizeUrl: 'https://lms/auth',
-    }),
+  getLtiPlatformConfig: vi.fn().mockResolvedValue({
+    issuer: 'https://lms',
+    clientId: 'c1',
+    deploymentId: 'd1',
+    authorizeUrl: 'https://lms/auth',
+  }),
   TOOL_ORIGIN: 'https://app.example',
   TOOL_LAUNCH_URL: 'https://app.example/lti/launch',
   MESSAGE_TYPE_DEEP_LINKING: 'LtiDeepLinkingRequest',

--- a/functions/src/lti/launchEndpoints.ts
+++ b/functions/src/lti/launchEndpoints.ts
@@ -305,9 +305,10 @@ export const ltiExchange = onCall(
         // student — the same preservation pattern applied to contextTitle in
         // nrpsStore.ts.
         const existingGradeLink = await gradeLinkRef.get();
-        const storedContextId =
-          typeof existingGradeLink.data()?.contextId === 'string'
-            ? (existingGradeLink.data()?.contextId as string)
+        const gradeLinkData = existingGradeLink.data();
+        const storedContextId: string | null =
+          gradeLinkData && typeof gradeLinkData.contextId === 'string'
+            ? gradeLinkData.contextId
             : null;
         await gradeLinkRef.set(
           {

--- a/functions/src/lti/launchEndpoints.ts
+++ b/functions/src/lti/launchEndpoints.ts
@@ -296,18 +296,29 @@ export const ltiExchange = onCall(
     // linked/merged sections post correctly (each section's lineitem differs).
     if (launch.resourceLinkId && launch.ags) {
       try {
-        await db
-          .doc(`lti_grade_links/${uid}/resources/${launch.resourceLinkId}`)
-          .set(
-            {
-              sub: launch.sub,
-              contextId: launch.contextId,
-              resourceLinkId: launch.resourceLinkId,
-              ags: launch.ags,
-              updatedAt: Date.now(),
-            },
-            { merge: true }
-          );
+        const gradeLinkRef = db.doc(
+          `lti_grade_links/${uid}/resources/${launch.resourceLinkId}`
+        );
+        // Preserve a previously-captured contextId: some Schoology deployments
+        // omit the context claim on relaunches (privacy config). Overwriting a
+        // stored contextId with null would break AGS grade-push routing for that
+        // student — the same preservation pattern applied to contextTitle in
+        // nrpsStore.ts.
+        const existingGradeLink = await gradeLinkRef.get();
+        const storedContextId =
+          typeof existingGradeLink.data()?.contextId === 'string'
+            ? (existingGradeLink.data()?.contextId as string)
+            : null;
+        await gradeLinkRef.set(
+          {
+            sub: launch.sub,
+            contextId: launch.contextId ?? storedContextId,
+            resourceLinkId: launch.resourceLinkId,
+            ags: launch.ags,
+            updatedAt: Date.now(),
+          },
+          { merge: true }
+        );
       } catch (err) {
         console.warn(
           '[ltiExchange] grade-link persist failed (non-fatal)',


### PR DESCRIPTION
## Bug

In `functions/src/lti/launchEndpoints.ts`, the `lti_grade_links` Firestore write used:

```ts
contextId: launch.contextId,
```

Some LTI platforms strip privacy fields (including `context_id`) from relaunch payloads. When `launch.contextId` is `null`, this write clobbered the stored value from the original launch — breaking grade passback for that resource link.

## Fix

Read the existing `lti_grade_links` document before writing; fall back to the stored `contextId` if the incoming payload omits it:

```ts
const gradeLinkRef = db.doc(`lti_grade_links/${uid}/resources/${launch.resourceLinkId}`);
const existingGradeLink = await gradeLinkRef.get();
const storedContextId =
  typeof existingGradeLink.data()?.contextId === 'string'
    ? (existingGradeLink.data()?.contextId as string)
    : null;
await gradeLinkRef.set({
  sub: launch.sub,
  contextId: launch.contextId ?? storedContextId,
  ...
}, { merge: true });
```

## Regression test

Added to `functions/src/lti/launchEndpoints.test.ts`:

- Simulates a first launch that stores `contextId: 'ctx-original'`
- Simulates a privacy-stripped relaunch with `contextId: null`
- Asserts the stored document still has `contextId: 'ctx-original'`

- **FAILS on unpatched code**: `contextId` is written as `null`, clobbering stored value
- **PASSES after fix**: stored `contextId` is preserved

## Validation

| Check | Result |
|---|---|
| tsc --noEmit (functions/) | ✓ |
| eslint (launchEndpoints files) | ✓ 0 warnings |
| format:check | ✓ |
| vitest (functions/ — 29 test files, 528 tests) | ✓ all pass |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWuzsxj5f2JoQPhfJEDGnU)_