### PR TITLE
ci: add Claude PR review workflow (subscription OAuth)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,64 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+      - dev-*
+    # Mirror pr-validation: skip docs-only PRs. The nightly agent fleet opens
+    # many journal-only PRs (docs/routines/*.md); reviewing Markdown burns
+    # subscription usage for no benefit. A PR touching any non-doc file still
+    # gets reviewed (paths-ignore only skips when *every* changed file matches).
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+
+# Cancel a superseded run when a newer commit lands on the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-24.04
+    name: Claude Code Review
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Pro/Max subscription auth — generate locally with `claude setup-token`
+          # and store as a repo secret. No metered API key required.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request (a React + TypeScript + Firebase app, pnpm
+            monorepo). Focus on:
+            - Correctness bugs and logic errors
+            - Security issues (auth, Firestore rules, secret handling, XSS)
+            - Performance regressions
+            - Adherence to existing patterns and conventions in the repo
+
+            Be concise and high-signal: only flag things that genuinely matter.
+            If the PR looks good, say so briefly rather than inventing nitpicks.
+
+            The PR branch is already checked out in the working directory.
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with
+            `confirmed: true`) for specific line-level issues.
+            Only post GitHub comments — do not return review text as a message.
+
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds `.github/workflows/claude-review.yml` — automated PR review via `anthropics/claude-code-action@v1`, authenticated with a Claude Pro/Max subscription OAuth token (repo secret `CLAUDE_CODE_OAUTH_TOKEN`).

- Triggers on PRs into `main` / `dev-*`, skips docs-only PRs (mirrors pr-validation paths-ignore).
- Model: claude-sonnet-4-6. Posts review comments only; no metered API key.

CI-config only — no application code changes. Landing it on `main` is what makes `main` PRs get reviewed (workflows run from the PR base branch).