### PR TITLE
action(admin-config): wire need-do-put-then building defaults + Sunday audit — 2026-06-14

### DIFF
--- a/components/admin/NeedDoPutThenConfigurationPanel.tsx
+++ b/components/admin/NeedDoPutThenConfigurationPanel.tsx
@@ -81,9 +81,12 @@ export const NeedDoPutThenConfigurationPanel: React.FC<
         <p className="text-xxs text-slate-500 leading-tight">
           These appearance defaults pre-populate the Need / Do / Put / Then
           widget when a teacher in{' '}
-          <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
-          it to their dashboard. Teachers can still override them per-instance
-          from the widget&apos;s Appearance tab.
+          <b>
+            {BUILDINGS.find((b) => b.id === selectedBuildingId)?.name ??
+              'this building'}
+          </b>{' '}
+          adds it to their dashboard. Teachers can still override them
+          per-instance from the widget&apos;s Appearance tab.
         </p>
 
         {/* Default Font Family */}

--- a/components/admin/NeedDoPutThenConfigurationPanel.tsx
+++ b/components/admin/NeedDoPutThenConfigurationPanel.tsx
@@ -1,31 +1,72 @@
 import React from 'react';
-import { ListTodo } from 'lucide-react';
-import { Card } from '@/components/common/Card';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useBuildingSelection } from '@/hooks/useBuildingSelection';
 import { BuildingSelector } from './BuildingSelector';
+import {
+  NeedDoPutThenGlobalConfig,
+  BuildingNeedDoPutThenDefaults,
+  TextSizePreset,
+} from '@/types';
+import { Card } from '@/components/common/Card';
+import { FONTS } from '@/config/fonts';
+import { HexColorField } from './HexColorField';
 
-export interface NeedDoPutThenGlobalConfig {
-  buildingDefaults?: Record<string, Record<string, unknown>>;
-}
-
-interface Props {
+interface NeedDoPutThenConfigurationPanelProps {
   config: NeedDoPutThenGlobalConfig;
+  onChange: (newConfig: NeedDoPutThenGlobalConfig) => void;
 }
 
-export const NeedDoPutThenConfigurationPanel: React.FC<Props> = ({
-  config,
-}) => {
+const TEXT_SIZE_PRESET_OPTIONS: { value: TextSizePreset; label: string }[] = [
+  { value: 'small', label: 'Small' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'large', label: 'Large' },
+  { value: 'x-large', label: 'Extra Large' },
+];
+
+/**
+ * Admin building-default panel for the Need / Do / Put / Then widget. Exposes
+ * the appearance fields the widget actually consumes (font family, text colour,
+ * card surface colour, card opacity, text size preset). `fontFamily` is stored
+ * in the shared `TypographySettings` value space (`FONTS` ids like
+ * `'font-sans'`), so the value seeded into a new widget instance matches what
+ * the teacher's own Appearance tab would write — keeping the in-widget font
+ * selector in sync. Content presets (preset Need/Do/Put/Then tiles) are
+ * configured per-instance by teachers and are intentionally not exposed here.
+ */
+export const NeedDoPutThenConfigurationPanel: React.FC<
+  NeedDoPutThenConfigurationPanelProps
+> = ({ config, onChange }) => {
   const BUILDINGS = useAdminBuildings();
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
-  const building = BUILDINGS.find((b) => b.id === selectedBuildingId);
-  const hasBuildingEntry = Boolean(
-    config.buildingDefaults?.[selectedBuildingId]
-  );
+
+  const buildingDefaults = config.buildingDefaults ?? {};
+  const currentBuildingConfig: BuildingNeedDoPutThenDefaults = buildingDefaults[
+    selectedBuildingId
+  ] ?? {
+    buildingId: selectedBuildingId,
+  };
+
+  const handleUpdateBuilding = (
+    updates: Partial<BuildingNeedDoPutThenDefaults>
+  ) => {
+    onChange({
+      ...config,
+      buildingDefaults: {
+        ...buildingDefaults,
+        [selectedBuildingId]: {
+          ...currentBuildingConfig,
+          ...updates,
+        },
+      },
+    });
+  };
+
+  const cardOpacity = currentBuildingConfig.cardOpacity ?? 1;
 
   return (
     <div className="space-y-6">
+      {/* Building Selector */}
       <div>
         <label className="text-xxs font-bold text-slate-500 uppercase mb-2 block">
           Configure Building Need / Do / Put / Then Defaults
@@ -36,28 +77,110 @@ export const NeedDoPutThenConfigurationPanel: React.FC<Props> = ({
         />
       </div>
 
-      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-3">
-        <div className="flex items-start gap-3">
-          <div className="p-2 rounded-xl bg-indigo-500/10 text-indigo-600 shrink-0">
-            <ListTodo className="w-5 h-5" />
-          </div>
-          <div>
-            <p className="text-sm font-bold text-slate-700">
-              No building-level defaults yet
-            </p>
-            <p className="text-xxs text-slate-500 leading-snug mt-1">
-              Teachers at <b>{building?.name ?? 'this building'}</b> configure
-              the Need / Do / Put / Then widget per-instance today.
-              Building-wide defaults (preset materials, turn-in destinations,
-              common next-up options) can be added here in a future release.
-            </p>
-            {hasBuildingEntry && (
-              <p className="text-xxs text-slate-400 mt-2 italic">
-                Stored defaults exist for this building but are not yet consumed
-                by the widget.
-              </p>
-            )}
-          </div>
+      <Card rounded="xl" shadow="none" className="bg-slate-50 space-y-4">
+        <p className="text-xxs text-slate-500 leading-tight">
+          These appearance defaults pre-populate the Need / Do / Put / Then
+          widget when a teacher in{' '}
+          <b>{BUILDINGS.find((b) => b.id === selectedBuildingId)?.name}</b> adds
+          it to their dashboard. Teachers can still override them per-instance
+          from the widget&apos;s Appearance tab.
+        </p>
+
+        {/* Default Font Family */}
+        <div>
+          <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+            Default Font Family
+          </label>
+          <select
+            value={currentBuildingConfig.fontFamily ?? 'global'}
+            onChange={(e) => {
+              const selected = e.target.value;
+              handleUpdateBuilding({
+                // 'global' is the sentinel for "inherit the dashboard font" —
+                // persist it as undefined so saved configs only ever hold a
+                // concrete FONTS id (mirrors TypographySettings behaviour).
+                fontFamily: selected === 'global' ? undefined : selected,
+              });
+            }}
+            className="w-full px-2 py-1.5 text-xs border border-slate-200 rounded focus:ring-1 focus:ring-brand-blue-primary outline-none bg-white"
+          >
+            {FONTS.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.id === 'global'
+                  ? 'Global (Dashboard default)'
+                  : `${f.label} (${f.icon})`}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Default Text Size */}
+        <div>
+          <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+            Default Text Size
+          </label>
+          <select
+            value={currentBuildingConfig.textSizePreset ?? 'medium'}
+            onChange={(e) =>
+              handleUpdateBuilding({
+                textSizePreset: e.target.value as TextSizePreset,
+              })
+            }
+            className="w-full px-2 py-1.5 text-xs border border-slate-200 rounded focus:ring-1 focus:ring-brand-blue-primary outline-none bg-white"
+          >
+            {TEXT_SIZE_PRESET_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Default Text Colour */}
+        <div>
+          <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+            Default Text Colour
+          </label>
+          <HexColorField
+            value={currentBuildingConfig.fontColor}
+            onChange={(fontColor) => handleUpdateBuilding({ fontColor })}
+            fallback="#1e293b"
+            ariaLabel="Pick default Need / Do / Put / Then text colour"
+          />
+        </div>
+
+        {/* Default Surface Colour */}
+        <div>
+          <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+            Default Surface Colour
+          </label>
+          <HexColorField
+            value={currentBuildingConfig.cardColor}
+            onChange={(cardColor) => handleUpdateBuilding({ cardColor })}
+            fallback="#ffffff"
+            ariaLabel="Pick default Need / Do / Put / Then surface colour"
+          />
+        </div>
+
+        {/* Default Surface Opacity */}
+        <div>
+          <label className="text-xxs font-bold text-slate-500 uppercase mb-1 block">
+            Default Surface Opacity ({Math.round(cardOpacity * 100)}%)
+          </label>
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.05"
+            value={cardOpacity}
+            onChange={(e) =>
+              handleUpdateBuilding({
+                cardOpacity: parseFloat(e.target.value),
+              })
+            }
+            className="w-full accent-brand-blue-primary"
+            aria-label="Default Need / Do / Put / Then surface opacity"
+          />
         </div>
       </Card>
     </div>

--- a/docs/scheduled-tasks/admin-settings-alignment.md
+++ b/docs/scheduled-tasks/admin-settings-alignment.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
 _Last audited: 2026-06-14_
-_Last action: 2026-06-11_
+_Last action: 2026-06-14_
 
 ---
 
@@ -65,16 +65,18 @@ _2026-05-24 audit notes: Reviewed all changes since 2026-05-17. (1) Music widget
 - **Detail:** `GuidedLearningConfigurationPanel` is registered in `BUILDING_CONFIG_PANELS` in `FeatureConfigurationPanel.tsx`. The panel renders only an informational message: "Guided Learning settings are managed directly — please interact with the widget directly on your board." It has no `onChange` handler, writes nothing to Firestore, and there is no building defaults infrastructure for guided-learning (`GuidedLearningConfig` does not have a `BuildingGuidedLearningDefaults` interface in types.ts, and there is no `case 'guided-learning':` in `utils/adminBuildingConfig.ts`). The GuidedLearning widget reads `widget.config` directly — it does not read from feature_permissions at all. The admin panel button for this widget opens a panel that provides no functional value and shows a message that could be misleading (implying settings exist but are in-widget only).
 - **Fix:** Option (a): Remove `guided-learning` from `BUILDING_CONFIG_PANELS` so the admin UI falls through to the standard "No global settings available for this widget." placeholder — more accurate than an info stub. Option (b): If guided-learning admin defaults are genuinely planned (e.g., default view, default set library source), implement building defaults infrastructure (types.ts interface + adminBuildingConfig.ts case + real panel controls). Option (a) is lower-effort and more honest about current state.
 
-### MEDIUM `need-do-put-then` has stub admin config panel but no getAdminBuildingConfig handler
-
-- **Detected:** 2026-04-26
-- **File:** components/admin/NeedDoPutThenConfigurationPanel.tsx, context/DashboardContext.tsx (getAdminBuildingConfig)
-- **Detail:** `need-do-put-then` was added with `NeedDoPutThenConfigurationPanel.tsx` registered in `BUILDING_CONFIG_PANELS`. However: (1) the panel is a non-functional stub showing "No building-level defaults yet" with no input controls; (2) there is no `case 'need-do-put-then':` in `getAdminBuildingConfig()` in DashboardContext.tsx; (3) `NeedDoPutThenConfig` (types.ts:2897) has no building defaults interface. When a teacher adds the widget, `getAdminBuildingConfig('need-do-put-then')` falls through to `default: break` and returns `{}`. The admin gear button for this widget opens a panel but provides no functional controls and stores nothing useful.
-- **Fix:** Either (a) implement building-level defaults for the widget: add a `NeedDoPutThenBuildingDefaults` interface to types.ts, add a `case 'need-do-put-then':` handler in `getAdminBuildingConfig()`, and replace the stub panel with actual form controls for preset items per column; or (b) remove `NeedDoPutThenConfigurationPanel` from `BUILDING_CONFIG_PANELS` so the admin UI shows the standard "No global settings available" placeholder instead of a misleading stub.
-
 ---
 
 ## Completed
+
+### MEDIUM `need-do-put-then` has stub admin config panel but no getAdminBuildingConfig handler
+
+- **Detected:** 2026-04-26
+- **Completed:** 2026-06-14
+- **File:** types.ts (`BuildingNeedDoPutThenDefaults`, `NeedDoPutThenGlobalConfig`), components/admin/NeedDoPutThenConfigurationPanel.tsx, utils/adminBuildingConfig.ts (`case 'need-do-put-then'`), tests/utils/adminBuildingConfig.test.ts
+- **Detail:** `need-do-put-then` was registered in `BUILDING_CONFIG_PANELS` but (1) the panel was a non-functional stub ("No building-level defaults yet", no controls, took only `config` and no `onChange` so it could never persist), (2) there was no `case 'need-do-put-then':` in `getAdminBuildingConfig()`, and (3) there was no building-defaults interface. The admin gear opened a panel that stored nothing.
+- **Resolution:** Chose option (a) scoped to the **appearance** surface (not the per-column preset-tile editor — those Need/Do/Put/Then tiles are inherently per-instance content, not building-wide defaults). Verified `NeedDoPutThen/Widget.tsx` actively consumes all five appearance fields: `fontFamily` via `getFontClass()` (prefixed `FONTS`-id space, like `stations`), `fontColor`, `cardColor`/`cardOpacity` via `hexToRgba()`, and `textSizePreset` via `resolveTextPresetMultiplier()`. The widget's Settings tab uses the shared `TypographySettings` / `SurfaceColorSettings` / `TextSizePresetSettings` primitives, so this mirrors the resolved `stations` case exactly, plus `textSizePreset`. Added `BuildingNeedDoPutThenDefaults` + `NeedDoPutThenGlobalConfig` to types.ts; rewrote the panel into a functional `{config, onChange}` form (building selector + font family / text size / text colour / surface colour / surface opacity, mirroring `StationsConfigurationPanel`); added a validating `case 'need-do-put-then':` to `getAdminBuildingConfig()` (`isWidgetFontFamily` for the prefixed font, `isHexColor` for colours, `isCardOpacity` for opacity, enum-membership check for `textSizePreset`).
+- **Verification:** 4 new unit tests in `tests/utils/adminBuildingConfig.test.ts` (pass-through of all five fields; rejection of bare `GlobalFontFamily` ids; rejection of invalid font/colour/opacity/preset values; `cardOpacity` exact bounds 0 and 1) — `vitest run tests/utils/adminBuildingConfig.test.ts` → 34 passed. `pnpm exec tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` all clean on the four changed files.
 
 ### MEDIUM `activity-wall` admin ConfigurationPanel writes building defaults that nothing reads
 

--- a/docs/scheduled-tasks/admin-settings-alignment.md
+++ b/docs/scheduled-tasks/admin-settings-alignment.md
@@ -3,8 +3,8 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: 2026-06-07_
-_Last action: 2026-06-07_
+_Last audited: 2026-06-14_
+_Last action: 2026-06-11_
 
 ---
 
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-14 audit notes (Sunday): Full cross-check of commits since 2026-06-07 (Remote v2 series, wide-distro anonymous-join + user-tier gating, GL media pipeline overhaul, per-slide playback-range trim, GL PR review fixes, TimeTool i18n, bug fixes). Key findings: (1) GL media pipeline (013c58d3) added `GuidedLearning/Settings.tsx` (new file) — panel is stub-only ("Use the main widget panel…"; "Go to Library" button only), no new building-config fields needed. GuidedLearningConfig has no new per-building-defaultable fields in this commit. The existing LOW open item for the GL stub admin panel remains. (2) GL per-slide playback-range trim (d964872d) added `videoTrims` to `GuidedLearningSet` — this is a Firestore document field (per-set, not per-widget), not a widget config field; no building-config impact. (3) TimeTool i18n (bcfde20a) replaced 4 hardcoded strings with t() keys in `TimeTool/Settings.tsx` — string extraction only, no new config fields. (4) Wide-distro user tier (20a5dc17) added `utils/userTier.ts` + `userTier` field to `AuthContextValue` — this is auth state, not widget config. (5) Wide-distro anonymous join (885ea0b6) changed ActivityWall/Widget.tsx (adding join-link UI), types.ts (GlobalFeaturePermission minTier/userTiers fields) — no new widget-config building-default impact. (6) Checklist `rosterMode` status re-verified: `case 'checklist'` in adminBuildingConfig.ts handles items/scaleMultiplier/fontFamily/cardColor/cardOpacity/fontColor — no rosterMode. `BuildingChecklistDefaults` interface confirmed: buildingId/items/scaleMultiplier/fontFamily/fontColor/cardColor/cardOpacity (no rosterMode). The LOW open item remains valid. All other existing open items (MEDIUM: need-do-put-then stub; LOWs: SmartNotebook dead controls, Drawing shapeFill, Scoreboard layout) also remain unresolved. No new items found._
 
 _2026-06-11 action notes (Thursday): Selected the MEDIUM `activity-wall` item — highest-severity Open across today's reading list (dailies widget-registry/typescript-eslint had no open items, css-scaling only LOW; legacy-cleanup only LOW). The other MEDIUM (`need-do-put-then` stub panel) was the same severity in the same weekly journal but lower in document order. File-recency check passed: `components/widgets/ActivityWall/`, `hooks/useActivityWallLibrary.ts`, and `utils/adminBuildingConfig.ts` are all outside the last 5 branch commits. **Resolved via wiring (the journal's recommended fix), not by adding a `case 'activity-wall'` to `getAdminBuildingConfig()`** — these are activity-level (not widget-instance) defaults, so they're applied at activity-creation time. Added a pure, tested helper `resolveActivityWallBuildingDefaults()` (`components/widgets/ActivityWall/buildingDefaults.ts`) that reads `feature_permissions/activity-wall → config.buildingDefaults[building]` (canonicalizing legacy building keys, validating each persisted value), and seeded `buildBlankActivity()` from it in `ActivityWall/Widget.tsx` so the "New" activity editor opens pre-filled with the building's `defaultMode` / `defaultIdentificationMode` / `defaultModerationEnabled`. 8 new unit tests + updated the existing Widget test mock (added `featurePermissions`/`selectedBuildings`). `pnpm type-check`/`lint`/`format:check` clean; ActivityWall + new tests green. Moved the item to Completed. See PR to dev-paul._
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-13_
+_Last audited: 2026-06-14_
 _Last action: 2026-06-13_
 
 ---
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-14: Full scan of all Widget.tsx files after rebasing onto dev-paul (new commits since 2026-06-13: Remote v2 series, wide-distro anonymous-join gating, CalendarWidget midnight staleness fix, ActivityWall state extract, bug fixes). Widget.tsx files changed: (1) ActivityWall/Widget.tsx — changed by 885ea0b6 (wide-distro: adds anonymous-join gating UI to share modals; no new hardcoded Tailwind sizing in front-face content) and confirmed a0c2666b (ActivityWall checkbox cqmin fix already marked Completed in last entry). (2) CalendarWidget/Widget.tsx — changed by 6aa57535 (fix(widgets): CalendarWidget midnight staleness + useEffect ref-sync anti-pattern; logic-only change). Full Calendar widget CSS audit: widget has skipScaling:true; uses `min(calc((100% - min(30px, 6cqmin)) / 4), min(120px, 22cqmin))` for row heights and `min(Npx, Xcqmin)` throughout for all text/icon/spacing — no violations. Remote v2 control components (components/remote/controls/Remote\*.tsx) are not widget front-face content (they render in the MobileRemoteView on the teacher's phone, not inside a CSS container query context). All pre-existing open items re-confirmed valid. Zero new anti-patterns detected._
 
 _2026-06-13 (action): Fixed the highest-priority genuinely-open item — ActivityWall inline activity-editor "Require moderation" checkbox hardcoded `h-4 w-4` (ActivityWall/Widget.tsx, now :1376). Replaced the fixed 16px `h-4 w-4` Tailwind size classes with an inline `cqmin` size (`style={{ width: 'min(16px, 4cqmin)', height: 'min(16px, 4cqmin)' }}`), keeping `accent-brand-blue-primary` on className for the accent color. This caps the checkbox at 16px on large widgets while scaling it down proportionally at small sizes, matching the sibling "Require moderation" label which uses `min(12px, 3.8cqmin)`. File-recency check passed: ActivityWall/Widget.tsx was last touched at 592dd523 (2026-06-11 audit) — outside the last 5 branch commits. `tsc --noEmit`, `eslint --max-warnings 0`, and `prettier --check` on the changed file all clean; ActivityWall test suite (Widget + Settings, 11 tests) green. Moved the item to Completed. ALSO cleaned up two stale Open entries: (1) the CarRiderPro/First5 external-link overlay button group was already resolved in commit f60141cc (PR #1768 — both files now use `top: min(8px, 2cqmin)` / `right: min(8px, 2cqmin)` / `padding: min(6px, 1.5cqmin)`); removed from Open. (2) the GraphicOrganizer EditableNode `min-h-[50px]` entry was a duplicate of the already-Completed entry (completed 2026-05-31); removed from Open. Remaining open items: PollWidget progress bar (:161), EmbedWidget portaled toolbar, QuizResults period-filter text-sm (:1530), RevealGrid spacing, multi-widget group, MiniApp dialog text sizes._
 

--- a/docs/scheduled-tasks/legacy-cleanup.md
+++ b/docs/scheduled-tasks/legacy-cleanup.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Thursday_
-_Last audited: 2026-06-07_
+_Last audited: 2026-06-14_
 _Last action: never_
 
 ---
@@ -40,6 +40,18 @@ _Nothing currently in progress._
 ---
 
 ## Clean (no issues found)
+
+Migration code + dead exports + console.log audit (2026-06-14, re-verified after dev-paul rebase):
+
+- Old type strings 'timer', 'stopwatch': Only in `utils/migration.ts:71-80` and as `TimeToolMode` values in components — correct.
+- Old type string 'workSymbols': Only in `utils/migration.ts:93` — correct.
+- `migrateLocalStorageToFirestore()`: Still actively called in `context/DashboardContext.tsx:2042`. Still needed.
+- New dev-paul commits merged since 2026-06-07: Remote v2 series (components/remote/controls/ + MobileRemoteView.tsx + useRemoteConnection.ts), wide-distro (utils/userTier.ts + config/featureDefaults.ts), fix(state) utils/activityWallNormalize.ts. All new utilities confirmed actively imported in production code: `userTier.ts` imported by `context/AuthContext.tsx`; `activityWallNormalize.ts` imported by `hooks/useActivityWallLibrary.ts`; all `components/remote/controls/` files imported by `RemoteWidgetCard.tsx`; `useRemoteConnection.ts` imported by `MobileRemoteView.tsx`. Clean.
+- Commented-out code: None in new commits. `components/remote/` files have inline explanatory comments only — not commented-out code.
+- console.log(): Zero in components/, context/, hooks/, utils/.
+- `useScaledFont.ts`: Still dead — `ScheduleWidget.test.tsx` mocks it but no production component imports it. Existing LOW open item still valid.
+- `videoActivityDriveService.ts`: Still no production imports. Existing LOW open item still valid.
+- `scripts/tools/`: Still present with 9 Python/Playwright scripts. Existing LOW open item still valid.
 
 Migration code + dead exports + console.log audit (2026-06-07, re-verified after dev-paul merge):
 

--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -4,6 +4,37 @@ _Automated nightly review by claude-opus-4-6_
 
 ---
 
+## 2026-06-14
+
+- PRs reviewed: 8 (all open PRs; all head branches are `nightly/*` or `scheduled-tasks` → base `dev-paul`, all in-scope for pushing)
+  - #1969 — action(admin-config): wire need-do-put-then building defaults + Sunday audit (head `scheduled-tasks`)
+  - #1966 — chore: nightly debugger log 2026-06-14 (run 17) (head `nightly/debugger-log-2026-06-14`)
+  - #1965 — fix: Escape while editing widget title saves cancelled text to Firestore (head `nightly/dashboard-layout-2026-06-14`)
+  - #1964 — fix(i18n): translate 59 verbatim-English strings in DE/ES/FR collection UI (head `nightly/admin-config-2026-06-14`)
+  - #1963 — fix: CalendarWidget 'Today' label uses UTC date instead of local date (head `nightly/widgets-2026-06-14`)
+  - #1962 — chore(unifier): run 15 log (head `nightly/unifier-log-2026-06-14`)
+  - #1951 — fix(i18n): replace EN-placeholder strings in boardsModal/shareCollection (DE/ES/FR) (head `nightly/admin-config-2026-06-12`)
+  - #1945 — docs(unifier): run 14 memory log (head `nightly/unifier-log-2026-06-12`)
+- Comments processed: 8 total — 8 fixed, 0 explained-no-op (plus 1 pre-resolved thread on #1951 skipped)
+  - #1965: 1 gemini thread (MEDIUM) — removed redundant `setIsEditingTitle(false)` in `saveTitle` cancel guard. Fixed + replied.
+  - #1964: 3 gemini threads (MEDIUM) — DE `abgeheftet`→`entpinnt`; FR `échoué(s)`→`en échec` (×2). Fixed + replied.
+  - #1963: 3 gemini threads (MEDIUM) — `vi.restoreAllMocks()` to `afterEach`; drop manual call; derive `todayD` from `todayMidnightMs`. Fixed + replied.
+  - #1962: 1 gemini thread (MEDIUM) — corrected run-15 file-location wording (`useRemoteConnection.ts` is at `remote/` root; `.test.tsx` files). Fixed + replied.
+  - #1969, #1966, #1945: no open review comments.
+  - #1951: 1 pre-existing thread already resolved (Cyrillic fix) — no action.
+- Fixes pushed: 5
+  - #1965 / `nightly/dashboard-layout-2026-06-14` — remove redundant setState in saveTitle cancel guard (b7251be)
+  - #1964 / `nightly/admin-config-2026-06-14` — DE/FR translation phrasing fixes (7ee2af6)
+  - #1963 / `nightly/widgets-2026-06-14` — sync Today label to todayMidnightMs + centralize mock cleanup (e7bcf26)
+  - #1962 / `nightly/unifier-log-2026-06-14` — correct run-15 file-location note (f2c5720)
+  - (no push needed for #1969/#1966/#1945/#1951)
+  - All verified with type-check ✓ / lint ✓ / targeted tests ✓ before push. No pushes to `main`/`dev-*`.
+- Reviews posted: 8 (one structured `COMMENT` review per open PR)
+  - Ready: #1965, #1964, #1963, #1966, #1962, #1945, #1951
+  - Ready with minor notes: #1969 (small preset-list duplication in the new `getAdminBuildingConfig` case — non-blocking)
+
+---
+
 ## 2026-06-13
 
 - PRs reviewed: 11 (all open PRs; one head is `dev-paul` — read-only, review-only)

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-13_
+_Last audited: 2026-06-14_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-14. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: Remote v2 series (useRemoteConnection hook, RemoteActivityWallControl, RemoteEmbedControl, live-sync, immediate-write fast-path, board-name navigation, review-fixes), [AI] Phase 3b wide-distro anonymous-join gating (utils/userTier.ts, GlobalPermissionsManager, ActivityWall/Widget.tsx, config/featureDefaults.ts), fix(state) normalizeActivityWallLibraryEntry extraction (utils/activityWallNormalize.ts, hooks/useActivityWallLibrary.ts), fix(widgets) CalendarWidget midnight staleness (logic-only refactor), fix(lti) contextId privacy-strip, fix(i18n) TimeTool Stations strings, fix(keyboard) Alt+P CapsLock guard, action(css-scaling) ActivityWall checkbox cqmin. All new and modified code type-safe and lint-clean._
 
 _No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-06-13. TypeScript: 0 errors. ESLint: 0 errors, 0 warnings (`--max-warnings 0`). Rebased onto dev-paul: pr-review batch 12 PRs reviewed/5 fixes pushed, refactor(admin-config) shared isCardOpacity guard in adminBuildingConfig.ts, audit(friday) journal updates, [AI] wide-distro phases 1-3 (tiering/landing page/rollout), [AI] legal pages, [AI] drop restricted OAuth scopes. All new and modified code type-safe and lint-clean._
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-06-13_
+_Last audited: 2026-06-14_
 _Last action: 2026-05-15_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-06-14: Full audit after rebasing scheduled-tasks onto dev-paul (new commits since 2026-06-13: [AI] Remote v2 series — useRemoteConnection hook, RemoteActivityWallControl, RemoteEmbedControl, demo-path polish, live sync reflection, immediate-write fast-path, two-device smoke-test, review fixes, tap-board-name navigation; [AI] Phase 3b wide-distro anonymous-join gating; [AI] Specs for public poll participation and remote v2 design; fix(state) normalizeActivityWallLibraryEntry extraction; fix(lti) contextId across relaunches; fix(i18n) TimeTool Stations strings; fix(keyboard) Alt+P CapsLock guard; fix(widgets) CalendarWidget midnight staleness; docs(unifier) run 14; action(css-scaling) ActivityWall checkbox cqmin). None of these touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. types.ts was changed only for GlobalFeaturePermission (wide-distro tier gating), ActivityWall assignment classIds/rosterIds, and a GL commit that reformatted the WidgetType union but added no new members. VERIFIED COUNT: 63 WidgetType members (unchanged). All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (7 intentionally excluded sub-types: blooms-detail, catalyst-instruction, catalyst-visual, custom-widget, mathTool, onboarding, sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). pnpm type-check and pnpm lint both clean. Zero new gaps._
 
 _2026-06-13: Full audit after rebasing scheduled-tasks onto dev-paul (new commits since 2026-06-12: pr-review batch 12 PRs, refactor(admin-config) shared isCardOpacity guard, audit(friday) journals, [AI] wide-distro phases 1-3, [AI] legal pages, [AI] drop restricted OAuth scopes). None of these touch types.ts WidgetType union, WidgetRegistry.ts, widgetDefaults.ts, tools.ts, or widgetGradeLevels.ts. VERIFIED COUNT: 63 WidgetType members (unchanged). All 63 WidgetTypes correctly registered: 62 non-sticker in WIDGET_COMPONENTS (sticker intentional WidgetRenderer special-case per JSDoc), 63/63 in widgetDefaults.ts and widgetGradeLevels.ts, 59 user-selectable in tools.ts (7 intentionally excluded sub-types: blooms-detail, catalyst-instruction, catalyst-visual, custom-widget, mathTool, onboarding, sticker), 3 InternalToolType entries (magic, record, remote) correctly in tools.ts and widgetGradeLevels.ts but not WidgetType union (documented). pnpm type-check and pnpm lint both clean. Zero new gaps._
 

--- a/tests/utils/adminBuildingConfig.test.ts
+++ b/tests/utils/adminBuildingConfig.test.ts
@@ -348,6 +348,71 @@ describe('getAdminBuildingConfig', () => {
     });
   });
 
+  describe('need-do-put-then', () => {
+    it('passes through the prefixed font family, surface fields, and text size preset', () => {
+      const perm = makePerm('need-do-put-then', {
+        high: {
+          fontFamily: 'font-handwritten',
+          fontColor: '#0f172a',
+          cardColor: '#fef3c7',
+          cardOpacity: 0.6,
+          textSizePreset: 'large',
+        },
+      });
+      expect(
+        getAdminBuildingConfig('need-do-put-then', [perm], ['high'])
+      ).toEqual({
+        fontFamily: 'font-handwritten',
+        fontColor: '#0f172a',
+        cardColor: '#fef3c7',
+        cardOpacity: 0.6,
+        textSizePreset: 'large',
+      });
+    });
+
+    it('rejects bare GlobalFontFamily ids — uses the prefixed space', () => {
+      // 'sans' is a valid GlobalFontFamily value but NOT a FONTS id; the
+      // TypographySettings-backed widget expects 'font-sans'.
+      const perm = makePerm('need-do-put-then', {
+        high: { fontFamily: 'sans' },
+      });
+      expect(
+        getAdminBuildingConfig('need-do-put-then', [perm], ['high'])
+      ).toEqual({});
+    });
+
+    it('rejects invalid surface values, fonts, and text size presets', () => {
+      const perm = makePerm('need-do-put-then', {
+        high: {
+          fontFamily: 'not-a-font',
+          fontColor: 'rgb(0,0,0)',
+          cardColor: 'banana',
+          cardOpacity: 1.5,
+          textSizePreset: 'gigantic',
+        },
+      });
+      expect(
+        getAdminBuildingConfig('need-do-put-then', [perm], ['high'])
+      ).toEqual({});
+    });
+
+    it('accepts cardOpacity at exact bounds 0 and 1', () => {
+      const permZero = makePerm('need-do-put-then', {
+        high: { cardOpacity: 0 },
+      });
+      expect(
+        getAdminBuildingConfig('need-do-put-then', [permZero], ['high'])
+      ).toEqual({ cardOpacity: 0 });
+
+      const permOne = makePerm('need-do-put-then', {
+        high: { cardOpacity: 1 },
+      });
+      expect(
+        getAdminBuildingConfig('need-do-put-then', [permOne], ['high'])
+      ).toEqual({ cardOpacity: 1 });
+    });
+  });
+
   describe('checklist', () => {
     it('passes through scale, items, font family, and appearance fields', () => {
       const perm = makePerm('checklist', {

--- a/types.ts
+++ b/types.ts
@@ -5051,6 +5051,27 @@ export interface NeedDoPutThenConfig {
   };
 }
 
+// --- Need / Do / Put / Then Global Config ---
+export interface BuildingNeedDoPutThenDefaults {
+  buildingId: string;
+  /**
+   * Stored in the shared `TypographySettings` value space — a `FONTS` id such
+   * as `'font-sans'` / `'font-mono'`. The `'global'` sentinel (inherit from the
+   * dashboard) is represented by absence/`undefined`, never the literal string.
+   * Seeds `NeedDoPutThenConfig.fontFamily`, decoded at render via
+   * `getFontClass()` (same prefixed space the Stations widget uses).
+   */
+  fontFamily?: string;
+  fontColor?: string;
+  cardColor?: string;
+  cardOpacity?: number;
+  textSizePreset?: TextSizePreset;
+}
+
+export interface NeedDoPutThenGlobalConfig {
+  buildingDefaults: Record<string, BuildingNeedDoPutThenDefaults>;
+}
+
 /**
  * One station in the Stations widget. Stations are defined by the teacher in the
  * settings panel; students drag their name chips into the corresponding StationCard

--- a/utils/adminBuildingConfig.ts
+++ b/utils/adminBuildingConfig.ts
@@ -280,6 +280,30 @@ export const getAdminBuildingConfig = (
       if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
       if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
       break;
+    case 'need-do-put-then': {
+      // Like `stations`, the widget uses the shared TypographySettings /
+      // SurfaceColorSettings / TextSizePresetSettings primitives, so
+      // `fontFamily` is a prefixed `FONTS`-id (validated by
+      // `isWidgetFontFamily`). All five fields are actively consumed by
+      // NeedDoPutThen/Widget.tsx (getFontClass, hexToRgba, fontColor,
+      // resolveTextPresetMultiplier).
+      const validTextSizePresets = [
+        'small',
+        'medium',
+        'large',
+        'x-large',
+      ] as const;
+      if (isWidgetFontFamily(raw.fontFamily)) out.fontFamily = raw.fontFamily;
+      if (isHexColor(raw.fontColor)) out.fontColor = raw.fontColor;
+      if (isHexColor(raw.cardColor)) out.cardColor = raw.cardColor;
+      if (isCardOpacity(raw.cardOpacity)) out.cardOpacity = raw.cardOpacity;
+      if (
+        typeof raw.textSizePreset === 'string' &&
+        (validTextSizePresets as readonly string[]).includes(raw.textSizePreset)
+      )
+        out.textSizePreset = raw.textSizePreset;
+      break;
+    }
     case 'sound':
       if (raw.visual) out.visual = raw.visual;
       if (raw.sensitivity !== undefined) out.sensitivity = raw.sensitivity;


### PR DESCRIPTION
## Summary

This branch contains the Sunday 2026-06-14 scheduled-task audit plus one follow-up code action resolving the highest-priority open item.

### Code action — MEDIUM (admin-settings-alignment): wire `need-do-put-then` building appearance defaults

The `need-do-put-then` widget had a stub admin config panel registered in `BUILDING_CONFIG_PANELS` that stored nothing (it took only `config`, no `onChange`) and there was no `case 'need-do-put-then':` in `getAdminBuildingConfig()` — so the admin gear opened a panel that did nothing.

Verified the widget actively consumes its appearance config: `fontFamily` via `getFontClass()` (prefixed `FONTS`-id space, same as `stations`), `fontColor`, `cardColor`/`cardOpacity` via `hexToRgba()`, and `textSizePreset` via `resolveTextPresetMultiplier()`. The Settings tab uses the shared `TypographySettings` / `SurfaceColorSettings` / `TextSizePresetSettings` primitives, so building appearance defaults are genuinely consumed (this is the `stations` pattern + `textSizePreset`).

- **types.ts**: add `BuildingNeedDoPutThenDefaults` + `NeedDoPutThenGlobalConfig`
- **NeedDoPutThenConfigurationPanel.tsx**: rewrite the stub into a functional `{config, onChange}` appearance form (building selector + font family / text size / text colour / surface colour / surface opacity), mirroring `StationsConfigurationPanel`
- **utils/adminBuildingConfig.ts**: add a validating `case 'need-do-put-then':` (`isWidgetFontFamily`, `isHexColor`, `isCardOpacity`, enum check for `textSizePreset`)
- **tests/utils/adminBuildingConfig.test.ts**: 4 new cases (pass-through of all five fields, prefixed-font rejection, invalid-value rejection, `cardOpacity` exact bounds 0 and 1)

Per-column preset tiles (the actual Need/Do/Put/Then content) remain per-instance and are intentionally **not** building-defaultable.

**Verification:** `pnpm exec tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` all clean; `vitest run tests/utils/adminBuildingConfig.test.ts` → 34 passed.

### Sunday audit (journals)

- **Widget Registry:** 63 WidgetType members unchanged; no registry files touched. Zero new gaps.
- **CSS Scaling:** CalendarWidget midnight-staleness fix logic-only; ActivityWall anonymous-join adds no front-face violations. Zero new anti-patterns.
- **TypeScript & ESLint:** 0 errors, 0 warnings.
- **Admin Config & Settings Alignment:** MEDIUM item above moved to Completed; 4 LOW items remain.
- **Legacy Code & Cleanup:** three existing LOW items still valid.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxdgrYKG8CXAbZJGJJAPnR)_