### PR TITLE
Remote Control v2 + admin-gated anonymous-join (Phase 3b)

### DIFF
--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -43,6 +43,7 @@ import {
   ListChecks,
   PlayCircle,
   Music2,
+  Link2,
 } from 'lucide-react';
 import { useAuth } from '@/context/useAuth';
 import { useStorage } from '@/hooks/useStorage';
@@ -150,6 +151,13 @@ const GLOBAL_FEATURES: {
     icon: Music2,
     description:
       'Let teachers connect their personal Spotify account in the Music widget. When off, Music shows only curated stations.',
+  },
+  {
+    id: 'anonymous-join',
+    label: 'Anonymous join links (no sign-in)',
+    icon: Link2,
+    description:
+      "Controls which teachers can offer the no-sign-in join URL for activities. Restrict by access level, beta users, building, or minimum tier. Participants' join experience is unaffected.",
   },
 ];
 

--- a/components/remote/MobileRemoteView.test.tsx
+++ b/components/remote/MobileRemoteView.test.tsx
@@ -59,7 +59,7 @@ describe('MobileRemoteView', () => {
       dashboardCtx(makeDashboard([makeWidget('w1')]))
     );
     render(<MobileRemoteView />);
-    expect(screen.getByText(/connected/i)).toBeInTheDocument();
+    expect(screen.getByText('remote.status.connected')).toBeInTheDocument();
   });
 
   it('reflects a new context snapshot without a manual Sync tap', () => {

--- a/components/remote/MobileRemoteView.test.tsx
+++ b/components/remote/MobileRemoteView.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MobileRemoteView } from './MobileRemoteView';
 import { useDashboard } from '@/context/useDashboard';
@@ -80,5 +81,75 @@ describe('MobileRemoteView', () => {
     expect(screen.getAllByRole('button', { name: /spotlight/i })).toHaveLength(
       2
     );
+  });
+
+  describe('board picker', () => {
+    const multiBoardCtx = () => {
+      const boardA = {
+        id: 'board-a',
+        name: 'Board A',
+        widgets: [makeWidget('w1')],
+        settings: {},
+      };
+      const boardB = {
+        id: 'board-b',
+        name: 'Board B',
+        widgets: [makeWidget('w2')],
+        settings: {},
+      };
+      return {
+        activeDashboard: boardA,
+        updateWidget: vi.fn(),
+        updateDashboardSettings: vi.fn(),
+        loadDashboard: vi.fn(),
+        dashboards: [boardA, boardB],
+      };
+    };
+
+    it('opens the picker showing all board names when the board name is tapped', async () => {
+      const user = userEvent.setup();
+      mockedUseDashboard.mockReturnValue(multiBoardCtx());
+      render(<MobileRemoteView />);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: 'remote.boardPicker.switch' })
+      );
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+      expect(within(dialog).getByText('Board A')).toBeInTheDocument();
+      expect(within(dialog).getByText('Board B')).toBeInTheDocument();
+    });
+
+    it('jumps to a non-active board and closes the picker', async () => {
+      const user = userEvent.setup();
+      const ctx = multiBoardCtx();
+      mockedUseDashboard.mockReturnValue(ctx);
+      render(<MobileRemoteView />);
+
+      await user.click(
+        screen.getByRole('button', { name: 'remote.boardPicker.switch' })
+      );
+      const dialog = screen.getByRole('dialog');
+      await user.click(within(dialog).getByRole('button', { name: /Board B/ }));
+
+      expect(ctx.loadDashboard).toHaveBeenCalledWith('board-b');
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('marks the active board row as current', async () => {
+      const user = userEvent.setup();
+      mockedUseDashboard.mockReturnValue(multiBoardCtx());
+      render(<MobileRemoteView />);
+
+      await user.click(
+        screen.getByRole('button', { name: 'remote.boardPicker.switch' })
+      );
+      const dialog = screen.getByRole('dialog');
+      const activeRow = within(dialog).getByRole('button', { name: /Board A/ });
+      expect(activeRow).toHaveAttribute('aria-current', 'true');
+    });
   });
 });

--- a/components/remote/MobileRemoteView.test.tsx
+++ b/components/remote/MobileRemoteView.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MobileRemoteView } from './MobileRemoteView';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const makeWidget = (id: string, overrides: Record<string, unknown> = {}) => ({
+  id,
+  type: 'scoreboard',
+  z: 1,
+  config: {},
+  ...overrides,
+});
+
+const makeDashboard = (widgets: ReturnType<typeof makeWidget>[]) => ({
+  id: 'board-123',
+  name: 'Board 123',
+  widgets,
+  settings: {},
+});
+
+describe('MobileRemoteView', () => {
+  const mockedUseDashboard = useDashboard as unknown as ReturnType<
+    typeof vi.fn
+  >;
+  const mockedUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('https://spart.test/remote'),
+    });
+    mockedUseAuth.mockReturnValue({ remoteControlEnabled: true });
+  });
+
+  const dashboardCtx = (dashboard: ReturnType<typeof makeDashboard>) => ({
+    activeDashboard: dashboard,
+    updateWidget: vi.fn(),
+    updateDashboardSettings: vi.fn(),
+    loadDashboard: vi.fn(),
+    dashboards: [dashboard],
+  });
+
+  it('renders a Connected status chip', () => {
+    mockedUseDashboard.mockReturnValue(
+      dashboardCtx(makeDashboard([makeWidget('w1')]))
+    );
+    render(<MobileRemoteView />);
+    expect(screen.getByText(/connected/i)).toBeInTheDocument();
+  });
+
+  it('reflects a new context snapshot without a manual Sync tap', () => {
+    const ctx = dashboardCtx(makeDashboard([makeWidget('w1')]));
+    mockedUseDashboard.mockReturnValue(ctx);
+    const { rerender } = render(<MobileRemoteView />);
+    // Initially one widget card heading present.
+    expect(screen.getAllByRole('button', { name: /spotlight/i })).toHaveLength(
+      1
+    );
+
+    // Desktop adds a widget -> new snapshot from context.
+    ctx.activeDashboard = makeDashboard([makeWidget('w1'), makeWidget('w2')]);
+    mockedUseDashboard.mockReturnValue(ctx);
+    rerender(<MobileRemoteView />);
+
+    // Reflected automatically, no Sync tap.
+    expect(screen.getAllByRole('button', { name: /spotlight/i })).toHaveLength(
+      2
+    );
+  });
+});

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -54,6 +54,7 @@ const REMOTE_SUPPORTED_TYPES: WidgetType[] = [
   'nextUp',
   'sound',
   'webcam',
+  'activity-wall',
 ];
 
 /** Widget types that are always skipped on the remote (truly non-interactive) */

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -35,6 +35,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { WidgetData, WidgetType, DashboardSettings } from '@/types';
 import { RemoteWidgetCard } from './RemoteWidgetCard';
+import { useRemoteConnection } from './useRemoteConnection';
 
 /** Widget types with full custom remote controls — sorted to the front of the carousel */
 const REMOTE_SUPPORTED_TYPES: WidgetType[] = [
@@ -74,6 +75,7 @@ export const MobileRemoteView: React.FC = () => {
     dashboards,
   } = useDashboard();
   const { remoteControlEnabled: accountRemoteEnabled } = useAuth();
+  const conn = useRemoteConnection();
 
   // ---- Local snapshot state ----
   // Initialised once from activeDashboard, then only updated on manual Sync.
@@ -175,7 +177,10 @@ export const MobileRemoteView: React.FC = () => {
         activeDashboard.settings ? { ...activeDashboard.settings } : undefined
       );
     }
-  }, [activeDashboard, initializedDashboardId]);
+
+    // A fresh context snapshot has been reflected — keep "updated just now" honest.
+    conn.markSynced();
+  }, [activeDashboard, initializedDashboardId, conn.markSynced]);
 
   // Manual sync — pull latest state from context and clear any pending write guards.
   const handleSync = useCallback(() => {
@@ -186,8 +191,9 @@ export const MobileRemoteView: React.FC = () => {
     setLocalSettings(
       activeDashboard.settings ? { ...activeDashboard.settings } : undefined
     );
+    conn.markSynced();
     setTimeout(() => setSyncing(false), 600);
-  }, [activeDashboard, clearPendingWriteGuards]);
+  }, [activeDashboard, clearPendingWriteGuards, conn]);
 
   // Write-through updateWidget: update local snapshot AND write to Firestore.
   // Cancels any existing timer for this widget before starting a fresh one so
@@ -213,7 +219,7 @@ export const MobileRemoteView: React.FC = () => {
           };
         });
       });
-      ctxUpdateWidget(id, updates);
+      ctxUpdateWidget(id, updates, { immediate: true });
     },
     [ctxUpdateWidget]
   );
@@ -230,7 +236,7 @@ export const MobileRemoteView: React.FC = () => {
         pendingSettingsTimer.current = null;
       }, 5000);
       setLocalSettings((prev) => ({ ...(prev ?? {}), ...updates }));
-      ctxUpdateDashboardSettings(updates);
+      ctxUpdateDashboardSettings(updates, { immediate: true });
     },
     [ctxUpdateDashboardSettings]
   );
@@ -350,6 +356,30 @@ export const MobileRemoteView: React.FC = () => {
             {activeDashboard.name}
           </span>
           <span className="text-white/40 text-xs">Remote Control</span>
+          <div className="flex items-center gap-1.5">
+            <span
+              className={`w-1.5 h-1.5 rounded-full ${
+                conn.status === 'connected'
+                  ? 'bg-emerald-400'
+                  : 'bg-amber-400 animate-pulse'
+              }`}
+              aria-hidden="true"
+            />
+            <span
+              className={`text-[10px] font-semibold ${
+                conn.status === 'connected'
+                  ? 'text-emerald-300/80'
+                  : 'text-amber-300/80'
+              }`}
+            >
+              {conn.status === 'connected' ? 'Connected' : 'Reconnecting…'}
+            </span>
+            {conn.lastSyncedAt !== null && (
+              <span className="text-white/30 text-[10px]">
+                · updated just now
+              </span>
+            )}
+          </div>
         </div>
 
         {/* Sync button — manually pull the latest board state from Firestore */}

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -24,12 +24,15 @@
 import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
+  Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   LayoutGrid,
   Loader2,
   RefreshCw,
   Smartphone,
+  X,
 } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -260,6 +263,7 @@ export const MobileRemoteView: React.FC = () => {
   );
 
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [isBoardPickerOpen, setIsBoardPickerOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const remoteWidgets = React.useMemo(() => {
@@ -358,9 +362,17 @@ export const MobileRemoteView: React.FC = () => {
         </button>
 
         <div className="flex flex-col items-center gap-0.5">
-          <span className="text-white font-black text-sm truncate max-w-40">
-            {activeDashboard.name}
-          </span>
+          <button
+            type="button"
+            onClick={() => setIsBoardPickerOpen(true)}
+            aria-haspopup="dialog"
+            aria-expanded={isBoardPickerOpen}
+            aria-label={t('remote.boardPicker.switch')}
+            className="flex items-center gap-1 text-white font-black text-sm touch-manipulation active:scale-95 transition-transform"
+          >
+            <span className="truncate max-w-40">{activeDashboard.name}</span>
+            <ChevronDown className="w-3.5 h-3.5 text-white/40 shrink-0" />
+          </button>
           <span className="text-white/40 text-xs">Remote Control</span>
           <div className="flex items-center gap-1.5">
             <span
@@ -465,6 +477,68 @@ export const MobileRemoteView: React.FC = () => {
               aria-label={`Go to widget ${i + 1}`}
             />
           ))}
+        </div>
+      )}
+
+      {/* Board picker overlay — jump directly to any board */}
+      {isBoardPickerOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-end justify-center bg-black/70 backdrop-blur-sm"
+          onClick={() => setIsBoardPickerOpen(false)}
+        >
+          <div
+            role="dialog"
+            aria-label={t('remote.boardPicker.title')}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-md bg-slate-900 border-t border-white/10 rounded-t-2xl flex flex-col max-h-[70vh]"
+            style={{
+              paddingBottom: 'max(env(safe-area-inset-bottom, 0px), 0.75rem)',
+            }}
+          >
+            <div className="flex items-center justify-between px-4 py-3 shrink-0 border-b border-white/5">
+              <span className="text-white font-black text-sm">
+                {t('remote.boardPicker.title')}
+              </span>
+              <button
+                type="button"
+                onClick={() => setIsBoardPickerOpen(false)}
+                aria-label={t('remote.boardPicker.close')}
+                className="p-2 -mr-2 text-white/40 hover:text-white touch-manipulation active:scale-95 transition-transform"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="overflow-y-auto p-2 flex flex-col gap-1">
+              {dashboards.map((board) => {
+                const isActive = board.id === activeDashboard.id;
+                return (
+                  <button
+                    key={board.id}
+                    type="button"
+                    aria-current={isActive ? 'true' : undefined}
+                    onClick={() => {
+                      handleLoadDashboard(board.id);
+                      setCurrentIndex(0);
+                      if (scrollRef.current) scrollRef.current.scrollLeft = 0;
+                      setIsBoardPickerOpen(false);
+                    }}
+                    className={`flex items-center justify-between gap-3 min-h-12 px-4 rounded-2xl text-left touch-manipulation active:scale-95 transition-all ${
+                      isActive
+                        ? 'bg-blue-500/20 text-white'
+                        : 'text-white/70 hover:bg-white/5'
+                    }`}
+                  >
+                    <span className="font-semibold text-sm truncate">
+                      {board.name}
+                    </span>
+                    {isActive && (
+                      <Check className="w-5 h-5 text-blue-400 shrink-0" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -182,6 +182,10 @@ export const MobileRemoteView: React.FC = () => {
 
     // A fresh context snapshot has been reflected — keep "updated just now" honest.
     conn.markSynced();
+    // conn.markSynced is intentionally the sole conn dependency: it's useCallback([])-stable,
+    // whereas depending on the whole `conn` object would re-fire this effect on every
+    // lastSyncedAt change → render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeDashboard, initializedDashboardId, conn.markSynced]);
 
   // Manual sync — pull latest state from context and clear any pending write guards.
@@ -377,9 +381,7 @@ export const MobileRemoteView: React.FC = () => {
               {conn.status === 'connected' ? 'Connected' : 'Reconnecting…'}
             </span>
             {conn.lastSyncedAt !== null && (
-              <span className="text-white/30 text-[10px]">
-                · updated just now
-              </span>
+              <span className="text-white/30 text-[10px]">· live</span>
             )}
           </div>
         </div>

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -55,6 +55,7 @@ const REMOTE_SUPPORTED_TYPES: WidgetType[] = [
   'sound',
   'webcam',
   'activity-wall',
+  'embed',
 ];
 
 /** Widget types that are always skipped on the remote (truly non-interactive) */

--- a/components/remote/MobileRemoteView.tsx
+++ b/components/remote/MobileRemoteView.tsx
@@ -77,7 +77,11 @@ export const MobileRemoteView: React.FC = () => {
     dashboards,
   } = useDashboard();
   const { remoteControlEnabled: accountRemoteEnabled } = useAuth();
-  const conn = useRemoteConnection();
+  const {
+    status: connStatus,
+    lastSyncedAt: connLastSyncedAt,
+    markSynced,
+  } = useRemoteConnection();
 
   // ---- Local snapshot state ----
   // Initialised once from activeDashboard, then only updated on manual Sync.
@@ -181,12 +185,8 @@ export const MobileRemoteView: React.FC = () => {
     }
 
     // A fresh context snapshot has been reflected — keep "updated just now" honest.
-    conn.markSynced();
-    // conn.markSynced is intentionally the sole conn dependency: it's useCallback([])-stable,
-    // whereas depending on the whole `conn` object would re-fire this effect on every
-    // lastSyncedAt change → render loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeDashboard, initializedDashboardId, conn.markSynced]);
+    markSynced();
+  }, [activeDashboard, initializedDashboardId, markSynced]);
 
   // Manual sync — pull latest state from context and clear any pending write guards.
   const handleSync = useCallback(() => {
@@ -197,9 +197,9 @@ export const MobileRemoteView: React.FC = () => {
     setLocalSettings(
       activeDashboard.settings ? { ...activeDashboard.settings } : undefined
     );
-    conn.markSynced();
+    markSynced();
     setTimeout(() => setSyncing(false), 600);
-  }, [activeDashboard, clearPendingWriteGuards, conn]);
+  }, [activeDashboard, clearPendingWriteGuards, markSynced]);
 
   // Write-through updateWidget: update local snapshot AND write to Firestore.
   // Cancels any existing timer for this widget before starting a fresh one so
@@ -365,7 +365,7 @@ export const MobileRemoteView: React.FC = () => {
           <div className="flex items-center gap-1.5">
             <span
               className={`w-1.5 h-1.5 rounded-full ${
-                conn.status === 'connected'
+                connStatus === 'connected'
                   ? 'bg-emerald-400'
                   : 'bg-amber-400 animate-pulse'
               }`}
@@ -373,14 +373,16 @@ export const MobileRemoteView: React.FC = () => {
             />
             <span
               className={`text-[10px] font-semibold ${
-                conn.status === 'connected'
+                connStatus === 'connected'
                   ? 'text-emerald-300/80'
                   : 'text-amber-300/80'
               }`}
             >
-              {conn.status === 'connected' ? 'Connected' : 'Reconnecting…'}
+              {connStatus === 'connected'
+                ? t('remote.status.connected')
+                : t('remote.status.reconnecting')}
             </span>
-            {conn.lastSyncedAt !== null && (
+            {connLastSyncedAt !== null && (
               <span className="text-white/30 text-[10px]">· live</span>
             )}
           </div>

--- a/components/remote/RemoteWidgetCard.tsx
+++ b/components/remote/RemoteWidgetCard.tsx
@@ -190,7 +190,7 @@ export const RemoteWidgetCard: React.FC<RemoteWidgetCardProps> = ({
           <button
             onClick={handleSpotlight}
             style={{ touchAction: 'manipulation' }}
-            className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-bold transition-all active:scale-95 ${
+            className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
               isSpotlighted
                 ? 'bg-yellow-400/20 border-yellow-400/60 text-yellow-300'
                 : 'bg-white/10 border-white/20 text-white/60 hover:bg-white/20'
@@ -212,7 +212,7 @@ export const RemoteWidgetCard: React.FC<RemoteWidgetCardProps> = ({
           <button
             onClick={handleMaximize}
             style={{ touchAction: 'manipulation' }}
-            className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-bold transition-all active:scale-95 ${
+            className={`flex items-center gap-1.5 px-3 py-2 rounded-xl border text-sm font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
               isMaximized
                 ? 'bg-blue-500/20 border-blue-400/60 text-blue-300'
                 : 'bg-white/10 border-white/20 text-white/60 hover:bg-white/20'

--- a/components/remote/RemoteWidgetCard.tsx
+++ b/components/remote/RemoteWidgetCard.tsx
@@ -25,6 +25,7 @@ import { RemoteNextUpControl } from './controls/RemoteNextUpControl';
 import { RemoteSoundControl } from './controls/RemoteSoundControl';
 import { RemoteWebcamControl } from './controls/RemoteWebcamControl';
 import { RemoteActivityWallControl } from './controls/RemoteActivityWallControl';
+import { RemoteEmbedControl } from './controls/RemoteEmbedControl';
 
 interface RemoteWidgetCardProps {
   widget: WidgetData;
@@ -137,6 +138,8 @@ const renderControls = (
           updateWidget={updateWidget}
         />
       );
+    case 'embed':
+      return <RemoteEmbedControl widget={widget} updateWidget={updateWidget} />;
     default:
       return (
         <div className="flex flex-col items-center justify-center h-full gap-4 text-white/40 p-8 text-center">

--- a/components/remote/RemoteWidgetCard.tsx
+++ b/components/remote/RemoteWidgetCard.tsx
@@ -24,6 +24,7 @@ import { RemoteMusicControl } from './controls/RemoteMusicControl';
 import { RemoteNextUpControl } from './controls/RemoteNextUpControl';
 import { RemoteSoundControl } from './controls/RemoteSoundControl';
 import { RemoteWebcamControl } from './controls/RemoteWebcamControl';
+import { RemoteActivityWallControl } from './controls/RemoteActivityWallControl';
 
 interface RemoteWidgetCardProps {
   widget: WidgetData;
@@ -128,6 +129,13 @@ const renderControls = (
     case 'webcam':
       return (
         <RemoteWebcamControl widget={widget} updateWidget={updateWidget} />
+      );
+    case 'activity-wall':
+      return (
+        <RemoteActivityWallControl
+          widget={widget}
+          updateWidget={updateWidget}
+        />
       );
     default:
       return (

--- a/components/remote/controls/RemoteActivityWallControl.test.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.test.tsx
@@ -1,0 +1,211 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteActivityWallControl } from './RemoteActivityWallControl';
+import { WidgetData } from '@/types';
+
+const {
+  mockUpdateDoc,
+  mockDeleteDoc,
+  mockOnSnapshot,
+  mockCollection,
+  mockDoc,
+  mockUser,
+  mockCanAccessFeature,
+} = vi.hoisted(() => ({
+  mockUpdateDoc: vi.fn(),
+  mockDeleteDoc: vi.fn(),
+  mockOnSnapshot: vi.fn(),
+  mockCollection: vi.fn(),
+  mockDoc: vi.fn(),
+  mockUser: { uid: 'teacher-1' },
+  mockCanAccessFeature: vi.fn(() => true),
+}));
+
+let snapshotDocs: Record<string, unknown>[] = [];
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: mockUser,
+    canAccessFeature: mockCanAccessFeature,
+  }),
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collection: mockCollection,
+  doc: mockDoc,
+  onSnapshot: mockOnSnapshot,
+  updateDoc: mockUpdateDoc,
+  deleteDoc: mockDeleteDoc,
+}));
+
+const baseWidget: WidgetData = {
+  id: 'widget-1',
+  type: 'activity-wall',
+  x: 0,
+  y: 0,
+  w: 4,
+  h: 4,
+  z: 1,
+  flipped: false,
+  config: {
+    activeActivityId: 'activity-1',
+    activities: [
+      {
+        id: 'activity-1',
+        title: 'Warm Up',
+        prompt: 'Share one idea',
+        mode: 'text',
+        moderationEnabled: true,
+        identificationMode: 'anonymous',
+        submissions: [],
+        startedAt: Date.now(),
+      },
+    ],
+  },
+} as WidgetData;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  snapshotDocs = [];
+  mockCanAccessFeature.mockReturnValue(true);
+  mockCollection.mockReturnValue('submissions-ref');
+  // Each doc() call returns a distinct ref keyed by the submission id segment
+  // so assertions can verify the right submission was targeted.
+  mockDoc.mockImplementation((..._args: unknown[]) => ({
+    __ref: _args[_args.length - 1],
+  }));
+  mockUpdateDoc.mockResolvedValue(undefined);
+  mockDeleteDoc.mockResolvedValue(undefined);
+  mockOnSnapshot.mockImplementation(
+    (
+      _ref: unknown,
+      callback: (value: {
+        docs: { id: string; data: () => Record<string, unknown> }[];
+      }) => void
+    ) => {
+      callback({
+        docs: snapshotDocs.map((entry) => ({
+          id: entry.id as string,
+          data: () => entry,
+        })),
+      });
+      return vi.fn();
+    }
+  );
+});
+
+const renderControl = () =>
+  render(
+    <RemoteActivityWallControl widget={baseWidget} updateWidget={vi.fn()} />
+  );
+
+describe('RemoteActivityWallControl', () => {
+  it('renders pending submissions with a count badge', async () => {
+    snapshotDocs = [
+      {
+        id: 'submission-1',
+        content: 'Pending idea one',
+        submittedAt: 100,
+        status: 'pending',
+      },
+      {
+        id: 'submission-2',
+        content: 'Pending idea two',
+        submittedAt: 200,
+        status: 'pending',
+      },
+      {
+        id: 'submission-3',
+        content: 'Already approved',
+        submittedAt: 300,
+        status: 'approved',
+      },
+    ];
+
+    renderControl();
+
+    expect(await screen.findByText('2 pending')).toBeInTheDocument();
+    expect(screen.getByText('Pending idea one')).toBeInTheDocument();
+    expect(screen.getByText('Pending idea two')).toBeInTheDocument();
+    // Approved submissions are not part of the moderation queue.
+    expect(screen.queryByText('Already approved')).not.toBeInTheDocument();
+  });
+
+  it('approves a pending submission via updateDoc with status approved', async () => {
+    snapshotDocs = [
+      {
+        id: 'submission-1',
+        content: 'Pending idea one',
+        submittedAt: 100,
+        status: 'pending',
+      },
+    ];
+
+    renderControl();
+
+    const approveBtn = await screen.findByRole('button', {
+      name: /approve submission submission-1/i,
+    });
+    await userEvent.click(approveBtn);
+
+    await waitFor(() => {
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        { __ref: 'submission-1' },
+        { status: 'approved' }
+      );
+    });
+  });
+
+  it('removes a pending submission via deleteDoc', async () => {
+    snapshotDocs = [
+      {
+        id: 'submission-1',
+        content: 'Pending idea one',
+        submittedAt: 100,
+        status: 'pending',
+      },
+    ];
+
+    renderControl();
+
+    const removeBtn = await screen.findByRole('button', {
+      name: /remove submission submission-1/i,
+    });
+    await userEvent.click(removeBtn);
+
+    await waitFor(() => {
+      expect(mockDeleteDoc).toHaveBeenCalledWith({ __ref: 'submission-1' });
+    });
+  });
+
+  it('hides the QR affordance when anonymous-join is not permitted', async () => {
+    mockCanAccessFeature.mockReturnValue(false);
+    snapshotDocs = [];
+
+    renderControl();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /join qr/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(mockCanAccessFeature).toHaveBeenCalledWith('anonymous-join');
+  });
+
+  it('shows the QR affordance when anonymous-join is permitted', async () => {
+    mockCanAccessFeature.mockReturnValue(true);
+    snapshotDocs = [];
+
+    renderControl();
+
+    expect(
+      await screen.findByRole('button', { name: /join qr/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/components/remote/controls/RemoteActivityWallControl.test.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.test.tsx
@@ -162,6 +162,28 @@ describe('RemoteActivityWallControl', () => {
     });
   });
 
+  it('surfaces an error banner when an approve write is rejected', async () => {
+    mockUpdateDoc.mockRejectedValueOnce(new Error('x'));
+    snapshotDocs = [
+      {
+        id: 'submission-1',
+        content: 'Pending idea one',
+        submittedAt: 100,
+        status: 'pending',
+      },
+    ];
+
+    renderControl();
+
+    const approveBtn = await screen.findByRole('button', {
+      name: /approve submission submission-1/i,
+    });
+    await userEvent.click(approveBtn);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/couldn't update the submission/i);
+  });
+
   it('removes a pending submission via deleteDoc', async () => {
     snapshotDocs = [
       {

--- a/components/remote/controls/RemoteActivityWallControl.test.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.test.tsx
@@ -208,4 +208,51 @@ describe('RemoteActivityWallControl', () => {
       await screen.findByRole('button', { name: /join qr/i })
     ).toBeInTheDocument();
   });
+
+  it('renders a scannable join QR + join URL when the QR button is toggled on', async () => {
+    mockCanAccessFeature.mockReturnValue(true);
+    snapshotDocs = [];
+
+    renderControl();
+
+    // Panel is hidden until toggled.
+    expect(screen.queryByAltText(/join qr/i)).not.toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /show join qr/i })
+    );
+
+    // QR image points at the qrserver endpoint and encodes the participant
+    // join URL (which must contain the activity id, a ?data= payload, and the
+    // /activity-wall/ path the student app routes on).
+    const qrImg = await screen.findByAltText(/join qr/i);
+    const src = qrImg.getAttribute('src') ?? '';
+    expect(src).toContain('https://api.qrserver.com/v1/create-qr-code/');
+    const decoded = decodeURIComponent(src.split('data=')[1] ?? '');
+    expect(decoded).toContain('/activity-wall/activity-1');
+    expect(decoded).toContain('data=');
+
+    // The join URL is also rendered as selectable/copyable text.
+    const joinUrlText = screen.getByTestId('activity-wall-join-url');
+    expect(joinUrlText.textContent ?? '').toContain(
+      '/activity-wall/activity-1'
+    );
+  });
+
+  it('hides the QR panel (not just the button) when anonymous-join is gated off', async () => {
+    mockCanAccessFeature.mockReturnValue(false);
+    snapshotDocs = [];
+
+    renderControl();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /join qr/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByAltText(/join qr/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('activity-wall-join-url')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/components/remote/controls/RemoteActivityWallControl.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.tsx
@@ -33,6 +33,47 @@ interface RemoteActivityWallControlProps {
   updateWidget: (id: string, updates: Partial<WidgetData>) => void;
 }
 
+/**
+ * Reconstruct the EXACT participant join URL the desktop Activity Wall widget
+ * hands out. The widget builds it in `components/widgets/ActivityWall/Widget.tsx`
+ * via `buildPublicActivityLink` → `encodeActivityData`: a base64url JSON `?data=`
+ * payload appended to `/activity-wall/<activityId>`. The remote's
+ * `config.activities` carries the same `ActivityWallActivity` fields, and the
+ * teacher's `user.uid` is the `teacherUid`, so the remote can build a byte-for-byte
+ * identical URL without inventing a shape. The student app
+ * (`ActivityWallStudentApp.tsx`) decodes this `?data=` payload directly — no
+ * Firestore session-doc read or ClassLink class gate required — so a scan lands
+ * the participant in the right session immediately.
+ */
+const encodeActivityData = (
+  activity: ActivityWallActivity,
+  teacherUid: string
+): string => {
+  const payload = JSON.stringify({
+    id: activity.id,
+    title: activity.title,
+    prompt: activity.prompt,
+    mode: activity.mode,
+    moderationEnabled: activity.moderationEnabled,
+    identificationMode: activity.identificationMode,
+    teacherUid,
+  });
+  const bytes = new TextEncoder().encode(payload);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+  return encodeURIComponent(btoa(binary));
+};
+
+const buildPublicActivityLink = (
+  activity: ActivityWallActivity,
+  teacherUid: string
+): string => {
+  const encoded = encodeActivityData(activity, teacherUid);
+  return `${window.location.origin}/activity-wall/${activity.id}?data=${encoded}`;
+};
+
 /** Live submission shape mirrored from the desktop widget's onSnapshot map. */
 interface RemoteSubmission {
   id: string;
@@ -63,6 +104,20 @@ export const RemoteActivityWallControl: React.FC<
 
   const [submissions, setSubmissions] = useState<RemoteSubmission[]>([]);
   const [showQr, setShowQr] = useState(false);
+
+  // Participant join URL for the active activity, identical to the desktop
+  // widget's. Empty until an activity is active and the teacher is known.
+  const participantUrl = useMemo(() => {
+    if (!activeActivity || !user) return '';
+    return buildPublicActivityLink(activeActivity, user.uid);
+  }, [activeActivity, user]);
+
+  const qrUrl = useMemo(() => {
+    if (!participantUrl) return '';
+    return `https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(
+      participantUrl
+    )}`;
+  }, [participantUrl]);
 
   // Subscribe to the active session's submissions subcollection. Path and
   // session-id format match the desktop widget exactly so writes line up.
@@ -188,6 +243,37 @@ export const RemoteActivityWallControl: React.FC<
           <QrCode className="w-5 h-5" />
           {showQr ? 'Hide Join QR' : 'Show Join QR'}
         </button>
+      )}
+
+      {/* Join QR panel — shows a scannable code + the join URL so students can
+          land in the active session. Only meaningful with an active activity. */}
+      {canOfferAnonymousJoin && showQr && (
+        <div className="flex flex-col items-center gap-3 p-4 rounded-2xl bg-white/5 border border-white/10">
+          {participantUrl ? (
+            <>
+              <img
+                src={qrUrl}
+                alt="Join QR code"
+                width={220}
+                height={220}
+                className="rounded-xl bg-white p-2"
+              />
+              <p className="text-white/50 text-xs text-center">
+                Scan to join, or open this link:
+              </p>
+              <code
+                data-testid="activity-wall-join-url"
+                className="select-all break-all text-center text-blue-300 text-xs font-mono px-2"
+              >
+                {participantUrl}
+              </code>
+            </>
+          ) : (
+            <p className="text-white/40 text-sm text-center">
+              Start the wall to generate a join link.
+            </p>
+          )}
+        </div>
       )}
 
       {/* Moderation queue */}

--- a/components/remote/controls/RemoteActivityWallControl.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.tsx
@@ -87,7 +87,7 @@ export const RemoteActivityWallControl: React.FC<
   RemoteActivityWallControlProps
 > = ({ widget, updateWidget }) => {
   const { user, canAccessFeature } = useAuth();
-  const config = widget.config as ActivityWallConfig;
+  const config = (widget.config ?? {}) as ActivityWallConfig;
   const canOfferAnonymousJoin = canAccessFeature('anonymous-join');
 
   // Activities the widget knows about. The remote reads the same
@@ -104,6 +104,7 @@ export const RemoteActivityWallControl: React.FC<
 
   const [submissions, setSubmissions] = useState<RemoteSubmission[]>([]);
   const [showQr, setShowQr] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // Participant join URL for the active activity, identical to the desktop
   // widget's. Empty until an activity is active and the teacher is known.
@@ -175,16 +176,26 @@ export const RemoteActivityWallControl: React.FC<
 
   const approve = (submissionId: string) => {
     if (!activeActivity || !user) return;
+    setActionError(null);
     void updateDoc(submissionRef(submissionId), { status: 'approved' }).catch(
-      (err) => console.error('[RemoteActivityWall] approve failed:', err)
+      (err) => {
+        console.error('[RemoteActivityWall] approve failed:', err);
+        setActionError(
+          "Couldn't update the submission. Check your connection and try again."
+        );
+      }
     );
   };
 
   const remove = (submissionId: string) => {
     if (!activeActivity || !user) return;
-    void deleteDoc(submissionRef(submissionId)).catch((err) =>
-      console.error('[RemoteActivityWall] remove failed:', err)
-    );
+    setActionError(null);
+    void deleteDoc(submissionRef(submissionId)).catch((err) => {
+      console.error('[RemoteActivityWall] remove failed:', err);
+      setActionError(
+        "Couldn't update the submission. Check your connection and try again."
+      );
+    });
   };
 
   const toggleRunning = () => {
@@ -273,6 +284,24 @@ export const RemoteActivityWallControl: React.FC<
               Start the wall to generate a join link.
             </p>
           )}
+        </div>
+      )}
+
+      {/* Moderation action error banner */}
+      {actionError && (
+        <div
+          role="alert"
+          className="flex items-start justify-between gap-3 px-4 py-3 rounded-xl bg-red-500/20 border border-red-400/50 text-red-200 text-sm"
+        >
+          <span className="flex-1">{actionError}</span>
+          <button
+            onClick={() => setActionError(null)}
+            style={{ touchAction: 'manipulation' }}
+            className="touch-manipulation shrink-0 text-red-200/80 hover:text-red-100 font-black leading-none"
+            aria-label="Dismiss error"
+          >
+            ×
+          </button>
         </div>
       )}
 

--- a/components/remote/controls/RemoteActivityWallControl.tsx
+++ b/components/remote/controls/RemoteActivityWallControl.tsx
@@ -1,0 +1,251 @@
+/**
+ * RemoteActivityWallControl
+ *
+ * Phone remote for the Activity Wall widget. Lets a teacher:
+ *   • Start / pause the wall (toggles `config.activeActivityId`).
+ *   • Moderate the live submission queue — approve pending submissions
+ *     (`updateDoc(ref, { status: 'approved' })`) or remove them
+ *     (`deleteDoc(ref)`).
+ *   • Toggle a join-QR affordance (gated by the `anonymous-join` feature).
+ *
+ * The moderation writes target the SAME Firestore subcollection the desktop
+ * Activity Wall widget reads/writes — `activity_wall_sessions/{uid}_{activityId}
+ * /submissions` — so approve/remove reflect on the projected board live. They
+ * write DIRECTLY to Firestore (not through `updateWidget`); only start/pause
+ * goes through `updateWidget`.
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Check, Play, QrCode, Square, Trash2 } from 'lucide-react';
+import { WidgetData, ActivityWallConfig, ActivityWallActivity } from '@/types';
+import { useAuth } from '@/context/useAuth';
+import { db } from '@/config/firebase';
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  updateDoc,
+} from 'firebase/firestore';
+
+interface RemoteActivityWallControlProps {
+  widget: WidgetData;
+  updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+}
+
+/** Live submission shape mirrored from the desktop widget's onSnapshot map. */
+interface RemoteSubmission {
+  id: string;
+  content: string;
+  submittedAt: number;
+  status?: 'approved' | 'pending';
+  participantLabel?: string;
+}
+
+export const RemoteActivityWallControl: React.FC<
+  RemoteActivityWallControlProps
+> = ({ widget, updateWidget }) => {
+  const { user, canAccessFeature } = useAuth();
+  const config = widget.config as ActivityWallConfig;
+  const canOfferAnonymousJoin = canAccessFeature('anonymous-join');
+
+  // Activities the widget knows about. The remote reads the same
+  // `config.activities` the widget seeds; the active one is whichever id
+  // `config.activeActivityId` points at (set = running, null = paused).
+  const activities = useMemo<ActivityWallActivity[]>(
+    () => config.activities ?? [],
+    [config.activities]
+  );
+  const activeActivityId = config.activeActivityId ?? null;
+  const activeActivity =
+    activities.find((a) => a.id === activeActivityId) ?? null;
+  const isRunning = !!activeActivity;
+
+  const [submissions, setSubmissions] = useState<RemoteSubmission[]>([]);
+  const [showQr, setShowQr] = useState(false);
+
+  // Subscribe to the active session's submissions subcollection. Path and
+  // session-id format match the desktop widget exactly so writes line up.
+  useEffect(() => {
+    if (!activeActivity || !user) {
+      return;
+    }
+    const sessionId = `${user.uid}_${activeActivity.id}`;
+    const submissionsRef = collection(
+      db,
+      'activity_wall_sessions',
+      sessionId,
+      'submissions'
+    );
+    const unsubscribe = onSnapshot(submissionsRef, (snap) => {
+      setSubmissions(
+        snap.docs.map((docSnap) => {
+          const data = docSnap.data();
+          return {
+            // The widget reads `data.id`, which equals the doc id. Prefer
+            // `docSnap.id` for addressing writes (it's the path segment),
+            // falling back to the field for parity.
+            id: docSnap.id ?? (data.id as string),
+            content: data.content as string,
+            submittedAt: data.submittedAt as number,
+            status: data.status as 'approved' | 'pending' | undefined,
+            participantLabel: data.participantLabel as string | undefined,
+          };
+        })
+      );
+    });
+    return () => {
+      unsubscribe();
+      // Clear on teardown (dep change / pause / unmount) so a previous
+      // session's submissions don't linger once it's no longer active.
+      setSubmissions([]);
+    };
+  }, [activeActivity, user]);
+
+  const pending = useMemo(
+    () => submissions.filter((s) => s.status === 'pending'),
+    [submissions]
+  );
+
+  const submissionRef = (submissionId: string) => {
+    const sessionId = `${user?.uid}_${activeActivity?.id}`;
+    return doc(
+      db,
+      'activity_wall_sessions',
+      sessionId,
+      'submissions',
+      submissionId
+    );
+  };
+
+  const approve = (submissionId: string) => {
+    if (!activeActivity || !user) return;
+    void updateDoc(submissionRef(submissionId), { status: 'approved' }).catch(
+      (err) => console.error('[RemoteActivityWall] approve failed:', err)
+    );
+  };
+
+  const remove = (submissionId: string) => {
+    if (!activeActivity || !user) return;
+    void deleteDoc(submissionRef(submissionId)).catch((err) =>
+      console.error('[RemoteActivityWall] remove failed:', err)
+    );
+  };
+
+  const toggleRunning = () => {
+    const nextConfig: Partial<ActivityWallConfig> = {
+      ...config,
+      activeActivityId: isRunning ? null : (activities[0]?.id ?? null),
+    };
+    updateWidget(widget.id, { config: nextConfig as ActivityWallConfig });
+  };
+
+  const canStart = activities.length > 0;
+
+  return (
+    <div className="flex flex-col gap-5 p-6 h-full">
+      <div className="text-white/60 text-xs uppercase tracking-widest font-bold text-center">
+        Activity Wall
+      </div>
+
+      {/* Start / Pause */}
+      <button
+        onClick={toggleRunning}
+        disabled={!isRunning && !canStart}
+        style={{ touchAction: 'manipulation' }}
+        className={`touch-manipulation flex items-center justify-center gap-3 px-8 py-4 rounded-2xl font-black text-lg shadow-lg transition-all active:scale-95 disabled:opacity-40 ${
+          isRunning
+            ? 'bg-red-500 hover:bg-red-600 text-white'
+            : 'bg-green-500 hover:bg-green-600 text-white'
+        }`}
+        aria-label={isRunning ? 'Pause wall' : 'Start wall'}
+        aria-pressed={isRunning}
+      >
+        {isRunning ? (
+          <>
+            <Square className="w-6 h-6" /> Pause Wall
+          </>
+        ) : (
+          <>
+            <Play className="w-6 h-6" /> Start Wall
+          </>
+        )}
+      </button>
+
+      {/* Join QR toggle — gated by anonymous-join */}
+      {canOfferAnonymousJoin && (
+        <button
+          onClick={() => setShowQr((v) => !v)}
+          style={{ touchAction: 'manipulation' }}
+          className={`touch-manipulation flex items-center justify-center gap-2 px-6 py-3 rounded-xl border font-bold transition-all active:scale-95 ${
+            showQr
+              ? 'bg-blue-500/20 border-blue-400/60 text-blue-300'
+              : 'bg-white/10 border-white/20 text-white/60 hover:bg-white/20'
+          }`}
+          aria-label={showQr ? 'Hide join QR' : 'Show join QR'}
+          aria-pressed={showQr}
+        >
+          <QrCode className="w-5 h-5" />
+          {showQr ? 'Hide Join QR' : 'Show Join QR'}
+        </button>
+      )}
+
+      {/* Moderation queue */}
+      <div className="flex items-center justify-between">
+        <span className="text-white/50 text-xs uppercase tracking-wide font-bold">
+          Pending
+        </span>
+        <span
+          className="px-3 py-1 rounded-full bg-amber-500/20 border border-amber-400/50 text-amber-300 text-xs font-black"
+          aria-label={`${pending.length} pending`}
+        >
+          {pending.length} pending
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3 overflow-auto">
+        {pending.length === 0 ? (
+          <p className="text-white/30 text-sm text-center py-6">
+            {isRunning
+              ? 'No submissions waiting for approval.'
+              : 'Start the wall to collect submissions.'}
+          </p>
+        ) : (
+          pending.map((submission) => (
+            <div
+              key={submission.id}
+              className="flex items-center gap-3 p-3 rounded-xl bg-white/5 border border-white/10"
+            >
+              <div className="flex-1 min-w-0">
+                {submission.participantLabel && (
+                  <div className="text-white/40 text-[10px] uppercase tracking-wide font-bold truncate">
+                    {submission.participantLabel}
+                  </div>
+                )}
+                <div className="text-white text-sm break-words">
+                  {submission.content}
+                </div>
+              </div>
+              <button
+                onClick={() => approve(submission.id)}
+                style={{ touchAction: 'manipulation' }}
+                className="touch-manipulation shrink-0 w-11 h-11 rounded-xl bg-green-500/20 border border-green-400/50 text-green-300 flex items-center justify-center transition-all active:scale-95 hover:bg-green-500/30"
+                aria-label={`Approve submission ${submission.id}`}
+              >
+                <Check className="w-5 h-5" />
+              </button>
+              <button
+                onClick={() => remove(submission.id)}
+                style={{ touchAction: 'manipulation' }}
+                className="touch-manipulation shrink-0 w-11 h-11 rounded-xl bg-red-500/20 border border-red-400/50 text-red-300 flex items-center justify-center transition-all active:scale-95 hover:bg-red-500/30"
+                aria-label={`Remove submission ${submission.id}`}
+              >
+                <Trash2 className="w-5 h-5" />
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/components/remote/controls/RemoteClockControl.tsx
+++ b/components/remote/controls/RemoteClockControl.tsx
@@ -16,7 +16,7 @@ const ToggleRow: React.FC<{
     // touch-action:manipulation prevents the 300 ms ghost-click delay on mobile
     // and stops double-fire events that would immediately re-toggle the value.
     style={{ touchAction: 'manipulation' }}
-    className={`flex items-center justify-between w-full px-4 py-4 rounded-2xl border transition-all active:scale-95 ${
+    className={`flex items-center justify-between w-full px-4 py-4 rounded-2xl border transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
       value
         ? 'bg-blue-500/20 border-blue-400/60 text-white'
         : 'bg-white/5 border-white/10 text-white/60'

--- a/components/remote/controls/RemoteEmbedControl.test.tsx
+++ b/components/remote/controls/RemoteEmbedControl.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteEmbedControl } from './RemoteEmbedControl';
+import { WidgetData } from '@/types';
+
+const baseWidget: WidgetData = {
+  id: 'widget-1',
+  type: 'embed',
+  x: 0,
+  y: 0,
+  w: 4,
+  h: 4,
+  z: 1,
+  flipped: false,
+  maximized: false,
+  config: {
+    url: 'https://docs.google.com/presentation/d/abc123/preview',
+    mode: 'url',
+  },
+} as WidgetData;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('RemoteEmbedControl', () => {
+  it('features the embed on the board using the real maximize mechanism', async () => {
+    const updateWidget = vi.fn();
+    render(
+      <RemoteEmbedControl widget={baseWidget} updateWidget={updateWidget} />
+    );
+
+    const btn = screen.getByRole('button', { name: /feature on board/i });
+    await userEvent.click(btn);
+
+    // Must match the existing Maximize button mechanism exactly
+    // (RemoteWidgetCard handleMaximize): { maximized, flipped: false }.
+    expect(updateWidget).toHaveBeenCalledWith('widget-1', {
+      maximized: true,
+      flipped: false,
+    });
+  });
+
+  it('exits full screen when already maximized', async () => {
+    const updateWidget = vi.fn();
+    const maximizedWidget = {
+      ...baseWidget,
+      maximized: true,
+    } as WidgetData;
+    render(
+      <RemoteEmbedControl
+        widget={maximizedWidget}
+        updateWidget={updateWidget}
+      />
+    );
+
+    const btn = screen.getByRole('button', { name: /exit full screen/i });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    await userEvent.click(btn);
+
+    expect(updateWidget).toHaveBeenCalledWith('widget-1', {
+      maximized: false,
+      flipped: false,
+    });
+  });
+});

--- a/components/remote/controls/RemoteEmbedControl.tsx
+++ b/components/remote/controls/RemoteEmbedControl.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Maximize, Minimize2 } from 'lucide-react';
+import { WidgetData } from '@/types';
+
+interface RemoteEmbedControlProps {
+  widget: WidgetData;
+  updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+}
+
+/**
+ * RemoteEmbedControl — spotlight/swap only.
+ *
+ * A single large "Feature on Board" button that maximizes the embed full-screen
+ * on the projected desktop board, mirroring the existing Maximize button in
+ * RemoteWidgetCard (handleMaximize): `{ maximized, flipped: false }`. Using the
+ * same field keeps the remote and desktop on one maximize code path.
+ *
+ * NOTE: Slide next/prev navigation for Google Slides decks was assessed and found
+ * infeasible through the current embed pipeline — the stored/rendered URL is the
+ * `/preview` form, which has no slide-index contract, and `convertToEmbedUrl`
+ * strips params at render time. See
+ * docs/superpowers/spikes/2026-06-13-embed-slide-control.md (VERDICT: FAIL).
+ * This control therefore ships spotlight/swap only — no slide controls.
+ */
+export const RemoteEmbedControl: React.FC<RemoteEmbedControlProps> = ({
+  widget,
+  updateWidget,
+}) => {
+  const isMaximized = widget.maximized ?? false;
+
+  const handleFeature = () => {
+    // Same mechanism as RemoteWidgetCard's Maximize button.
+    updateWidget(widget.id, { maximized: !isMaximized, flipped: false });
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 p-6 h-full justify-center">
+      <div className="text-white/60 text-xs uppercase tracking-widest font-bold">
+        Embed
+      </div>
+
+      <button
+        onClick={handleFeature}
+        // touch-action:manipulation removes the 300 ms mobile tap delay.
+        style={{ touchAction: 'manipulation' }}
+        className={`touch-manipulation flex flex-col items-center justify-center gap-3 w-full px-6 py-10 rounded-3xl border transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
+          isMaximized
+            ? 'bg-blue-500/20 border-blue-400/60 text-blue-200'
+            : 'bg-white/10 border-white/20 text-white hover:bg-white/20'
+        }`}
+        aria-label={isMaximized ? 'Exit full screen' : 'Feature on board'}
+        aria-pressed={isMaximized}
+      >
+        {isMaximized ? (
+          <Minimize2 className="w-10 h-10" />
+        ) : (
+          <Maximize className="w-10 h-10" />
+        )}
+        <span className="font-black text-xl">
+          {isMaximized ? 'Exit Full Screen' : 'Feature on Board'}
+        </span>
+      </button>
+
+      <p className="text-white/40 text-xs text-center leading-relaxed max-w-xs">
+        Spotlight (in the header above) overlays this embed on the board without
+        maximizing it.
+      </p>
+    </div>
+  );
+};

--- a/components/remote/controls/RemotePollControl.tsx
+++ b/components/remote/controls/RemotePollControl.tsx
@@ -97,14 +97,14 @@ export const RemotePollControl: React.FC<RemotePollControlProps> = ({
                   <button
                     onClick={() => adjustVote(i, -1)}
                     disabled={(opt.votes ?? 0) <= 0}
-                    className="touch-manipulation flex-1 py-2 rounded-xl bg-white/10 hover:bg-white/20 disabled:opacity-40 font-bold flex items-center justify-center transition-all active:scale-95"
+                    className="touch-manipulation flex-1 py-2 rounded-xl bg-white/10 hover:bg-white/20 disabled:opacity-40 font-bold flex items-center justify-center transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60"
                     aria-label={`Remove vote from ${opt.label}`}
                   >
                     <Minus className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => adjustVote(i, 1)}
-                    className="touch-manipulation flex-1 py-2 rounded-xl bg-white/20 hover:bg-white/30 font-bold flex items-center justify-center transition-all active:scale-95"
+                    className="touch-manipulation flex-1 py-2 rounded-xl bg-white/20 hover:bg-white/30 font-bold flex items-center justify-center transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60"
                     aria-label={`Add vote to ${opt.label}`}
                   >
                     <Plus className="w-4 h-4" />
@@ -121,7 +121,7 @@ export const RemotePollControl: React.FC<RemotePollControlProps> = ({
         <div className="px-4 pb-3 shrink-0">
           <button
             onClick={resetVotes}
-            className="touch-manipulation w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 font-bold transition-all active:scale-95"
+            className="touch-manipulation w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-white/10 hover:bg-white/20 border border-white/20 text-white/60 font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60"
           >
             <RotateCcw className="w-4 h-4" />
             Reset All Votes

--- a/components/remote/controls/RemoteScheduleControl.tsx
+++ b/components/remote/controls/RemoteScheduleControl.tsx
@@ -90,7 +90,7 @@ export const RemoteScheduleControl: React.FC<RemoteScheduleControlProps> = ({
         </div>
         <button
           onClick={resetAll}
-          className="touch-manipulation flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/10 border border-white/20 text-white/60 text-xs font-bold transition-all active:scale-95"
+          className="touch-manipulation flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/10 border border-white/20 text-white/60 text-xs font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60"
         >
           <RotateCcw className="w-3.5 h-3.5" />
           Reset
@@ -108,7 +108,7 @@ export const RemoteScheduleControl: React.FC<RemoteScheduleControlProps> = ({
             <button
               key={item.id ?? index}
               onClick={() => toggleItem(index)}
-              className={`touch-manipulation flex items-start gap-3 w-full px-4 py-3 rounded-xl border text-left transition-all active:scale-[0.98] ${
+              className={`touch-manipulation flex items-start gap-3 w-full px-4 py-3 rounded-xl border text-left transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
                 item.done
                   ? 'bg-green-500/10 border-green-500/20 text-white/40'
                   : 'bg-white/5 border-white/10 text-white'

--- a/components/remote/controls/RemoteSoundControl.tsx
+++ b/components/remote/controls/RemoteSoundControl.tsx
@@ -79,7 +79,7 @@ export const RemoteSoundControl: React.FC<RemoteSoundControlProps> = ({
               <button
                 key={value}
                 onClick={() => setVisual(value)}
-                className={`touch-manipulation flex items-center gap-3 px-4 py-3 rounded-2xl border font-bold transition-all active:scale-95 ${
+                className={`touch-manipulation flex items-center gap-3 px-4 py-3 rounded-2xl border font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
                   isActive
                     ? 'bg-blue-500/20 border-blue-400/50 text-white'
                     : 'bg-white/5 border-white/10 text-white/50'
@@ -97,7 +97,7 @@ export const RemoteSoundControl: React.FC<RemoteSoundControlProps> = ({
       {/* Auto traffic light toggle */}
       <button
         onClick={toggleTrafficLight}
-        className={`touch-manipulation flex items-center justify-between w-full px-4 py-4 rounded-2xl border transition-all active:scale-95 ${
+        className={`touch-manipulation flex items-center justify-between w-full px-4 py-4 rounded-2xl border transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
           config.autoTrafficLight
             ? 'bg-green-500/20 border-green-400/50 text-white'
             : 'bg-white/5 border-white/10 text-white/60'

--- a/components/remote/controls/RemoteTimerControl.tsx
+++ b/components/remote/controls/RemoteTimerControl.tsx
@@ -136,14 +136,14 @@ export const RemoteTimerControl: React.FC<RemoteTimerControlProps> = ({
       <div className="flex gap-4">
         <button
           onClick={resetTimer}
-          className="touch-manipulation w-14 h-14 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white flex items-center justify-center transition-all active:scale-95"
+          className="touch-manipulation w-14 h-14 rounded-full bg-white/10 hover:bg-white/20 border border-white/20 text-white flex items-center justify-center transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60"
           aria-label="Reset"
         >
           <RotateCcw className="w-6 h-6" />
         </button>
         <button
           onClick={togglePlay}
-          className={`touch-manipulation w-20 h-20 rounded-full border-2 text-white flex items-center justify-center transition-all active:scale-95 shadow-lg ${
+          className={`touch-manipulation w-20 h-20 rounded-full border-2 text-white flex items-center justify-center transition-all active:scale-95 shadow-lg focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
             config.isRunning
               ? 'bg-red-500/80 border-red-400 hover:bg-red-500'
               : 'bg-blue-500/80 border-blue-400 hover:bg-blue-500'
@@ -166,7 +166,7 @@ export const RemoteTimerControl: React.FC<RemoteTimerControlProps> = ({
             <button
               key={s}
               onClick={() => setPreset(s)}
-              className={`touch-manipulation px-3 py-1.5 rounded-lg text-sm font-bold transition-all active:scale-95 ${
+              className={`touch-manipulation px-3 py-1.5 rounded-lg text-sm font-bold transition-all active:scale-95 focus-visible:ring-2 focus-visible:ring-blue-400/60 ${
                 config.duration === s
                   ? 'bg-blue-500 text-white'
                   : 'bg-white/10 hover:bg-white/20 text-white/80'

--- a/components/remote/useRemoteConnection.test.tsx
+++ b/components/remote/useRemoteConnection.test.tsx
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useRemoteConnection } from './useRemoteConnection';
+
+describe('useRemoteConnection', () => {
+  it('starts connected and updates lastSyncedAt when markSynced is called', () => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-06-13T10:00:00Z'));
+    const { result } = renderHook(() => useRemoteConnection());
+    expect(result.current.status).toBe('connected');
+    expect(result.current.lastSyncedAt).toBeNull();
+    act(() => {
+      result.current.markSynced();
+    });
+    expect(result.current.lastSyncedAt).toBe(
+      Date.parse('2026-06-13T10:00:00Z')
+    );
+    vi.useRealTimers();
+  });
+
+  it('reports reconnecting when the browser goes offline', () => {
+    const { result } = renderHook(() => useRemoteConnection());
+    act(() => {
+      Object.defineProperty(navigator, 'onLine', {
+        configurable: true,
+        value: false,
+      });
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(result.current.status).toBe('reconnecting');
+  });
+});

--- a/components/remote/useRemoteConnection.ts
+++ b/components/remote/useRemoteConnection.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type RemoteConnectionStatus = 'connected' | 'reconnecting';
+
+export interface RemoteConnection {
+  status: RemoteConnectionStatus;
+  lastSyncedAt: number | null;
+  markSynced: () => void;
+}
+
+/**
+ * Drives the remote's connection chip + last-synced indicator. Uses the
+ * browser online/offline signal as a cheap proxy for Firestore reachability
+ * (no new channel); `markSynced` is called whenever a fresh context snapshot
+ * is reflected so "updated just now" stays honest.
+ */
+export const useRemoteConnection = (): RemoteConnection => {
+  const [status, setStatus] = useState<RemoteConnectionStatus>(
+    typeof navigator !== 'undefined' && navigator.onLine === false
+      ? 'reconnecting'
+      : 'connected'
+  );
+  const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
+  useEffect(() => {
+    const online = () => setStatus('connected');
+    const offline = () => setStatus('reconnecting');
+    window.addEventListener('online', online);
+    window.addEventListener('offline', offline);
+    return () => {
+      window.removeEventListener('online', online);
+      window.removeEventListener('offline', offline);
+    };
+  }, []);
+  const markSynced = useCallback(() => setLastSyncedAt(Date.now()), []);
+  return { status, lastSyncedAt, markSynced };
+};

--- a/components/remote/useRemoteConnection.ts
+++ b/components/remote/useRemoteConnection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export type RemoteConnectionStatus = 'connected' | 'reconnecting';
 
@@ -32,5 +32,8 @@ export const useRemoteConnection = (): RemoteConnection => {
     };
   }, []);
   const markSynced = useCallback(() => setLastSyncedAt(Date.now()), []);
-  return { status, lastSyncedAt, markSynced };
+  return useMemo(
+    () => ({ status, lastSyncedAt, markSynced }),
+    [status, lastSyncedAt, markSynced]
+  );
 };

--- a/components/widgets/ActivityWall/Widget.test.tsx
+++ b/components/widgets/ActivityWall/Widget.test.tsx
@@ -26,6 +26,7 @@ const {
   mockHttpsCallable,
   mockGetDownloadURL,
   mockStorageRef,
+  mockCanAccessFeature,
 } = vi.hoisted(() => ({
   mockAddWidget: vi.fn<
     (
@@ -55,6 +56,10 @@ const {
   mockHttpsCallable: vi.fn(),
   mockGetDownloadURL: vi.fn(),
   mockStorageRef: vi.fn(),
+  // Phase 3b: gate on the no-sign-in (anonymous) join affordances. Defaults
+  // to allowed (set in beforeEach) so existing assertions about the
+  // "Copy link"/"Pop-out QR" buttons keep passing.
+  mockCanAccessFeature: vi.fn(() => true),
 }));
 
 let snapshotDocs: Record<string, unknown>[] = [];
@@ -74,6 +79,7 @@ vi.mock('@/context/useAuth', () => ({
     refreshGoogleToken: mockRefreshGoogleToken,
     featurePermissions: [],
     selectedBuildings: [],
+    canAccessFeature: mockCanAccessFeature,
   }),
 }));
 
@@ -165,6 +171,9 @@ describe('ActivityWallWidget', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: teacher may offer the no-sign-in join link (anonymous-join
+    // is default-public). Individual tests override to exercise the gate.
+    mockCanAccessFeature.mockReturnValue(true);
     mockUseGoogleDrive.mockReturnValue({
       isConnected: false,
     });
@@ -589,5 +598,44 @@ describe('ActivityWallWidget', () => {
     expect(widgetConfig?.config.url).toContain(
       '/activity-wall/activity-1?data='
     );
+  });
+
+  it('shows the no-sign-in join affordances when anonymous-join is allowed', async () => {
+    render(<ActivityWallWidget widget={baseWidget} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Copy link' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Pop-out QR' })
+    ).toBeInTheDocument();
+    // The view-only gallery share is a separate affordance and stays visible.
+    expect(
+      screen.getByRole('button', { name: 'Share gallery' })
+    ).toBeInTheDocument();
+  });
+
+  it('hides the no-sign-in join affordances when anonymous-join is denied', async () => {
+    // Phase 3b: an admin has restricted `anonymous-join`. The teacher loses
+    // the anonymous link/QR but keeps the view-only gallery share, and the
+    // UI degrades cleanly (no error).
+    // The widget only consults canAccessFeature for 'anonymous-join', so a
+    // blanket false models the restricted state for this gate.
+    mockCanAccessFeature.mockReturnValue(false);
+    render(<ActivityWallWidget widget={baseWidget} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'View' }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy link' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Pop-out QR' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Share gallery' })
+    ).toBeInTheDocument();
   });
 });

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -289,7 +289,14 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
     refreshGoogleToken,
     featurePermissions,
     selectedBuildings,
+    canAccessFeature,
   } = useAuth();
+  // Phase 3b (docs/wide-distro-plan.md): admin-gated capability for offering
+  // the no-sign-in (anonymous) participant join link. Default-public, so this
+  // is true for every teacher until an admin restricts `anonymous-join`. The
+  // participant route itself stays anonymous — this only hides the teacher's
+  // link/QR affordances, not the join experience.
+  const canOfferAnonymousJoin = canAccessFeature('anonymous-join');
   const { isConnected: isDriveConnected } = useGoogleDrive();
   const config = widget.config as ActivityWallConfig;
   const {
@@ -1782,45 +1789,56 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
             )}
 
             <div
-              className="grid grid-cols-3"
+              className={`grid ${
+                canOfferAnonymousJoin ? 'grid-cols-3' : 'grid-cols-1'
+              }`}
               style={{ gap: 'min(6px, 1.8cqmin)' }}
             >
-              <button
-                type="button"
-                onClick={copyLink}
-                className="rounded-xl bg-brand-blue-primary text-white font-bold flex items-center justify-center"
-                style={{
-                  gap: 'min(6px, 1.8cqmin)',
-                  padding: 'min(8px, 2cqmin)',
-                  fontSize: 'min(11px, 3.8cqmin)',
-                }}
-              >
-                <Copy
-                  style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
-                  }}
-                />
-                Copy link
-              </button>
-              <button
-                type="button"
-                onClick={spawnQrWidget}
-                className="rounded-xl bg-emerald-600 text-white font-bold flex items-center justify-center"
-                style={{
-                  gap: 'min(6px, 1.8cqmin)',
-                  padding: 'min(8px, 2cqmin)',
-                  fontSize: 'min(11px, 3.8cqmin)',
-                }}
-              >
-                <QrCode
-                  style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
-                  }}
-                />
-                Pop-out QR
-              </button>
+              {/* No-sign-in (anonymous) join affordances — gated behind the
+                  admin-configurable `anonymous-join` feature (Phase 3b). When
+                  denied, only the view-only "Share gallery" option below
+                  remains; the rostered sign-in join link is separate planned
+                  work (TODO: wire a rostered link for Activity Wall). */}
+              {canOfferAnonymousJoin && (
+                <>
+                  <button
+                    type="button"
+                    onClick={copyLink}
+                    className="rounded-xl bg-brand-blue-primary text-white font-bold flex items-center justify-center"
+                    style={{
+                      gap: 'min(6px, 1.8cqmin)',
+                      padding: 'min(8px, 2cqmin)',
+                      fontSize: 'min(11px, 3.8cqmin)',
+                    }}
+                  >
+                    <Copy
+                      style={{
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
+                      }}
+                    />
+                    Copy link
+                  </button>
+                  <button
+                    type="button"
+                    onClick={spawnQrWidget}
+                    className="rounded-xl bg-emerald-600 text-white font-bold flex items-center justify-center"
+                    style={{
+                      gap: 'min(6px, 1.8cqmin)',
+                      padding: 'min(8px, 2cqmin)',
+                      fontSize: 'min(11px, 3.8cqmin)',
+                    }}
+                  >
+                    <QrCode
+                      style={{
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
+                      }}
+                    />
+                    Pop-out QR
+                  </button>
+                </>
+              )}
               <button
                 type="button"
                 onClick={() => setIsShareModalOpen(true)}

--- a/config/featureDefaults.test.ts
+++ b/config/featureDefaults.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { FEATURE_DEFAULTS } from './featureDefaults';
+
+describe('FEATURE_DEFAULTS', () => {
+  it('declares an anonymous-join entry that is default-public', () => {
+    // Phase 3b: the no-sign-in join link must stay available to every
+    // teacher until an admin restricts it, so the missing-doc default is
+    // public (docs/wide-distro-plan.md).
+    const entry = FEATURE_DEFAULTS['anonymous-join'];
+    expect(entry).toBeDefined();
+    expect(entry.defaultAccessLevel).toBe('public');
+    expect(entry.defaultEnabled).toBe(true);
+    expect(entry.missingDocPublic).toBe(true);
+  });
+});

--- a/config/featureDefaults.ts
+++ b/config/featureDefaults.ts
@@ -149,4 +149,13 @@ export const FEATURE_DEFAULTS: Record<GlobalFeature, FeatureDefault> = {
     defaultEnabled: true,
     missingDocPublic: true,
   },
+  // Default-public preserves today's behavior: every teacher keeps the
+  // no-sign-in (anonymous) join link until an admin creates a restricting
+  // doc (docs/wide-distro-plan.md Phase 3b). Gates the TEACHER's ability to
+  // offer the link, not the participant join experience.
+  'anonymous-join': {
+    defaultAccessLevel: 'public',
+    defaultEnabled: true,
+    missingDocPublic: true,
+  },
 };

--- a/context/DashboardContext.immediate.test.tsx
+++ b/context/DashboardContext.immediate.test.tsx
@@ -287,4 +287,45 @@ describe('DashboardContext immediate-write fast-path', () => {
     });
     expect(saveDashboardMock).toHaveBeenCalledTimes(1);
   });
+
+  it('does not let an immediate write leak its 0ms fast-path onto a following normal write', async () => {
+    const stateRef = setup();
+    await settleSnapshot(stateRef, [makeDashboard([makeWidget('w1')])]);
+    saveDashboardMock.mockClear();
+
+    // 1) Immediate write — schedules a 0ms flush.
+    act(() => {
+      stateRef.current?.updateWidget(
+        'w1',
+        { config: { text: 'immediate' } as WidgetData['config'] },
+        { immediate: true }
+      );
+    });
+
+    // 2) Normal write lands BEFORE the 0ms timer fires. This re-runs the
+    //    auto-save effect, clearing the immediate write's pending timer. If the
+    //    immediate flag were still set at this point, the normal write would
+    //    inherit the 0ms fast-path and flush immediately, defeating its debounce.
+    act(() => {
+      stateRef.current?.updateWidget('w1', {
+        config: { text: 'normal' } as WidgetData['config'],
+      });
+    });
+    expect(
+      stateRef.current?.activeDashboard?.widgets[0].config as { text: string }
+    ).toMatchObject({ text: 'normal' });
+
+    // 3) After ~20ms the normal write must NOT have persisted (still in its
+    //    800ms debounce). No leak means saveDashboard is untouched here.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    expect(saveDashboardMock).not.toHaveBeenCalled();
+
+    // 4) Only after the full 800ms config debounce does it persist.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+    expect(saveDashboardMock).toHaveBeenCalled();
+  });
 });

--- a/context/DashboardContext.immediate.test.tsx
+++ b/context/DashboardContext.immediate.test.tsx
@@ -1,0 +1,290 @@
+import React, { useEffect } from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DashboardProvider } from './DashboardContext';
+import { useDashboard } from './useDashboard';
+import { Dashboard, WidgetData } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors DashboardContext.bringToFront.test.tsx)
+// ---------------------------------------------------------------------------
+
+// Stable singleton — see firestoreMock note. Returning a fresh object/fns each
+// render churns identity-sensitive deps (driveService memo, load effect) and
+// keeps `loading` pinned true.
+const authMock = {
+  user: {
+    uid: 'test-user',
+    displayName: 'Test User',
+    email: 'test@example.com',
+  },
+  isAdmin: false,
+  featurePermissions: [],
+  selectedBuildings: [],
+  savedWidgetConfigs: {},
+  saveWidgetConfig: vi.fn(),
+  refreshGoogleToken: vi.fn(),
+  googleAccessToken: null,
+  remoteControlEnabled: true,
+  profileLoaded: true,
+};
+
+vi.mock('./useAuth', () => ({
+  useAuth: () => authMock,
+}));
+
+const driveMock = {
+  driveService: null,
+  userDomain: 'example.com',
+  isConnected: false,
+};
+
+vi.mock('../hooks/useGoogleDrive', () => ({
+  useGoogleDrive: () => driveMock,
+}));
+
+type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+let capturedSnapshotCb: SnapshotCb | null = null;
+// Latest dashboards pushed via the snapshot. Replayed synchronously on every
+// (re)subscribe, mirroring real Firestore — without this the load effect's
+// re-subscriptions leave `loading` stuck true (no snapshot to clear it).
+const saveDashboardMock = vi.fn().mockResolvedValue(Date.now());
+
+// IMPORTANT: the mock returns a STABLE singleton object. The DashboardProvider
+// load effect depends on `subscribeToDashboards`, so returning fresh function
+// identities each render (as a naive `() => ({...})` mock does) would make that
+// effect re-run every render, re-calling `setLoading(true)` forever and
+// trapping the auto-save effect behind its `loading` guard.
+const firestoreMock = {
+  saveDashboard: saveDashboardMock,
+  saveDashboards: vi.fn().mockResolvedValue(undefined),
+  deleteDashboard: vi.fn().mockResolvedValue(undefined),
+  subscribeToDashboards: vi.fn((cb: SnapshotCb) => {
+    capturedSnapshotCb = cb;
+    return () => {
+      // cleanup
+    };
+  }),
+  shareDashboard: vi.fn(),
+  loadSharedDashboard: vi.fn().mockResolvedValue(null),
+  rosters: [],
+  addRoster: vi.fn(),
+  updateRoster: vi.fn(),
+  deleteRoster: vi.fn(),
+  setActiveRoster: vi.fn(),
+  activeRosterId: null,
+};
+
+vi.mock('../hooks/useFirestore', () => ({
+  useFirestore: () => firestoreMock,
+}));
+
+vi.mock('../hooks/useRosters', () => ({
+  useRosters: () => ({
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useSharedCollection', () => ({
+  useSharedCollection: () => ({
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test consumer
+// ---------------------------------------------------------------------------
+
+interface ContextSnapshot {
+  dashboards: Dashboard[];
+  activeDashboard: Dashboard | null;
+  loading: boolean;
+  updateWidget: (
+    id: string,
+    updates: Partial<WidgetData>,
+    opts?: { immediate?: boolean }
+  ) => void;
+}
+
+const TestConsumer: React.FC<{
+  stateRef: { current: ContextSnapshot | null };
+}> = ({ stateRef }) => {
+  const ctx = useDashboard();
+  useEffect(() => {
+    stateRef.current = {
+      dashboards: ctx.dashboards,
+      activeDashboard: ctx.activeDashboard,
+      loading: ctx.loading,
+      updateWidget: ctx.updateWidget,
+    };
+  });
+  return null;
+};
+
+function setup() {
+  const stateRef: { current: ContextSnapshot | null } = { current: null };
+  render(
+    <DashboardProvider>
+      <TestConsumer stateRef={stateRef} />
+    </DashboardProvider>
+  );
+  return stateRef;
+}
+
+function makeWidget(id: string): WidgetData {
+  return {
+    id,
+    type: 'text',
+    x: 0,
+    y: 0,
+    w: 1,
+    h: 1,
+    z: 1,
+    flipped: false,
+    config: { text: 'test' } as WidgetData['config'],
+  };
+}
+
+function makeDashboard(widgets: WidgetData[]): Dashboard {
+  return {
+    id: 'dash-1',
+    name: 'Test Board',
+    background: 'bg-slate-900',
+    widgets,
+    createdAt: 1000,
+    updatedAt: 1000,
+  };
+}
+
+async function pushSnapshot(dashboards: Dashboard[]): Promise<void> {
+  if (!capturedSnapshotCb) throw new Error('Provider not mounted');
+  const cb = capturedSnapshotCb;
+  await act(async () => {
+    cb(dashboards, false);
+    await Promise.resolve();
+  });
+}
+
+// Deliver the snapshot and let effects flush so `loading` lands on false and
+// an active dashboard is selected before the auto-save assertions run.
+async function settleSnapshot(
+  stateRef: { current: ContextSnapshot | null },
+  dashboards: Dashboard[]
+): Promise<void> {
+  await pushSnapshot(dashboards);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  if (!stateRef.current?.activeDashboard)
+    throw new Error('active dashboard not loaded');
+  if (stateRef.current?.loading)
+    throw new Error('loading did not settle to false');
+}
+
+describe('DashboardContext immediate-write fast-path', () => {
+  beforeEach(() => {
+    capturedSnapshotCb = null;
+    saveDashboardMock.mockClear();
+    saveDashboardMock.mockResolvedValue(Date.now());
+    firestoreMock.subscribeToDashboards.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flushes an immediate config write before the 800ms debounce, while a normal write waits', async () => {
+    const stateRef = setup();
+    await settleSnapshot(stateRef, [makeDashboard([makeWidget('w1')])]);
+    saveDashboardMock.mockClear();
+
+    // Normal config write: should NOT have persisted within ~20ms.
+    act(() => {
+      stateRef.current?.updateWidget('w1', {
+        config: { text: 'normal' } as WidgetData['config'],
+      });
+    });
+    // Sanity: the write mutated context state.
+    expect(
+      stateRef.current?.activeDashboard?.widgets[0].config as { text: string }
+    ).toMatchObject({ text: 'normal' });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    expect(saveDashboardMock).not.toHaveBeenCalled();
+
+    // Let the 800ms config debounce flush so we start clean for the
+    // immediate-write assertion.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(saveDashboardMock).toHaveBeenCalled(); // normal write did eventually flush
+    saveDashboardMock.mockClear();
+
+    // Immediate config write: should persist within ~20ms.
+    act(() => {
+      stateRef.current?.updateWidget(
+        'w1',
+        { config: { text: 'immediate' } as WidgetData['config'] },
+        { immediate: true }
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    expect(saveDashboardMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -390,7 +390,12 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // not a useEffect — per CLAUDE.md, refs derived from values can be
   // assigned in the render body and don't need an effect.
   const updateWidgetRef = useRef<
-    ((id: string, updates: Partial<WidgetData>) => void) | null
+    | ((
+        id: string,
+        updates: Partial<WidgetData>,
+        opts?: { immediate?: boolean }
+      ) => void)
+    | null
   >(null);
   // Keep a ref to account-level remote control so the Firestore snapshot
   // handler can read the latest value without triggering a re-subscription.
@@ -1197,6 +1202,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // (e.g. spotlight/maximize toggle).  Used to apply a faster Firestore
   // write debounce for these small, high-priority changes.
   const lastUpdateWasSettingsOnly = useRef<boolean>(false);
+  // Set true by a remote-originated control write to bypass the auto-save
+  // debounce for that one scheduling pass; consumed (reset) inside the effect.
+  const pendingImmediateWrite = useRef<boolean>(false);
   // Counter (not boolean) to correctly track overlapping in-flight saves
   const pendingSaveCountRef = useRef<number>(0);
   // Tracks Drive file IDs for PII supplements per dashboard to enable in-place updates
@@ -2226,16 +2234,19 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     // Settings-only changes (spotlight, maximize) are small and urgent —
     // use a fast 100 ms debounce so the desktop board reflects remote-
     // controlled presentation changes with minimal perceived delay.
-    const debounceMs = isStructuralChange
-      ? 200 // add/remove widget
-      : lastUpdateWasSettingsOnly.current
-        ? 100 // settings toggle (spotlight, maximize, etc.)
-        : 800; // widget config / position
+    const debounceMs = pendingImmediateWrite.current
+      ? 0 // remote control write — flush now
+      : isStructuralChange
+        ? 200 // add/remove widget
+        : lastUpdateWasSettingsOnly.current
+          ? 100 // settings toggle (spotlight, maximize, etc.)
+          : 800; // widget config / position
 
     const showSavingTimer = setTimeout(() => setIsSaving(true), 0);
     auxTimers.add(showSavingTimer);
     saveTimerRef.current = setTimeout(() => {
       lastUpdateWasSettingsOnly.current = false; // reset after consuming debounce
+      pendingImmediateWrite.current = false; // reset after consuming debounce
       const savedData = currentData;
       // Capture per-field state at save time for field-granular merge decisions
       const savedFields = {
@@ -4657,11 +4668,16 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [activeId, addToast]);
 
   const updateWidget = useCallback(
-    (id: string, updates: Partial<WidgetData>) => {
+    (
+      id: string,
+      updates: Partial<WidgetData>,
+      opts?: { immediate?: boolean }
+    ) => {
       if (!activeIdRef.current) return;
       if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = false;
+      if (opts?.immediate) pendingImmediateWrite.current = true;
 
       // A pixel-size change implies the user resized — refresh aspectRatio.
       // A pure position change keeps the locked aspect ratio.
@@ -5068,11 +5084,15 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const updateDashboardSettings = useCallback(
-    (updates: Partial<Dashboard['settings']>) => {
+    (
+      updates: Partial<Dashboard['settings']>,
+      opts?: { immediate?: boolean }
+    ) => {
       if (!activeIdRef.current) return;
       if (isActiveBoardReadOnlyRef.current) return;
       lastLocalUpdateAt.current = Date.now();
       lastUpdateWasSettingsOnly.current = true;
+      if (opts?.immediate) pendingImmediateWrite.current = true;
       setDashboards((prev) =>
         prev.map((d) =>
           d.id === activeIdRef.current
@@ -5386,8 +5406,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // Empty deps is the point: identity fixed for the provider's lifetime.
   const stableActions = useMemo<DashboardActions>(
     () => ({
-      updateWidget: (id, updates) =>
-        liveActionsRef.current.updateWidget(id, updates),
+      updateWidget: (id, updates, opts) =>
+        liveActionsRef.current.updateWidget(id, updates, opts),
       updateWidgets: (updates) => liveActionsRef.current.updateWidgets(updates),
       removeWidget: (id) => liveActionsRef.current.removeWidget(id),
       duplicateWidget: (id) => liveActionsRef.current.duplicateWidget(id),

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -2241,12 +2241,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         : lastUpdateWasSettingsOnly.current
           ? 100 // settings toggle (spotlight, maximize, etc.)
           : 800; // widget config / position
+    // The immediate-write flag has now been consumed for this scheduling pass.
+    // Reset it immediately so that a normal write whose state update lands
+    // before the 0 ms timer fires (re-running this effect) does not inherit the
+    // immediate fast-path and lose its own debounce. See immediate.test.tsx.
+    pendingImmediateWrite.current = false;
 
     const showSavingTimer = setTimeout(() => setIsSaving(true), 0);
     auxTimers.add(showSavingTimer);
     saveTimerRef.current = setTimeout(() => {
       lastUpdateWasSettingsOnly.current = false; // reset after consuming debounce
-      pendingImmediateWrite.current = false; // reset after consuming debounce
+      // pendingImmediateWrite is reset on consume (above, right after debounceMs)
       const savedData = currentData;
       // Capture per-field state at save time for field-granular merge decisions
       const savedFields = {

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -187,7 +187,11 @@ export interface DashboardContextValue {
   removeWidgets: (ids: string[]) => void;
   clearAllStickers: () => void;
   clearAllWidgets: () => void;
-  updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+  updateWidget: (
+    id: string,
+    updates: Partial<WidgetData>,
+    opts?: { immediate?: boolean }
+  ) => void;
   bringToFront: (id: string) => void;
   moveWidgetLayer: (id: string, direction: 'up' | 'down') => void;
   minimizeAllWidgets: () => void;
@@ -202,7 +206,10 @@ export interface DashboardContextValue {
   reorderLibrary: (tools: (WidgetType | InternalToolType)[]) => void;
   reorderDockItems: (items: DockItem[]) => void;
   libraryOrder: (WidgetType | InternalToolType)[];
-  updateDashboardSettings: (settings: Partial<Dashboard['settings']>) => void;
+  updateDashboardSettings: (
+    settings: Partial<Dashboard['settings']>,
+    opts?: { immediate?: boolean }
+  ) => void;
   updateDashboard: (updates: Partial<Dashboard>) => void;
 
   // Annotation (ephemeral full-screen draw-over overlay; NOT a widget)

--- a/docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md
+++ b/docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md
@@ -1,0 +1,65 @@
+# Remote Control v2 — Two-Device Smoke Test (acceptance gate, pre-Tuesday)
+
+Setup: projected board open on desktop (logged in), phone open to
+`/remote?boardId=<id>` (same account). Test on the dev preview first, then
+re-run once on `main` after deploy.
+
+## Latency (priority 1)
+
+- [ ] Timer start/pause/reset reflects on the board in ~300–500ms (reads as instant).
+- [ ] Traffic light colour change reflects near-instantly.
+- [ ] Poll reveal reflects near-instantly.
+- [ ] Structural change (add/remove a widget on desktop) still debounces normally (no thrash).
+
+## Reliability + feedback (priority 2)
+
+- [ ] Connection chip shows "Connected" on a good network.
+- [ ] Toggle phone airplane mode → chip shows "Reconnecting…"; restore → "Connected".
+- [ ] No command is silently dropped across a brief disconnect/reconnect.
+- [ ] "Updated just now" / last-synced indicator appears after a sync.
+- [ ] Each control button shows a brief press-confirm (scale/ring) on tap.
+- [ ] Live sync: change a widget on the desktop → the phone reflects it WITHOUT tapping Sync.
+- [ ] Pending-guard: rapidly drive a widget from the phone → the desktop echo does not revert the phone within 5s.
+
+## Demo widgets (priority 3)
+
+- [ ] Timer / stopwatch: start, pause, reset all drive the board.
+- [ ] Traffic light: red/yellow/green/off all drive the board.
+- [ ] Poll: reveal/hide drives the board.
+- [ ] Noise meter (sound): control drives the board.
+- [ ] Schedule: control drives the board.
+- [ ] Clock: control drives the board.
+
+## Activity Wall (new)
+
+- [ ] **Start the wall on the DESKTOP first** (see caveat below), confirm it is running.
+- [ ] Pending count badge on the phone matches the number of unapproved submissions.
+- [ ] Approve from the phone moves a submission onto the board (live).
+- [ ] Remove from the phone deletes the submission from the board (live).
+- [ ] Join QR button shows only when `anonymous-join` is permitted; hidden cleanly otherwise.
+- [ ] (If your widget's activities are NOT migrated to the library) Start/Pause from
+      the phone toggles the wall — otherwise expect Start/Pause to no-op (caveat below).
+
+> **Caveat — Activity Wall Start/Pause from the remote.** The remote reads
+> activities from `widget.config.activities`. Some Activity Wall widgets store
+> their activities in the Firestore-backed library (post-migration) with an
+> empty `config.activities`; for those, the remote Start button has nothing to
+> start. **Moderation of an already-running wall works regardless** (it keys off
+> `config.activeActivityId` + the live submissions subcollection). For Tuesday:
+> start the wall on the projected desktop, then moderate from the phone — the
+> core engagement loop. Wiring the remote to the activity library is deferred
+> follow-up work.
+
+## Embed (new)
+
+- [ ] "Feature on Board" maximizes the embed full-screen; "Exit Full Screen" restores.
+- [ ] Spotlight (header) overlays the embed without maximizing.
+- [ ] Slide next/prev is intentionally ABSENT — confirmed infeasible by the Task 1
+      spike (`docs/superpowers/spikes/2026-06-13-embed-slide-control.md`); advance
+      slides with the deck's own remote/arrow keys, feature/spotlight from the phone.
+
+## Sign-off
+
+- [ ] All priority-1 and priority-2 items pass.
+- [ ] All demo widgets pass.
+- [ ] Ready to PR `dev-paul` → `main` and deploy before Tuesday.

--- a/docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md
+++ b/docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md
@@ -37,6 +37,7 @@ re-run once on `main` after deploy.
 - [ ] Approve from the phone moves a submission onto the board (live).
 - [ ] Remove from the phone deletes the submission from the board (live).
 - [ ] Join QR button shows only when `anonymous-join` is permitted; hidden cleanly otherwise.
+- [ ] Approve/remove fails gracefully with a visible error banner if the Firestore write is rejected (e.g. offline).
 - [ ] (If your widget's activities are NOT migrated to the library) Start/Pause from
       the phone toggles the wall — otherwise expect Start/Pause to no-op (caveat below).
 

--- a/docs/superpowers/plans/2026-06-13-remote-control-v2.md
+++ b/docs/superpowers/plans/2026-06-13-remote-control-v2.md
@@ -1,0 +1,939 @@
+# Remote Control v2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing teacher remote (`/remote`) feel production-quality for Tuesday's live-board presentation by cutting tap-to-board latency, adding live two-way sync + reliability UI, and shipping Activity Wall and Embed remote controls.
+
+**Architecture:** The remote reuses the dashboard's existing Firestore transport (`updateWidget`/`updateDashboardSettings` → `DashboardContext` debounced auto-save → `onSnapshot` on desktop). We thread an additive `{ immediate: true }` intent flag from remote control call sites through `updateWidget`/`updateDashboardSettings` into the save scheduler so control writes flush immediately while structural/position writes keep their current debounce. `MobileRemoteView` switches from manual-Sync-only to live snapshot reflection (keeping its 5s pending-write echo guard) and gains a connection chip, last-synced indicator, and tap feedback. New `RemoteActivityWallControl` reuses the Activity Wall submissions subcollection and its read/write shapes; the Embed control ships spotlight/swap (slide nav only if the spike passes).
+
+**Tech Stack:** React + Vite + TypeScript, Firebase/Firestore (modular SDK), pnpm, vitest + @testing-library/react.
+
+---
+
+## File Structure
+
+| File                                                             | Create/Modify | Single responsibility                                                                                                                                                       |
+| ---------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `docs/superpowers/spikes/2026-06-13-embed-slide-control.md`      | Create        | Written outcome of the Embed slide-control feasibility spike (Task 1).                                                                                                      |
+| `context/DashboardContext.tsx`                                   | Modify        | Thread an `immediate` intent flag through `updateWidget`/`updateDashboardSettings` into the debounced auto-save effect so control writes bypass the debounce (Task 2).      |
+| `context/DashboardContext.immediate.test.tsx`                    | Create        | Unit tests asserting control writes schedule immediately while structural/position writes stay debounced (Task 2).                                                          |
+| `components/remote/MobileRemoteView.tsx`                         | Modify        | Live snapshot reflection (no manual Sync required), connection status chip, last-synced indicator; pass `immediate` through write-through handlers (Task 3).                |
+| `components/remote/MobileRemoteView.test.tsx`                    | Create        | Tests for live-sync reflection + pending-guard echo suppression + connection chip (Task 3).                                                                                 |
+| `components/remote/useRemoteConnection.ts`                       | Create        | Hook returning Firestore connection status + last-synced timestamp for the chip/indicator (Task 3).                                                                         |
+| `components/remote/useRemoteConnection.test.tsx`                 | Create        | Unit test for the connection hook (Task 3).                                                                                                                                 |
+| `components/remote/controls/RemoteActivityWallControl.tsx`       | Create        | Activity Wall remote control: active/pause toggle, QR affordance (anonymous-join gated), pending-queue listener, approve, remove, count badge (Task 4).                     |
+| `components/remote/controls/RemoteActivityWallControl.test.tsx`  | Create        | Tests for the Activity Wall control (Task 4).                                                                                                                               |
+| `components/remote/RemoteWidgetCard.tsx`                         | Modify        | Register `activity-wall` → `RemoteActivityWallControl` and `embed` → `RemoteEmbedControl` in `renderControls`; add tap-feedback prop pass-through (Task 4, Task 5, Task 6). |
+| `components/remote/controls/RemoteEmbedControl.tsx`              | Create        | Embed remote control: spotlight/swap (always); slide prev/next only if the spike passed (Task 5).                                                                           |
+| `components/remote/controls/RemoteEmbedControl.test.tsx`         | Create        | Tests for the Embed control (Task 5).                                                                                                                                       |
+| `docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md` | Create        | Manual two-device acceptance checklist (Task 7).                                                                                                                            |
+
+Reference points (read before editing):
+
+- Debounced auto-save effect: `context/DashboardContext.tsx` L2180–2294. Tiers (L2229–2233): `200` structural (`isStructuralChange`), `100` settings-only (`lastUpdateWasSettingsOnly.current`), `800` config/position. `updateWidget` def L4659–4733 (sets `lastUpdateWasSettingsOnly.current = false`, L4664). `updateDashboardSettings` def L5070–5091 (sets `lastUpdateWasSettingsOnly.current = true`, L5075). Context value exports L5493+ / L5619+.
+- `MobileRemoteView`: `components/remote/MobileRemoteView.tsx` — `REMOTE_SUPPORTED_TYPES` L40–56, `REMOTE_SKIP_TYPES` L59–65, live auto-sync effect with `pendingWidgetTimers` 5s guard L148–178, `handleUpdateWidget` L195–219, `handleUpdateDashboardSettings` L224–236, Sync button L356–366.
+- `RemoteWidgetCard`: `components/remote/RemoteWidgetCard.tsx` — `renderControls` switch L73–146, Spotlight/Maximize L159–173.
+- Control templates: `components/remote/controls/RemoteTrafficLightControl.tsx` (config write pattern), `RemoteNextUpControl.tsx` (active-toggle + counter pattern).
+- Activity Wall: `components/widgets/ActivityWall/Widget.tsx` — `LiveSubmission` L220–232, submissions subcollection listener L470–504 (path `collection(db, 'activity_wall_sessions', `${user.uid}_${activeActivity.id}`, 'submissions')`), `moderationCounts` L1096–1106, `deleteSubmission` (deleteDoc) L1202–1257, session metadata `setDoc(doc(db,'activity_wall_sessions',activeSessionId), { active... })` L452–467, `activeActivityId` selects active activity L336/L849. Type id is `'activity-wall'` (`types.ts` L58). `canOfferAnonymousJoin = canAccessFeature('anonymous-join')` L299.
+- Embed: `components/widgets/Embed/Widget.tsx` — config L45–56, iframe `src={finalEmbedUrl}` L568, `finalEmbedUrl = applyStartAt(applyAutoplay(embedUrl, autoplay), startAtSeconds)` L215–218. `EmbedConfig` `types.ts` L1142–1153. `convertToEmbedUrl` `utils/urlHelpers.ts` L68; Google Slides branch L151–167 rewrites to `/presentation/d/<id>/preview` and **clears `parsed.search`/`parsed.hash`** (L163–164).
+- Firebase mock convention (co-located tests): `components/widgets/ActivityWall/Widget.test.tsx` L104–133 — `vi.mock('@/config/firebase', () => ({ db: {}, functions: {}, storage: {} }))` and `vi.mock('firebase/firestore', () => ({ collection, doc, onSnapshot, setDoc, updateDoc, deleteDoc, ... }))`.
+- Existing remote test conventions: `components/layout/RemoteControlMenu.test.tsx` — `vi.mock('@/context/useDashboard')`, `vi.mock('@/context/useAuth')`, `@testing-library/user-event`.
+
+Run all tests with `pnpm vitest run <path>`. Pre-commit runs eslint+prettier; commit messages are prefixed `[AI] `.
+
+---
+
+### Task 1: Embed slide-control feasibility spike (timeboxed — do FIRST)
+
+Investigation only — no feature code. Decide whether slide next/prev is drivable for Paul's deck. Timebox: 45 minutes. Outcome gates Task 5.
+
+**Files:**
+
+- Create: `docs/superpowers/spikes/2026-06-13-embed-slide-control.md`
+- Read: `utils/urlHelpers.ts` (`convertToEmbedUrl`, Google Slides branch L151–167), `components/widgets/Embed/Widget.tsx` (L210–218, L563–581), `components/widgets/Embed/applyStartAt.ts`, `components/widgets/Embed/applyAutoplay.ts`
+
+Steps:
+
+- [ ] Read `convertToEmbedUrl` in `utils/urlHelpers.ts` L68–167 and record exactly how a `docs.google.com/presentation/...` URL is transformed. Note (already confirmed): the Slides branch sets `parsed.pathname = '/presentation/d/<id>/preview'`, then `parsed.search = ''` and `parsed.hash = ''` (L162–164) — any `?slide=` / `#slide=id.p` is stripped.
+- [ ] Read `components/widgets/Embed/Widget.tsx` L210–218 and L563–581 — confirm the iframe `src` is `finalEmbedUrl` (derived from `convertToEmbedUrl` output) and that there is no slide-index field on `EmbedConfig` (`types.ts` L1142–1153).
+- [ ] Determine the deck format Paul will present: ask whether it is a Google Slides "publish to web" (`/presentation/d/e/<id>/pubembed?...`) link or a normal `/edit` / share link. The publish-to-web `pubembed` form supports `&slide=N` and `&start=false`, but `convertToEmbedUrl`'s Slides branch matches `/presentation/(?:u/\d+/)?d/([\w-]+)` and rewrites to `/preview`, discarding it.
+- [ ] Decision checkpoint — write the verdict in the spike doc:
+  - PASS only if the deck is a publish-to-web link whose slide param survives `convertToEmbedUrl` (it does **not** today) OR Task 5 adds a narrow bypass that preserves a slide param for `pubembed` URLs without regressing existing embeds, AND a manual two-device check shows smooth/reliable slide changes.
+  - FAIL (expected, per current code): `/preview` has no slide-index URL contract and `convertToEmbedUrl` strips query/hash, so iframe-src slide navigation is not reliably drivable. Task 5 ships spotlight/swap only.
+- [ ] Record the verdict (`PASS` or `FAIL`) and a one-line rationale at the top of `docs/superpowers/spikes/2026-06-13-embed-slide-control.md`.
+- [ ] Commit: `git add docs/superpowers/spikes/2026-06-13-embed-slide-control.md && git commit -m "[AI] Spike: Embed slide-control feasibility verdict"`
+
+---
+
+### Task 2: Latency fast-path — immediate-write intent flag
+
+Add an additive `immediate` flag so remote control writes flush to Firestore right away while structural/position writes keep their debounce. Default path unchanged.
+
+**Files:**
+
+- Modify: `context/DashboardContext.tsx` — `updateWidget` L4659–4733, `updateDashboardSettings` L5070–5091, debounce-tier logic L2223–2233, context value exports (~L5493, ~L5619)
+- Modify: `types.ts` — extend the `updateWidget`/`updateDashboardSettings` signatures in `DashboardContextType` (find the interface that types the context value)
+- Test: Create `context/DashboardContext.immediate.test.tsx`
+
+Steps:
+
+- [ ] Add an `immediate` intent ref near `lastUpdateWasSettingsOnly` (L1199 region) in `context/DashboardContext.tsx`:
+  ```tsx
+  // Set true by a remote-originated control write to bypass the auto-save
+  // debounce for that one scheduling pass; consumed (reset) inside the effect.
+  const pendingImmediateWrite = useRef<boolean>(false);
+  ```
+- [ ] Write the failing test `context/DashboardContext.immediate.test.tsx` that renders a harness consuming the context and asserts an immediate widget write schedules with a 0ms (immediate) timer while a structural write uses the 200ms debounce. Use fake timers:
+
+  ```tsx
+  import { render, act } from '@testing-library/react';
+  import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+  import { useDashboard } from '@/context/useDashboard';
+  import { DashboardProvider } from '@/context/DashboardContext';
+
+  vi.mock('@/services/dashboardService', () => ({
+    saveDashboard: vi.fn().mockResolvedValue(undefined),
+  }));
+
+  const Harness = ({
+    onReady,
+  }: {
+    onReady: (api: ReturnType<typeof useDashboard>) => void;
+  }) => {
+    const api = useDashboard();
+    onReady(api);
+    return null;
+  };
+
+  describe('updateWidget immediate fast-path', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('flushes a control write to saveDashboard before the 800ms config debounce', async () => {
+      const { saveDashboard } = await import('@/services/dashboardService');
+      let api!: ReturnType<typeof useDashboard>;
+      render(
+        <DashboardProvider>
+          <Harness
+            onReady={(a) => {
+              api = a;
+            }}
+          />
+        </DashboardProvider>
+      );
+      act(() => {
+        api.updateWidget(
+          'w1',
+          { config: { active: 'red' } },
+          { immediate: true }
+        );
+      });
+      act(() => {
+        vi.advanceTimersByTime(20);
+      });
+      expect(saveDashboard).toHaveBeenCalledTimes(1);
+    });
+  });
+  ```
+
+  > Note: if `DashboardProvider` needs auth/board fixtures to mount, mirror the provider/mocks used in the nearest existing `context/*.test.tsx`; keep the assertion (immediate flush < debounce window) intact.
+
+- [ ] Run it & expect FAIL: `pnpm vitest run context/DashboardContext.immediate.test.tsx` → fails (signature rejects the 3rd arg / write not flushed immediately).
+- [ ] Update the `updateWidget` signature and body (L4659–4664) to accept and record the flag:
+  ```tsx
+  const updateWidget = useCallback(
+    (id: string, updates: Partial<WidgetData>, opts?: { immediate?: boolean }) => {
+      if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
+      lastLocalUpdateAt.current = Date.now();
+      lastUpdateWasSettingsOnly.current = false;
+      if (opts?.immediate) pendingImmediateWrite.current = true;
+  ```
+  (leave the rest of the body L4665–4731 unchanged).
+- [ ] Update `updateDashboardSettings` (L5070–5075) the same way:
+  ```tsx
+  const updateDashboardSettings = useCallback(
+    (updates: Partial<Dashboard['settings']>, opts?: { immediate?: boolean }) => {
+      if (!activeIdRef.current) return;
+      if (isActiveBoardReadOnlyRef.current) return;
+      lastLocalUpdateAt.current = Date.now();
+      lastUpdateWasSettingsOnly.current = true;
+      if (opts?.immediate) pendingImmediateWrite.current = true;
+  ```
+- [ ] In the debounce-tier logic (L2229–2234), consume the flag so an immediate write wins and resets:
+  ```tsx
+  const debounceMs = pendingImmediateWrite.current
+    ? 0 // remote control write — flush now (Firestore round-trip is the only latency)
+    : isStructuralChange
+      ? 200 // add/remove widget
+      : lastUpdateWasSettingsOnly.current
+        ? 100 // settings toggle (spotlight, maximize, etc.)
+        : 800; // widget config / position
+  ```
+- [ ] Reset the flag where the debounce is consumed, alongside `lastUpdateWasSettingsOnly.current = false` at L2238:
+  ```tsx
+  saveTimerRef.current = setTimeout(() => {
+    lastUpdateWasSettingsOnly.current = false; // reset after consuming debounce
+    pendingImmediateWrite.current = false; // reset immediate intent after flush
+  ```
+- [ ] Update the `DashboardContextType` signatures in `types.ts` for `updateWidget` and `updateDashboardSettings` to add the optional `opts?: { immediate?: boolean }` parameter, and update any `liveActionsRef`/wrapper call sites in `DashboardContext.tsx` (e.g. L5389–5391) to forward the 3rd arg.
+- [ ] Run it & expect PASS: `pnpm vitest run context/DashboardContext.immediate.test.tsx` → passes.
+- [ ] Run the existing context suite to confirm no regression: `pnpm vitest run context/` → passes.
+- [ ] Commit: `git add context/DashboardContext.tsx context/DashboardContext.immediate.test.tsx types.ts && git commit -m "[AI] Remote v2: immediate-write fast-path through updateWidget/updateDashboardSettings"`
+
+---
+
+### Task 3: Live two-way sync + connection status + last-synced + tap feedback
+
+Reflect the live context snapshot without requiring manual Sync (keep the 5s echo guard), add a connection chip + last-synced indicator, and thread `immediate` through the write-through handlers.
+
+**Files:**
+
+- Create: `components/remote/useRemoteConnection.ts`
+- Create: `components/remote/useRemoteConnection.test.tsx`
+- Modify: `components/remote/MobileRemoteView.tsx` — handlers L195–236, top bar L324–385
+- Create: `components/remote/MobileRemoteView.test.tsx`
+
+Steps:
+
+- [ ] Write the failing test `components/remote/useRemoteConnection.test.tsx`:
+
+  ```tsx
+  import { renderHook, act } from '@testing-library/react';
+  import { describe, it, expect, vi } from 'vitest';
+  import { useRemoteConnection } from './useRemoteConnection';
+
+  describe('useRemoteConnection', () => {
+    it('starts connected and updates lastSyncedAt when markSynced is called', () => {
+      vi.useFakeTimers().setSystemTime(new Date('2026-06-13T10:00:00Z'));
+      const { result } = renderHook(() => useRemoteConnection());
+      expect(result.current.status).toBe('connected');
+      expect(result.current.lastSyncedAt).toBeNull();
+      act(() => {
+        result.current.markSynced();
+      });
+      expect(result.current.lastSyncedAt).toBe(
+        Date.parse('2026-06-13T10:00:00Z')
+      );
+      vi.useRealTimers();
+    });
+
+    it('reports reconnecting when the browser goes offline', () => {
+      const { result } = renderHook(() => useRemoteConnection());
+      act(() => {
+        Object.defineProperty(navigator, 'onLine', {
+          configurable: true,
+          value: false,
+        });
+        window.dispatchEvent(new Event('offline'));
+      });
+      expect(result.current.status).toBe('reconnecting');
+    });
+  });
+  ```
+
+- [ ] Run it & expect FAIL: `pnpm vitest run components/remote/useRemoteConnection.test.tsx` → fails (module missing).
+- [ ] Implement `components/remote/useRemoteConnection.ts`:
+
+  ```tsx
+  import { useCallback, useEffect, useState } from 'react';
+
+  export type RemoteConnectionStatus = 'connected' | 'reconnecting';
+
+  export interface RemoteConnection {
+    status: RemoteConnectionStatus;
+    lastSyncedAt: number | null;
+    markSynced: () => void;
+  }
+
+  /**
+   * Drives the remote's connection chip + last-synced indicator. Uses the
+   * browser online/offline signal as a cheap proxy for Firestore reachability
+   * (no new channel); `markSynced` is called whenever a fresh context snapshot
+   * is reflected so "updated just now" stays honest.
+   */
+  export const useRemoteConnection = (): RemoteConnection => {
+    const [status, setStatus] = useState<RemoteConnectionStatus>(
+      typeof navigator !== 'undefined' && navigator.onLine === false
+        ? 'reconnecting'
+        : 'connected'
+    );
+    const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
+
+    useEffect(() => {
+      const online = () => setStatus('connected');
+      const offline = () => setStatus('reconnecting');
+      window.addEventListener('online', online);
+      window.addEventListener('offline', offline);
+      return () => {
+        window.removeEventListener('online', online);
+        window.removeEventListener('offline', offline);
+      };
+    }, []);
+
+    const markSynced = useCallback(() => setLastSyncedAt(Date.now()), []);
+    return { status, lastSyncedAt, markSynced };
+  };
+  ```
+
+- [ ] Run it & expect PASS: `pnpm vitest run components/remote/useRemoteConnection.test.tsx` → passes.
+- [ ] Commit: `git add components/remote/useRemoteConnection.ts components/remote/useRemoteConnection.test.tsx && git commit -m "[AI] Remote v2: useRemoteConnection hook for connection chip + last-synced"`
+- [ ] Write the failing test `components/remote/MobileRemoteView.test.tsx` (live-sync reflection + pending-guard echo + connection chip). Mock `useDashboard`/`useAuth` per `RemoteControlMenu.test.tsx`:
+
+  ```tsx
+  import { render, screen, act } from '@testing-library/react';
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+  import { MobileRemoteView } from './MobileRemoteView';
+  import { useDashboard } from '@/context/useDashboard';
+  import { useAuth } from '@/context/useAuth';
+
+  vi.mock('@/context/useDashboard', () => ({ useDashboard: vi.fn() }));
+  vi.mock('@/context/useAuth', () => ({ useAuth: vi.fn() }));
+  vi.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (k: string) => k }),
+  }));
+
+  const board = (active: string | undefined) => ({
+    id: 'b1',
+    name: 'Board 1',
+    widgets: [
+      { id: 'tl', type: 'traffic', z: 1, config: { active }, version: 1 },
+    ],
+    settings: {},
+  });
+
+  describe('MobileRemoteView live sync', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        remoteControlEnabled: true,
+      });
+    });
+
+    it('reflects a new context snapshot without a manual Sync tap', () => {
+      const updateWidget = vi.fn();
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: board(undefined),
+        updateWidget,
+        updateDashboardSettings: vi.fn(),
+        loadDashboard: vi.fn(),
+        dashboards: [board(undefined)],
+      });
+      const { rerender } = render(<MobileRemoteView />);
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: board('green'),
+        updateWidget,
+        updateDashboardSettings: vi.fn(),
+        loadDashboard: vi.fn(),
+        dashboards: [board('green')],
+      });
+      act(() => rerender(<MobileRemoteView />));
+      expect(
+        screen.getByRole('button', { name: /Set traffic light to Green/i })
+      ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('renders a Connected status chip', () => {
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: board(undefined),
+        updateWidget: vi.fn(),
+        updateDashboardSettings: vi.fn(),
+        loadDashboard: vi.fn(),
+        dashboards: [board(undefined)],
+      });
+      render(<MobileRemoteView />);
+      expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+    });
+  });
+  ```
+
+  > Note: the live-sync reflection already exists (L148–178) — this test pins that behavior before the chip change so the refactor can't regress it.
+
+- [ ] Run it & expect FAIL: `pnpm vitest run components/remote/MobileRemoteView.test.tsx` → the "Connected" chip assertion fails (chip not rendered yet); reflection assertion may already pass.
+- [ ] In `MobileRemoteView.tsx`, import and use the hook near the other hooks (after L76): `const conn = useRemoteConnection();` and call `conn.markSynced()` inside the live auto-sync effect (after the `setLocalWidgets(...)` reconciliation, ~L177) and in `handleSync` (~L188).
+- [ ] Thread `immediate` through the write-through handlers. `handleUpdateWidget` (L216) becomes `ctxUpdateWidget(id, updates, { immediate: true });` and `handleUpdateDashboardSettings` (L233) becomes `ctxUpdateDashboardSettings(updates, { immediate: true });` — every remote control write is intent-classified as immediate.
+- [ ] Add the connection chip + last-synced indicator to the top bar. Insert into the centre column (replace the static subtitle at L348–353):
+  ```tsx
+  <div className="flex flex-col items-center gap-0.5">
+    <span className="text-white font-black text-sm truncate max-w-40">
+      {activeDashboard.name}
+    </span>
+    <span className="flex items-center gap-1.5 text-xs">
+      <span
+        className={`w-1.5 h-1.5 rounded-full ${
+          conn.status === 'connected'
+            ? 'bg-green-400'
+            : 'bg-amber-400 animate-pulse'
+        }`}
+      />
+      <span
+        className={
+          conn.status === 'connected' ? 'text-white/50' : 'text-amber-300'
+        }
+      >
+        {conn.status === 'connected' ? 'Connected' : 'Reconnecting…'}
+      </span>
+      {conn.lastSyncedAt && (
+        <span className="text-white/30">· updated just now</span>
+      )}
+    </span>
+  </div>
+  ```
+- [ ] Run it & expect PASS: `pnpm vitest run components/remote/MobileRemoteView.test.tsx` → passes.
+- [ ] Add tap-feedback to `RemoteWidgetCard` control buttons via the existing `active:scale-95` pattern (already present on Spotlight/Maximize L193/L215) — confirm both control buttons carry `active:scale-95` and add a brief pressed ring: append `focus-visible:ring-2 focus-visible:ring-blue-400/60` to both button `className`s (L193, L215). (Per-control press-confirm is added in Task 6 for the demo-path controls.)
+- [ ] Run the remote suite: `pnpm vitest run components/remote/` → passes.
+- [ ] Commit: `git add components/remote/MobileRemoteView.tsx components/remote/MobileRemoteView.test.tsx components/remote/RemoteWidgetCard.tsx && git commit -m "[AI] Remote v2: live sync reflection, connection chip, last-synced, immediate writes"`
+
+---
+
+### Task 4: RemoteActivityWallControl (active/pause, QR gate, moderation: pending queue, approve, remove, count badge)
+
+New control reusing the Activity Wall submissions subcollection (path `activity_wall_sessions/{teacherUid}_{activityId}/submissions`) and its read/write shapes. Approve writes `status: 'approved'` via `updateDoc`; remove uses `deleteDoc` (same as the widget's `deleteSubmission`, `Widget.tsx` L1212).
+
+**Files:**
+
+- Create: `components/remote/controls/RemoteActivityWallControl.tsx`
+- Create: `components/remote/controls/RemoteActivityWallControl.test.tsx`
+- Modify: `components/remote/RemoteWidgetCard.tsx` — import + `renderControls` switch (L73–146)
+- Modify: `components/remote/MobileRemoteView.tsx` — add `'activity-wall'` to `REMOTE_SUPPORTED_TYPES` (L40–56)
+
+Steps:
+
+- [ ] Write the failing test `components/remote/controls/RemoteActivityWallControl.test.tsx` using the ActivityWall firebase-mock convention (`Widget.test.tsx` L104–133):
+
+  ```tsx
+  import { render, screen, act } from '@testing-library/react';
+  import userEvent from '@testing-library/user-event';
+  import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+  const mockCollection = vi.fn(() => ({}));
+  const mockDoc = vi.fn(() => ({}));
+  const mockOnSnapshot = vi.fn();
+  const mockUpdateDoc = vi.fn().mockResolvedValue(undefined);
+  const mockDeleteDoc = vi.fn().mockResolvedValue(undefined);
+
+  vi.mock('@/config/firebase', () => ({ db: {} }));
+  vi.mock('firebase/firestore', () => ({
+    collection: mockCollection,
+    doc: mockDoc,
+    onSnapshot: mockOnSnapshot,
+    updateDoc: mockUpdateDoc,
+    deleteDoc: mockDeleteDoc,
+  }));
+  vi.mock('@/context/useAuth', () => ({
+    useAuth: () => ({
+      user: { uid: 'teacher1' },
+      canAccessFeature: () => true,
+    }),
+  }));
+
+  import { RemoteActivityWallControl } from './RemoteActivityWallControl';
+  import type { WidgetData } from '@/types';
+
+  const widget = {
+    id: 'aw1',
+    type: 'activity-wall',
+    z: 1,
+    version: 1,
+    config: {
+      activeActivityId: 'act1',
+      activities: [{ id: 'act1', title: 'Q', moderationEnabled: true }],
+    },
+  } as unknown as WidgetData;
+
+  const emitSubmissions = (
+    subs: Array<{ id: string; content: string; status: string }>
+  ) => {
+    const cb = mockOnSnapshot.mock.calls.at(-1)?.[1] as (snap: unknown) => void;
+    act(() =>
+      cb({
+        docs: subs.map((s) => ({ data: () => ({ ...s, submittedAt: 1 }) })),
+      })
+    );
+  };
+
+  describe('RemoteActivityWallControl', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('lists pending submissions with a count badge', () => {
+      render(
+        <RemoteActivityWallControl widget={widget} updateWidget={vi.fn()} />
+      );
+      emitSubmissions([
+        { id: 's1', content: 'hello', status: 'pending' },
+        { id: 's2', content: 'world', status: 'approved' },
+      ]);
+      expect(screen.getByText('hello')).toBeInTheDocument();
+      expect(screen.getByText(/1 pending/i)).toBeInTheDocument();
+    });
+
+    it('approve fires updateDoc with status approved', async () => {
+      const user = userEvent.setup();
+      render(
+        <RemoteActivityWallControl widget={widget} updateWidget={vi.fn()} />
+      );
+      emitSubmissions([{ id: 's1', content: 'hello', status: 'pending' }]);
+      await user.click(screen.getByRole('button', { name: /approve hello/i }));
+      expect(mockUpdateDoc).toHaveBeenCalledWith(expect.anything(), {
+        status: 'approved',
+      });
+    });
+
+    it('remove fires deleteDoc', async () => {
+      const user = userEvent.setup();
+      render(
+        <RemoteActivityWallControl widget={widget} updateWidget={vi.fn()} />
+      );
+      emitSubmissions([{ id: 's1', content: 'hello', status: 'pending' }]);
+      await user.click(screen.getByRole('button', { name: /remove hello/i }));
+      expect(mockDeleteDoc).toHaveBeenCalled();
+    });
+
+    it('hides the QR affordance when anonymous-join is gated off', () => {
+      vi.doMock('@/context/useAuth', () => ({
+        useAuth: () => ({
+          user: { uid: 'teacher1' },
+          canAccessFeature: () => false,
+        }),
+      }));
+      render(
+        <RemoteActivityWallControl widget={widget} updateWidget={vi.fn()} />
+      );
+      expect(
+        screen.queryByRole('button', { name: /show join qr/i })
+      ).toBeNull();
+    });
+  });
+  ```
+
+- [ ] Run it & expect FAIL: `pnpm vitest run components/remote/controls/RemoteActivityWallControl.test.tsx` → fails (module missing).
+- [ ] Implement `components/remote/controls/RemoteActivityWallControl.tsx`:
+
+  ```tsx
+  import React, { useEffect, useMemo, useState } from 'react';
+  import { Check, Trash2, QrCode, Play, Pause } from 'lucide-react';
+  import {
+    collection,
+    doc,
+    onSnapshot,
+    updateDoc,
+    deleteDoc,
+  } from 'firebase/firestore';
+  import { db } from '@/config/firebase';
+  import { useAuth } from '@/context/useAuth';
+  import { WidgetData } from '@/types';
+
+  interface RemoteActivityWallControlProps {
+    widget: WidgetData;
+    updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+  }
+
+  interface RemoteSubmission {
+    id: string;
+    content: string;
+    submittedAt: number;
+    status: 'approved' | 'pending';
+  }
+
+  interface AWActivity {
+    id: string;
+    title?: string;
+    moderationEnabled?: boolean;
+  }
+
+  export const RemoteActivityWallControl: React.FC<
+    RemoteActivityWallControlProps
+  > = ({ widget, updateWidget }) => {
+    const { user, canAccessFeature } = useAuth();
+    const canOfferAnonymousJoin = canAccessFeature('anonymous-join');
+    const config = widget.config as {
+      activeActivityId?: string;
+      activities?: AWActivity[];
+    };
+    const activeActivity =
+      config.activities?.find((a) => a.id === config.activeActivityId) ?? null;
+    const isActive = Boolean(config.activeActivityId);
+
+    const [submissions, setSubmissions] = useState<RemoteSubmission[]>([]);
+    const [showQr, setShowQr] = useState(false);
+
+    const sessionId =
+      user && activeActivity ? `${user.uid}_${activeActivity.id}` : null;
+
+    useEffect(() => {
+      if (!sessionId) {
+        setSubmissions([]);
+        return;
+      }
+      const ref = collection(
+        db,
+        'activity_wall_sessions',
+        sessionId,
+        'submissions'
+      );
+      const unsub = onSnapshot(ref, (snap) => {
+        setSubmissions(
+          (
+            snap as { docs: Array<{ data: () => Record<string, unknown> }> }
+          ).docs.map((d) => {
+            const data = d.data();
+            return {
+              id: data.id as string,
+              content: (data.content as string) ?? '',
+              submittedAt: (data.submittedAt as number) ?? 0,
+              status: (data.status as 'approved' | 'pending') ?? 'approved',
+            };
+          })
+        );
+      });
+      return () => unsub();
+    }, [sessionId]);
+
+    const pending = useMemo(
+      () => submissions.filter((s) => s.status === 'pending'),
+      [submissions]
+    );
+
+    const approve = (s: RemoteSubmission) => {
+      if (!sessionId) return;
+      void updateDoc(
+        doc(db, 'activity_wall_sessions', sessionId, 'submissions', s.id),
+        { status: 'approved' }
+      );
+    };
+
+    const remove = (s: RemoteSubmission) => {
+      if (!sessionId) return;
+      void deleteDoc(
+        doc(db, 'activity_wall_sessions', sessionId, 'submissions', s.id)
+      );
+    };
+
+    const toggleActive = () => {
+      updateWidget(widget.id, {
+        config: {
+          ...config,
+          activeActivityId: isActive ? undefined : config.activities?.[0]?.id,
+        },
+      });
+    };
+
+    return (
+      <div className="flex flex-col gap-4 p-6 h-full">
+        <div className="text-white/60 text-xs uppercase tracking-widest font-bold">
+          Activity Wall
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={toggleActive}
+            className={`touch-manipulation flex items-center gap-2 px-5 py-3 rounded-2xl font-black text-base transition-all active:scale-95 ${
+              isActive ? 'bg-red-500 text-white' : 'bg-green-500 text-white'
+            }`}
+            aria-label={
+              isActive ? 'Pause activity wall' : 'Start activity wall'
+            }
+            aria-pressed={isActive}
+          >
+            {isActive ? (
+              <Pause className="w-5 h-5" />
+            ) : (
+              <Play className="w-5 h-5" />
+            )}
+            {isActive ? 'Pause' : 'Start'}
+          </button>
+
+          {canOfferAnonymousJoin && (
+            <button
+              onClick={() => setShowQr((v) => !v)}
+              className={`touch-manipulation flex items-center gap-2 px-5 py-3 rounded-2xl font-bold text-base border transition-all active:scale-95 ${
+                showQr
+                  ? 'bg-blue-500/20 border-blue-400/60 text-blue-300'
+                  : 'bg-white/10 border-white/20 text-white/60'
+              }`}
+              aria-label={showQr ? 'Hide join QR' : 'Show join QR'}
+              aria-pressed={showQr}
+            >
+              <QrCode className="w-5 h-5" />
+              {showQr ? 'Hide QR' : 'Join QR'}
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-white/50 text-xs uppercase tracking-wide font-bold">
+            Pending
+          </span>
+          <span className="inline-flex items-center justify-center min-w-6 h-6 px-2 rounded-full bg-amber-400/20 border border-amber-400/50 text-amber-300 text-xs font-black">
+            {pending.length} pending
+          </span>
+        </div>
+
+        <div className="flex-1 overflow-auto flex flex-col gap-2">
+          {pending.length === 0 ? (
+            <p className="text-white/30 text-sm">No pending submissions.</p>
+          ) : (
+            pending.map((s) => (
+              <div
+                key={s.id}
+                className="flex items-center gap-2 rounded-xl bg-white/5 border border-white/10 px-3 py-2"
+              >
+                <p className="flex-1 truncate text-white/80 text-sm">
+                  {s.content}
+                </p>
+                <button
+                  onClick={() => approve(s)}
+                  className="touch-manipulation w-10 h-10 rounded-full bg-green-500/20 border border-green-400/50 text-green-300 flex items-center justify-center active:scale-95"
+                  aria-label={`Approve ${s.content}`}
+                >
+                  <Check className="w-5 h-5" />
+                </button>
+                <button
+                  onClick={() => remove(s)}
+                  className="touch-manipulation w-10 h-10 rounded-full bg-rose-500/20 border border-rose-400/50 text-rose-300 flex items-center justify-center active:scale-95"
+                  aria-label={`Remove ${s.content}`}
+                >
+                  <Trash2 className="w-5 h-5" />
+                </button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  };
+  ```
+
+  > Note: `toggleActive` mirrors the widget's `activeActivityId`-driven active/pause model (`Widget.tsx` L336/L849); approve/remove write directly to the same submissions subcollection (`Widget.tsx` L470–504, L1212) rather than re-deriving the widget's heavier `deleteSubmission` (which also handles Storage cleanup — out of scope for the remote, which only needs the Firestore write). The QR affordance is a local toggle gated by `anonymous-join`; wiring it to the desktop QR popout is a polish follow-up but the gate behavior is tested here.
+
+- [ ] Run it & expect PASS: `pnpm vitest run components/remote/controls/RemoteActivityWallControl.test.tsx` → passes.
+- [ ] Register the control in `RemoteWidgetCard.tsx`: add `import { RemoteActivityWallControl } from './controls/RemoteActivityWallControl';` (after L26) and a case in `renderControls` (before `default`, L132):
+  ```tsx
+      case 'activity-wall':
+        return (
+          <RemoteActivityWallControl widget={widget} updateWidget={updateWidget} />
+        );
+  ```
+- [ ] Add `'activity-wall'` to `REMOTE_SUPPORTED_TYPES` in `MobileRemoteView.tsx` (after `'webcam'`, L55).
+- [ ] Run the remote suite: `pnpm vitest run components/remote/` → passes.
+- [ ] Commit: `git add components/remote/controls/RemoteActivityWallControl.tsx components/remote/controls/RemoteActivityWallControl.test.tsx components/remote/RemoteWidgetCard.tsx components/remote/MobileRemoteView.tsx && git commit -m "[AI] Remote v2: RemoteActivityWallControl with live moderation (pending queue, approve, remove, count badge, QR gate)"`
+
+---
+
+### Task 5: RemoteEmbedControl (spotlight/swap always; slide prev/next only if spike PASSED)
+
+Spotlight/swap ships regardless. Slide prev/next is wired **only** if Task 1's verdict was PASS.
+
+**Files:**
+
+- Create: `components/remote/controls/RemoteEmbedControl.tsx`
+- Create: `components/remote/controls/RemoteEmbedControl.test.tsx`
+- Modify: `components/remote/RemoteWidgetCard.tsx` — import + `renderControls` switch (L73–146)
+- Modify: `components/remote/MobileRemoteView.tsx` — add `'embed'` to `REMOTE_SUPPORTED_TYPES` (L40–56)
+- Read: `docs/superpowers/spikes/2026-06-13-embed-slide-control.md` (Task 1 verdict)
+
+Steps:
+
+- [ ] Read the spike verdict in `docs/superpowers/spikes/2026-06-13-embed-slide-control.md`. If FAIL (expected), this task ships spotlight/swap only and slide controls are omitted.
+- [ ] Write the failing test `components/remote/controls/RemoteEmbedControl.test.tsx`:
+
+  ```tsx
+  import { render, screen } from '@testing-library/react';
+  import userEvent from '@testing-library/user-event';
+  import { describe, it, expect, vi } from 'vitest';
+  import { RemoteEmbedControl } from './RemoteEmbedControl';
+  import type { WidgetData } from '@/types';
+
+  const widget = {
+    id: 'em1',
+    type: 'embed',
+    z: 1,
+    version: 1,
+    maximized: false,
+    config: {
+      mode: 'url',
+      url: 'https://docs.google.com/presentation/d/abc/edit',
+    },
+  } as unknown as WidgetData;
+
+  describe('RemoteEmbedControl', () => {
+    it('feature-on-board (swap) maximizes the embed', async () => {
+      const user = userEvent.setup();
+      const updateWidget = vi.fn();
+      render(
+        <RemoteEmbedControl widget={widget} updateWidget={updateWidget} />
+      );
+      await user.click(
+        screen.getByRole('button', { name: /feature on board/i })
+      );
+      expect(updateWidget).toHaveBeenCalledWith('em1', {
+        maximized: true,
+        flipped: false,
+      });
+    });
+  });
+  ```
+
+- [ ] Run it & expect FAIL: `pnpm vitest run components/remote/controls/RemoteEmbedControl.test.tsx` → fails (module missing).
+- [ ] Implement `components/remote/controls/RemoteEmbedControl.tsx` (spotlight/swap only; the Spotlight toggle in `RemoteWidgetCard` header already covers spotlight, so this control owns the "feature on board" swap/maximize + an explicit large tap target):
+
+  ```tsx
+  import React from 'react';
+  import { Maximize, Minimize2 } from 'lucide-react';
+  import { WidgetData } from '@/types';
+
+  interface RemoteEmbedControlProps {
+    widget: WidgetData;
+    updateWidget: (id: string, updates: Partial<WidgetData>) => void;
+  }
+
+  export const RemoteEmbedControl: React.FC<RemoteEmbedControlProps> = ({
+    widget,
+    updateWidget,
+  }) => {
+    const isMaximized = widget.maximized ?? false;
+    const toggleFeature = () => {
+      updateWidget(widget.id, { maximized: !isMaximized, flipped: false });
+    };
+
+    return (
+      <div className="flex flex-col items-center gap-6 p-6 h-full justify-center">
+        <div className="text-white/60 text-xs uppercase tracking-widest font-bold">
+          Embed
+        </div>
+        <p className="text-white/40 text-sm text-center max-w-xs">
+          Feature this embed full-screen on the classroom board. Use Spotlight
+          in the header to overlay it without maximizing.
+        </p>
+        <button
+          onClick={toggleFeature}
+          className={`touch-manipulation flex items-center gap-3 px-8 py-4 rounded-2xl font-black text-lg shadow-lg transition-all active:scale-95 ${
+            isMaximized
+              ? 'bg-blue-500/20 border border-blue-400/60 text-blue-300'
+              : 'bg-blue-500 text-white'
+          }`}
+          aria-label={isMaximized ? 'Exit full screen' : 'Feature on board'}
+          aria-pressed={isMaximized}
+        >
+          {isMaximized ? (
+            <>
+              <Minimize2 className="w-6 h-6" /> Exit Full Screen
+            </>
+          ) : (
+            <>
+              <Maximize className="w-6 h-6" /> Feature on Board
+            </>
+          )}
+        </button>
+      </div>
+    );
+  };
+  ```
+
+  > Note: slide prev/next is intentionally omitted — `convertToEmbedUrl` rewrites Google Slides URLs to `/presentation/d/<id>/preview` and clears `search`/`hash` (`utils/urlHelpers.ts` L162–164), so no iframe-src slide-index contract survives. If the spike verdict is PASS, add a prev/next row here that writes a slide param into a new `EmbedConfig.slideIndex` field AND a bypass in the embed URL pipeline that preserves it for `pubembed` URLs — but only under a PASS verdict.
+
+- [ ] Run it & expect PASS: `pnpm vitest run components/remote/controls/RemoteEmbedControl.test.tsx` → passes.
+- [ ] Register in `RemoteWidgetCard.tsx`: add `import { RemoteEmbedControl } from './controls/RemoteEmbedControl';` (after L26) and a case before `default` (L132):
+  ```tsx
+      case 'embed':
+        return <RemoteEmbedControl widget={widget} updateWidget={updateWidget} />;
+  ```
+- [ ] Add `'embed'` to `REMOTE_SUPPORTED_TYPES` in `MobileRemoteView.tsx` (after `'activity-wall'`).
+- [ ] Run the remote suite: `pnpm vitest run components/remote/` → passes.
+- [ ] Commit: `git add components/remote/controls/RemoteEmbedControl.tsx components/remote/controls/RemoteEmbedControl.test.tsx components/remote/RemoteWidgetCard.tsx components/remote/MobileRemoteView.tsx && git commit -m "[AI] Remote v2: RemoteEmbedControl (spotlight/swap; slide nav gated on spike)"`
+
+---
+
+### Task 6: UI/UX polish pass (demo-path controls only)
+
+Tighten the controls Paul will drive: timer, traffic, poll, noise (sound), schedule, clock, plus the new Activity Wall control. Larger tap targets, clearer active/selected states, projector-dark styling, per-control press-confirm.
+
+**Files:**
+
+- Modify: `components/remote/controls/RemoteTrafficLightControl.tsx`
+- Modify: `components/remote/controls/RemotePollControl.tsx`
+- Modify: `components/remote/controls/RemoteSoundControl.tsx`
+- Modify: `components/remote/controls/RemoteScheduleControl.tsx`
+- Modify: `components/remote/controls/RemoteClockControl.tsx`
+- Modify: `components/remote/controls/RemoteTimerControl.tsx`
+- Test: re-run the full remote suite after each change
+
+Steps:
+
+- [ ] Read each demo-path control file and confirm interactive buttons carry `touch-manipulation`, a minimum tap target (`w`/`h` ≥ `12` / `min-h-12`), `active:scale-95`, and an explicit active state (e.g. `aria-pressed` + a high-contrast `bg-*`/`border-*`). The traffic control (`RemoteTrafficLightControl.tsx`) is the reference for active-state contrast.
+- [ ] For `RemoteTrafficLightControl.tsx`: confirm the three light buttons (L57–77) already meet the bar (`w-32 h-32`, `touch-manipulation`, `active:scale-95`, `aria-pressed`). No change required — record as verified.
+- [ ] For each of `RemotePollControl.tsx`, `RemoteSoundControl.tsx`, `RemoteScheduleControl.tsx`, `RemoteClockControl.tsx`, `RemoteTimerControl.tsx`: add `touch-manipulation` and `active:scale-95` to any control button missing them, bump any sub-`min-h-12` primary action button to at least `min-h-12`, and add a pressed-confirm ring (`focus-visible:ring-2 focus-visible:ring-blue-400/60`). Do not change control logic or write shapes — visual classes only.
+- [ ] Run the full remote suite after the polish edits: `pnpm vitest run components/remote/` → passes (no behavioral assertions break — these are class-only changes).
+- [ ] Run lint to catch any class/JSX issues before commit: `pnpm exec eslint components/remote --max-warnings 0` → clean.
+- [ ] Commit: `git add components/remote/controls && git commit -m "[AI] Remote v2: demo-path control polish (tap targets, active states, projector styling)"`
+
+---
+
+### Task 7: Manual two-device smoke-test checklist (acceptance gate)
+
+Markdown checklist only — the real acceptance gate before Tuesday. No code.
+
+**Files:**
+
+- Create: `docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md`
+
+Steps:
+
+- [ ] Create `docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md` with this content:
+
+  ```markdown
+  # Remote Control v2 — Two-Device Smoke Test (acceptance gate, pre-Tuesday)
+
+  Setup: projected board open on desktop (logged in), phone open to
+  `/remote?boardId=<id>` (same account). Test on the dev preview, then
+  re-run once on `main` after deploy.
+
+  ## Latency (priority 1)
+
+  - [ ] Timer start/pause/reset reflects on the board in ~300–500ms (reads as instant).
+  - [ ] Traffic light colour change reflects near-instantly.
+  - [ ] Poll reveal reflects near-instantly.
+  - [ ] Structural change (add/remove a widget on desktop) still debounces normally (no thrash).
+
+  ## Reliability + feedback (priority 2)
+
+  - [ ] Connection chip shows "Connected" on a good network.
+  - [ ] Toggle phone airplane mode → chip shows "Reconnecting…"; restore → "Connected".
+  - [ ] No command is silently dropped across a brief disconnect/reconnect.
+  - [ ] "Updated just now" / last-synced indicator updates when the desktop changes the board.
+  - [ ] Each control button shows a brief press-confirm (scale/ring) on tap.
+  - [ ] Live sync: change a widget on the desktop → the phone reflects it WITHOUT tapping Sync.
+  - [ ] Pending-guard: rapidly drive a widget from the phone → the desktop echo does not revert the phone within 5s.
+
+  ## Demo widgets (priority 3)
+
+  - [ ] Timer / stopwatch: start, pause, reset all drive the board.
+  - [ ] Traffic light: red/yellow/green/off all drive the board.
+  - [ ] Poll: reveal/hide drives the board.
+  - [ ] Noise meter (sound): control drives the board.
+  - [ ] Schedule: control drives the board.
+  - [ ] Clock: control drives the board.
+
+  ## Activity Wall (new)
+
+  - [ ] Start/pause toggles the wall on the board.
+  - [ ] Pending count badge matches the number of unapproved submissions.
+  - [ ] Approve from the phone moves a submission onto the board.
+  - [ ] Remove from the phone deletes the submission from the board.
+  - [ ] Join QR button shows only when `anonymous-join` is permitted; hidden cleanly otherwise.
+
+  ## Embed (new)
+
+  - [ ] "Feature on Board" maximizes the embed full-screen; "Exit Full Screen" restores.
+  - [ ] Spotlight (header) overlays the embed without maximizing.
+  - [ ] If the spike PASSED: slide prev/next advances the deck smoothly when projected.
+        If the spike FAILED: confirm slide nav is absent and spotlight/swap is the documented path.
+
+  ## Sign-off
+
+  - [ ] All priority-1 and priority-2 items pass.
+  - [ ] All demo widgets pass.
+  - [ ] Ready to PR `dev-paul` → `main` and deploy before Tuesday.
+  ```
+
+- [ ] Commit: `git add docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md && git commit -m "[AI] Remote v2: two-device smoke-test acceptance checklist"`

--- a/docs/superpowers/specs/2026-06-13-remote-control-v2-design.md
+++ b/docs/superpowers/specs/2026-06-13-remote-control-v2-design.md
@@ -1,0 +1,140 @@
+# Remote Control v2 — Design Spec
+
+_Date: 2026-06-13. Owner: Paul Ivers. Status: approved design, pre-implementation._
+
+## Goal & constraint
+
+Make the existing remote-control feature (`spartboard.web.app/remote`) feel
+production-quality rather than a prototype, **scoped to be live and stable for
+a presentation on Tuesday 2026-06-16**. The presentation use is **live board
+control**: Paul drives widgets from his phone while the audience watches the
+projected board. Therefore the priorities, in order, are:
+
+1. **Latency** — tap-to-board delay the audience can see.
+2. **Reliability + feedback** — never silently drift or drop a command on stage.
+3. **Polish + targeted new capability** — the specific widgets Paul will drive.
+
+Breadth of widget coverage is explicitly NOT a priority (he isn't walking
+through every feature; he's running a session).
+
+## Current state (as explored 2026-06-13)
+
+- Route `/remote?boardId=<id>` → `MobileRemoteView`
+  (`components/remote/MobileRemoteView.tsx`), wrapped in the same provider
+  stack as the dashboard (DialogProvider → AuthProvider → CustomWidgets →
+  SavedWidgets → DashboardProvider). Requires the same Firebase login.
+- Transport: remote calls `updateWidget`/`updateDashboardSettings`; writes go
+  through `DashboardContext`'s debounced auto-save
+  (`context/DashboardContext.tsx` ~L2223–2286): **100ms** settings-only,
+  **200ms** structural, **800ms** config/position. Desktop reflects changes via
+  an `onSnapshot` listener. Observable tap-to-board latency ~200–1500ms.
+- The remote keeps a LOCAL copy of widget state and only refreshes from context
+  on a manual **Sync** button tap; a 5s per-widget `pendingWidgetTimers` guard
+  prevents echo-reversion of in-flight edits.
+- 15 widget control types exist in `components/remote/controls/`
+  (timer, scoreboard, dice, random, traffic, clock, checklist, poll,
+  expectations, schedule, breathing, music, nextUp, sound, webcam). ~45 other
+  widget types show a "use Spotlight/Full Screen" placeholder.
+- Permissions: `remote-control` global feature (default-public) + an
+  account-level `remoteControlEnabled` preference. Both default on.
+- Tests: only `RemoteControlMenu.test.tsx` (URL/QR). No coverage of
+  `MobileRemoteView`, the control components, or sync behavior.
+
+Demo widgets Paul will drive: timer/stopwatch, traffic, poll, noise (sound),
+schedule, clock (all already supported → benefit from latency/reliability/
+polish), plus **Embed/slide deck** and **Activity Wall** (NOT currently
+remote-controllable → new work).
+
+## Design
+
+### 1. Latency fix — intent-aware write path
+
+Remote-originated control actions (start/pause/reset timer, ±score, reveal
+poll, advance NextUp, toggle traffic, etc.) currently change widget `config`
+and therefore inherit the 800ms config debounce before the write even leaves
+the phone. That client-side debounce — not Firestore — is the dominant latency.
+
+**Change:** add a fast-path so remote-originated _control_ writes flush to
+Firestore immediately (bypass the debounce), reusing the existing Firestore
+transport (no new channel/collection). Structural and position writes keep
+their current debounce. Mechanism: an explicit `{ immediate: true }`-style
+flag (or equivalent intent classification) threaded from the remote control
+call sites through `updateWidget` to the save scheduler, so the change is
+additive and desktop-side behavior is untouched.
+
+Expected result: ~300–500ms tap-to-board (Firestore round-trip only), which
+reads as "instant" when projected.
+
+**Risk control:** additive flag; default path unchanged. Covered by tests that
+assert control writes are scheduled immediately while structural writes remain
+debounced, plus a live two-device check.
+
+### 2. Live two-way sync + reliability UI
+
+- **Live sync:** stop requiring the manual Sync tap. `MobileRemoteView`
+  reflects the live `DashboardContext` snapshot it already receives (it is
+  inside `DashboardProvider`), retaining the 5s pending-write guard so Paul's
+  own in-flight edits aren't echoed back. The Sync button may remain as a
+  manual "force refresh" affordance but is no longer required for correctness.
+- **Connection status chip:** persistent indicator — "Connected" /
+  "Reconnecting…" — driven by Firestore connection/snapshot state.
+- **Last-synced indicator:** subtle timestamp/"updated just now".
+- **Tap feedback:** brief press-confirm state on control buttons so a command
+  visibly registers even before the board reflects it.
+
+### 3. Activity Wall remote control (new)
+
+New `components/remote/controls/RemoteActivityWallControl.tsx`:
+
+- Toggle the wall **active/paused**.
+- **Show/hide the join QR** (drive the existing QR/popout affordance).
+- A **moderation** action (hide/clear a submission) if it maps cleanly to
+  existing Activity Wall config/Firestore writes; otherwise ship active-toggle
+  - QR for Tuesday and defer moderation.
+- Register `activityWall` (the actual widget type id — verify in
+  `WidgetRegistry`/`REMOTE_SUPPORTED_TYPES`) into the remote supported list.
+- Respects the `anonymous-join` gate shipped 2026-06-13: if the teacher can't
+  offer the anonymous link, the QR/show-link affordance hides cleanly.
+
+### 4. Embed control
+
+- **Guaranteed:** spotlight/swap from the phone — feature the embed
+  full-screen / make it the active widget. This is the fallback and ships
+  regardless.
+- **Stretch spike (do early, timeboxed):** assess whether slide next/prev is
+  reliably drivable for Paul's specific deck — e.g. a Google Slides
+  published-to-web embed navigated by updating the iframe `src` `?slide=`
+  index. Acceptance: smooth and reliable when projected. If it passes, wire a
+  prev/next control; if not, keep spotlight/swap and drop the slide nav with no
+  other impact.
+
+### 5. UI/UX polish (demo path only)
+
+Tighten the controls Paul will use (timer, traffic, poll, noise, schedule,
+clock, activity wall): larger/clearer tap targets, consistent
+dark-on-projector styling, clearer active/selected states, tap feedback from
+§2. No full visual redesign; focused polish on the demo path.
+
+## Testing
+
+- Unit: write-classification (control writes immediate vs structural debounced);
+  `RemoteActivityWallControl` behavior; `MobileRemoteView` live-sync reflection
+  (snapshot updates appear without manual Sync; pending-guard still suppresses
+  echo).
+- **Manual two-device smoke test** (phone + projected board) is the real
+  acceptance gate before Tuesday — delivered as a checklist covering each demo
+  widget, the latency feel, connection-drop/reconnect, and the Embed path.
+
+## Out of scope (deferred — not Tuesday)
+
+Broad remote coverage for the other ~45 widgets; code/QR pairing handshake;
+offline write queue + Firestore offline persistence; multi-remote (phone A ↔
+phone B) sync; the deeper transport rebuild (e.g. dedicated low-latency
+channel/RTDB). These are candidates for a follow-up once the demo-critical path
+is solid.
+
+## Rollout
+
+Work on `dev-paul` → dev preview for two-device testing → PR to `main` and
+deploy **before** Tuesday's presentation. Remote control is default-public, so
+no admin config is required to demo.

--- a/docs/superpowers/specs/2026-06-13-remote-control-v2-design.md
+++ b/docs/superpowers/specs/2026-06-13-remote-control-v2-design.md
@@ -88,10 +88,17 @@ New `components/remote/controls/RemoteActivityWallControl.tsx`:
 
 - Toggle the wall **active/paused**.
 - **Show/hide the join QR** (drive the existing QR/popout affordance).
-- A **moderation** action (hide/clear a submission) if it maps cleanly to
-  existing Activity Wall config/Firestore writes; otherwise ship active-toggle
-  - QR for Tuesday and defer moderation.
-- Register `activityWall` (the actual widget type id — verify in
+- **Moderation — GUARANTEED in scope.** Approve pending submissions and
+  remove/hide submissions from the phone. This reuses the widget's existing
+  writes (verified 2026-06-13): live submissions are a Firestore subcollection
+  with `status: 'approved' | 'pending'`; `Widget.tsx` already approves via a
+  `setDoc` status→`approved` (~L872) and removes via `deleteDoc` (~L1212), and
+  tracks approved/pending counts (~L1099). The remote control adds a listener
+  on that submissions subcollection (path `{teacherUid}_{activityId}`) to show
+  the pending queue and a count badge, then fires the same approve/remove
+  writes. This is the core audience-engagement loop: attendees submit, Paul
+  approves live from his phone, the board updates.
+- Register `activityWall` (confirm the exact widget type id in
   `WidgetRegistry`/`REMOTE_SUPPORTED_TYPES`) into the remote supported list.
 - Respects the `anonymous-join` gate shipped 2026-06-13: if the teacher can't
   offer the anonymous link, the QR/show-link affordance hides cleanly.
@@ -118,9 +125,10 @@ dark-on-projector styling, clearer active/selected states, tap feedback from
 ## Testing
 
 - Unit: write-classification (control writes immediate vs structural debounced);
-  `RemoteActivityWallControl` behavior; `MobileRemoteView` live-sync reflection
-  (snapshot updates appear without manual Sync; pending-guard still suppresses
-  echo).
+  `RemoteActivityWallControl` behavior (pending-queue listener renders pending
+  submissions; approve fires status→approved; remove fires deleteDoc; count
+  badge); `MobileRemoteView` live-sync reflection (snapshot updates appear
+  without manual Sync; pending-guard still suppresses echo).
 - **Manual two-device smoke test** (phone + projected board) is the real
   acceptance gate before Tuesday — delivered as a checklist covering each demo
   widget, the latency feel, connection-drop/reconnect, and the Embed path.

--- a/docs/superpowers/specs/2026-06-14-public-poll-participation-design.md
+++ b/docs/superpowers/specs/2026-06-14-public-poll-participation-design.md
@@ -1,0 +1,144 @@
+# Public Poll Participation — Design Spec (follow-up)
+
+_Date: 2026-06-14. Owner: Paul Ivers. Status: follow-up spec — NOT for the
+Tuesday 2026-06-16 demo. Build after PR #1961 (Remote Control v2) merges, in
+its own branch/PR._
+
+## Goal
+
+Give the **Poll** widget a public, audience-facing participation flow like the
+Activity Wall has: a copyable/scannable link that lets participants vote from
+their own devices, with live tallies reflected on the projected board and a
+"Show Join QR" affordance on the teacher remote. One vote per participant
+device, anonymous (no sign-in).
+
+## Why this is a real feature, not a wire-in
+
+The Activity Wall remote control shipped quickly in v2 because its **entire
+participant side already existed** — `/activity-wall/...` route,
+`ActivityWallStudentApp`, the `activity_wall_sessions/{uid}_{activityId}/submissions`
+subcollection, and Firestore rules. v2 only added the teacher remote control on
+top.
+
+Poll has **none** of that participant infrastructure (verified 2026-06-14):
+
+- No `/poll` participant route in `App.tsx`.
+- No `PollVoteApp` / participant component (only the dashboard widget, the admin
+  panel, and `RemotePollControl`).
+- The only shared-vote storage is `pollVotes` nested under
+  `/announcements/{id}/` (`firestore.rules:2679`) — tied to the announcement
+  system, not a standalone poll session.
+
+So this builds the participant side from scratch, reusing **patterns** (not
+plumbing) from Activity Wall: the `?data=<base64>` join-link encoding, anonymous
+join, the live-tally Firestore listener shape, and the QR panel. Scope is
+comparable to the original Activity Wall participant build — roughly a focused
+day with tests + rules.
+
+## Current Poll model (for reference)
+
+- `PollWidget` (`components/widgets/PollWidget/Widget.tsx`): `PollConfig` has
+  `question` + `options[]` (each `{ label, votes }`). Votes are stored either
+  **locally in widget config** (teacher-driven tally, adjusted on-board or via
+  `RemotePollControl` ±/reset) or — when embedded in an announcement
+  (`config._announcementId`) — in `/announcements/{id}/pollVotes/{optionIndex}`
+  as `{ count }`, shared live via `onSnapshot` + `increment`.
+- `RemotePollControl` only does manual ±/reset of tallies; no link/QR.
+
+## Design
+
+### 1. Participant route + app
+
+- New route in `App.tsx`: `/poll/:pollId` (anonymous entry, outside
+  `AuthProvider` — mirror the `/activity-wall` branch: `DialogProvider` +
+  `StudentIdleTimeoutGuard` + a lazy `PollVoteApp`). Add an `isPollRoute` guard.
+- New `components/poll/PollVoteApp.tsx`: decodes the `?data=` payload (poll
+  question + options + `pollId` + `teacherUid`), signs in anonymously
+  (`signInAnonymously`), renders the options as large vote buttons, casts one
+  vote, then shows a "thanks / your vote is in" confirmation with the live
+  tally. Reuses the dark, mobile-first participant styling of
+  `ActivityWallStudentApp`.
+
+### 2. Join link encoding (mirror Activity Wall)
+
+- A `buildPublicPollLink(poll, teacherUid)` →
+  `${origin}/poll/${pollId}?data=${encodeURIComponent(btoa(JSON.stringify({ id, question, options, teacherUid })))}`.
+  Same base64-of-JSON `?data=` shape as `buildPublicActivityLink`, so the
+  participant app renders without a Firestore read of the poll config. (Keep the
+  encoded payload small — only what's needed to render and route the vote.)
+
+### 3. Vote storage + one-vote-per-device
+
+- New collection: `poll_sessions/{teacherUid}_{pollId}/votes/{participantUid}`,
+  doc `{ optionIndex: number, votedAt: number }`. Using the anonymous
+  participant's `uid` as the **doc id** enforces one vote per device/session
+  naturally (re-voting overwrites). This mirrors Activity Wall's per-doc /
+  uid-keyed pattern and is cleaner than `increment` counters for dedup.
+- Live tally: the dashboard `PollWidget` (and the participant confirmation
+  screen) subscribe to the `votes` subcollection and aggregate counts per
+  `optionIndex` client-side. This is a NEW read path for the widget — today it
+  reads local config or announcement votes; add a third "session-backed" mode
+  keyed on an active `poll_sessions` session id.
+
+### 4. Widget-side (teacher) changes
+
+- `PollWidget`: when a public session is active, generate the participant link +
+  QR (gated by `canAccessFeature('anonymous-join')`, consistent with Activity
+  Wall) and show live aggregated tallies from the votes subcollection on the
+  projected board. Add a "Start/stop accepting votes" notion (an active session
+  id in config, analogous to `activeActivityId`) so the link is only live when
+  the teacher opens voting.
+- Decide: does a public session REPLACE the local-tally mode or coexist? Default:
+  coexist — local ± tally stays for show-of-hands; public session is opt-in when
+  the teacher wants device voting.
+
+### 5. Remote control
+
+- Extend `RemotePollControl` with a "Show Join QR" panel (same component shape as
+  `RemoteActivityWallControl`'s QR panel, gated by `anonymous-join`) plus a
+  start/stop-voting toggle. Keep the existing ±/reset tally controls.
+
+### 6. Firestore rules
+
+- New rules for `poll_sessions/{sessionId}/votes/{participantUid}`: an
+  authenticated (incl. anonymous) user may create/update ONLY the doc whose id ==
+  their own `request.auth.uid`; `optionIndex` is a number within range;
+  `votedAt` is a number. Teacher (sessionId matches `{uid}_*`) + admin may read
+  all and delete (reset). Model on the `activity_wall_sessions` submission rules
+  (`firestore.rules`) and the existing `pollVotes` rule shape.
+
+## Reuse map (Activity Wall → Poll)
+
+| Activity Wall                                                   | Poll equivalent                                       |
+| --------------------------------------------------------------- | ----------------------------------------------------- |
+| `/activity-wall/:id` route + `ActivityWallStudentApp`           | `/poll/:pollId` route + `PollVoteApp`                 |
+| `buildPublicActivityLink` / `encodeActivityData`                | `buildPublicPollLink` / `encodePollData`              |
+| `activity_wall_sessions/{uid}_{activityId}/submissions/{docId}` | `poll_sessions/{uid}_{pollId}/votes/{participantUid}` |
+| Remote QR panel (`anonymous-join` gated)                        | same, in `RemotePollControl`                          |
+| `activeActivityId` (active session)                             | new active-poll-session id in `PollConfig`            |
+
+## Out of scope (YAGNI)
+
+- Stronger anti-fraud than one-vote-per-anonymous-device (acceptable for
+  classroom/presentation use, same bar as Activity Wall).
+- Ranked/multi-select voting, open-ended poll responses, results export.
+- Migrating the existing announcement `pollVotes` path — leave it as-is; this is
+  an additive third mode.
+
+## Testing
+
+- `PollVoteApp`: decodes `?data=`, casts a vote (writes the uid-keyed doc),
+  blocks/overwrites a second vote, renders the live tally.
+- `PollWidget`: with an active session, generates the link/QR (gated by
+  `anonymous-join`) and aggregates live tallies from the votes subcollection.
+- `RemotePollControl`: QR panel shows only when `anonymous-join` is permitted;
+  start/stop toggles the session.
+- Firestore rules tests: a participant can write only their own `votes/{uid}`
+  doc; cannot write another participant's; teacher/admin can read+reset.
+- Manual: phone scans QR → votes → tally updates live on the projected board.
+
+## Rollout
+
+Own branch off `main` (after #1961 merges) → `dev-paul` preview → PR. New public
+route + Firestore rules deploy on the `main` merge. Gated by `anonymous-join`
+(already shipped), so it composes with the wide-distro tiering.

--- a/docs/superpowers/spikes/2026-06-13-embed-slide-control.md
+++ b/docs/superpowers/spikes/2026-06-13-embed-slide-control.md
@@ -1,0 +1,132 @@
+# Spike: Embed slide-control feasibility (Remote Control v2, Task 1)
+
+**VERDICT: FAIL** — When a teacher pastes a Google Slides link, SpartBoard stores and
+renders the **`/presentation/d/<id>/preview`** form (via `convertToEmbedUrl`), NOT a
+publish-to-web (`pubembed`/`pub`) form. The `/preview` iframe has no `&slide=N` URL
+contract, so slide next/prev is **not** reliably drivable by updating the iframe `src`.
+Task 5 should ship **spotlight/swap only** for Slides decks.
+
+Date: 2026-06-13 · Branch: `dev-paul` · Investigation only, no feature code.
+
+---
+
+## What smart paste actually produces for a Slides link
+
+There is **no** publish-to-web / `pubembed` / `pub` conversion anywhere in the paste
+pipeline. The smart-paste "convert a pasted Slides URL to a published embed" behavior
+described as a possibility by the product owner **does not exist in the code**. Searched
+the whole repo for `pubembed`, `/pub`, `publishedUrl`, `published`, `normalizeUrl` — the
+only `pub`-related hits are `utils/assignmentExportShared.ts` and
+`utils/publishGradePush.ts` (grade-pushing, unrelated to embeds).
+
+### Exact code path (file:line)
+
+1. **Paste entry → detection.** `utils/smartPaste.ts` `detectWidgetType(text)` routes a
+   pasted string. URLs hit `tryParseEmbedWidget` (`utils/smartPaste.ts:191-203`):
+
+   ```ts
+   const EMBED_PROVIDERS =
+     /(youtube\.com|youtu\.be|vimeo\.com|docs\.google\.com|...)/; // :188
+   function tryParseEmbedWidget(url: string): PasteResult | null {
+     if (EMBED_PROVIDERS.test(url)) {
+       return {
+         action: 'create-widget',
+         type: 'embed',
+         config: { url: convertToEmbedUrl(url), mode: 'url' } as WidgetConfig, // :197
+       };
+     }
+     return null;
+   }
+   ```
+
+   The stored `EmbedConfig.url` is whatever `convertToEmbedUrl(url)` returns. No further
+   transformation.
+
+2. **URL transform.** `utils/urlHelpers.ts` `convertToEmbedUrl`, Slides branch
+   (`utils/urlHelpers.ts:151-167`):
+
+   ```ts
+   parsed.pathname = `/presentation/d/${slideId}/preview`;
+   parsed.search = ''; // strips ?slide=...
+   parsed.hash = ''; // strips #slide=id.p
+   return parsed.toString();
+   ```
+
+   So `https://docs.google.com/presentation/d/<id>/edit?slide=id.gXXX#slide=id.gXXX`
+   becomes `https://docs.google.com/presentation/d/<id>/preview` — any slide anchor is
+   discarded.
+
+3. **Test confirms it.** `utils/smartPaste.test.ts:11-26` ("detects Google Slides and
+   converts to preview URL") asserts the stored config URL `toContain('/presentation/
+d/<id>/preview')`. This is a locked-in, tested contract — the published form is never
+   produced.
+
+4. **Render.** `components/widgets/Embed/Widget.tsx:210-218` derives the iframe src:
+
+   ```ts
+   const sanitizedUrl = ensureProtocol(url);
+   const embedUrl = convertToEmbedUrl(sanitizedUrl); // idempotent for /preview
+   const finalEmbedUrl = applyStartAt(
+     applyAutoplay(embedUrl, autoplay),
+     startAtSeconds
+   );
+   ```
+
+   and `<iframe src={displayMode === 'url' ? finalEmbedUrl : undefined} ...>`
+   (`Widget.tsx:565-568`). The rendered src is the `/preview` URL. `applyAutoplay` /
+   `applyStartAt` are YouTube-oriented and add no slide param.
+
+   Note: `convertToEmbedUrl` runs **again** at render on the already-stored `/preview`
+   URL. That branch matches `/presentation/` but the slide-id regex still matches the id,
+   re-sets `search=''`/`hash=''` — so even if Task 5 stored a `?slide=N` on the config
+   URL, this render-time pass would **strip it**. Any future slide-param approach must
+   account for this double-conversion (it would need to be appended after
+   `convertToEmbedUrl`, like `applyAutoplay` does, not stored on `config.url`).
+
+## Does the `/preview` form support slide-index navigation via src changes?
+
+No. The Google Slides `/preview` viewer does not honor `&slide=N` / `#slide=N` for
+programmatic navigation. Only the **publish-to-web** embed
+(`/presentation/d/e/<pubId>/embed?...`, sometimes called `pubembed`) honors `slide=` and
+auto-advance (`start`, `loop`, `delayms`) params. SpartBoard never generates that form,
+so the precondition for iframe-src slide control is absent.
+
+## EmbedConfig shape
+
+`types.ts:1142-1153` — `EmbedConfig` = `{ url, mode?, html?, refreshInterval?,
+isEmbeddable?, blockedReason?, zoom?, autoplay?, startAtSeconds? }`. **No slide-index
+field.** (Comment at `:1151` even notes Drive `/preview` ignores `startAtSeconds`, the
+same class of limitation.)
+
+---
+
+## Guidance for Task 5
+
+- **Do not** attempt iframe-src slide next/prev for Slides embeds. The stored/rendered URL
+  is `/preview`, which has no slide-index contract; appending a param won't navigate, and
+  `convertToEmbedUrl` strips params at render time anyway.
+- **Ship spotlight/swap only** for Slides decks, per the plan's FAIL branch.
+- **If slide control is ever revisited** it would require a different architecture, not a
+  param tweak:
+  1. Detect Slides URLs in `convertToEmbedUrl` / `tryParseEmbedWidget` and convert to the
+     **publish-to-web** form. This requires the _published_ doc id (`/d/e/<pubId>/`), which
+     is **not derivable from the editing id** — the teacher must publish the deck to web
+     first, so this can't be done transparently from a normal share link.
+  2. Add a `slideIndex` field to `EmbedConfig` (`types.ts:1142`).
+  3. Thread it through as a post-`convertToEmbedUrl` appender (mirror `applyAutoplay` at
+     `Widget.tsx:215-218`) so the render-time `convertToEmbedUrl` pass doesn't strip it.
+  4. Update `utils/smartPaste.test.ts:11-26`, which currently locks in the `/preview`
+     contract.
+     This is materially larger than a remote-control wiring task and is gated on teachers
+     publishing decks — out of scope for Task 5.
+
+## Confidence / uncertainty
+
+- **High confidence** on the code path: the stored URL is `/preview`, evidenced by
+  `smartPaste.ts:197` → `urlHelpers.ts:151-167` and the passing test
+  `smartPaste.test.ts:11-26`.
+- The claim that Google's `/preview` viewer ignores `slide=` (vs. published `pubembed`
+  honoring it) is based on Google Slides embed behavior, not on SpartBoard code. It does
+  not change the verdict: even if `/preview` _did_ honor a param, SpartBoard's render-time
+  `convertToEmbedUrl` strips `search`/`hash`, so src-based control is still broken without
+  code changes. Either way the verdict is FAIL for the current pipeline.

--- a/docs/wide-distro-plan.md
+++ b/docs/wide-distro-plan.md
@@ -157,6 +157,43 @@ Implementation notes:
 - The participant routes themselves stay anonymous and untouched — this gates
   the TEACHER's ability to generate the link, not the participant experience.
 
+#### Status (2026-06-13, commit `885ea0b6`)
+
+- DONE: `anonymous-join` global feature registered (default-public), admin UI
+  entry "Anonymous join links (no sign-in)" in `GlobalPermissionsManager` with
+  accessLevel + buildings + minTier controls, tests, full suite green.
+- DONE: **Activity Wall** anonymous join affordances gated
+  (`components/widgets/ActivityWall/Widget.tsx` — the "Copy link" + "Pop-out
+  QR" buttons exposing the participant `/activity-wall/{id}?data=...` URL). The
+  view-only "Share gallery" button stays. Participant route untouched.
+- KEY FINDING: the two-link model only cleanly exists in Activity Wall today.
+  In **Quiz**, **Video Activity**, **Guided Learning**, and **NextUp**, the
+  "anonymous join URL" _is_ the normal in-class PIN-join lobby (the live-
+  session join-code bar, archive "copy student link", PLC/peer share), not a
+  separate wide-distribution link. Gating those as-is would break ordinary
+  in-class teaching the moment an admin restricted the feature. They were
+  deliberately left UNGATED and flagged. NextUp has no share/join affordance
+  at all.
+
+#### Phase 3b follow-up — build the rostered-join path (NOT yet done)
+
+Offering a genuine "no sign-in vs. rostered sign-in" CHOICE on quiz / video-
+activity / guided-learning (and a share affordance for NextUp if wanted)
+requires first building the **rostered-join link** alongside the existing
+anonymous one — routing participants through `spartboard.web.app/student/login`
+(PII-free GIS → custom token, like the existing student academic flow) so they
+land in the activity as a rostered student with saved data. Only once both
+links exist per widget can the anonymous side be gated behind
+`canAccessFeature('anonymous-join')` without removing the teacher's only way to
+start an in-class activity.
+
+Per widget this means: a share surface that presents both links; the rostered
+URL carrying enough context to resolve the student into the right
+session/roster after `/student/login`; and then ANDing the anonymous affordance
+with the `anonymous-join` gate. Treat each widget as its own slice (Quiz is the
+natural first). This is the real remaining build; the gate is already in place
+waiting for it.
+
 ### Phase 5 (deferred) — Formal trials / licensing
 
 Only after the operator-model decision and real external demand. Needs an

--- a/docs/wide-distro-plan.md
+++ b/docs/wide-distro-plan.md
@@ -116,9 +116,46 @@ Prereqs, in order:
    answer.
 4. Console → Google Auth Platform → Audience: switch User type to External,
    publish to production.
-5. Before/alongside: phase out anonymous auth (student PIN flow) and tighten
-   Firestore rules that assume `request.auth != null` implies a real Google
-   account.
+5. Before/alongside: phase out anonymous auth **for the student academic
+   flow only** and tighten Firestore rules that assume `request.auth != null`
+   implies a real Google account. **Keep anonymous auth enabled** — it is the
+   right primitive for public presentations and the no-sign-in join option
+   (see "Two-link join model" below). The phase-out is scoped to the rostered
+   student path, NOT a global disable of the Anonymous provider.
+
+### Phase 3b — Two-link join model + admin-gated anonymous join
+
+Every assignable / student-facing widget (quiz, video activity, activity
+wall, guided learning, NextUp) offers the teacher two ways to share an
+activity:
+
+1. **No sign-in (anonymous):** a join-code URL. Participants enter via
+   `signInAnonymously` — temporary results, nothing saved to a roster. This
+   is what powers public presentations (e.g. the Activity Wall with a room of
+   attendees). Stays working regardless of the Phase 4 external flip.
+2. **Sign in (rostered):** routes through `spartboard.web.app/student/login`
+   (PII-free GIS → custom token). Gives rostered courses and saved/persistent
+   student data.
+
+**Admin gate on the anonymous link.** Whether a teacher may offer the
+no-sign-in link is an admin-configurable capability, modeled as a
+`GlobalFeaturePermission` doc (proposed featureId `anonymous-join`) — the
+exact `accessLevel` (`admin` | `beta` | `public`) + `buildings[]` shape the
+permission system already supports, consumed via `canAccessFeature` and
+edited in `GlobalPermissionsManager`. This composes with the Phase 3 `minTier`
+field too. When denied, the teacher's share UI hides the no-sign-in option
+and offers only the rostered sign-in link (hide cleanly, no error).
+
+Implementation notes:
+
+- Add `'anonymous-join'` to the `GlobalFeature` union + a `FEATURE_DEFAULTS`
+  entry (default-public to preserve today's behavior until an admin restricts
+  it), and register it in the Global Permissions manager's feature registry.
+- Gate the "no sign-in / anonymous link" affordance in each widget's share
+  modal (e.g. `components/widgets/ActivityWall/ShareModal.tsx` and the quiz /
+  video-activity share surfaces) behind `canAccessFeature('anonymous-join')`.
+- The participant routes themselves stay anonymous and untouched — this gates
+  the TEACHER's ability to generate the link, not the participant experience.
 
 ### Phase 5 (deferred) — Formal trials / licensing
 

--- a/locales/de.json
+++ b/locales/de.json
@@ -3,6 +3,11 @@
     "status": {
       "connected": "Verbunden",
       "reconnecting": "Wird neu verbunden…"
+    },
+    "boardPicker": {
+      "title": "Boards",
+      "switch": "Board wechseln",
+      "close": "Schließen"
     }
   },
   "common": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,4 +1,10 @@
 {
+  "remote": {
+    "status": {
+      "connected": "Verbunden",
+      "reconnecting": "Wird neu verbunden…"
+    }
+  },
   "common": {
     "cancel": "Abbrechen",
     "save": "Speichern",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "remote": {
+    "status": {
+      "connected": "Connected",
+      "reconnecting": "Reconnecting…"
+    }
+  },
   "common": {
     "cancel": "Cancel",
     "save": "Save",

--- a/locales/en.json
+++ b/locales/en.json
@@ -3,6 +3,11 @@
     "status": {
       "connected": "Connected",
       "reconnecting": "Reconnecting…"
+    },
+    "boardPicker": {
+      "title": "Boards",
+      "switch": "Switch board",
+      "close": "Close"
     }
   },
   "common": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,4 +1,10 @@
 {
+  "remote": {
+    "status": {
+      "connected": "Conectado",
+      "reconnecting": "Reconectando…"
+    }
+  },
   "common": {
     "cancel": "Cancelar",
     "save": "Guardar",

--- a/locales/es.json
+++ b/locales/es.json
@@ -3,6 +3,11 @@
     "status": {
       "connected": "Conectado",
       "reconnecting": "Reconectando…"
+    },
+    "boardPicker": {
+      "title": "Tableros",
+      "switch": "Cambiar de tablero",
+      "close": "Cerrar"
     }
   },
   "common": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -3,6 +3,11 @@
     "status": {
       "connected": "Connecté",
       "reconnecting": "Reconnexion…"
+    },
+    "boardPicker": {
+      "title": "Tableaux",
+      "switch": "Changer de tableau",
+      "close": "Fermer"
     }
   },
   "common": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,4 +1,10 @@
 {
+  "remote": {
+    "status": {
+      "connected": "Connecté",
+      "reconnecting": "Reconnexion…"
+    }
+  },
   "common": {
     "cancel": "Annuler",
     "save": "Enregistrer",

--- a/tests/context/AuthContext.canAccessFeatureAnonymousJoin.test.tsx
+++ b/tests/context/AuthContext.canAccessFeatureAnonymousJoin.test.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { GlobalFeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn((c: unknown) => c),
+  limit: vi.fn(() => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: { adminEmail: string | null }): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => false,
+        data: () => undefined,
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+function deliverGlobalPermissions(perms: GlobalFeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'global_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { id: string; data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ id: p.featureId, data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    return () => undefined;
+  });
+}
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  perms: GlobalFeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({ adminEmail: opts.isAdmin ? opts.email : null });
+  deliverGlobalPermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessFeature("anonymous-join") (Phase 3b gate)', () => {
+  it('returns TRUE for non-admin when no permission doc exists (default-public preserves todays behavior)', async () => {
+    // missingDocPublic: true — until an admin creates a restricting doc,
+    // every teacher keeps the no-sign-in join link exactly as before.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [],
+    });
+    expect(getCtx().canAccessFeature('anonymous-join')).toBe(true);
+  });
+
+  it('returns FALSE for a non-admin teacher when restricted to admin access', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      perms: [
+        {
+          featureId: 'anonymous-join',
+          accessLevel: 'admin',
+          betaUsers: [],
+          enabled: true,
+        },
+      ],
+    });
+    expect(getCtx().canAccessFeature('anonymous-join')).toBe(false);
+  });
+
+  it('still returns TRUE for an admin when restricted to admin access', async () => {
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      perms: [
+        {
+          featureId: 'anonymous-join',
+          accessLevel: 'admin',
+          betaUsers: [],
+          enabled: true,
+        },
+      ],
+    });
+    expect(getCtx().canAccessFeature('anonymous-join')).toBe(true);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -5700,7 +5700,8 @@ export type GlobalFeature =
   | 'assignment-modes'
   | 'share-link-tracking'
   | 'personal-spotify'
-  | 'google-classroom';
+  | 'google-classroom'
+  | 'anonymous-join';
 
 export interface GlobalFeaturePermission {
   featureId: GlobalFeature;


### PR DESCRIPTION
## Summary

Two shipped workstreams on `dev-paul`, both default-safe (no behavior change until an admin opts in) and fully tested.

### Remote Control v2 (`/remote`) — Tuesday-presentation hardening
Makes the teacher remote production-quality for live board control:
- **Latency:** additive `immediate` write flag flushes remote control writes past the auto-save debounce (~1s+ → Firestore round-trip ~300–500ms); structural writes stay debounced (leak-tested).
- **Reliability/feedback:** live two-way sync (no manual Sync needed), Connected/Reconnecting chip, last-synced indicator, tap-feedback rings; 5s echo guard preserved.
- **Activity Wall remote control (new):** live moderation from the phone — pending queue + count badge, approve (`updateDoc {status:'approved'}`), remove (`deleteDoc`), start/pause, and a real Join QR panel reusing the widget's exact participant URL. Writes hit the same `activity_wall_sessions/{uid}_{activityId}/submissions` subcollection the board reads, so moderation reflects live.
- **Embed remote control (new):** feature-on-board (maximize) + spotlight. Slide next/prev intentionally omitted — proven infeasible by a feasibility spike (`convertToEmbedUrl` strips slide params).
- Demo-path control polish (tap targets, active states, projector styling).

Design/plan/spike/checklist under `docs/superpowers/`.

### Phase 3b — admin-gated anonymous-join
- New `anonymous-join` global feature (default-public) + admin UI entry in Global Permissions (access level / beta / building / min-tier controls).
- Activity Wall's no-sign-in Copy-link / Pop-out-QR affordances gated behind `canAccessFeature('anonymous-join')`; view-only gallery share stays. Participant join experience unchanged.

## Test Plan
- [x] Full suite green (449 files, 4,579 tests); `tsc --noEmit` clean.
- [x] Per-task spec + quality review, plus final holistic review and fix round.
- [ ] Two-device smoke test on the dev preview (`docs/superpowers/checklists/2026-06-13-remote-v2-smoke-test.md`) — desktop board + phone `/remote?boardId=<id>`, verifying latency, live moderation, and the Activity Wall start/QR caveat for library-migrated widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)