### PR TITLE
UI: redesign Quiz/Video Activity monitor & results views to match the library

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -214,6 +214,13 @@ const LibraryDevHarness = import.meta.env.DEV
       }))
     )
   : null;
+const SessionViewsDevHarness = import.meta.env.DEV
+  ? lazy(() =>
+      import('./components/dev/SessionViewsDevHarness').then((module) => ({
+        default: module.SessionViewsDevHarness,
+      }))
+    )
+  : null;
 
 const FullPageLoader = () => (
   <div className="h-screen w-screen flex items-center justify-center bg-slate-50">
@@ -525,6 +532,22 @@ const App: React.FC = () => {
     return (
       <Suspense fallback={<FullPageLoader />}>
         <LibraryDevHarness />
+      </Suspense>
+    );
+  }
+
+  // DEV-ONLY: visual harness for the four live teacher session views (Quiz
+  // Monitor / Quiz Results / VA Monitor / VA Results) against mock data, so
+  // the redesign can be iterated without Firestore. Relies on
+  // VITE_AUTH_BYPASS. Same import.meta.env.DEV gating as the harnesses above.
+  if (
+    import.meta.env.DEV &&
+    SessionViewsDevHarness &&
+    pathname === '/session-views-dev'
+  ) {
+    return (
+      <Suspense fallback={<FullPageLoader />}>
+        <SessionViewsDevHarness />
       </Suspense>
     );
   }

--- a/components/common/library/LibraryShell.tsx
+++ b/components/common/library/LibraryShell.tsx
@@ -16,6 +16,7 @@ import {
   LibraryFolderPanelContext,
   type FolderPanelMode,
 } from './LibraryFolderPanelContext';
+import { SegmentedTabs } from '@/components/common/sessionViews/SegmentedTabs';
 
 /**
  * Widget-width breakpoints (px) for auto-collapsing the folder panel. Below
@@ -235,66 +236,13 @@ export const LibraryShell: React.FC<LibraryShellProps> = ({
           }}
         >
           {tabs.length > 0 ? (
-            <nav
-              role="tablist"
-              aria-label={`${widgetLabel} library tabs`}
-              className="flex items-center rounded-xl bg-slate-200/50 min-w-0"
-              style={{
-                padding: 'min(3px, 0.8cqmin)',
-                gap: 'min(2px, 0.5cqmin)',
-              }}
-            >
-              {tabs.map(({ key, label, icon: Icon, count }) => {
-                const selected = tab === key;
-                return (
-                  <button
-                    key={key}
-                    type="button"
-                    role="tab"
-                    aria-selected={selected}
-                    aria-label={label}
-                    title={tabLabelsHidden ? label : undefined}
-                    onClick={() => onTabChange(key)}
-                    className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors ${
-                      selected
-                        ? 'bg-white text-brand-blue-dark shadow-sm'
-                        : 'text-slate-500 hover:text-slate-800'
-                    }`}
-                    style={{
-                      gap: 'min(6px, 1.5cqmin)',
-                      paddingInline: 'min(12px, 2.8cqmin)',
-                      paddingBlock: 'min(6px, 1.5cqmin)',
-                      fontSize: 'min(13px, 3.8cqmin)',
-                    }}
-                  >
-                    <Icon
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                      className="shrink-0"
-                    />
-                    {!tabLabelsHidden && <span>{label}</span>}
-                    {count != null && count > 0 && (
-                      <span
-                        className={`inline-flex items-center justify-center rounded-full font-bold leading-none ${
-                          selected
-                            ? 'bg-brand-blue-primary text-white'
-                            : 'bg-slate-200/70 text-slate-600'
-                        }`}
-                        style={{
-                          paddingInline: 'min(7px, 1.8cqmin)',
-                          paddingBlock: 'min(2px, 0.5cqmin)',
-                          fontSize: 'min(10px, 3cqmin)',
-                        }}
-                      >
-                        {count}
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
-            </nav>
+            <SegmentedTabs
+              tabs={tabs}
+              value={tab}
+              onChange={onTabChange}
+              labelsHidden={tabLabelsHidden}
+              ariaLabel={`${widgetLabel} library tabs`}
+            />
           ) : (
             <div className="min-w-0" />
           )}

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface ActionButtonProps {
+  variant: 'primary' | 'secondary' | 'danger';
+  label: string;
+  icon?: LucideIcon;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledReason?: string;
+  /** Collapse to icon-only (tooltip shows the label). */
+  labelHidden?: boolean;
+}
+
+const VARIANT: Record<ActionButtonProps['variant'], string> = {
+  primary: 'bg-brand-blue-primary hover:bg-brand-blue-dark text-white',
+  secondary:
+    'bg-white/70 backdrop-blur-sm hover:bg-brand-blue-lighter/40 text-brand-blue-primary border border-brand-blue-primary/20',
+  danger: 'bg-brand-red-primary hover:bg-brand-red-dark text-white',
+};
+
+/**
+ * Action button matching the library header buttons. Primary/secondary mirror
+ * LibraryShell; danger adds the brand-red destructive variant for End-session.
+ */
+export const ActionButton: React.FC<ActionButtonProps> = ({
+  variant,
+  label,
+  icon: Icon,
+  onClick,
+  disabled = false,
+  disabledReason,
+  labelHidden = false,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    title={disabled ? disabledReason : labelHidden ? label : undefined}
+    aria-label={label}
+    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${VARIANT[variant]}`}
+    style={{
+      paddingInline: labelHidden ? '0' : 'min(14px, 3cqmin)',
+      paddingBlock: 'min(8px, 1.8cqmin)',
+      fontSize: 'min(14px, 4cqmin)',
+      minWidth: labelHidden ? 'min(36px, 10cqmin)' : undefined,
+      height: labelHidden ? 'min(36px, 10cqmin)' : undefined,
+    }}
+  >
+    {Icon && (
+      <Icon
+        style={{ width: 'min(16px, 4.5cqmin)', height: 'min(16px, 4.5cqmin)' }}
+        className="shrink-0"
+      />
+    )}
+    {!labelHidden && <span className="truncate">{label}</span>}
+  </button>
+);

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -43,7 +43,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   <button
     type="button"
     onClick={onClick}
-    disabled={disabled}
+    disabled={disabled || loading}
     title={disabled ? disabledReason : labelHidden ? label : undefined}
     aria-label={label}
     aria-pressed={active}

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -37,7 +37,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   disabled = false,
   disabledReason,
   loading = false,
-  active = false,
+  active,
   labelHidden = false,
 }) => (
   <button

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Loader2 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 interface ActionButtonProps {
@@ -8,6 +9,8 @@ interface ActionButtonProps {
   onClick: () => void;
   disabled?: boolean;
   disabledReason?: string;
+  /** Show a spinner in place of the icon while an async operation is in flight. */
+  loading?: boolean;
   /** Collapse to icon-only (tooltip shows the label). */
   labelHidden?: boolean;
 }
@@ -30,6 +33,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   onClick,
   disabled = false,
   disabledReason,
+  loading = false,
   labelHidden = false,
 }) => (
   <button
@@ -47,11 +51,21 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
       height: labelHidden ? 'min(36px, 10cqmin)' : undefined,
     }}
   >
-    {Icon && (
-      <Icon
+    {loading ? (
+      <Loader2
         style={{ width: 'min(16px, 4.5cqmin)', height: 'min(16px, 4.5cqmin)' }}
-        className="shrink-0"
+        className="shrink-0 animate-spin"
       />
+    ) : (
+      Icon && (
+        <Icon
+          style={{
+            width: 'min(16px, 4.5cqmin)',
+            height: 'min(16px, 4.5cqmin)',
+          }}
+          className="shrink-0"
+        />
+      )
     )}
     {!labelHidden && <span className="truncate">{label}</span>}
   </button>

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -47,7 +47,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
     title={disabled ? disabledReason : labelHidden ? label : undefined}
     aria-label={label}
     aria-pressed={active}
-    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${
+    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
       active
         ? 'bg-amber-100 text-amber-700 ring-2 ring-amber-400 hover:bg-amber-200'
         : VARIANT[variant]

--- a/components/common/sessionViews/ActionButton.tsx
+++ b/components/common/sessionViews/ActionButton.tsx
@@ -11,6 +11,9 @@ interface ActionButtonProps {
   disabledReason?: string;
   /** Show a spinner in place of the icon while an async operation is in flight. */
   loading?: boolean;
+  /** Toggle "on" state — applies a glanceable amber treatment (e.g. for the
+   *  live-scoreboard toggle). Overrides the variant colors while active. */
+  active?: boolean;
   /** Collapse to icon-only (tooltip shows the label). */
   labelHidden?: boolean;
 }
@@ -34,6 +37,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
   disabled = false,
   disabledReason,
   loading = false,
+  active = false,
   labelHidden = false,
 }) => (
   <button
@@ -42,7 +46,12 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
     disabled={disabled}
     title={disabled ? disabledReason : labelHidden ? label : undefined}
     aria-label={label}
-    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${VARIANT[variant]}`}
+    aria-pressed={active}
+    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${
+      active
+        ? 'bg-amber-100 text-amber-700 ring-2 ring-amber-400 hover:bg-amber-200'
+        : VARIANT[variant]
+    }`}
     style={{
       paddingInline: labelHidden ? '0' : 'min(14px, 3cqmin)',
       paddingBlock: 'min(8px, 1.8cqmin)',

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -29,7 +29,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   useEffect(() => {
     if (!open) return undefined;
     const onDown = (e: MouseEvent): void => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
+      if (ref.current && e.target && !ref.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -118,7 +118,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
                 key={item.id ?? item.label}
                 type="button"
                 role="menuitem"
-                disabled={item.disabled}
+                disabled={!!item.disabled || !!item.loading}
                 onClick={() => {
                   setOpen(false);
                   item.onClick();

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -1,6 +1,14 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { MoreHorizontal, Loader2 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { useClickOutside } from '@/hooks/useClickOutside';
 import { Z_INDEX } from '@/config/zIndex';
 
 export interface OverflowMenuItem {
@@ -23,56 +31,64 @@ interface OverflowMenuProps {
 
 /**
  * Kebab overflow menu matching the library dropdown surface. Used to declutter
- * the results-view headers — secondary actions live here. Implements the core
- * ARIA menu-button keyboard pattern: focus moves to the first item on open,
- * Arrow Up/Down navigates items, and Escape closes + returns focus to the
- * trigger so a keyboard user keeps their place.
+ * the results-view headers — secondary actions live here. The dropdown is
+ * portalled to <body> (position:fixed, measured from the trigger) so it isn't
+ * clipped by the widget's overflow-hidden container (DraggableWindow), the same
+ * pattern the library's own overflow menus use. Implements the core ARIA
+ * menu-button keyboard pattern: focus moves to the first item on open, Arrow
+ * Up/Down navigates, Escape closes + returns focus to the trigger, and Tab
+ * closes so focus continues in document order.
  */
 export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   items,
   ariaLabel = 'More actions',
 }) => {
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(
+    null
+  );
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // Close on outside click + Escape. Escape returns focus to the trigger.
-  // External-system sync (document listeners) — a valid useEffect use.
-  useEffect(() => {
-    if (!open) return undefined;
-    const onDown = (e: MouseEvent): void => {
-      if (
-        containerRef.current &&
-        e.target &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-    document.addEventListener('mousedown', onDown);
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('mousedown', onDown);
-      document.removeEventListener('keydown', onKey);
-    };
+  // Dismiss on outside click — ignore the portalled menu so clicks inside it
+  // don't close it. Memoized so useClickOutside doesn't re-subscribe each render.
+  const ignoreRefs = useMemo(() => [menuRef], []);
+  useClickOutside(wrapperRef, () => setOpen(false), ignoreRefs);
+
+  // Measure the trigger when the menu opens so the portal renders flush under it.
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
   }, [open]);
 
-  // Move focus into the menu (first enabled item) when it opens.
+  // Move focus to the first enabled item once the menu is positioned + rendered.
   useEffect(() => {
-    if (!open) return;
+    if (!open || !menuPos) return;
     menuRef.current
       ?.querySelector<HTMLButtonElement>('[role="menuitem"]:not([disabled])')
       ?.focus();
+  }, [open, menuPos]);
+
+  // Close on scroll/resize — the fixed position is captured at open time.
+  useEffect(() => {
+    if (!open) return undefined;
+    const close = (): void => setOpen(false);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
   }, [open]);
 
   const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Escape') {
+      setOpen(false);
+      triggerRef.current?.focus();
+      return;
+    }
     if (e.key === 'Tab') {
       // Close on Tab so focus continues in normal document order (unlike
       // Escape, we don't pull focus back to the trigger).
@@ -96,7 +112,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   };
 
   return (
-    <div className="relative" ref={containerRef}>
+    <div className="relative" ref={wrapperRef}>
       <button
         ref={triggerRef}
         type="button"
@@ -111,46 +127,52 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
           style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
         />
       </button>
-      {open && (
-        <div
-          ref={menuRef}
-          role="menu"
-          onKeyDown={onMenuKeyDown}
-          style={{ zIndex: Z_INDEX.dropdown }}
-          className="absolute right-0 top-full mt-1 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
-        >
-          {items.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.id ?? item.label}
-                type="button"
-                role="menuitem"
-                disabled={!!item.disabled || !!item.loading}
-                onClick={() => {
-                  setOpen(false);
-                  // Return focus to the trigger so keyboard users keep their
-                  // place on the header bar after a secondary action.
-                  triggerRef.current?.focus();
-                  item.onClick();
-                }}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 ${
-                  item.destructive
-                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30 focus:bg-brand-red-lighter/30'
-                    : 'text-slate-700 hover:bg-slate-100 focus:bg-slate-100'
-                }`}
-              >
-                {item.loading ? (
-                  <Loader2 size={16} className="shrink-0 animate-spin" />
-                ) : (
-                  Icon && <Icon size={16} className="shrink-0" />
-                )}
-                <span className="truncate">{item.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {open &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            onKeyDown={onMenuKeyDown}
+            style={{
+              position: 'fixed',
+              top: menuPos.top,
+              right: menuPos.right,
+              zIndex: Z_INDEX.dropdown,
+            }}
+            className="min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+          >
+            {items.map((item) => {
+              const Icon = item.icon;
+              return (
+                <button
+                  key={item.id ?? item.label}
+                  type="button"
+                  role="menuitem"
+                  disabled={!!item.disabled || !!item.loading}
+                  onClick={() => {
+                    setOpen(false);
+                    triggerRef.current?.focus();
+                    item.onClick();
+                  }}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 ${
+                    item.destructive
+                      ? 'text-brand-red-dark hover:bg-brand-red-lighter/30 focus:bg-brand-red-lighter/30'
+                      : 'text-slate-700 hover:bg-slate-100 focus:bg-slate-100'
+                  }`}
+                >
+                  {item.loading ? (
+                    <Loader2 size={16} className="shrink-0 animate-spin" />
+                  ) : (
+                    Icon && <Icon size={16} className="shrink-0" />
+                  )}
+                  <span className="truncate">{item.label}</span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
     </div>
   );
 };

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { MoreHorizontal, Loader2 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { Z_INDEX } from '@/config/zIndex';
 
 export interface OverflowMenuItem {
   label: string;
@@ -109,7 +110,8 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
           ref={menuRef}
           role="menu"
           onKeyDown={onMenuKeyDown}
-          className="absolute right-0 top-full mt-1 z-50 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+          style={{ zIndex: Z_INDEX.dropdown }}
+          className="absolute right-0 top-full mt-1 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
         >
           {items.map((item) => {
             const Icon = item.icon;

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -97,7 +97,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+        className="inline-flex items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1"
         style={{ width: 'min(36px, 10cqmin)', height: 'min(36px, 10cqmin)' }}
       >
         <MoreHorizontal
@@ -126,10 +126,10 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
                   triggerRef.current?.focus();
                   item.onClick();
                 }}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 ${
                   item.destructive
-                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
-                    : 'text-slate-700 hover:bg-slate-100'
+                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30 focus:bg-brand-red-lighter/30'
+                    : 'text-slate-700 hover:bg-slate-100 focus:bg-slate-100'
                 }`}
               >
                 {item.loading ? (

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface OverflowMenuItem {
+  label: string;
+  icon?: LucideIcon;
+  onClick: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+}
+
+interface OverflowMenuProps {
+  items: OverflowMenuItem[];
+  ariaLabel?: string;
+}
+
+/**
+ * Kebab overflow menu matching the library dropdown surface. Used to declutter
+ * the results-view headers — secondary actions live here.
+ */
+export const OverflowMenu: React.FC<OverflowMenuProps> = ({
+  items,
+  ariaLabel = 'More actions',
+}) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  // External-system sync (document click) — a valid useEffect use.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+        style={{ width: 'min(36px, 10cqmin)', height: 'min(36px, 10cqmin)' }}
+      >
+        <MoreHorizontal
+          style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
+        />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-50 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+        >
+          {items.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => {
+                  setOpen(false);
+                  item.onClick();
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                  item.destructive
+                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                    : 'text-slate-700 hover:bg-slate-100'
+                }`}
+              >
+                {Icon && <Icon size={16} className="shrink-0" />}
+                <span className="truncate">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -66,9 +66,14 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   // Move focus to the first enabled item once the menu is positioned + rendered.
   useEffect(() => {
     if (!open || !menuPos) return;
-    menuRef.current
-      ?.querySelector<HTMLButtonElement>('[role="menuitem"]:not([disabled])')
-      ?.focus();
+    const menu = menuRef.current;
+    // Prefer the first enabled item, but fall back to the first item so focus
+    // still enters the menu when every item is (transiently) disabled.
+    const target =
+      menu?.querySelector<HTMLButtonElement>(
+        '[role="menuitem"]:not([aria-disabled="true"])'
+      ) ?? menu?.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    target?.focus();
   }, [open, menuPos]);
 
   // Close on scroll/resize — the fixed position is captured at open time.
@@ -102,7 +107,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
     e.preventDefault();
     const nodes = Array.from(
       menuRef.current?.querySelectorAll<HTMLButtonElement>(
-        '[role="menuitem"]:not([disabled])'
+        '[role="menuitem"]'
       ) ?? []
     );
     if (nodes.length === 0) return;
@@ -152,13 +157,16 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
                   key={item.id ?? item.label}
                   type="button"
                   role="menuitem"
-                  disabled={!!item.disabled || !!item.loading}
+                  aria-disabled={!!item.disabled || !!item.loading || undefined}
                   onClick={() => {
+                    // aria-disabled (not the native attribute) keeps the item
+                    // focusable + announced; guard activation here instead.
+                    if (item.disabled || item.loading) return;
                     setOpen(false);
                     triggerRef.current?.focus();
                     item.onClick();
                   }}
-                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors focus:outline-none disabled:cursor-not-allowed disabled:opacity-40 ${
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-40 ${
                     item.destructive
                       ? 'text-brand-red-dark hover:bg-brand-red-lighter/30 focus:bg-brand-red-lighter/30'
                       : 'text-slate-700 hover:bg-slate-100 focus:bg-slate-100'

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { MoreHorizontal } from 'lucide-react';
+import { MoreHorizontal, Loader2 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 export interface OverflowMenuItem {
@@ -11,6 +11,8 @@ export interface OverflowMenuItem {
   onClick: () => void;
   destructive?: boolean;
   disabled?: boolean;
+  /** Show a spinner in place of the icon while an async action is in flight. */
+  loading?: boolean;
 }
 
 interface OverflowMenuProps {
@@ -20,24 +22,38 @@ interface OverflowMenuProps {
 
 /**
  * Kebab overflow menu matching the library dropdown surface. Used to declutter
- * the results-view headers — secondary actions live here.
+ * the results-view headers — secondary actions live here. Implements the core
+ * ARIA menu-button keyboard pattern: focus moves to the first item on open,
+ * Arrow Up/Down navigates items, and Escape closes + returns focus to the
+ * trigger so a keyboard user keeps their place.
  */
 export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   items,
   ariaLabel = 'More actions',
 }) => {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  // External-system sync (document click + Escape key) — a valid useEffect use.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click + Escape. Escape returns focus to the trigger.
+  // External-system sync (document listeners) — a valid useEffect use.
   useEffect(() => {
     if (!open) return undefined;
     const onDown = (e: MouseEvent): void => {
-      if (ref.current && e.target && !ref.current.contains(e.target as Node)) {
+      if (
+        containerRef.current &&
+        e.target &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
         setOpen(false);
       }
     };
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     };
     document.addEventListener('mousedown', onDown);
     document.addEventListener('keydown', onKey);
@@ -46,9 +62,36 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
       document.removeEventListener('keydown', onKey);
     };
   }, [open]);
+
+  // Move focus into the menu (first enabled item) when it opens.
+  useEffect(() => {
+    if (!open) return;
+    menuRef.current
+      ?.querySelector<HTMLButtonElement>('[role="menuitem"]:not([disabled])')
+      ?.focus();
+  }, [open]);
+
+  const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    e.preventDefault();
+    const nodes = Array.from(
+      menuRef.current?.querySelectorAll<HTMLButtonElement>(
+        '[role="menuitem"]:not([disabled])'
+      ) ?? []
+    );
+    if (nodes.length === 0) return;
+    const idx = nodes.indexOf(document.activeElement as HTMLButtonElement);
+    const next =
+      e.key === 'ArrowDown'
+        ? nodes[(idx + 1) % nodes.length]
+        : nodes[(idx - 1 + nodes.length) % nodes.length];
+    next?.focus();
+  };
+
   return (
-    <div className="relative" ref={ref}>
+    <div className="relative" ref={containerRef}>
       <button
+        ref={triggerRef}
         type="button"
         aria-label={ariaLabel}
         aria-haspopup="menu"
@@ -63,7 +106,9 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
       </button>
       {open && (
         <div
+          ref={menuRef}
           role="menu"
+          onKeyDown={onMenuKeyDown}
           className="absolute right-0 top-full mt-1 z-50 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
         >
           {items.map((item) => {
@@ -84,7 +129,11 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
                     : 'text-slate-700 hover:bg-slate-100'
                 }`}
               >
-                {Icon && <Icon size={16} className="shrink-0" />}
+                {item.loading ? (
+                  <Loader2 size={16} className="shrink-0 animate-spin" />
+                ) : (
+                  Icon && <Icon size={16} className="shrink-0" />
+                )}
                 <span className="truncate">{item.label}</span>
               </button>
             );

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -90,9 +90,12 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
       return;
     }
     if (e.key === 'Tab') {
-      // Close on Tab so focus continues in normal document order (unlike
-      // Escape, we don't pull focus back to the trigger).
+      // The menu is portalled to <body>, so a native Tab from a menu item would
+      // jump to the end of the document, not the trigger's neighbour. Close and
+      // return focus to the trigger; the user's next Tab then advances naturally.
+      e.preventDefault();
       setOpen(false);
+      triggerRef.current?.focus();
       return;
     }
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -121,6 +121,9 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
                 disabled={!!item.disabled || !!item.loading}
                 onClick={() => {
                   setOpen(false);
+                  // Return focus to the trigger so keyboard users keep their
+                  // place on the header bar after a secondary action.
+                  triggerRef.current?.focus();
                   item.onClick();
                 }}
                 className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -4,6 +4,9 @@ import type { LucideIcon } from 'lucide-react';
 
 export interface OverflowMenuItem {
   label: string;
+  /** Stable React key; falls back to `label` when omitted. Set this when two
+   *  items could share a label (e.g. re-export variants). */
+  id?: string;
   icon?: LucideIcon;
   onClick: () => void;
   destructive?: boolean;
@@ -25,7 +28,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
 }) => {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  // External-system sync (document click) — a valid useEffect use.
+  // External-system sync (document click + Escape key) — a valid useEffect use.
   useEffect(() => {
     if (!open) return undefined;
     const onDown = (e: MouseEvent): void => {
@@ -33,8 +36,15 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
         setOpen(false);
       }
     };
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false);
+    };
     document.addEventListener('mousedown', onDown);
-    return () => document.removeEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+    };
   }, [open]);
   return (
     <div className="relative" ref={ref}>
@@ -60,7 +70,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
             const Icon = item.icon;
             return (
               <button
-                key={item.label}
+                key={item.id ?? item.label}
                 type="button"
                 role="menuitem"
                 disabled={item.disabled}

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -73,6 +73,12 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
   }, [open]);
 
   const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Tab') {
+      // Close on Tab so focus continues in normal document order (unlike
+      // Escape, we don't pull focus back to the trigger).
+      setOpen(false);
+      return;
+    }
     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
     e.preventDefault();
     const nodes = Array.from(

--- a/components/common/sessionViews/ScorePill.tsx
+++ b/components/common/sessionViews/ScorePill.tsx
@@ -40,7 +40,7 @@ export const ScorePill: React.FC<ScorePillProps> = ({
   let text: string;
   if (gamified) text = `${points ?? 0}`;
   else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;
-  else text = `${Math.round(score)}%`;
+  else text = `${Number.isFinite(score) ? Math.round(score) : 0}%`;
   if (suffix) text += suffix;
   return (
     <span

--- a/components/common/sessionViews/ScorePill.tsx
+++ b/components/common/sessionViews/ScorePill.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { scoreColorClasses } from '@/utils/scoreColor';
+
+interface ScorePillProps {
+  /** 0–100 percentage; ignored when display is 'count' or 'hidden'. */
+  score: number;
+  display: 'percent' | 'count' | 'hidden';
+  /** Answered count, used when display is 'count'. */
+  count?: number;
+  /** Total questions, used when display is 'count'. */
+  total?: number;
+  /** Gamified sessions show raw points in brand-blue rather than a graded color. */
+  gamified?: boolean;
+  /** Raw points to show when gamified. */
+  points?: number;
+}
+
+/**
+ * Score chip colored via the unified scoreColor helper. Supports the three
+ * teacher score-display modes (percent / raw count / hidden) plus the gamified
+ * points variant used by the live scoreboard.
+ */
+export const ScorePill: React.FC<ScorePillProps> = ({
+  score,
+  display,
+  count,
+  total,
+  gamified = false,
+  points,
+}) => {
+  if (display === 'hidden') return null;
+  const colorClass = gamified
+    ? 'text-brand-blue-dark'
+    : scoreColorClasses(score).text;
+  let text: string;
+  if (gamified) text = `${points ?? 0}`;
+  else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;
+  else text = `${Math.round(score)}%`;
+  return (
+    <span
+      data-testid="score-pill"
+      className={`font-black tabular-nums shrink-0 ${colorClass}`}
+      style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+    >
+      {text}
+    </span>
+  );
+};

--- a/components/common/sessionViews/ScorePill.tsx
+++ b/components/common/sessionViews/ScorePill.tsx
@@ -31,7 +31,9 @@ export const ScorePill: React.FC<ScorePillProps> = ({
   if (display === 'hidden') return null;
   const colorClass = gamified
     ? 'text-brand-blue-dark'
-    : scoreColorClasses(score).text;
+    : display === 'count'
+      ? 'text-slate-600'
+      : scoreColorClasses(score).text;
   let text: string;
   if (gamified) text = `${points ?? 0}`;
   else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;

--- a/components/common/sessionViews/ScorePill.tsx
+++ b/components/common/sessionViews/ScorePill.tsx
@@ -40,7 +40,8 @@ export const ScorePill: React.FC<ScorePillProps> = ({
   let text: string;
   if (gamified) text = `${points ?? 0}`;
   else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;
-  else text = `${Number.isFinite(score) ? Math.round(score) : 0}%`;
+  else
+    text = `${Number.isFinite(score) ? Math.round(Math.max(0, Math.min(100, score))) : 0}%`;
   if (suffix) text += suffix;
   return (
     <span

--- a/components/common/sessionViews/ScorePill.tsx
+++ b/components/common/sessionViews/ScorePill.tsx
@@ -13,6 +13,8 @@ interface ScorePillProps {
   gamified?: boolean;
   /** Raw points to show when gamified. */
   points?: number;
+  /** Optional unit suffix appended to the value (e.g. ' pts' for gamified points). */
+  suffix?: string;
 }
 
 /**
@@ -27,6 +29,7 @@ export const ScorePill: React.FC<ScorePillProps> = ({
   total,
   gamified = false,
   points,
+  suffix,
 }) => {
   if (display === 'hidden') return null;
   const colorClass = gamified
@@ -38,6 +41,7 @@ export const ScorePill: React.FC<ScorePillProps> = ({
   if (gamified) text = `${points ?? 0}`;
   else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;
   else text = `${Math.round(score)}%`;
+  if (suffix) text += suffix;
   return (
     <span
       data-testid="score-pill"

--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -19,6 +19,14 @@ interface SegmentedTabsProps<K extends string = string> {
   /** Accessible name for the tablist — required so multiple tab controls on a
    *  page are distinguishable (WCAG 4.1.2). */
   ariaLabel: string;
+  /**
+   * When set, each tab gets `id="{panelIdPrefix}-tab-{key}"` +
+   * `aria-controls="{panelIdPrefix}-panel-{key}"`. The caller must render the
+   * active panel with `id="{panelIdPrefix}-panel-{value}"` +
+   * `aria-labelledby="{panelIdPrefix}-tab-{value}"` to complete the ARIA tabs
+   * linkage. Use a per-instance prefix (e.g. React `useId()`).
+   */
+  panelIdPrefix?: string;
 }
 
 /**
@@ -31,6 +39,7 @@ export function SegmentedTabs<K extends string = string>({
   onChange,
   labelsHidden = false,
   ariaLabel,
+  panelIdPrefix,
 }: SegmentedTabsProps<K>): React.ReactElement {
   return (
     <nav
@@ -46,7 +55,11 @@ export function SegmentedTabs<K extends string = string>({
             key={key}
             type="button"
             role="tab"
+            id={panelIdPrefix ? `${panelIdPrefix}-tab-${key}` : undefined}
             aria-selected={selected}
+            aria-controls={
+              panelIdPrefix ? `${panelIdPrefix}-panel-${key}` : undefined
+            }
             aria-label={label}
             title={labelsHidden ? label : undefined}
             onClick={() => onChange(key)}

--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -16,7 +16,9 @@ interface SegmentedTabsProps<K extends string = string> {
   onChange: (key: K) => void;
   /** Collapse labels to icon-only (the caller measures width). */
   labelsHidden?: boolean;
-  ariaLabel?: string;
+  /** Accessible name for the tablist — required so multiple tab controls on a
+   *  page are distinguishable (WCAG 4.1.2). */
+  ariaLabel: string;
 }
 
 /**

--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+export interface SegmentedTab<K extends string = string> {
+  key: K;
+  label: string;
+  icon?: React.ComponentType<{
+    style?: React.CSSProperties;
+    className?: string;
+  }>;
+  count?: number;
+}
+
+interface SegmentedTabsProps<K extends string = string> {
+  tabs: SegmentedTab<K>[];
+  value: K;
+  onChange: (key: K) => void;
+  /** Collapse labels to icon-only (the caller measures width). */
+  labelsHidden?: boolean;
+  ariaLabel?: string;
+}
+
+/**
+ * Segmented-pill tab control extracted from LibraryShell so the library and the
+ * Quiz/VA results views share one tab component. Fully container-query scaled.
+ */
+export function SegmentedTabs<K extends string = string>({
+  tabs,
+  value,
+  onChange,
+  labelsHidden = false,
+  ariaLabel,
+}: SegmentedTabsProps<K>): React.ReactElement {
+  return (
+    <nav
+      role="tablist"
+      aria-label={ariaLabel}
+      className="flex items-center rounded-xl bg-slate-200/50 min-w-0"
+      style={{ padding: 'min(3px, 0.8cqmin)', gap: 'min(2px, 0.5cqmin)' }}
+    >
+      {tabs.map(({ key, label, icon: Icon, count }) => {
+        const selected = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            aria-label={label}
+            title={labelsHidden ? label : undefined}
+            onClick={() => onChange(key)}
+            className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors ${
+              selected
+                ? 'bg-white text-brand-blue-dark shadow-sm'
+                : 'text-slate-500 hover:text-slate-800'
+            }`}
+            style={{
+              gap: 'min(6px, 1.5cqmin)',
+              paddingInline: 'min(12px, 2.8cqmin)',
+              paddingBlock: 'min(6px, 1.5cqmin)',
+              fontSize: 'min(13px, 3.8cqmin)',
+            }}
+          >
+            {Icon && (
+              <Icon
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+                className="shrink-0"
+              />
+            )}
+            {!labelsHidden && <span>{label}</span>}
+            {count != null && count > 0 && (
+              <span
+                className={`inline-flex items-center justify-center rounded-full font-bold leading-none ${
+                  selected
+                    ? 'bg-brand-blue-primary text-white'
+                    : 'bg-slate-200/70 text-slate-600'
+                }`}
+                style={{
+                  paddingInline: 'min(7px, 1.8cqmin)',
+                  paddingBlock: 'min(2px, 0.5cqmin)',
+                  fontSize: 'min(10px, 3cqmin)',
+                }}
+              >
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -60,7 +60,7 @@ export function SegmentedTabs<K extends string = string>({
             aria-controls={
               panelIdPrefix ? `${panelIdPrefix}-panel-${key}` : undefined
             }
-            aria-label={label}
+            aria-label={labelsHidden ? label : undefined}
             title={labelsHidden ? label : undefined}
             onClick={() => onChange(key)}
             className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
@@ -87,6 +87,7 @@ export function SegmentedTabs<K extends string = string>({
             {!labelsHidden && <span>{label}</span>}
             {count != null && count > 0 && (
               <span
+                aria-hidden="true"
                 className={`inline-flex items-center justify-center rounded-full font-bold leading-none ${
                   selected
                     ? 'bg-brand-blue-primary text-white'

--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -48,7 +48,7 @@ export function SegmentedTabs<K extends string = string>({
             aria-label={label}
             title={labelsHidden ? label : undefined}
             onClick={() => onChange(key)}
-            className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors ${
+            className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1 ${
               selected
                 ? 'bg-white text-brand-blue-dark shadow-sm'
                 : 'text-slate-500 hover:text-slate-800'

--- a/components/common/sessionViews/SessionBadge.tsx
+++ b/components/common/sessionViews/SessionBadge.tsx
@@ -51,7 +51,7 @@ export const SessionBadge: React.FC<SessionBadgeProps> = ({
     >
       {dot && (
         <span
-          className={`rounded-full ${t.dot} ${tone === 'success' ? 'animate-pulse' : ''}`}
+          className={`rounded-full ${t.dot} ${tone === 'success' ? 'animate-pulse motion-reduce:animate-none' : ''}`}
           style={{ width: 'min(6px, 1.8cqmin)', height: 'min(6px, 1.8cqmin)' }}
         />
       )}

--- a/components/common/sessionViews/SessionBadge.tsx
+++ b/components/common/sessionViews/SessionBadge.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export type SessionTone = 'success' | 'warn' | 'info' | 'neutral' | 'danger';
+
+const TONE: Record<SessionTone, { bg: string; fg: string; dot: string }> = {
+  success: {
+    bg: 'bg-emerald-100',
+    fg: 'text-emerald-700',
+    dot: 'bg-emerald-500',
+  },
+  warn: { bg: 'bg-amber-100', fg: 'text-amber-700', dot: 'bg-amber-500' },
+  info: { bg: 'bg-blue-100', fg: 'text-blue-700', dot: 'bg-blue-500' },
+  neutral: { bg: 'bg-slate-200', fg: 'text-slate-500', dot: 'bg-slate-400' },
+  danger: { bg: 'bg-red-100', fg: 'text-red-700', dot: 'bg-red-500' },
+};
+
+interface SessionBadgeProps {
+  tone: SessionTone;
+  label: string;
+  icon?: LucideIcon;
+  /** Render a leading status dot (success dots pulse). */
+  dot?: boolean;
+  /** Reserve a fixed min-width so badges align in a column. */
+  fixedWidth?: boolean;
+}
+
+/**
+ * Tone-based status/info badge matching the library's badge language:
+ * pill-shaped, uppercase, tracking-wide, fully container-query scaled.
+ */
+export const SessionBadge: React.FC<SessionBadgeProps> = ({
+  tone,
+  label,
+  icon: Icon,
+  dot = false,
+  fixedWidth = false,
+}) => {
+  const t = TONE[tone];
+  return (
+    <span
+      data-testid="session-badge"
+      className={`inline-flex items-center justify-center rounded-full font-bold uppercase tracking-wide shrink-0 ${t.bg} ${t.fg}`}
+      style={{
+        gap: 'min(4px, 1cqmin)',
+        minWidth: fixedWidth ? 'min(60px, 14cqmin)' : undefined,
+        paddingInline: 'min(8px, 2cqmin)',
+        paddingBlock: 'min(2px, 0.6cqmin)',
+        fontSize: 'min(10px, 3cqmin)',
+      }}
+    >
+      {dot && (
+        <span
+          className={`rounded-full ${t.dot} ${tone === 'success' ? 'animate-pulse' : ''}`}
+          style={{ width: 'min(6px, 1.8cqmin)', height: 'min(6px, 1.8cqmin)' }}
+        />
+      )}
+      {Icon && (
+        <Icon
+          style={{ width: 'min(12px, 4cqmin)', height: 'min(12px, 4cqmin)' }}
+        />
+      )}
+      {label}
+    </span>
+  );
+};

--- a/components/common/sessionViews/SessionRow.tsx
+++ b/components/common/sessionViews/SessionRow.tsx
@@ -74,7 +74,7 @@ export const SessionRow: React.FC<SessionRowProps> = ({
         {dot && (
           <span
             className={`rounded-full ${DOT_COLOR[dot.tone]} ${
-              dot.pulse ? 'animate-pulse' : ''
+              dot.pulse ? 'animate-pulse motion-reduce:animate-none' : ''
             }`}
             style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
           />

--- a/components/common/sessionViews/SessionRow.tsx
+++ b/components/common/sessionViews/SessionRow.tsx
@@ -45,6 +45,18 @@ export const SessionRow: React.FC<SessionRowProps> = ({
     <div
       data-testid="session-row"
       onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
       className={`flex items-center border-b border-slate-200/60 last:border-b-0 rounded-lg transition-colors ${
         tintTone ? TINT[tintTone] : 'hover:bg-white/60'
       } ${onClick ? 'cursor-pointer' : ''}`}

--- a/components/common/sessionViews/SessionRow.tsx
+++ b/components/common/sessionViews/SessionRow.tsx
@@ -58,7 +58,7 @@ export const SessionRow: React.FC<SessionRowProps> = ({
           : undefined
       }
       className={`flex items-center border-b border-slate-200/60 last:border-b-0 rounded-lg transition-colors ${
-        tintTone ? TINT[tintTone] : 'hover:bg-white/60'
+        tintTone ? `${TINT[tintTone]} hover:brightness-95` : 'hover:bg-white/60'
       } ${onClick ? 'cursor-pointer' : ''}`}
       style={{
         gap: 'min(10px, 2.2cqmin)',

--- a/components/common/sessionViews/SessionRow.tsx
+++ b/components/common/sessionViews/SessionRow.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import type { ScoreTone } from '@/utils/scoreColor';
+
+type DotTone = 'success' | 'warn' | 'neutral' | 'danger';
+
+const TINT: Record<ScoreTone, string> = {
+  success: 'bg-emerald-50/60',
+  warn: 'bg-amber-50/60',
+  danger: 'bg-rose-50/60',
+};
+
+const DOT_COLOR: Record<DotTone, string> = {
+  success: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  neutral: 'bg-slate-400',
+  danger: 'bg-red-500',
+};
+
+interface SessionRowProps {
+  /** Leading status dot; pulse for live. Omit to render an empty reserved slot. */
+  dot?: { tone: DotTone; pulse?: boolean };
+  /** Subtle full-row score-band wash (teacher "colors" toggle). */
+  tintTone?: ScoreTone;
+  /** Main row content (name, badges, meta). */
+  children: React.ReactNode;
+  /** Right-aligned trailing slot (score pill, actions, overflow). */
+  trailing?: React.ReactNode;
+  onClick?: () => void;
+}
+
+/**
+ * Hairline list-row shell matching the library's list rows: gapless container
+ * (each row carries its own bottom border), a reserved status-dot slot for
+ * column alignment, an optional score-band wash, and a transient hover. Content
+ * and trailing slot are supplied by each view.
+ */
+export const SessionRow: React.FC<SessionRowProps> = ({
+  dot,
+  tintTone,
+  children,
+  trailing,
+  onClick,
+}) => {
+  return (
+    <div
+      data-testid="session-row"
+      onClick={onClick}
+      className={`flex items-center border-b border-slate-200/60 last:border-b-0 rounded-lg transition-colors ${
+        tintTone ? TINT[tintTone] : 'hover:bg-white/60'
+      } ${onClick ? 'cursor-pointer' : ''}`}
+      style={{
+        gap: 'min(10px, 2.2cqmin)',
+        paddingInline: 'min(12px, 2.6cqmin)',
+        paddingBlock: 'min(10px, 2.2cqmin)',
+      }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-center"
+        style={{ width: 'min(8px, 2cqmin)' }}
+        aria-hidden="true"
+      >
+        {dot && (
+          <span
+            className={`rounded-full ${DOT_COLOR[dot.tone]} ${
+              dot.pulse ? 'animate-pulse' : ''
+            }`}
+            style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">{children}</div>
+      {trailing && (
+        <div
+          className="flex items-center shrink-0"
+          style={{ gap: 'min(8px, 2cqmin)' }}
+        >
+          {trailing}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/common/sessionViews/SessionRow.tsx
+++ b/components/common/sessionViews/SessionRow.tsx
@@ -59,7 +59,7 @@ export const SessionRow: React.FC<SessionRowProps> = ({
       }
       className={`flex items-center border-b border-slate-200/60 last:border-b-0 rounded-lg transition-colors ${
         tintTone ? `${TINT[tintTone]} hover:brightness-95` : 'hover:bg-white/60'
-      } ${onClick ? 'cursor-pointer' : ''}`}
+      } ${onClick ? 'cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-primary focus-visible:ring-offset-1' : ''}`}
       style={{
         gap: 'min(10px, 2.2cqmin)',
         paddingInline: 'min(12px, 2.6cqmin)',

--- a/components/common/sessionViews/SessionViewHeader.tsx
+++ b/components/common/sessionViews/SessionViewHeader.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { ChevronLeft } from 'lucide-react';
+
+type ViewStatus = 'live' | 'paused' | 'ended' | 'none';
+
+interface SessionViewHeaderProps {
+  onBack: () => void;
+  status?: ViewStatus;
+  title: string;
+  subtitle?: string;
+  /** Right-aligned action buttons / overflow. */
+  actions?: React.ReactNode;
+}
+
+const STATUS: Record<
+  Exclude<ViewStatus, 'none'>,
+  { dot: string; label: string; text: string; pulse: boolean }
+> = {
+  live: {
+    dot: 'bg-brand-red-primary',
+    label: 'Live',
+    text: 'text-brand-red-primary',
+    pulse: true,
+  },
+  paused: {
+    dot: 'bg-amber-500',
+    label: 'Paused',
+    text: 'text-amber-600',
+    pulse: false,
+  },
+  ended: {
+    dot: 'bg-slate-400',
+    label: 'Ended',
+    text: 'text-slate-500',
+    pulse: false,
+  },
+};
+
+/**
+ * Shared header for the monitor and results views: glass chrome, back button,
+ * an optional live/paused/ended status pulse, title/subtitle, and a
+ * right-aligned actions slot. Matches the library header surface.
+ */
+export const SessionViewHeader: React.FC<SessionViewHeaderProps> = ({
+  onBack,
+  status = 'none',
+  title,
+  subtitle,
+  actions,
+}) => {
+  const s = status !== 'none' ? STATUS[status] : null;
+  return (
+    <div
+      className="flex items-center justify-between bg-white/60 backdrop-blur-sm border-b border-slate-200/70 shrink-0"
+      style={{
+        gap: 'min(12px, 2.5cqmin)',
+        paddingInline: 'min(16px, 3.5cqmin)',
+        paddingBlock: 'min(8px, 1.8cqmin)',
+      }}
+    >
+      <div
+        className="flex items-center min-w-0"
+        style={{ gap: 'min(10px, 2.2cqmin)' }}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back"
+          className="inline-flex shrink-0 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+          style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
+        >
+          <ChevronLeft
+            style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
+          />
+        </button>
+        {s && (
+          <span
+            className="flex shrink-0 items-center"
+            style={{ gap: 'min(5px, 1.2cqmin)' }}
+          >
+            <span
+              className={`rounded-full ${s.dot} ${s.pulse ? 'animate-pulse' : ''}`}
+              style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
+            />
+            <span
+              className={`font-black uppercase tracking-tight leading-none ${s.text}`}
+              style={{ fontSize: 'min(12px, 4cqmin)' }}
+            >
+              {s.label}
+            </span>
+          </span>
+        )}
+        <div className="min-w-0">
+          <div
+            className="font-black text-slate-800 truncate"
+            style={{ fontSize: 'min(15px, 4.8cqmin)' }}
+          >
+            {title}
+          </div>
+          {subtitle && (
+            <div
+              className="font-medium text-slate-500 truncate"
+              style={{ fontSize: 'min(11px, 3.2cqmin)' }}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
+      </div>
+      {actions && (
+        <div
+          className="flex items-center shrink-0"
+          style={{ gap: 'min(8px, 2cqmin)' }}
+        >
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/components/common/sessionViews/SessionViewHeader.tsx
+++ b/components/common/sessionViews/SessionViewHeader.tsx
@@ -4,7 +4,8 @@ import { ChevronLeft } from 'lucide-react';
 type ViewStatus = 'live' | 'paused' | 'ended' | 'none';
 
 interface SessionViewHeaderProps {
-  onBack: () => void;
+  /** Back handler. When omitted, no back button renders. */
+  onBack?: () => void;
   status?: ViewStatus;
   title: string;
   subtitle?: string;
@@ -62,17 +63,22 @@ export const SessionViewHeader: React.FC<SessionViewHeaderProps> = ({
         className="flex items-center min-w-0"
         style={{ gap: 'min(10px, 2.2cqmin)' }}
       >
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="Back"
-          className="inline-flex shrink-0 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
-          style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
-        >
-          <ChevronLeft
-            style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
-          />
-        </button>
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="Back"
+            className="inline-flex shrink-0 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+            style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
+          >
+            <ChevronLeft
+              style={{
+                width: 'min(18px, 5cqmin)',
+                height: 'min(18px, 5cqmin)',
+              }}
+            />
+          </button>
+        )}
         {s && (
           <span
             className="flex shrink-0 items-center"

--- a/components/common/sessionViews/SessionViewHeader.tsx
+++ b/components/common/sessionViews/SessionViewHeader.tsx
@@ -85,7 +85,7 @@ export const SessionViewHeader: React.FC<SessionViewHeaderProps> = ({
             style={{ gap: 'min(5px, 1.2cqmin)' }}
           >
             <span
-              className={`rounded-full ${s.dot} ${s.pulse ? 'animate-pulse' : ''}`}
+              className={`rounded-full ${s.dot} ${s.pulse ? 'animate-pulse motion-reduce:animate-none' : ''}`}
               style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
             />
             <span

--- a/components/common/sessionViews/StatTile.tsx
+++ b/components/common/sessionViews/StatTile.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+type StatTone = 'blue' | 'amber' | 'green' | 'violet';
+
+const ICON_TONE: Record<StatTone, string> = {
+  blue: 'text-brand-blue-primary',
+  amber: 'text-amber-600',
+  green: 'text-emerald-600',
+  violet: 'text-violet-600',
+};
+
+interface StatTileProps {
+  icon: React.ReactNode;
+  value: number | string;
+  label: string;
+  tone?: StatTone;
+  /** Interactive tiles get hover affordance + optional selected ring. */
+  interactive?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+  /** Expandable content (e.g. a student-name list) shown below the value. */
+  children?: React.ReactNode;
+}
+
+/**
+ * KPI / overview stat tile on a glass surface matching the library card
+ * language. Replaces the bespoke StatBox / InteractiveStatBox / StatTile copies
+ * across the monitor and results views.
+ */
+export const StatTile: React.FC<StatTileProps> = ({
+  icon,
+  value,
+  label,
+  tone = 'blue',
+  interactive = false,
+  selected = false,
+  onClick,
+  children,
+}) => {
+  const surface =
+    'bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm transition-all';
+  const interactiveClass = interactive
+    ? `cursor-pointer hover:bg-white/85 hover:shadow-md ${
+        selected ? 'ring-2 ring-brand-blue-primary/40' : ''
+      }`
+    : '';
+  const inner = (
+    <>
+      <div
+        className={`flex items-center justify-center ${ICON_TONE[tone]}`}
+        style={{ gap: 'min(4px, 1cqmin)', marginBottom: 'min(4px, 1cqmin)' }}
+      >
+        {icon}
+      </div>
+      <div
+        className={`font-black leading-none ${ICON_TONE[tone]}`}
+        style={{ fontSize: 'min(22px, 7cqmin)' }}
+      >
+        {value}
+      </div>
+      <div
+        className="font-bold uppercase tracking-wider text-slate-500"
+        style={{
+          fontSize: 'min(10px, 3cqmin)',
+          marginTop: 'min(3px, 0.8cqmin)',
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </>
+  );
+  const style: React.CSSProperties = { padding: 'min(10px, 2.5cqmin)' };
+  if (interactive) {
+    return (
+      <button
+        type="button"
+        data-testid="stat-tile"
+        onClick={onClick}
+        className={`block w-full text-center ${surface} ${interactiveClass}`}
+        style={style}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div
+      data-testid="stat-tile"
+      className={`text-center ${surface}`}
+      style={style}
+    >
+      {inner}
+    </div>
+  );
+};

--- a/components/common/sessionViews/StatTile.tsx
+++ b/components/common/sessionViews/StatTile.tsx
@@ -33,7 +33,7 @@ export const StatTile: React.FC<StatTileProps> = ({
   label,
   tone = 'blue',
   interactive = false,
-  selected = false,
+  selected,
   onClick,
   children,
 }) => {
@@ -77,6 +77,7 @@ export const StatTile: React.FC<StatTileProps> = ({
         type="button"
         data-testid="stat-tile"
         onClick={onClick}
+        aria-pressed={selected}
         className={`block w-full text-center ${surface} ${interactiveClass}`}
         style={style}
       >

--- a/components/common/sessionViews/index.ts
+++ b/components/common/sessionViews/index.ts
@@ -1,0 +1,11 @@
+export { SessionViewHeader } from './SessionViewHeader';
+export { SegmentedTabs } from './SegmentedTabs';
+export type { SegmentedTab } from './SegmentedTabs';
+export { StatTile } from './StatTile';
+export { SessionBadge } from './SessionBadge';
+export type { SessionTone } from './SessionBadge';
+export { ScorePill } from './ScorePill';
+export { SessionRow } from './SessionRow';
+export { OverflowMenu } from './OverflowMenu';
+export type { OverflowMenuItem } from './OverflowMenu';
+export { ActionButton } from './ActionButton';

--- a/components/dev/SessionViewsDevHarness.tsx
+++ b/components/dev/SessionViewsDevHarness.tsx
@@ -139,6 +139,18 @@ export const SessionViewsDevHarness: React.FC = () => {
   const [state, setState] = useState<StateKey>('live');
   const [width, setWidth] = useState<number>(520);
 
+  // Guard: without auth-bypass this harness would boot the real AuthProvider +
+  // DashboardProvider against a live Firebase account (real Firestore
+  // listeners). Bail early. (Hooks above run unconditionally — rules-of-hooks.)
+  if (import.meta.env.VITE_AUTH_BYPASS !== 'true') {
+    return (
+      <div className="flex h-screen items-center justify-center text-slate-500">
+        Set <code className="mx-1 font-mono">VITE_AUTH_BYPASS=true</code> to use
+        this harness.
+      </div>
+    );
+  }
+
   return (
     <DialogProvider>
       <AuthProvider>

--- a/components/dev/SessionViewsDevHarness.tsx
+++ b/components/dev/SessionViewsDevHarness.tsx
@@ -1,0 +1,210 @@
+/**
+ * SessionViewsDevHarness — DEV-only visual harness for the four live teacher
+ * session views (Quiz Monitor / Quiz Results / Video Activity Monitor /
+ * Video Activity Results).
+ *
+ * These views are Firestore- and Drive-backed in production, which makes it
+ * slow to iterate on their redesign with realistic data. This harness mounts
+ * the REAL view components (no forks, no copies) inside the same provider
+ * stack the teacher app uses, against the fixtures in `sessionViewsMocks.ts`,
+ * inside a `container-type: size` box so cqmin scaling can be checked at the
+ * widget sizes that matter.
+ *
+ * The provider stack relies on auth-bypass: set `VITE_AUTH_BYPASS='true'` in
+ * the dev environment so AuthProvider mounts a mock admin user and skips the
+ * Firestore permission listeners (see context/AuthContext.tsx).
+ *
+ * Mounted at /session-views-dev in DEV builds only (same gating pattern as
+ * LibraryDevHarness) — excluded from production bundles.
+ */
+
+import React, { useState } from 'react';
+import { DialogProvider } from '@/context/DialogContext';
+import { AuthProvider } from '@/context/AuthContext';
+import { CustomWidgetsProvider } from '@/context/CustomWidgetsContext';
+import { SavedWidgetsProvider } from '@/context/SavedWidgetsContext';
+import { DashboardProvider } from '@/context/DashboardContext';
+import { QuizLiveMonitor } from '@/components/widgets/QuizWidget/components/QuizLiveMonitor';
+import { QuizResults } from '@/components/widgets/QuizWidget/components/QuizResults';
+import { VideoActivityLiveMonitor } from '@/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor';
+import { Results as VideoActivityResults } from '@/components/widgets/VideoActivityWidget/components/Results';
+import {
+  makeQuizSession,
+  makeQuizResponses,
+  makeQuizData,
+  makeQuizConfig,
+  makeVaSession,
+  makeVaResponses,
+} from './sessionViewsMocks';
+
+type ViewKey = 'quiz-monitor' | 'quiz-results' | 'va-monitor' | 'va-results';
+type StateKey = 'waiting' | 'live' | 'paused' | 'ended' | 'populated' | 'empty';
+
+const VIEWS: { key: ViewKey; label: string }[] = [
+  { key: 'quiz-monitor', label: 'Quiz Monitor' },
+  { key: 'quiz-results', label: 'Quiz Results' },
+  { key: 'va-monitor', label: 'VA Monitor' },
+  { key: 'va-results', label: 'VA Results' },
+];
+
+// State keys are partitioned by view family: monitors use the lifecycle
+// states (waiting/live/paused/ended), results use populated/empty. Offering
+// an irrelevant state for a view (e.g. "paused" on a results view) is a
+// harmless no-op — the mapper coerces to a sensible session status.
+const STATES: { key: StateKey; label: string }[] = [
+  { key: 'waiting', label: 'Waiting (no responses)' },
+  { key: 'live', label: 'Live' },
+  { key: 'paused', label: 'Paused' },
+  { key: 'ended', label: 'Ended' },
+  { key: 'populated', label: 'Populated (results)' },
+  { key: 'empty', label: 'Empty (results)' },
+];
+
+const WIDTHS = [340, 520, 820];
+
+const noop = (): Promise<void> => Promise.resolve();
+
+const SessionView: React.FC<{ view: ViewKey; state: StateKey }> = ({
+  view,
+  state,
+}) => {
+  if (view === 'quiz-monitor') {
+    const status =
+      state === 'paused' ? 'paused' : state === 'ended' ? 'ended' : 'active';
+    const responses = state === 'waiting' ? [] : makeQuizResponses();
+    return (
+      <QuizLiveMonitor
+        session={makeQuizSession(status)}
+        responses={responses}
+        quizData={makeQuizData()}
+        config={makeQuizConfig()}
+        rosters={[]}
+        onAdvance={noop}
+        onEnd={noop}
+        onPause={noop}
+        onResume={noop}
+        onUpdateConfig={() => undefined}
+        onRemoveStudent={noop}
+        onUnlockStudent={noop}
+        onUnlockResultsForStudent={noop}
+        onRevealAnswer={noop}
+        onHideAnswer={noop}
+        onBack={() => undefined}
+      />
+    );
+  }
+
+  if (view === 'quiz-results') {
+    const responses = state === 'empty' ? [] : makeQuizResponses();
+    return (
+      <QuizResults
+        quiz={makeQuizData()}
+        responses={responses}
+        config={makeQuizConfig()}
+        session={makeQuizSession('ended')}
+        onBack={() => undefined}
+      />
+    );
+  }
+
+  if (view === 'va-monitor') {
+    const status = state === 'ended' ? 'ended' : 'active';
+    const responses = state === 'waiting' ? [] : makeVaResponses();
+    return (
+      <VideoActivityLiveMonitor
+        session={makeVaSession(status)}
+        responses={responses}
+        onEnd={noop}
+        onPause={noop}
+        onResume={noop}
+        onUnlockStudent={noop}
+        onBack={() => undefined}
+      />
+    );
+  }
+
+  // va-results
+  const responses = state === 'empty' ? [] : makeVaResponses();
+  return (
+    <VideoActivityResults
+      session={makeVaSession('ended')}
+      responses={responses}
+      onBack={() => undefined}
+    />
+  );
+};
+
+export const SessionViewsDevHarness: React.FC = () => {
+  const [view, setView] = useState<ViewKey>('quiz-monitor');
+  const [state, setState] = useState<StateKey>('live');
+  const [width, setWidth] = useState<number>(520);
+
+  return (
+    <DialogProvider>
+      <AuthProvider>
+        <CustomWidgetsProvider>
+          <SavedWidgetsProvider>
+            <DashboardProvider>
+              <div className="min-h-screen w-full bg-slate-900 p-8 flex flex-col items-start gap-6 overflow-auto">
+                <div className="flex flex-wrap items-center gap-3">
+                  <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+                    View
+                    <select
+                      value={view}
+                      onChange={(e) => setView(e.target.value as ViewKey)}
+                      className="bg-slate-800 border border-slate-600 rounded px-3 py-2 text-sm font-normal normal-case tracking-normal text-white"
+                    >
+                      {VIEWS.map((v) => (
+                        <option key={v.key} value={v.key}>
+                          {v.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <label className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+                    State
+                    <select
+                      value={state}
+                      onChange={(e) => setState(e.target.value as StateKey)}
+                      className="bg-slate-800 border border-slate-600 rounded px-3 py-2 text-sm font-normal normal-case tracking-normal text-white"
+                    >
+                      {STATES.map((s) => (
+                        <option key={s.key} value={s.key}>
+                          {s.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <div className="flex items-center gap-1">
+                    {WIDTHS.map((w) => (
+                      <button
+                        key={w}
+                        onClick={() => setWidth(w)}
+                        className={`px-3 py-2 rounded text-sm font-bold transition ${
+                          width === w
+                            ? 'bg-blue-500 text-white'
+                            : 'bg-slate-800 text-slate-300 hover:bg-slate-700'
+                        }`}
+                      >
+                        {w}px
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div
+                  className="rounded-2xl border border-slate-700 bg-slate-100 shadow-xl overflow-hidden"
+                  style={{ width, height: 640, containerType: 'size' }}
+                >
+                  <SessionView view={view} state={state} />
+                </div>
+              </div>
+            </DashboardProvider>
+          </SavedWidgetsProvider>
+        </CustomWidgetsProvider>
+      </AuthProvider>
+    </DialogProvider>
+  );
+};

--- a/components/dev/sessionViewsMocks.ts
+++ b/components/dev/sessionViewsMocks.ts
@@ -1,0 +1,326 @@
+/**
+ * sessionViewsMocks — fixture builders for SessionViewsDevHarness.
+ *
+ * Each builder returns an object typed as the REAL data type from `@/types`
+ * (no `any` casts), so the harness exercises the live monitor/results views
+ * against representative data without a Firestore round-trip. The fixtures
+ * deliberately span the interesting per-student states the views branch on:
+ *   - completed responses across the score spectrum (high / mid / low)
+ *   - an in-progress attempt
+ *   - a joined-only attempt (no answers yet)
+ *   - a response carrying tab-switch warnings
+ *   - a locked / auto-submitted response
+ *
+ * Keep these as plain data — no React, no Firestore. They must satisfy every
+ * REQUIRED field on the underlying interfaces (`pnpm run type-check` is the
+ * gate); optional fields are filled only where a view reads them.
+ */
+
+import {
+  QuizSession,
+  QuizSessionStatus,
+  QuizResponse,
+  QuizResponseStatus,
+  QuizData,
+  QuizConfig,
+  QuizPublicQuestion,
+  VideoActivitySession,
+  VideoActivityResponse,
+  VideoActivityQuestion,
+} from '@/types';
+
+const QUIZ_ID = 'dev-quiz-1';
+const QUIZ_SESSION_ID = 'dev-quiz-session-1';
+const VA_ID = 'dev-va-1';
+const VA_SESSION_ID = 'dev-va-session-1';
+
+// Stable-ish base time so timestamps look realistic relative to one another.
+const NOW = 1_700_000_000_000;
+
+/* ─── Quiz quiz data ─────────────────────────────────────────────────────── */
+
+const QUIZ_Q1_ID = 'q1';
+const QUIZ_Q2_ID = 'q2';
+
+export function makeQuizData(): QuizData {
+  return {
+    id: QUIZ_ID,
+    title: 'Fractions Review',
+    createdAt: NOW - 86_400_000,
+    updatedAt: NOW - 3_600_000,
+    questions: [
+      {
+        id: QUIZ_Q1_ID,
+        type: 'MC',
+        text: 'What is 1/2 + 1/4?',
+        timeLimit: 30,
+        correctAnswer: '3/4',
+        incorrectAnswers: ['1/4', '2/6', '1/8'],
+        points: 1,
+      },
+      {
+        id: QUIZ_Q2_ID,
+        type: 'FIB',
+        text: 'Simplify 4/8 to lowest terms.',
+        timeLimit: 0,
+        correctAnswer: '1/2',
+        incorrectAnswers: [],
+        points: 1,
+      },
+    ],
+  };
+}
+
+function quizPublicQuestions(): QuizPublicQuestion[] {
+  return [
+    {
+      id: QUIZ_Q1_ID,
+      type: 'MC',
+      text: 'What is 1/2 + 1/4?',
+      timeLimit: 30,
+      choices: ['3/4', '1/4', '2/6', '1/8'],
+    },
+    {
+      id: QUIZ_Q2_ID,
+      type: 'FIB',
+      text: 'Simplify 4/8 to lowest terms.',
+      timeLimit: 0,
+    },
+  ];
+}
+
+export function makeQuizSession(
+  status: QuizSessionStatus = 'active'
+): QuizSession {
+  return {
+    id: QUIZ_SESSION_ID,
+    assignmentId: QUIZ_SESSION_ID,
+    quizId: QUIZ_ID,
+    quizTitle: 'Fractions Review',
+    teacherUid: 'mock-user-id',
+    status,
+    sessionMode: 'teacher',
+    currentQuestionIndex: status === 'waiting' ? -1 : 0,
+    startedAt: status === 'waiting' ? null : NOW - 600_000,
+    endedAt: status === 'ended' ? NOW - 60_000 : null,
+    code: 'ABC123',
+    totalQuestions: 2,
+    publicQuestions: quizPublicQuestions(),
+    periodNames: ['Period 3'],
+    tabWarningsEnabled: true,
+  };
+}
+
+export function makeQuizConfig(): QuizConfig {
+  return {
+    view: 'monitor',
+    selectedQuizId: QUIZ_ID,
+    selectedQuizTitle: 'Fractions Review',
+    activeAssignmentId: QUIZ_SESSION_ID,
+    activeLiveSessionCode: 'ABC123',
+    resultsSessionId: QUIZ_SESSION_ID,
+    periodNames: ['Period 3'],
+  };
+}
+
+/* ─── Quiz responses ─────────────────────────────────────────────────────── */
+
+function quizCompleted(
+  key: string,
+  pin: string,
+  q1Answer: string,
+  q2Answer: string,
+  warnings = 0
+): QuizResponse {
+  return {
+    _responseKey: key,
+    studentUid: key,
+    pin,
+    joinedAt: NOW - 540_000,
+    status: 'completed' as QuizResponseStatus,
+    answers: [
+      { questionId: QUIZ_Q1_ID, answer: q1Answer, answeredAt: NOW - 480_000 },
+      { questionId: QUIZ_Q2_ID, answer: q2Answer, answeredAt: NOW - 420_000 },
+    ],
+    score: null,
+    submittedAt: NOW - 400_000,
+    classPeriod: 'Period 3',
+    completedAttempts: 1,
+    ...(warnings > 0 ? { tabSwitchWarnings: warnings } : {}),
+  };
+}
+
+export function makeQuizResponses(): QuizResponse[] {
+  return [
+    // High score — both correct.
+    quizCompleted('pin-Period 3-1001', '1001', '3/4', '1/2'),
+    // Mid score — first correct, second wrong.
+    quizCompleted('pin-Period 3-1002', '1002', '3/4', '2/4'),
+    // Low score — both wrong, plus a tab-switch warning.
+    quizCompleted('pin-Period 3-1003', '1003', '1/4', '4/8', 2),
+    // In-progress — one answer submitted, not finished.
+    {
+      _responseKey: 'pin-Period 3-1004',
+      studentUid: 'pin-Period 3-1004',
+      pin: '1004',
+      joinedAt: NOW - 300_000,
+      status: 'in-progress',
+      answers: [
+        { questionId: QUIZ_Q1_ID, answer: '3/4', answeredAt: NOW - 200_000 },
+      ],
+      score: null,
+      submittedAt: null,
+      classPeriod: 'Period 3',
+    },
+    // Joined only — no answers yet.
+    {
+      _responseKey: 'pin-Period 3-1005',
+      studentUid: 'pin-Period 3-1005',
+      pin: '1005',
+      joinedAt: NOW - 120_000,
+      status: 'joined',
+      answers: [],
+      score: null,
+      submittedAt: null,
+      classPeriod: 'Period 3',
+    },
+    // Locked / auto-submitted attempt.
+    {
+      _responseKey: 'pin-Period 3-1006',
+      studentUid: 'pin-Period 3-1006',
+      pin: '1006',
+      joinedAt: NOW - 500_000,
+      status: 'completed',
+      answers: [
+        { questionId: QUIZ_Q1_ID, answer: '1/8', answeredAt: NOW - 470_000 },
+      ],
+      score: null,
+      submittedAt: NOW - 450_000,
+      classPeriod: 'Period 3',
+      completedAttempts: 1,
+      autoSubmitted: true,
+      tabSwitchWarnings: 3,
+    },
+  ];
+}
+
+/* ─── Video Activity data ────────────────────────────────────────────────── */
+
+const VA_Q1_ID = 'vq1';
+const VA_Q2_ID = 'vq2';
+
+function vaQuestions(): VideoActivityQuestion[] {
+  return [
+    {
+      id: VA_Q1_ID,
+      type: 'MC',
+      text: 'What gas do plants absorb during photosynthesis?',
+      timeLimit: 0,
+      timestamp: 45,
+      correctAnswer: 'Carbon dioxide',
+      incorrectAnswers: ['Oxygen', 'Nitrogen', 'Hydrogen'],
+      points: 1,
+    },
+    {
+      id: VA_Q2_ID,
+      type: 'FIB',
+      text: 'Photosynthesis happens in the ____ of the cell.',
+      timeLimit: 0,
+      timestamp: 120,
+      correctAnswer: 'chloroplast',
+      incorrectAnswers: [],
+      points: 1,
+    },
+  ];
+}
+
+export function makeVaSession(
+  status: VideoActivitySession['status'] = 'active'
+): VideoActivitySession {
+  return {
+    id: VA_SESSION_ID,
+    activityId: VA_ID,
+    activityTitle: 'Photosynthesis Explained',
+    assignmentName: 'Photosynthesis — Period 1',
+    teacherUid: 'mock-user-id',
+    youtubeUrl: 'https://www.youtube.com/watch?v=dev-mock',
+    questions: vaQuestions(),
+    status,
+    allowedPins: [],
+    createdAt: NOW - 7_200_000,
+    endedAt: status === 'ended' ? NOW - 60_000 : undefined,
+    periodNames: ['Period 1'],
+  };
+}
+
+/* ─── Video Activity responses ───────────────────────────────────────────── */
+
+function vaResponse(
+  key: string,
+  pin: string,
+  answers: { questionId: string; answer: string }[],
+  completed: boolean,
+  warnings = 0
+): VideoActivityResponse {
+  return {
+    _responseKey: key,
+    studentUid: key,
+    pin,
+    joinedAt: NOW - 540_000,
+    answers: answers.map((a, i) => ({
+      questionId: a.questionId,
+      answer: a.answer,
+      answeredAt: NOW - 480_000 + i * 30_000,
+    })),
+    completedAt: completed ? NOW - 400_000 : null,
+    score: null,
+    classPeriod: 'Period 1',
+    ...(completed ? { completedAttempts: 1 } : {}),
+    ...(warnings > 0 ? { tabSwitchWarnings: warnings } : {}),
+  };
+}
+
+export function makeVaResponses(): VideoActivityResponse[] {
+  return [
+    // Both correct.
+    vaResponse(
+      'pin-Period 1-2001',
+      '2001',
+      [
+        { questionId: VA_Q1_ID, answer: 'Carbon dioxide' },
+        { questionId: VA_Q2_ID, answer: 'chloroplast' },
+      ],
+      true
+    ),
+    // One correct, one wrong.
+    vaResponse(
+      'pin-Period 1-2002',
+      '2002',
+      [
+        { questionId: VA_Q1_ID, answer: 'Carbon dioxide' },
+        { questionId: VA_Q2_ID, answer: 'nucleus' },
+      ],
+      true
+    ),
+    // Both wrong, with tab warnings.
+    vaResponse(
+      'pin-Period 1-2003',
+      '2003',
+      [
+        { questionId: VA_Q1_ID, answer: 'Oxygen' },
+        { questionId: VA_Q2_ID, answer: 'mitochondria' },
+      ],
+      true,
+      2
+    ),
+    // In-progress — one answer so far.
+    vaResponse(
+      'pin-Period 1-2004',
+      '2004',
+      [{ questionId: VA_Q1_ID, answer: 'Carbon dioxide' }],
+      false
+    ),
+    // Joined only — no answers.
+    vaResponse('pin-Period 1-2005', '2005', [], false),
+  ];
+}

--- a/components/dev/sessionViewsMocks.ts
+++ b/components/dev/sessionViewsMocks.ts
@@ -34,8 +34,10 @@ const QUIZ_SESSION_ID = 'dev-quiz-session-1';
 const VA_ID = 'dev-va-1';
 const VA_SESSION_ID = 'dev-va-session-1';
 
-// Stable-ish base time so timestamps look realistic relative to one another.
-const NOW = 1_700_000_000_000;
+// Current time so relative-time formatting in the views reads realistically
+// ("5 minutes ago", not "2 years ago"). Date.now() is fine in source files —
+// the restriction is specific to workflow scripts.
+const NOW = Date.now();
 
 /* ─── Quiz quiz data ─────────────────────────────────────────────────────── */
 
@@ -100,7 +102,8 @@ export function makeQuizSession(
     teacherUid: 'mock-user-id',
     status,
     sessionMode: 'teacher',
-    currentQuestionIndex: status === 'waiting' ? -1 : 0,
+    currentQuestionIndex:
+      status === 'waiting' ? -1 : status === 'ended' ? 1 : 0,
     startedAt: status === 'waiting' ? null : NOW - 600_000,
     endedAt: status === 'ended' ? NOW - 60_000 : null,
     code: 'ABC123',

--- a/components/widgets/ClockWidget/Widget.test.tsx
+++ b/components/widgets/ClockWidget/Widget.test.tsx
@@ -155,6 +155,19 @@ describe('ClockWidget', () => {
     expect(seconds.className).toContain('opacity-80');
   });
 
+  // Seconds are rendered slightly smaller than the main time (em-based so they
+  // scale with it), but were bumped up from 0.7em to 0.85em for distance
+  // legibility on a projector. Guard against regressing back below that.
+  it('renders seconds at a glanceable relative size', () => {
+    const date = new Date('2023-01-01T14:30:45');
+    vi.setSystemTime(date);
+
+    renderWidget(createWidget({ format24: true, showSeconds: true }));
+
+    const seconds = screen.getByText('45');
+    expect(seconds).toHaveStyle({ fontSize: '0.85em' });
+  });
+
   it('keeps the AM/PM label above the low-contrast opacity floor', () => {
     const date = new Date('2023-01-01T14:30:45');
     vi.setSystemTime(date);

--- a/components/widgets/ClockWidget/Widget.tsx
+++ b/components/widgets/ClockWidget/Widget.tsx
@@ -104,7 +104,7 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             {showSeconds && (
               <>
                 <span className="opacity-60 mx-[0.1em]">:</span>
-                <span className="opacity-80" style={{ fontSize: '0.7em' }}>
+                <span className="opacity-80" style={{ fontSize: '0.85em' }}>
                   {seconds}
                 </span>
               </>

--- a/components/widgets/First5/Widget.test.tsx
+++ b/components/widgets/First5/Widget.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { WidgetData } from '@/types';
+import { First5Widget } from './Widget';
+import { useFirst5Url } from './hooks/useFirst5Url';
+
+vi.mock('./hooks/useFirst5Url');
+
+const mockUseFirst5Url = vi.mocked(useFirst5Url);
+
+const createWidget = (): WidgetData =>
+  ({
+    id: 'first5-1',
+    type: 'first-5',
+    x: 0,
+    y: 0,
+    w: 400,
+    h: 300,
+    z: 1,
+    config: {},
+  }) as WidgetData;
+
+describe('First5Widget', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('exposes an accessible label on the external-link control when a URL is loaded', () => {
+    mockUseFirst5Url.mockReturnValue({
+      url: 'https://www.edtomorrow.com/today/1j',
+      error: null,
+      isLoading: false,
+    });
+
+    render(<First5Widget widget={createWidget()} />);
+
+    // The icon-only link must be reachable by its accessible name for screen
+    // readers; the title attribute is preserved for sighted hover users.
+    const link = screen.getByRole('link', { name: 'Open in new tab' });
+    expect(link).toHaveAttribute('href', 'https://www.edtomorrow.com/today/1j');
+    expect(link).toHaveAttribute('title', 'Open in new tab');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders an empty state (no link) when no URL is available', () => {
+    mockUseFirst5Url.mockReturnValue({
+      url: null,
+      error: 'Unable to load First 5 content.',
+      isLoading: false,
+    });
+
+    render(<First5Widget widget={createWidget()} />);
+
+    expect(
+      screen.queryByRole('link', { name: 'Open in new tab' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/widgets/First5/Widget.tsx
+++ b/components/widgets/First5/Widget.tsx
@@ -53,19 +53,20 @@ export const First5Widget: React.FC<{ widget: WidgetData }> = ({
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="absolute z-10 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-500 hover:text-blue-500 shadow-sm border border-slate-200/50 rounded-lg transition-colors"
+            className="absolute z-10 bg-white/80 backdrop-blur-sm hover:bg-white text-slate-700 hover:text-blue-600 shadow-sm border border-slate-200/50 rounded-lg transition-colors"
             style={{
               top: 'min(8px, 2cqmin)',
               right: 'min(8px, 2cqmin)',
               padding: 'min(6px, 1.5cqmin)',
             }}
             title="Open in new tab"
+            aria-label="Open in new tab"
             onPointerDown={(e) => e.stopPropagation()}
           >
             <ExternalLink
               style={{
-                width: 'min(12px, 2.5cqmin)',
-                height: 'min(12px, 2.5cqmin)',
+                width: 'min(16px, 4cqmin)',
+                height: 'min(16px, 4cqmin)',
               }}
             />
           </a>

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -36,7 +36,6 @@ import {
   Medal,
   Pause,
   Play,
-  ArrowLeft,
   Lock,
   Unlock,
 } from 'lucide-react';
@@ -81,6 +80,15 @@ import {
 } from '@/utils/quizAudio';
 import { logError } from '@/utils/logError';
 import { withPreviewFlag } from '@/utils/urlHelpers';
+import {
+  SessionViewHeader,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+} from '@/components/common/sessionViews';
+import { scoreTone } from '@/utils/scoreColor';
 
 interface QuizLiveMonitorProps {
   session: QuizSession;
@@ -152,7 +160,7 @@ const LiveScoreboardSetupPopup: React.FC<LiveScoreboardSetupPopupProps> = ({
 }) => (
   <div
     ref={setupRef}
-    className="absolute left-0 right-0 top-full mt-2 bg-white rounded-2xl shadow-xl border border-brand-blue-primary/10 z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+    className="absolute right-0 top-full mt-2 w-64 bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm z-50 animate-in fade-in slide-in-from-top-2 duration-200"
     style={{ padding: 'min(16px, 4cqmin)' }}
   >
     <p
@@ -953,154 +961,65 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       };
     }, [filteredResponses, currentQ, pinToName, byStudentUid]);
 
-  const modeIcon =
-    session.sessionMode === 'auto' ? (
-      <Zap className="w-3.5 h-3.5" />
-    ) : session.sessionMode === 'student' ? (
-      <Clock className="w-3.5 h-3.5" />
-    ) : (
-      <User className="w-3.5 h-3.5" />
-    );
-
-  const modeLabel =
-    session.sessionMode === 'auto'
-      ? 'Auto-progress'
-      : session.sessionMode === 'student'
-        ? 'Self-paced'
-        : 'Teacher-paced';
-
   return (
     <div className="flex flex-col h-full font-sans">
-      {/* Header */}
-      <div
-        className="border-b border-brand-red-primary/10"
-        style={{ padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)' }}
-      >
-        <div className="flex items-center justify-between">
-          <div
-            className="flex items-center"
-            style={{ gap: 'min(8px, 2cqmin)' }}
-          >
-            {onBack && (
-              <button
-                onClick={onBack}
-                className="flex items-center justify-center rounded-lg text-brand-blue-dark/70 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors"
-                style={{
-                  width: 'min(28px, 7cqmin)',
-                  height: 'min(28px, 7cqmin)',
-                }}
-                title="Back to assignments"
-                aria-label="Back to assignments"
-              >
-                <ArrowLeft
-                  style={{
-                    width: 'min(16px, 4cqmin)',
-                    height: 'min(16px, 4cqmin)',
-                  }}
-                />
-              </button>
-            )}
-            <div
-              className="rounded-full bg-brand-red-primary animate-pulse shadow-[0_0_8px_rgba(173,33,34,0.5)]"
-              style={{
-                width: 'min(10px, 2.5cqmin)',
-                height: 'min(10px, 2.5cqmin)',
-              }}
-            />
-            <div className="flex flex-col">
-              <div
-                className="flex items-center gap-1.5 font-black text-brand-red-primary leading-none uppercase tracking-tight"
-                style={{ fontSize: 'min(12px, 4cqmin)' }}
-              >
-                {modeIcon}
-                <span>{modeLabel}</span>
-              </div>
-              <span
-                className="text-brand-blue-dark font-bold truncate"
-                style={{ fontSize: 'min(11px, 3.5cqmin)', maxWidth: '140px' }}
-              >
-                {session.quizTitle}
-              </span>
-            </div>
-          </div>
-          <div
-            className="flex items-center"
-            style={{ gap: 'min(6px, 1.5cqmin)' }}
-          >
+      {/* Header — shared session-view chrome (status pulse, title, actions) */}
+      <SessionViewHeader
+        onBack={onBack ?? (() => undefined)}
+        status={
+          session.status === 'paused'
+            ? 'paused'
+            : session.status === 'ended'
+              ? 'ended'
+              : 'live'
+        }
+        title={session.quizTitle || quizData.title}
+        subtitle={session.code ? `Join code ${session.code}` : undefined}
+        actions={
+          <>
             {(onPause ?? onResume) && session.status !== 'ended' && (
-              <button
+              <ActionButton
+                variant="secondary"
+                label={session.status === 'paused' ? 'Resume' : 'Pause'}
+                icon={session.status === 'paused' ? Play : Pause}
                 onClick={() => void handleTogglePause()}
                 disabled={toggling}
-                className="flex items-center bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-                style={{
-                  gap: 'min(6px, 1.5cqmin)',
-                  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                  fontSize: 'min(11px, 3.5cqmin)',
-                }}
-                title={
-                  session.status === 'paused'
-                    ? 'Resume — students can answer again'
-                    : 'Pause — students see a paused screen'
-                }
-              >
-                {toggling ? (
-                  <Loader2
-                    className="animate-spin"
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                ) : session.status === 'paused' ? (
-                  <Play
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                ) : (
-                  <Pause
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
+              />
+            )}
+            {showScoreboardControl && (
+              <div className="relative flex">
+                <ActionButton
+                  variant="secondary"
+                  label={
+                    isLiveScoreboardActive ? 'Scoreboard on' : 'Scoreboard'
+                  }
+                  icon={Trophy}
+                  onClick={handleToggleLiveScoreboard}
+                  labelHidden
+                />
+                {showLiveScoreboardSetup && (
+                  <LiveScoreboardSetupPopup
+                    setupRef={liveScoreboardSetupRef}
+                    mode={liveScoreboardMode}
+                    onModeChange={setLiveScoreboardMode}
+                    scoring={liveScoreboardScoring}
+                    onScoringChange={setLiveScoreboardScoring}
+                    hasNames={hasNames}
+                    onEnable={handleEnableLiveScoreboard}
                   />
                 )}
-                {session.status === 'paused' ? 'RESUME' : 'PAUSE'}
-              </button>
+              </div>
             )}
-            <button
+            <ActionButton
+              variant="danger"
+              label="End"
+              icon={Square}
               onClick={() => void handleEnd()}
               disabled={ending}
-              className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-              title="Make this assignment inactive. Responses are preserved."
-            >
-              {ending ? (
-                <Loader2
-                  className="animate-spin"
-                  style={{
-                    width: 'min(14px, 3.5cqmin)',
-                    height: 'min(14px, 3.5cqmin)',
-                  }}
-                />
-              ) : (
-                <Square
-                  style={{
-                    width: 'min(14px, 3.5cqmin)',
-                    height: 'min(14px, 3.5cqmin)',
-                  }}
-                />
-              )}
-              END
-            </button>
-          </div>
-        </div>
-      </div>
+            />
+          </>
+        }
+      />
 
       <div
         className="flex-1 overflow-y-auto custom-scrollbar"
@@ -1163,7 +1082,10 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 </div>
               ) : (
                 /* 1b. QUESTION — hero content (teacher/auto-paced only) */
-                <div className="relative">
+                <div
+                  className="relative bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm"
+                  style={{ padding: 'min(12px, 3cqmin) min(16px, 4cqmin)' }}
+                >
                   {autoCountdown !== null && (
                     <div
                       className="absolute top-0 left-0 right-0 rounded-full overflow-hidden bg-brand-blue-lighter"
@@ -1274,7 +1196,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   {((session.showCorrectOnBoard ?? false) || isReviewing) &&
                     session.revealedAnswers?.[currentQ.id] && (
                       <div
-                        className="bg-emerald-50 border border-emerald-200 rounded-xl flex items-center justify-between"
+                        className="bg-emerald-50/70 border border-emerald-200 rounded-2xl backdrop-blur-sm shadow-sm flex items-center justify-between"
                         style={{
                           fontSize: 'min(13px, 4.5cqmin)',
                           marginTop: 'min(6px, 1.5cqmin)',
@@ -1363,7 +1285,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                   {/* Live answer distribution (MC only) */}
                   {showStats && currentQ.type === 'MC' && (
                     <div
-                      className="border-t border-brand-blue-primary/5"
+                      className="border-t border-slate-200/60"
                       style={{
                         marginTop: 'min(8px, 2cqmin)',
                         paddingTop: 'min(8px, 2cqmin)',
@@ -1411,71 +1333,86 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 onPointerDown={(e) => e.stopPropagation()}
                 style={{ gap: 'min(4px, 1cqmin)', touchAction: 'auto' }}
               >
-                <InteractiveStatBox
+                <StatTile
                   label="Joined"
                   value={joined + inProgress + completed}
                   icon={
                     <Users
                       style={{
-                        width: 'min(12px, 3.5cqmin)',
-                        height: 'min(12px, 3.5cqmin)',
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
                       }}
                     />
                   }
-                  color="blue"
-                  expanded={expandedStat === 'joined'}
-                  onToggle={() =>
+                  tone="blue"
+                  interactive
+                  selected={expandedStat === 'joined'}
+                  onClick={() =>
                     setExpandedStat(expandedStat === 'joined' ? null : 'joined')
                   }
-                  students={[
-                    ...studentsByStatus.joined,
-                    ...studentsByStatus.active,
-                    ...studentsByStatus.finished,
-                  ]}
-                />
-                <InteractiveStatBox
+                >
+                  <StatTileStudentList
+                    show={expandedStat === 'joined'}
+                    students={[
+                      ...studentsByStatus.joined,
+                      ...studentsByStatus.active,
+                      ...studentsByStatus.finished,
+                    ]}
+                  />
+                </StatTile>
+                <StatTile
                   label="Active"
                   value={inProgress}
                   icon={
                     <Clock
                       style={{
-                        width: 'min(12px, 3.5cqmin)',
-                        height: 'min(12px, 3.5cqmin)',
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
                       }}
                     />
                   }
-                  color="amber"
-                  expanded={expandedStat === 'active'}
-                  onToggle={() =>
+                  tone="amber"
+                  interactive
+                  selected={expandedStat === 'active'}
+                  onClick={() =>
                     setExpandedStat(expandedStat === 'active' ? null : 'active')
                   }
-                  students={studentsByStatus.active}
-                />
-                <InteractiveStatBox
+                >
+                  <StatTileStudentList
+                    show={expandedStat === 'active'}
+                    students={studentsByStatus.active}
+                  />
+                </StatTile>
+                <StatTile
                   label="Finished"
                   value={completed}
                   icon={
                     <CheckCircle2
                       style={{
-                        width: 'min(12px, 3.5cqmin)',
-                        height: 'min(12px, 3.5cqmin)',
+                        width: 'min(14px, 4cqmin)',
+                        height: 'min(14px, 4cqmin)',
                       }}
                     />
                   }
-                  color="green"
-                  expanded={expandedStat === 'finished'}
-                  onToggle={() =>
+                  tone="green"
+                  interactive
+                  selected={expandedStat === 'finished'}
+                  onClick={() =>
                     setExpandedStat(
                       expandedStat === 'finished' ? null : 'finished'
                     )
                   }
-                  students={studentsByStatus.finished}
-                />
+                >
+                  <StatTileStudentList
+                    show={expandedStat === 'finished'}
+                    students={studentsByStatus.finished}
+                  />
+                </StatTile>
               </div>
 
               {/* 3. JOIN CODE bar (compact) */}
               <div
-                className="flex items-center bg-white border border-brand-blue-primary/10 rounded-xl shadow-sm"
+                className="flex items-center bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm"
                 style={{
                   padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
                   gap: 'min(6px, 1.5cqmin)',
@@ -1591,53 +1528,6 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 )}
               </div>
 
-              {/* 4. Live Scoreboard Toggle (compact) — icon-only, gated on
-                  gamification signals so plain quizzes don't surface it. */}
-              {showScoreboardControl && (
-                <div className="relative flex justify-end">
-                  <button
-                    onClick={handleToggleLiveScoreboard}
-                    aria-label={
-                      isLiveScoreboardActive
-                        ? 'Live scoreboard on — click to configure or disable'
-                        : 'Enable live scoreboard'
-                    }
-                    title={
-                      isLiveScoreboardActive
-                        ? 'Live scoreboard on'
-                        : 'Enable live scoreboard'
-                    }
-                    className={`flex items-center justify-center rounded-lg transition-all active:scale-95 border ${
-                      isLiveScoreboardActive
-                        ? 'bg-amber-500 hover:bg-amber-600 text-white border-amber-600 ring-1 ring-amber-300 shadow-sm'
-                        : 'bg-white hover:bg-amber-50 text-amber-600 border-amber-200'
-                    }`}
-                    style={{
-                      width: 'min(28px, 7cqmin)',
-                      height: 'min(28px, 7cqmin)',
-                    }}
-                  >
-                    <Trophy
-                      style={{
-                        width: 'min(14px, 3.5cqmin)',
-                        height: 'min(14px, 3.5cqmin)',
-                      }}
-                    />
-                  </button>
-                  {showLiveScoreboardSetup && (
-                    <LiveScoreboardSetupPopup
-                      setupRef={liveScoreboardSetupRef}
-                      mode={liveScoreboardMode}
-                      onModeChange={setLiveScoreboardMode}
-                      scoring={liveScoreboardScoring}
-                      onScoringChange={setLiveScoreboardScoring}
-                      hasNames={hasNames}
-                      onEnable={handleEnableLiveScoreboard}
-                    />
-                  )}
-                </div>
-              )}
-
               {/* 5. ROSTER show/hide + student list. The gate also stays
                    open when a class-period filter is active even if the
                    filter currently produces zero rows — otherwise the
@@ -1645,7 +1535,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                    no way for the teacher to widen the selection again. */}
               {(responses.length > 0 || filterActive) && (
                 <div className="space-y-2">
-                  <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
+                  <div className="flex items-center justify-between border-b border-slate-200/60 pb-1">
                     <button
                       onClick={() => setShowRoster(!showRoster)}
                       className="flex items-center gap-1"
@@ -1712,14 +1602,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </div>
                   )}
                   {showRoster && filteredResponses.length > 0 && (
-                    <div
-                      className="max-h-60 overflow-y-auto pr-1 custom-scrollbar"
-                      style={{
-                        gap: 'min(6px, 1.5cqmin)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                      }}
-                    >
+                    <div className="max-h-60 overflow-y-auto pr-1 custom-scrollbar flex flex-col">
                       {filteredResponses
                         .slice()
                         .sort((a, b) =>
@@ -1816,7 +1699,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
             <>
               {/* Join code bar (full size) */}
               <div
-                className="flex items-center bg-white border border-brand-blue-primary/10 rounded-xl shadow-sm"
+                className="flex items-center bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm"
                 style={{
                   padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
                   gap: 'min(8px, 2cqmin)',
@@ -1931,53 +1814,6 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 )}
               </div>
 
-              {/* Live Scoreboard Toggle (full size) — icon-only, gated on
-                  gamification signals so plain quizzes don't surface it. */}
-              {showScoreboardControl && (
-                <div className="relative flex justify-end">
-                  <button
-                    onClick={handleToggleLiveScoreboard}
-                    aria-label={
-                      isLiveScoreboardActive
-                        ? 'Live scoreboard on — click to configure or disable'
-                        : 'Enable live scoreboard'
-                    }
-                    title={
-                      isLiveScoreboardActive
-                        ? 'Live scoreboard on'
-                        : 'Enable live scoreboard'
-                    }
-                    className={`flex items-center justify-center rounded-lg transition-all active:scale-95 border ${
-                      isLiveScoreboardActive
-                        ? 'bg-amber-500 hover:bg-amber-600 text-white border-amber-600 ring-1 ring-amber-300 shadow-sm'
-                        : 'bg-white hover:bg-amber-50 text-amber-600 border-amber-200'
-                    }`}
-                    style={{
-                      width: 'min(32px, 8cqmin)',
-                      height: 'min(32px, 8cqmin)',
-                    }}
-                  >
-                    <Trophy
-                      style={{
-                        width: 'min(16px, 4cqmin)',
-                        height: 'min(16px, 4cqmin)',
-                      }}
-                    />
-                  </button>
-                  {showLiveScoreboardSetup && (
-                    <LiveScoreboardSetupPopup
-                      setupRef={liveScoreboardSetupRef}
-                      mode={liveScoreboardMode}
-                      onModeChange={setLiveScoreboardMode}
-                      scoring={liveScoreboardScoring}
-                      onScoringChange={setLiveScoreboardScoring}
-                      hasNames={hasNames}
-                      onEnable={handleEnableLiveScoreboard}
-                    />
-                  )}
-                </div>
-              )}
-
               {/* Period chips above stat boxes — same pattern as the
                   active layout so teachers can preview / review one
                   period at a time before starting or after ending. */}
@@ -1993,7 +1829,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 className="grid grid-cols-3"
                 style={{ gap: 'min(8px, 2cqmin)' }}
               >
-                <StatBox
+                <StatTile
                   label="Joined"
                   value={joined + inProgress + completed}
                   icon={
@@ -2004,9 +1840,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       }}
                     />
                   }
-                  color="blue"
+                  tone="blue"
                 />
-                <StatBox
+                <StatTile
                   label="Active"
                   value={inProgress}
                   icon={
@@ -2017,9 +1853,9 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       }}
                     />
                   }
-                  color="amber"
+                  tone="amber"
                 />
-                <StatBox
+                <StatTile
                   label="Finished"
                   value={completed}
                   icon={
@@ -2030,7 +1866,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                       }}
                     />
                   }
-                  color="green"
+                  tone="green"
                 />
               </div>
 
@@ -2096,7 +1932,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                    zero rows. */}
               {(responses.length > 0 || filterActive) && (
                 <div className="space-y-2 mt-2">
-                  <div className="flex items-center justify-between border-b border-brand-blue-primary/10 pb-1">
+                  <div className="flex items-center justify-between border-b border-slate-200/60 pb-1">
                     <button
                       onClick={() => setShowRoster(!showRoster)}
                       className="flex items-center gap-1"
@@ -2163,14 +1999,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     </div>
                   )}
                   {showRoster && filteredResponses.length > 0 && (
-                    <div
-                      className="max-h-60 overflow-y-auto pr-1 custom-scrollbar"
-                      style={{
-                        gap: 'min(6px, 1.5cqmin)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                      }}
-                    >
+                    <div className="max-h-60 overflow-y-auto pr-1 custom-scrollbar flex flex-col">
                       {filteredResponses
                         .slice()
                         .sort((a, b) =>
@@ -2268,7 +2097,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
       {(session.status === 'waiting' ||
         (session.status === 'active' && session.sessionMode !== 'student')) && (
         <div
-          className="border-t border-brand-blue-primary/10"
+          className="border-t border-slate-200/60"
           style={{ padding: 'min(16px, 4cqmin)' }}
         >
           <button
@@ -2318,54 +2147,8 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
   );
 };
 
-const StatBox: React.FC<{
-  label: string;
-  value: number;
-  icon: React.ReactNode;
-  color: 'blue' | 'amber' | 'green';
-}> = ({ label, value, icon, color }) => {
-  const themes = {
-    blue: 'bg-brand-blue-lighter border-brand-blue-primary/10 text-brand-blue-primary',
-    amber: 'bg-amber-50 border-amber-200 text-amber-600',
-    green: 'bg-emerald-50 border-emerald-200 text-emerald-600',
-  };
-
-  return (
-    <div
-      className={`${themes[color]} rounded-2xl text-center border shadow-sm`}
-      style={{ padding: 'min(10px, 2.5cqmin)' }}
-    >
-      <div
-        className="opacity-60"
-        style={{
-          display: 'flex',
-          justifyContent: 'center',
-          marginBottom: 'min(4px, 1cqmin)',
-        }}
-      >
-        {icon}
-      </div>
-      <p
-        className="font-black leading-none"
-        style={{ fontSize: 'min(20px, 6.5cqmin)' }}
-      >
-        {value}
-      </p>
-      <p
-        className="font-bold uppercase tracking-tighter opacity-70"
-        style={{
-          fontSize: 'min(10px, 3.5cqmin)',
-          marginTop: 'min(2px, 0.5cqmin)',
-        }}
-      >
-        {label}
-      </p>
-    </div>
-  );
-};
-
 /**
- * Row shape passed to `InteractiveStatBox`. `key` is whatever uniquely
+ * Row shape passed to the interactive KPI tiles. `key` is whatever uniquely
  * identifies the student within the session — `pin` for anonymous joiners,
  * `studentUid` for SSO joiners.
  */
@@ -2374,83 +2157,37 @@ interface StatBoxStudent {
   name: string;
 }
 
-const InteractiveStatBox: React.FC<{
-  label: string;
-  value: number;
-  icon: React.ReactNode;
-  color: 'blue' | 'amber' | 'green';
-  expanded: boolean;
-  onToggle: () => void;
+/**
+ * Expandable student-name list rendered inside an interactive `StatTile`
+ * (the KPI tile's `children`). Shown only when the tile is selected and at
+ * least one student is in that bucket, mirroring the previous inline
+ * stat-box expansion.
+ */
+const StatTileStudentList: React.FC<{
+  show: boolean;
   students: StatBoxStudent[];
-}> = ({ label, value, icon, color, expanded, onToggle, students }) => {
-  const themes = {
-    blue: 'bg-brand-blue-lighter border-brand-blue-primary/10 text-brand-blue-primary',
-    amber: 'bg-amber-50 border-amber-200 text-amber-600',
-    green: 'bg-emerald-50 border-emerald-200 text-emerald-600',
-  };
-  const expandedBorder = {
-    blue: 'border-brand-blue-primary/30',
-    amber: 'border-amber-300',
-    green: 'border-emerald-300',
-  };
-
+}> = ({ show, students }) => {
+  if (!show || students.length === 0) return null;
   return (
-    <div className="flex flex-col">
-      <button
-        onClick={onToggle}
-        className={`${themes[color]} rounded-xl text-center border shadow-sm transition-all active:scale-95 cursor-pointer ${
-          expanded ? `ring-2 ring-offset-1 ${expandedBorder[color]}` : ''
-        }`}
-        style={{ padding: 'min(6px, 1.5cqmin) min(4px, 1cqmin)' }}
-      >
-        <div
-          className="opacity-60"
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            marginBottom: 'min(2px, 0.5cqmin)',
-          }}
-        >
-          {icon}
-        </div>
+    <div
+      className="text-left overflow-y-auto"
+      style={{
+        maxHeight: 'min(100px, 25cqmin)',
+        marginTop: 'min(6px, 1.5cqmin)',
+      }}
+    >
+      {students.map((s) => (
         <p
-          className="font-black leading-none"
-          style={{ fontSize: 'min(18px, 5.5cqmin)' }}
-        >
-          {value}
-        </p>
-        <p
-          className="font-bold uppercase tracking-tighter opacity-70"
+          key={s.key}
+          className="truncate font-bold text-slate-600"
           style={{
-            fontSize: 'min(9px, 3cqmin)',
-            marginTop: 'min(1px, 0.3cqmin)',
+            fontSize: 'min(10px, 2.8cqmin)',
+            padding: 'min(2px, 0.5cqmin) min(4px, 1cqmin)',
           }}
         >
-          {label}
+          {s.name}
         </p>
-      </button>
-      {expanded && students.length > 0 && (
-        <div
-          className={`${themes[color]} rounded-lg border mt-1 overflow-y-auto`}
-          style={{
-            maxHeight: 'min(100px, 25cqmin)',
-            padding: 'min(4px, 1cqmin)',
-          }}
-        >
-          {students.map((s) => (
-            <p
-              key={s.key}
-              className="truncate font-bold"
-              style={{
-                fontSize: 'min(10px, 2.8cqmin)',
-                padding: 'min(2px, 0.5cqmin) min(4px, 1cqmin)',
-              }}
-            >
-              {s.name}
-            </p>
-          ))}
-        </div>
-      )}
+      ))}
     </div>
   );
 };
@@ -2745,36 +2482,24 @@ const StudentRow: React.FC<{
   const displayScore = scoreable
     ? getDisplayScore(response, questions, scoringConfig)
     : null;
-  const scoreSuffix = getScoreSuffix(scoringConfig);
 
-  // Row background. When colors are enabled AND the student has finished,
-  // tint by score band (≥80% green / 60-79% amber / <60% rose). Active and
-  // joined rows always render as a clean white surface — there's no score
-  // to encode yet. With colors off, every row is white.
-  const rowBg = (() => {
-    if (!colorsEnabled || bandScore == null) {
-      return 'bg-white border-slate-200';
-    }
-    if (bandScore >= 80) return 'bg-emerald-50 border-emerald-200';
-    if (bandScore >= 60) return 'bg-amber-50 border-amber-200';
-    return 'bg-rose-50 border-rose-200';
-  })();
+  // Row score-band wash. When colors are enabled AND the student has
+  // finished, tint by score band via the unified scoreColor scale (≥80
+  // success / 60-79 warn / <60 danger) — the same un-bonused band score the
+  // local `scoreBandBg` helper used. Active and joined rows have no score to
+  // encode yet, and with colors off every row stays untinted.
+  const tintTone =
+    colorsEnabled && bandScore != null ? scoreTone(bandScore) : undefined;
 
-  // Status icon mirrors the KPI cards above (Joined → Users, Active → Clock,
-  // Finished → CheckCircle2). Renders in a neutral slate so the row band
-  // carries the semantic color.
-  const StatusIcon =
-    response.status === 'completed'
-      ? CheckCircle2
-      : response.status === 'in-progress'
-        ? Clock
-        : Users;
-  const statusIconColor =
-    response.status === 'completed'
-      ? 'text-emerald-600'
-      : response.status === 'in-progress'
-        ? 'text-amber-600'
-        : 'text-slate-400';
+  // Leading status dot mirrors the KPI buckets: in-progress students pulse
+  // (actively answering), completed students are a steady success dot, and
+  // joined-but-not-started rows get a neutral dot.
+  const statusDot: { tone: 'success' | 'neutral'; pulse?: boolean } =
+    response.status === 'in-progress'
+      ? { tone: 'success', pulse: true }
+      : response.status === 'completed'
+        ? { tone: 'success' }
+        : { tone: 'neutral' };
 
   const displayName = resolveResponseDisplayName(
     response,
@@ -2784,97 +2509,209 @@ const StudentRow: React.FC<{
 
   if (confirmRemove) {
     return (
-      <div
-        className="flex items-center rounded-xl border bg-red-50 border-red-200"
-        style={{
-          gap: 'min(8px, 2cqmin)',
-          padding: 'min(8px, 2cqmin)',
-        }}
+      <SessionRow
+        dot={{ tone: 'danger' }}
+        tintTone="danger"
+        trailing={
+          <>
+            <button
+              onClick={onRemove}
+              className="bg-red-500 hover:bg-red-600 text-white font-bold rounded-lg transition-colors"
+              style={{
+                padding: 'min(4px, 1cqmin) min(10px, 2.5cqmin)',
+                fontSize: 'min(10px, 3cqmin)',
+              }}
+            >
+              Yes
+            </button>
+            <button
+              onClick={onConfirmRemoveToggle}
+              className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-colors"
+              style={{
+                padding: 'min(4px, 1cqmin) min(10px, 2.5cqmin)',
+                fontSize: 'min(10px, 3cqmin)',
+              }}
+            >
+              No
+            </button>
+          </>
+        }
       >
         <span
-          className="flex-1 text-red-700 font-bold"
+          className="text-red-700 font-bold"
           style={{ fontSize: 'min(11px, 3.5cqmin)' }}
         >
           Remove {displayName}?
         </span>
-        <button
-          onClick={onRemove}
-          className="bg-red-500 hover:bg-red-600 text-white font-bold rounded-lg transition-colors"
-          style={{
-            padding: 'min(4px, 1cqmin) min(10px, 2.5cqmin)',
-            fontSize: 'min(10px, 3cqmin)',
-          }}
-        >
-          Yes
-        </button>
-        <button
-          onClick={onConfirmRemoveToggle}
-          className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg transition-colors"
-          style={{
-            padding: 'min(4px, 1cqmin) min(10px, 2.5cqmin)',
-            fontSize: 'min(10px, 3cqmin)',
-          }}
-        >
-          No
-        </button>
-      </div>
+      </SessionRow>
     );
   }
 
-  // Right-column pill content. `count` mode is intentionally
+  // Right-column score chip. `count` mode is intentionally
   // "answered / total" (progress), not "correct / total" — teachers
   // running self-paced sessions want to see where each student is in
   // the quiz, which is why the toolbar button title spells out
   // "Answered / Total" rather than the ambiguous "n/N".
-  let pillText: string | null;
-  if (scoreDisplay === 'hidden') {
-    pillText = null;
-  } else if (scoreDisplay === 'count') {
-    pillText = `${response.answers.length}/${totalQuestions}`;
-  } else if (response.status === 'completed' && displayScore != null) {
-    pillText = `${displayScore}${scoreSuffix}`;
-  } else if (response.status === 'completed') {
-    // Completed but not scoreable yet — the answer key is still loading, or
-    // this response's answers don't match the loaded quiz (e.g. synced-quiz
-    // id drift). Show a neutral placeholder rather than a misleading 0% or an
-    // "answered/total" count that could be misread as a perfect score.
-    pillText = '—';
-  } else {
-    // No completed score yet — fall back to progress so teachers always see
-    // *something* about in-progress students even when "percent" is selected.
-    pillText = `${response.answers.length}/${totalQuestions}`;
-  }
-  const pillTextClass =
-    response.status === 'completed'
-      ? 'text-emerald-700 font-black'
-      : response.status === 'in-progress'
-        ? 'text-amber-700 font-bold'
-        : 'text-brand-gray-primary font-medium';
+  //
+  // The shared ScorePill renders the score cases (count mode + a completed,
+  // scoreable score in percent mode). The two cases ScorePill can't express
+  // are preserved with a styled span so behavior stays identical:
+  //   - completed but not yet scoreable → a neutral "—" placeholder (rather
+  //     than a misleading 0% / count that reads like a perfect score);
+  //   - in-progress / joined under percent mode → progress fallback so
+  //     teachers always see *something* even when "percent" is selected.
+  const isGamified = isGamificationActive(scoringConfig);
+  const scoreTrailing = (() => {
+    if (scoreDisplay === 'hidden') return null;
+    if (scoreDisplay === 'count') {
+      return (
+        <ScorePill
+          score={0}
+          display="count"
+          count={response.answers.length}
+          total={totalQuestions}
+        />
+      );
+    }
+    // percent mode
+    if (response.status === 'completed' && displayScore != null) {
+      return (
+        <ScorePill
+          score={displayScore}
+          display="percent"
+          gamified={isGamified}
+          points={displayScore}
+        />
+      );
+    }
+    const fallbackText =
+      response.status === 'completed'
+        ? '—'
+        : `${response.answers.length}/${totalQuestions}`;
+    const fallbackClass =
+      response.status === 'completed'
+        ? 'text-emerald-700 font-black'
+        : response.status === 'in-progress'
+          ? 'text-amber-700 font-bold'
+          : 'text-brand-gray-primary font-medium';
+    return (
+      <span
+        className={`px-1.5 py-0.5 rounded-md bg-white/60 border border-white/80 shrink-0 ${fallbackClass}`}
+        style={{ fontSize: 'min(11px, 3cqmin)' }}
+      >
+        {fallbackText}
+      </span>
+    );
+  })();
+
+  // Lock state — a row is "locked" when the student's attempt was
+  // auto-submitted by the tab-switch tripwire (3+ warnings on a completed
+  // response) or when they hit the cross-launch attempt cap. The teacher
+  // clicks the badge to reopen the attempt — underlying answers are
+  // preserved and the next strike finalizes immediately.
+  const lockBadge = (() => {
+    if (!onUnlock) return null;
+    const isAutoSubmittedByWarnings =
+      response.status === 'completed' && warnings >= 3 && !response.unlocked;
+    const completedCount = response.completedAttempts ?? 0;
+    const hitAttemptCap =
+      typeof attemptLimit === 'number' &&
+      attemptLimit > 0 &&
+      completedCount >= attemptLimit &&
+      !response.unlocked;
+    const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
+    if (isLocked) {
+      return (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnlock(displayName);
+          }}
+          className="shrink-0 rounded-full transition-opacity hover:opacity-80"
+          title={
+            isAutoSubmittedByWarnings
+              ? 'Auto-submitted from tab-switch warnings — click to allow resume'
+              : 'Attempt limit reached — click to allow resume'
+          }
+          aria-label={`Unlock ${displayName}'s attempt`}
+        >
+          <SessionBadge tone="warn" label="Locked" icon={Lock} />
+        </button>
+      );
+    }
+    if (
+      response.unlocked &&
+      (response.status === 'in-progress' || response.status === 'joined')
+    ) {
+      return (
+        <span
+          className="shrink-0"
+          title="Unlocked — one more tab-switch will finalize the attempt"
+        >
+          <SessionBadge tone="success" label="Resumed" icon={Unlock} />
+        </span>
+      );
+    }
+    return null;
+  })();
 
   return (
-    <div
-      className={`flex items-center rounded-xl border transition-all ${rowBg}`}
-      style={{
-        gap: 'min(8px, 2cqmin)',
-        padding: 'min(8px, 2cqmin)',
-      }}
+    <SessionRow
+      dot={statusDot}
+      tintTone={tintTone}
+      trailing={
+        <>
+          {scoreTrailing}
+          {/* Unlock-results action — only when the student is currently
+              locked out of viewing published results. Decrements warnings by
+              1 and clears the lockout (one more tab-switch will re-lock). */}
+          {response.resultsLockedOut === true && onUnlockResults && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onUnlockResults(displayName);
+              }}
+              className="bg-amber-400 hover:bg-amber-300 text-slate-900 font-bold rounded-md transition-colors shrink-0"
+              style={{
+                padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
+                fontSize: 'min(10px, 3cqmin)',
+              }}
+              title="Decrement warnings by 1 and reopen the results view for this student"
+              aria-label={`Unlock results for ${displayName}`}
+            >
+              Unlock results
+            </button>
+          )}
+          {/* Remove button — always visible. Hover-only discoverability
+              failed on touch devices and made the action effectively
+              invisible. The icon stays muted so it doesn't compete with
+              the row content. */}
+          {onRemove && (
+            <button
+              onClick={onConfirmRemoveToggle}
+              className="text-slate-300 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors shrink-0 flex items-center justify-center"
+              style={{
+                width: 'min(20px, 5cqmin)',
+                height: 'min(20px, 5cqmin)',
+              }}
+              title="Remove student"
+              aria-label="Remove student"
+            >
+              <X
+                style={{
+                  width: 'min(14px, 3.5cqmin)',
+                  height: 'min(14px, 3.5cqmin)',
+                }}
+              />
+            </button>
+          )}
+        </>
+      }
     >
-      <StatusIcon
-        className={`shrink-0 ${statusIconColor}`}
-        style={{
-          width: 'min(14px, 3.5cqmin)',
-          height: 'min(14px, 3.5cqmin)',
-        }}
-        aria-label={
-          response.status === 'completed'
-            ? 'Finished'
-            : response.status === 'in-progress'
-              ? 'Active'
-              : 'Joined'
-        }
-      />
       <span
-        className="flex-1 flex items-center gap-1.5 text-brand-blue-dark font-bold truncate"
+        className="flex items-center gap-1.5 text-brand-blue-dark font-bold truncate"
         style={{ fontSize: 'min(12px, 3.5cqmin)' }}
       >
         <span
@@ -2892,191 +2729,48 @@ const StudentRow: React.FC<{
 
         {isPossibleDuplicate && (
           <span
-            className="flex items-center gap-0.5 bg-amber-100 text-amber-800 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
-            style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+            className="shrink-0"
             title="This name appears on more than one submission — a student may have joined twice (e.g. via Google sign-in and a PIN, or under the wrong class period). Review and remove the extra copy before grading."
           >
-            <Users
-              style={{
-                width: 'min(12px, 3cqmin)',
-                height: 'min(12px, 3cqmin)',
-              }}
-            />
-            Dup?
+            <SessionBadge tone="warn" label="Dup?" icon={Users} />
           </span>
         )}
 
         {showTabWarnings && warnings > 0 && (
           <span
-            className="flex items-center gap-0.5 bg-red-100 text-red-700 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
-            style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+            className="shrink-0"
             title={`${warnings} Tab Switch Warning(s)`}
           >
-            <AlertTriangle
-              style={{
-                width: 'min(12px, 3cqmin)',
-                height: 'min(12px, 3cqmin)',
-              }}
+            <SessionBadge
+              tone="danger"
+              label={`${warnings}`}
+              icon={AlertTriangle}
             />
-            {warnings}
           </span>
         )}
 
-        {/* Lock indicator + unlock action. A row is "locked" when the
-            student's attempt was auto-submitted by the tab-switch
-            tripwire (3+ warnings on a completed response) or when they
-            hit the cross-launch attempt cap. The teacher clicks to
-            reopen the attempt — the underlying answers are preserved
-            and the next strike will finalize immediately. */}
-        {(() => {
-          if (!onUnlock) return null;
-          const isAutoSubmittedByWarnings =
-            response.status === 'completed' &&
-            warnings >= 3 &&
-            !response.unlocked;
-          const completedCount = response.completedAttempts ?? 0;
-          const hitAttemptCap =
-            typeof attemptLimit === 'number' &&
-            attemptLimit > 0 &&
-            completedCount >= attemptLimit &&
-            !response.unlocked;
-          const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
-          if (isLocked) {
-            return (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onUnlock(displayName);
-                }}
-                className="flex items-center gap-0.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded uppercase font-black shrink-0 transition-colors"
-                style={{
-                  fontSize: 'min(9px, 2.5cqmin)',
-                  padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
-                }}
-                title={
-                  isAutoSubmittedByWarnings
-                    ? 'Auto-submitted from tab-switch warnings — click to allow resume'
-                    : 'Attempt limit reached — click to allow resume'
-                }
-                aria-label={`Unlock ${displayName}'s attempt`}
-              >
-                <Lock
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-                Locked
-              </button>
-            );
-          }
-          if (
-            response.unlocked &&
-            (response.status === 'in-progress' || response.status === 'joined')
-          ) {
-            return (
-              <span
-                className="flex items-center gap-0.5 bg-emerald-100 text-emerald-800 rounded uppercase font-black shrink-0"
-                style={{
-                  fontSize: 'min(9px, 2.5cqmin)',
-                  padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
-                }}
-                title="Unlocked — one more tab-switch will finalize the attempt"
-              >
-                <Unlock
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-                Resumed
-              </span>
-            );
-          }
-          return null;
-        })()}
+        {lockBadge}
 
-        {/* Results-view lockout indicator + unlock action. A row enters this
-            state when the student crossed `protection.tabWarningThreshold`
-            tab-switches while viewing published results — the student app
-            redirects them out and writes `resultsLockedOut: true`. The
-            teacher's unlock here decrements warnings by 1 (so a single
-            additional tab-switch re-locks them) and clears the flag. */}
+        {/* Results-view lockout indicator. A row enters this state when the
+            student crossed `protection.tabWarningThreshold` tab-switches while
+            viewing published results — the student app redirects them out and
+            writes `resultsLockedOut: true`. The accompanying unlock action
+            lives in the trailing slot. */}
         {response.resultsLockedOut === true && (
           <span
+            className="shrink-0"
             aria-label="Results locked"
-            className="flex items-center gap-0.5 bg-rose-100 text-rose-800 rounded uppercase font-black shrink-0"
-            style={{
-              fontSize: 'min(9px, 2.5cqmin)',
-              padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
-            }}
             title={`Results locked after ${response.resultsTabWarnings ?? 0} of ${resultsTabWarningThreshold} tab-switch warnings`}
           >
-            <Lock
-              style={{
-                width: 'min(12px, 3cqmin)',
-                height: 'min(12px, 3cqmin)',
-              }}
+            <SessionBadge
+              tone="danger"
+              label={`Results locked (${response.resultsTabWarnings ?? 0}/${resultsTabWarningThreshold})`}
+              icon={Lock}
             />
-            Results locked ({response.resultsTabWarnings ?? 0}/
-            {resultsTabWarningThreshold})
           </span>
         )}
       </span>
-      {pillText !== null && (
-        <span
-          className={`px-1.5 py-0.5 rounded-md bg-white/60 border border-white/80 ${pillTextClass}`}
-          style={{ fontSize: 'min(11px, 3cqmin)' }}
-        >
-          {pillText}
-        </span>
-      )}
-      {/* Unlock-results action — only when the student is currently locked
-          out of viewing published results. Decrements warnings by 1 and
-          clears the lockout (one more tab-switch will re-lock them). */}
-      {response.resultsLockedOut === true && onUnlockResults && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onUnlockResults(displayName);
-          }}
-          className="bg-amber-400 hover:bg-amber-300 text-slate-900 font-bold rounded-md transition-colors shrink-0"
-          style={{
-            padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-            fontSize: 'min(10px, 3cqmin)',
-          }}
-          title="Decrement warnings by 1 and reopen the results view for this student"
-          aria-label={`Unlock results for ${displayName}`}
-        >
-          Unlock results
-        </button>
-      )}
-      {/* Remove button — always visible. Hover-only discoverability
-          failed on touch devices and made the action effectively
-          invisible. The icon stays muted so it doesn't compete with
-          the row content. */}
-      {onRemove && (
-        <button
-          onClick={onConfirmRemoveToggle}
-          className="text-slate-300 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors shrink-0 flex items-center justify-center"
-          style={{
-            width: 'min(20px, 5cqmin)',
-            height: 'min(20px, 5cqmin)',
-          }}
-          title="Remove student"
-          aria-label="Remove student"
-        >
-          <X
-            style={{
-              width: 'min(14px, 3.5cqmin)',
-              height: 'min(14px, 3.5cqmin)',
-            }}
-          />
-        </button>
-      )}
-    </div>
+    </SessionRow>
   );
 };
 
@@ -3115,7 +2809,7 @@ const PodiumView: React.FC<{
 
   return (
     <div
-      className="bg-white border border-amber-200 rounded-2xl shadow-md text-center animate-in fade-in slide-in-from-bottom-2 duration-300"
+      className="bg-white/70 border border-amber-200 rounded-2xl backdrop-blur-sm shadow-sm text-center animate-in fade-in slide-in-from-bottom-2 duration-300"
       style={{ padding: 'min(16px, 4cqmin)' }}
     >
       <div

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -2494,9 +2494,9 @@ const StudentRow: React.FC<{
   // Leading status dot mirrors the KPI buckets: in-progress students pulse
   // (actively answering), completed students are a steady success dot, and
   // joined-but-not-started rows get a neutral dot.
-  const statusDot: { tone: 'success' | 'neutral'; pulse?: boolean } =
+  const statusDot: { tone: 'success' | 'warn' | 'neutral'; pulse?: boolean } =
     response.status === 'in-progress'
-      ? { tone: 'success', pulse: true }
+      ? { tone: 'warn', pulse: true }
       : response.status === 'completed'
         ? { tone: 'success' }
         : { tone: 'neutral' };

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -965,7 +965,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
     <div className="flex flex-col h-full font-sans">
       {/* Header — shared session-view chrome (status pulse, title, actions) */}
       <SessionViewHeader
-        onBack={onBack ?? (() => undefined)}
+        onBack={onBack}
         status={
           session.status === 'paused'
             ? 'paused'

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -991,6 +991,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
               <div className="relative flex">
                 <ActionButton
                   variant="secondary"
+                  active={isLiveScoreboardActive}
                   label={
                     isLiveScoreboardActive ? 'Scoreboard on' : 'Scoreboard'
                   }

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -2580,7 +2580,7 @@ const StudentRow: React.FC<{
     if (response.status === 'completed' && displayScore != null) {
       return (
         <ScorePill
-          score={displayScore}
+          score={isGamified ? 0 : displayScore}
           display="percent"
           gamified={isGamified}
           points={displayScore}

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -984,6 +984,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                 icon={session.status === 'paused' ? Play : Pause}
                 onClick={() => void handleTogglePause()}
                 disabled={toggling}
+                loading={toggling}
               />
             )}
             {showScoreboardControl && (
@@ -1016,6 +1017,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
               icon={Square}
               onClick={() => void handleEnd()}
               disabled={ending}
+              loading={ending}
             />
           </>
         }
@@ -2581,6 +2583,7 @@ const StudentRow: React.FC<{
           display="percent"
           gamified={isGamified}
           points={displayScore}
+          suffix={isGamified ? ' pts' : undefined}
         />
       );
     }

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -160,8 +160,8 @@ const LiveScoreboardSetupPopup: React.FC<LiveScoreboardSetupPopupProps> = ({
 }) => (
   <div
     ref={setupRef}
-    className="absolute right-0 top-full mt-2 w-64 bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm z-50 animate-in fade-in slide-in-from-top-2 duration-200"
-    style={{ padding: 'min(16px, 4cqmin)' }}
+    className="absolute right-0 top-full mt-2 bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+    style={{ width: 'min(256px, 80cqw)', padding: 'min(16px, 4cqmin)' }}
   >
     <p
       className="font-black text-brand-blue-dark text-center uppercase tracking-wider"

--- a/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+++ b/components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
@@ -1296,7 +1296,7 @@ export const QuizLiveMonitor: React.FC<QuizLiveMonitorProps> = ({
                     >
                       <MCDistribution
                         question={currentQ}
-                        responses={responses}
+                        responses={filteredResponses}
                       />
                     </div>
                   )}

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -579,13 +579,13 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     (mode: 'pin' | 'name') => {
       setShowScoreboardPrompt(false);
 
-      if (completed.length === 0) {
+      if (filteredCompleted.length === 0) {
         addToast('No completed students yet', 'error');
         return;
       }
 
       const newTeams = buildScoreboardTeams(
-        completed,
+        filteredCompleted,
         quiz.questions,
         mode,
         pinToName,
@@ -634,7 +634,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       }
     },
     [
-      completed,
+      filteredCompleted,
       quiz.questions,
       pinToName,
       byStudentUid,
@@ -647,7 +647,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   );
 
   const handleScoreboardClick = useCallback(() => {
-    if (completed.length === 0) {
+    if (filteredCompleted.length === 0) {
       addToast('No completed students yet', 'error');
       return;
     }
@@ -656,7 +656,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     } else {
       handleSendToScoreboard('pin');
     }
-  }, [completed.length, hasNames, addToast, handleSendToScoreboard]);
+  }, [filteredCompleted.length, hasNames, addToast, handleSendToScoreboard]);
 
   // Recovery path shared by handleExport (initial export) and
   // handleUpdateSheet (delta append). When the configured PLC sheet is
@@ -1245,7 +1245,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   //     (PLC)               (smart append-or-rebuild). Informative label.
   //   • Open Sheet        — shown when `exportUrl` is truthy; opens the sheet
   //                         in a new tab (was an <a target="_blank"> link).
-  //   • Send to Scoreboard— gated on `completed.length > 0`.
+  //   • Send to Scoreboard— gated on `filteredCompleted.length > 0` (respects
+  //                         the active period filter).
   // When a Schoology push applies it's the visible primary action, so it's
   // NOT duplicated here; there is no Classroom-vs-Schoology overlap (an
   // assignment is one or the other), so the visible primary push is Classroom
@@ -1294,7 +1295,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       disabled: updatingSheet,
     });
   }
-  if (completed.length > 0) {
+  if (filteredCompleted.length > 0) {
     overflowItems.push({
       label: 'Send to Scoreboard',
       icon: Trophy,

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1354,65 +1354,70 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
             {overflowItems.length > 0 && (
               <div className="relative shrink-0">
                 <OverflowMenu items={overflowItems} />
-                {showScoreboardPrompt && (
-                  <div
-                    ref={scoreboardPromptRef}
-                    className="absolute right-0 top-full mt-2 bg-white rounded-2xl shadow-xl border border-brand-blue-primary/10 z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+              </div>
+            )}
+            {/* Anchored separately from the overflow menu so deleting the last
+                completed student (which empties overflowItems) can't unmount the
+                prompt mid-interaction. */}
+            {showScoreboardPrompt && (
+              <div className="relative shrink-0">
+                <div
+                  ref={scoreboardPromptRef}
+                  className="absolute right-0 top-full mt-2 bg-white rounded-2xl shadow-xl border border-brand-blue-primary/10 z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+                  style={{
+                    padding: 'min(16px, 4cqmin)',
+                    width: 'max(220px, 50cqw)',
+                  }}
+                >
+                  <p
+                    className="font-black text-brand-blue-dark text-center uppercase tracking-wider"
                     style={{
-                      padding: 'min(16px, 4cqmin)',
-                      width: 'max(220px, 50cqw)',
+                      fontSize: 'min(11px, 3.5cqmin)',
+                      marginBottom: 'min(12px, 3cqmin)',
                     }}
                   >
-                    <p
-                      className="font-black text-brand-blue-dark text-center uppercase tracking-wider"
+                    How should students appear?
+                  </p>
+                  <div
+                    className="flex flex-col"
+                    style={{ gap: 'min(8px, 2cqmin)' }}
+                  >
+                    <button
+                      onClick={() => handleSendToScoreboard('name')}
+                      className="flex items-center w-full bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95"
                       style={{
-                        fontSize: 'min(11px, 3.5cqmin)',
-                        marginBottom: 'min(12px, 3cqmin)',
+                        gap: 'min(8px, 2cqmin)',
+                        padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
+                        fontSize: 'min(12px, 3.5cqmin)',
                       }}
                     >
-                      How should students appear?
-                    </p>
-                    <div
-                      className="flex flex-col"
-                      style={{ gap: 'min(8px, 2cqmin)' }}
+                      <User
+                        style={{
+                          width: 'min(16px, 4cqmin)',
+                          height: 'min(16px, 4cqmin)',
+                        }}
+                      />
+                      Student Names
+                    </button>
+                    <button
+                      onClick={() => handleSendToScoreboard('pin')}
+                      className="flex items-center w-full bg-slate-100 hover:bg-slate-200 text-brand-blue-dark font-bold rounded-xl transition-all active:scale-95"
+                      style={{
+                        gap: 'min(8px, 2cqmin)',
+                        padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
+                        fontSize: 'min(12px, 3.5cqmin)',
+                      }}
                     >
-                      <button
-                        onClick={() => handleSendToScoreboard('name')}
-                        className="flex items-center w-full bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95"
+                      <Hash
                         style={{
-                          gap: 'min(8px, 2cqmin)',
-                          padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
-                          fontSize: 'min(12px, 3.5cqmin)',
+                          width: 'min(16px, 4cqmin)',
+                          height: 'min(16px, 4cqmin)',
                         }}
-                      >
-                        <User
-                          style={{
-                            width: 'min(16px, 4cqmin)',
-                            height: 'min(16px, 4cqmin)',
-                          }}
-                        />
-                        Student Names
-                      </button>
-                      <button
-                        onClick={() => handleSendToScoreboard('pin')}
-                        className="flex items-center w-full bg-slate-100 hover:bg-slate-200 text-brand-blue-dark font-bold rounded-xl transition-all active:scale-95"
-                        style={{
-                          gap: 'min(8px, 2cqmin)',
-                          padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
-                          fontSize: 'min(12px, 3.5cqmin)',
-                        }}
-                      >
-                        <Hash
-                          style={{
-                            width: 'min(16px, 4cqmin)',
-                            height: 'min(16px, 4cqmin)',
-                          }}
-                        />
-                        PINs Only
-                      </button>
-                    </div>
+                      />
+                      PINs Only
+                    </button>
                   </div>
-                )}
+                </div>
               </div>
             )}
           </>

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1544,6 +1544,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           </div>
 
           <div
+            role="tabpanel"
+            aria-label={`${activeTab} results`}
             className="flex-1 overflow-y-auto custom-scrollbar"
             style={{ padding: 'min(16px, 4cqmin)' }}
           >

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -2089,7 +2089,7 @@ const StudentsTab: React.FC<{
                         {scoreable ? (
                           <>
                             <ScorePill
-                              score={score}
+                              score={gamified ? 0 : score}
                               display="percent"
                               gamified={gamified}
                               points={earned}

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1233,14 +1233,64 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     }
   };
 
-  // Overflow-menu items. Send to Scoreboard always lives here (decluttered out
-  // of the visible header), gated identically to the old visible button
-  // (`completed.length > 0`). When a Schoology push applies it's the visible
-  // primary action, so it's NOT duplicated here; there is no Classroom-vs-
-  // Schoology overlap (an assignment is one or the other), so the visible
-  // primary push is Classroom when attached, else Schoology — and the overflow
-  // never carries a push that's already visible.
+  // Overflow-menu items. The Sheet/Export family (Export, Re-export solo,
+  // Re-export/Update PLC, Open Sheet) and Send to Scoreboard all live here
+  // (decluttered out of the visible header per the approved design). Each
+  // item keeps the EXACT gate/handler/disabled condition it had as a visible
+  // header button — only the placement changes:
+  //   • Export            — shown when `!exportUrl`; handleExport; disabled
+  //                         while exporting or with zero responses.
+  //   • Re-export (solo)  — gated on `canShowSoloReExport`; handleExport.
+  //   • Re-export/Update  — gated on `canShowUpdateSheet`; handleUpdateSheet
+  //     (PLC)               (smart append-or-rebuild). Informative label.
+  //   • Open Sheet        — shown when `exportUrl` is truthy; opens the sheet
+  //                         in a new tab (was an <a target="_blank"> link).
+  //   • Send to Scoreboard— gated on `completed.length > 0`.
+  // When a Schoology push applies it's the visible primary action, so it's
+  // NOT duplicated here; there is no Classroom-vs-Schoology overlap (an
+  // assignment is one or the other), so the visible primary push is Classroom
+  // when attached, else Schoology — and the overflow never carries a push
+  // that's already visible.
   const overflowItems: OverflowMenuItem[] = [];
+  if (!exportUrl) {
+    overflowItems.push({
+      label: 'Export to Sheets',
+      icon: exporting ? Loader2 : Download,
+      onClick: () => void handleExport(),
+      disabled: exporting || responses.length === 0,
+    });
+  }
+  if (exportUrl) {
+    const sheetUrl = exportUrl;
+    overflowItems.push({
+      label: 'Open Sheet',
+      icon: ExternalLink,
+      onClick: () => window.open(sheetUrl, '_blank', 'noopener,noreferrer'),
+    });
+  }
+  if (canShowSoloReExport) {
+    overflowItems.push({
+      label: 'Re-export sheet (creates a new sheet)',
+      icon: exporting ? Loader2 : RefreshCw,
+      onClick: () => void handleExport(),
+      disabled: exporting,
+    });
+  }
+  if (canShowUpdateSheet) {
+    // Smart re-export: appends new responses when the sheet is behind,
+    // otherwise clears and rewrites the same sheet from scratch. Always
+    // enabled in PLC mode so the teacher always has a path to refresh — the
+    // label tells them which mode the next click will run in.
+    overflowItems.push({
+      label:
+        newResponsesToAppend.length === 0
+          ? 'Re-export sheet (rebuild from scratch)'
+          : `Re-export sheet (${newResponsesToAppend.length} new responses to append)`,
+      icon: updatingSheet ? Loader2 : RefreshCw,
+      onClick: () => void handleUpdateSheet(),
+      disabled: updatingSheet,
+    });
+  }
   if (completed.length > 0) {
     overflowItems.push({
       label: 'Send to Scoreboard',
@@ -1293,66 +1343,6 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
                 disabled={
                   pushingSchoologyGrades || schoologyGrades.length === 0
                 }
-              />
-            )}
-            {exportUrl ? (
-              <>
-                <a
-                  href={exportUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Open Sheet"
-                  className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 bg-emerald-600 hover:bg-emerald-700 text-white"
-                  style={{
-                    paddingInline: 'min(14px, 3cqmin)',
-                    paddingBlock: 'min(8px, 1.8cqmin)',
-                    fontSize: 'min(14px, 4cqmin)',
-                  }}
-                >
-                  <ExternalLink
-                    style={{
-                      width: 'min(16px, 4.5cqmin)',
-                      height: 'min(16px, 4.5cqmin)',
-                    }}
-                    className="shrink-0"
-                  />
-                  <span className="truncate">Open Sheet</span>
-                </a>
-                {canShowSoloReExport && (
-                  <ActionButton
-                    variant="primary"
-                    label="Re-export sheet (creates a new sheet)"
-                    icon={exporting ? Loader2 : RefreshCw}
-                    onClick={() => void handleExport()}
-                    disabled={exporting}
-                  />
-                )}
-                {canShowUpdateSheet && (
-                  // Smart re-export: appends new responses when the sheet is
-                  // behind, otherwise clears and rewrites the same sheet from
-                  // scratch. The button is always enabled in PLC mode so the
-                  // teacher always has a path to refresh — the title/aria hint
-                  // tells them which mode the next click will run in.
-                  <ActionButton
-                    variant="primary"
-                    label={
-                      newResponsesToAppend.length === 0
-                        ? 'Re-export sheet (rebuild from scratch)'
-                        : `Re-export sheet (${newResponsesToAppend.length} new responses to append)`
-                    }
-                    icon={updatingSheet ? Loader2 : RefreshCw}
-                    onClick={() => void handleUpdateSheet()}
-                    disabled={updatingSheet}
-                  />
-                )}
-              </>
-            ) : (
-              <ActionButton
-                variant="primary"
-                label="Export"
-                icon={exporting ? Loader2 : Download}
-                onClick={() => void handleExport()}
-                disabled={exporting || responses.length === 0}
               />
             )}
             {overflowItems.length > 0 && (

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1255,7 +1255,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   if (!exportUrl) {
     overflowItems.push({
       label: 'Export to Sheets',
-      icon: exporting ? Loader2 : Download,
+      icon: Download,
+      loading: exporting,
       onClick: () => void handleExport(),
       disabled: exporting || responses.length === 0,
     });
@@ -1271,7 +1272,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   if (canShowSoloReExport) {
     overflowItems.push({
       label: 'Re-export sheet (creates a new sheet)',
-      icon: exporting ? Loader2 : RefreshCw,
+      icon: RefreshCw,
+      loading: exporting,
       onClick: () => void handleExport(),
       disabled: exporting,
     });
@@ -1286,7 +1288,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
         newResponsesToAppend.length === 0
           ? 'Re-export sheet (rebuild from scratch)'
           : `Re-export sheet (${newResponsesToAppend.length} new responses to append)`,
-      icon: updatingSheet ? Loader2 : RefreshCw,
+      icon: RefreshCw,
+      loading: updatingSheet,
       onClick: () => void handleUpdateSheet(),
       disabled: updatingSheet,
     });
@@ -1329,7 +1332,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
               <ActionButton
                 variant="primary"
                 label="Push Grades"
-                icon={pushingGrades ? Loader2 : GraduationCap}
+                icon={GraduationCap}
+                loading={pushingGrades}
                 onClick={() => void handlePushGrades()}
                 disabled={pushingGrades}
               />
@@ -1338,7 +1342,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
               <ActionButton
                 variant="primary"
                 label="Push to Schoology"
-                icon={pushingSchoologyGrades ? Loader2 : Send}
+                icon={Send}
+                loading={pushingSchoologyGrades}
                 onClick={() => void handlePushSchoologyGrades()}
                 disabled={
                   pushingSchoologyGrades || schoologyGrades.length === 0

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -2092,7 +2092,7 @@ const StudentsTab: React.FC<{
                               score={score}
                               display="percent"
                               gamified={gamified}
-                              points={score}
+                              points={earned}
                             />
                             <p
                               className="text-brand-blue-primary/60 font-bold"

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -10,6 +10,7 @@ import React, {
   useEffect,
   useCallback,
   useMemo,
+  useId,
 } from 'react';
 import {
   Download,
@@ -304,6 +305,9 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   const [activeTab, setActiveTab] = useState<
     'overview' | 'questions' | 'students' | 'plc'
   >('overview');
+  // Per-instance prefix for the ARIA tab↔panel linkage (multiple quiz widgets
+  // can render on one dashboard).
+  const tabPanelId = useId();
   const [showScoreboardPrompt, setShowScoreboardPrompt] = useState(false);
   const scoreboardPromptRef = useRef<HTMLDivElement>(null);
 
@@ -1525,6 +1529,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
           >
             <SegmentedTabs
               ariaLabel="Quiz results sections"
+              panelIdPrefix={tabPanelId}
               value={activeTab}
               onChange={setActiveTab}
               tabs={[
@@ -1551,7 +1556,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 
           <div
             role="tabpanel"
-            aria-label={`${activeTab} results`}
+            id={`${tabPanelId}-panel-${activeTab}`}
+            aria-labelledby={`${tabPanelId}-tab-${activeTab}`}
             className="flex-1 overflow-y-auto custom-scrollbar"
             style={{ padding: 'min(16px, 4cqmin)' }}
           >

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -1320,7 +1320,7 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       <SessionViewHeader
         onBack={onBack}
         title={quiz.title}
-        subtitle={`${completed.length} of ${responses.length} students finished`}
+        subtitle={`${filteredCompleted.length} of ${filteredResponses.length} students finished`}
         actions={
           <>
             {hasWrittenQuestions && (

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -12,7 +12,6 @@ import React, {
   useMemo,
 } from 'react';
 import {
-  ArrowLeft,
   Download,
   BarChart3,
   Users,
@@ -67,6 +66,19 @@ import { useClickOutside } from '@/hooks/useClickOutside';
 import { useAssignmentPseudonymsMulti } from '@/hooks/useAssignmentPseudonyms';
 import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
 import { PlcTab } from '@/components/common/library/PlcTab';
+import {
+  SessionViewHeader,
+  SegmentedTabs,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+  OverflowMenu,
+} from '@/components/common/sessionViews';
+import type { OverflowMenuItem } from '@/components/common/sessionViews';
+import { scoreColorClasses } from '@/utils/scoreColor';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { WrittenResponseGrader } from './WrittenResponseGrader';
 import { doc, updateDoc } from 'firebase/firestore';
 import { httpsCallable } from 'firebase/functions';
@@ -1221,361 +1233,195 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
     }
   };
 
+  // Overflow-menu items. Send to Scoreboard always lives here (decluttered out
+  // of the visible header), gated identically to the old visible button
+  // (`completed.length > 0`). When a Schoology push applies it's the visible
+  // primary action, so it's NOT duplicated here; there is no Classroom-vs-
+  // Schoology overlap (an assignment is one or the other), so the visible
+  // primary push is Classroom when attached, else Schoology — and the overflow
+  // never carries a push that's already visible.
+  const overflowItems: OverflowMenuItem[] = [];
+  if (completed.length > 0) {
+    overflowItems.push({
+      label: 'Send to Scoreboard',
+      icon: Trophy,
+      onClick: handleScoreboardClick,
+    });
+  }
+
+  // Visible primary push: Classroom when this assignment is add-on-attached
+  // (and the admin gate permits), otherwise Schoology when LTI-launched. Same
+  // gating conditions/handlers as before — only the placement changes.
+  const showClassroomPush =
+    classroomAttachments.length > 0 && canAccessFeature('google-classroom');
+  const showSchoologyPush = !!ltiAttachment;
+
   return (
     <div className="flex flex-col h-full font-sans">
       {/* Header */}
-      <div
-        className="flex items-center border-b border-brand-blue-primary/10"
-        style={{
-          gap: 'min(12px, 3cqmin)',
-          padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)',
-        }}
-      >
-        <button
-          onClick={onBack}
-          className="p-1.5 hover:bg-brand-blue-primary/10 rounded-lg transition-colors text-brand-blue-primary shrink-0"
-        >
-          <ArrowLeft
-            style={{
-              width: 'min(16px, 4.5cqmin)',
-              height: 'min(16px, 4.5cqmin)',
-            }}
-          />
-        </button>
-        <div className="flex-1 min-w-0">
-          <p
-            className="font-black text-brand-blue-dark truncate"
-            style={{ fontSize: 'min(14px, 4.5cqmin)' }}
-          >
-            Results: {quiz.title}
-          </p>
-          <p
-            className="text-brand-blue-primary/60 font-bold"
-            style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-          >
-            {completed.length} of {responses.length} students finished
-          </p>
-        </div>
-
-        {hasWrittenQuestions && (
-          <button
-            onClick={() => setShowGrader(true)}
-            className="flex items-center bg-rose-600 hover:bg-rose-700 text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3.5cqmin)',
-            }}
-            title="Open the manual grading view for short-answer and essay responses."
-          >
-            <Pencil
-              style={{
-                width: 'min(14px, 4cqmin)',
-                height: 'min(14px, 4cqmin)',
-              }}
-            />
-            GRADE WRITTEN
-          </button>
-        )}
-
-        {completed.length > 0 && (
-          <div className="relative shrink-0">
-            <button
-              onClick={handleScoreboardClick}
-              className="flex items-center bg-amber-500 hover:bg-amber-600 text-white font-bold rounded-xl transition-all shadow-md active:scale-95"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-            >
-              <Trophy
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
-              />
-              SEND TO SCOREBOARD
-            </button>
-            {showScoreboardPrompt && (
-              <div
-                ref={scoreboardPromptRef}
-                className="absolute right-0 top-full mt-2 bg-white rounded-2xl shadow-xl border border-brand-blue-primary/10 z-50 animate-in fade-in slide-in-from-top-2 duration-200"
-                style={{
-                  padding: 'min(16px, 4cqmin)',
-                  width: 'max(220px, 50cqw)',
-                }}
-              >
-                <p
-                  className="font-black text-brand-blue-dark text-center uppercase tracking-wider"
-                  style={{
-                    fontSize: 'min(11px, 3.5cqmin)',
-                    marginBottom: 'min(12px, 3cqmin)',
-                  }}
-                >
-                  How should students appear?
-                </p>
-                <div
-                  className="flex flex-col"
-                  style={{ gap: 'min(8px, 2cqmin)' }}
-                >
-                  <button
-                    onClick={() => handleSendToScoreboard('name')}
-                    className="flex items-center w-full bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95"
-                    style={{
-                      gap: 'min(8px, 2cqmin)',
-                      padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
-                      fontSize: 'min(12px, 3.5cqmin)',
-                    }}
-                  >
-                    <User
-                      style={{
-                        width: 'min(16px, 4cqmin)',
-                        height: 'min(16px, 4cqmin)',
-                      }}
-                    />
-                    Student Names
-                  </button>
-                  <button
-                    onClick={() => handleSendToScoreboard('pin')}
-                    className="flex items-center w-full bg-slate-100 hover:bg-slate-200 text-brand-blue-dark font-bold rounded-xl transition-all active:scale-95"
-                    style={{
-                      gap: 'min(8px, 2cqmin)',
-                      padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
-                      fontSize: 'min(12px, 3.5cqmin)',
-                    }}
-                  >
-                    <Hash
-                      style={{
-                        width: 'min(16px, 4cqmin)',
-                        height: 'min(16px, 4cqmin)',
-                      }}
-                    />
-                    PINs Only
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-        {/* Admin-managed `google-classroom` gate hides the draft grade-push
-            entry point for users below the doc's minTier. */}
-        {classroomAttachments.length > 0 &&
-          canAccessFeature('google-classroom') && (
-            <button
-              onClick={() => void handlePushGrades()}
-              disabled={pushingGrades}
-              className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-              title="Write draft grades to this assignment's Google Classroom gradebook (matches the quiz score exactly)."
-            >
-              {pushingGrades ? (
-                <Loader2
-                  className="animate-spin"
-                  style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
-                  }}
-                />
-              ) : (
-                <GraduationCap
-                  style={{
-                    width: 'min(14px, 4cqmin)',
-                    height: 'min(14px, 4cqmin)',
-                  }}
-                />
-              )}
-              PUSH GRADES
-            </button>
-          )}
-        {ltiAttachment && (
-          <button
-            onClick={() => void handlePushSchoologyGrades()}
-            disabled={pushingSchoologyGrades || schoologyGrades.length === 0}
-            className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3.5cqmin)',
-            }}
-            title="Write grades to this assignment's Schoology gradebook (matches the quiz score exactly)."
-          >
-            {pushingSchoologyGrades ? (
-              <Loader2
-                className="animate-spin"
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
-              />
-            ) : (
-              <Send
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
-              />
-            )}
-            Push to Schoology
-          </button>
-        )}
-        {exportUrl ? (
+      <SessionViewHeader
+        onBack={onBack}
+        title={quiz.title}
+        subtitle={`${completed.length} of ${responses.length} students finished`}
+        actions={
           <>
-            <a
-              href={exportUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center bg-emerald-600 hover:bg-emerald-700 text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-            >
-              <ExternalLink
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
+            {hasWrittenQuestions && (
+              <ActionButton
+                variant="secondary"
+                label="Grade Written"
+                icon={Pencil}
+                onClick={() => setShowGrader(true)}
               />
-              OPEN SHEET
-            </a>
-            {canShowSoloReExport && (
-              <span
-                title="Re-export — creates a new sheet (the previous sheet stays in Drive)"
-                className="shrink-0 inline-flex"
-              >
-                <button
-                  onClick={() => void handleExport()}
-                  disabled={exporting}
-                  aria-label="Re-export sheet (creates a new sheet)"
-                  className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95"
-                  style={{
-                    gap: 'min(6px, 1.5cqmin)',
-                    padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                    fontSize: 'min(11px, 3.5cqmin)',
-                  }}
-                >
-                  {exporting ? (
-                    <Loader2
-                      className="animate-spin"
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  ) : (
-                    <RefreshCw
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  )}
-                  RE-EXPORT SHEET
-                </button>
-              </span>
             )}
-            {canShowUpdateSheet && (
-              // Smart re-export: appends new responses when the sheet is
-              // behind, otherwise clears and rewrites the same sheet from
-              // scratch. The button is always enabled in PLC mode so the
-              // teacher always has a path to refresh — the title hint
-              // tells them which mode the next click will run in.
-              <span
-                title={
-                  newResponsesToAppend.length === 0
-                    ? 'Re-export — rebuild this sheet from scratch'
-                    : `Add ${newResponsesToAppend.length} new response${
-                        newResponsesToAppend.length === 1 ? '' : 's'
-                      } to the sheet`
+            {/* Admin-managed `google-classroom` gate hides the draft grade-push
+                entry point for users below the doc's minTier. */}
+            {showClassroomPush && (
+              <ActionButton
+                variant="primary"
+                label="Push Grades"
+                icon={pushingGrades ? Loader2 : GraduationCap}
+                onClick={() => void handlePushGrades()}
+                disabled={pushingGrades}
+              />
+            )}
+            {showSchoologyPush && (
+              <ActionButton
+                variant="primary"
+                label="Push to Schoology"
+                icon={pushingSchoologyGrades ? Loader2 : Send}
+                onClick={() => void handlePushSchoologyGrades()}
+                disabled={
+                  pushingSchoologyGrades || schoologyGrades.length === 0
                 }
-                className="shrink-0 inline-flex"
-              >
-                <button
-                  onClick={() => void handleUpdateSheet()}
-                  disabled={updatingSheet}
-                  aria-label={
-                    newResponsesToAppend.length === 0
-                      ? 'Re-export sheet (rebuild from scratch)'
-                      : `Re-export sheet (${newResponsesToAppend.length} new responses to append)`
-                  }
-                  className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-md active:scale-95"
+              />
+            )}
+            {exportUrl ? (
+              <>
+                <a
+                  href={exportUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open Sheet"
+                  className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 bg-emerald-600 hover:bg-emerald-700 text-white"
                   style={{
-                    gap: 'min(6px, 1.5cqmin)',
-                    padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-                    fontSize: 'min(11px, 3.5cqmin)',
+                    paddingInline: 'min(14px, 3cqmin)',
+                    paddingBlock: 'min(8px, 1.8cqmin)',
+                    fontSize: 'min(14px, 4cqmin)',
                   }}
                 >
-                  {updatingSheet ? (
-                    <Loader2
-                      className="animate-spin"
+                  <ExternalLink
+                    style={{
+                      width: 'min(16px, 4.5cqmin)',
+                      height: 'min(16px, 4.5cqmin)',
+                    }}
+                    className="shrink-0"
+                  />
+                  <span className="truncate">Open Sheet</span>
+                </a>
+                {canShowSoloReExport && (
+                  <ActionButton
+                    variant="primary"
+                    label="Re-export sheet (creates a new sheet)"
+                    icon={exporting ? Loader2 : RefreshCw}
+                    onClick={() => void handleExport()}
+                    disabled={exporting}
+                  />
+                )}
+                {canShowUpdateSheet && (
+                  // Smart re-export: appends new responses when the sheet is
+                  // behind, otherwise clears and rewrites the same sheet from
+                  // scratch. The button is always enabled in PLC mode so the
+                  // teacher always has a path to refresh — the title/aria hint
+                  // tells them which mode the next click will run in.
+                  <ActionButton
+                    variant="primary"
+                    label={
+                      newResponsesToAppend.length === 0
+                        ? 'Re-export sheet (rebuild from scratch)'
+                        : `Re-export sheet (${newResponsesToAppend.length} new responses to append)`
+                    }
+                    icon={updatingSheet ? Loader2 : RefreshCw}
+                    onClick={() => void handleUpdateSheet()}
+                    disabled={updatingSheet}
+                  />
+                )}
+              </>
+            ) : (
+              <ActionButton
+                variant="primary"
+                label="Export"
+                icon={exporting ? Loader2 : Download}
+                onClick={() => void handleExport()}
+                disabled={exporting || responses.length === 0}
+              />
+            )}
+            {overflowItems.length > 0 && (
+              <div className="relative shrink-0">
+                <OverflowMenu items={overflowItems} />
+                {showScoreboardPrompt && (
+                  <div
+                    ref={scoreboardPromptRef}
+                    className="absolute right-0 top-full mt-2 bg-white rounded-2xl shadow-xl border border-brand-blue-primary/10 z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+                    style={{
+                      padding: 'min(16px, 4cqmin)',
+                      width: 'max(220px, 50cqw)',
+                    }}
+                  >
+                    <p
+                      className="font-black text-brand-blue-dark text-center uppercase tracking-wider"
                       style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  ) : (
-                    <RefreshCw
-                      style={{
-                        width: 'min(14px, 4cqmin)',
-                        height: 'min(14px, 4cqmin)',
-                      }}
-                    />
-                  )}
-                  RE-EXPORT SHEET
-                  {newResponsesToAppend.length > 0 && (
-                    <span
-                      className="ml-1 inline-flex items-center justify-center bg-white/25 rounded-full font-black"
-                      style={{
-                        minWidth: 'min(18px, 5cqmin)',
-                        height: 'min(18px, 5cqmin)',
-                        padding: '0 min(6px, 1.5cqmin)',
-                        fontSize: 'min(10px, 3cqmin)',
+                        fontSize: 'min(11px, 3.5cqmin)',
+                        marginBottom: 'min(12px, 3cqmin)',
                       }}
                     >
-                      {newResponsesToAppend.length}
-                    </span>
-                  )}
-                </button>
-              </span>
+                      How should students appear?
+                    </p>
+                    <div
+                      className="flex flex-col"
+                      style={{ gap: 'min(8px, 2cqmin)' }}
+                    >
+                      <button
+                        onClick={() => handleSendToScoreboard('name')}
+                        className="flex items-center w-full bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-xl transition-all active:scale-95"
+                        style={{
+                          gap: 'min(8px, 2cqmin)',
+                          padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
+                          fontSize: 'min(12px, 3.5cqmin)',
+                        }}
+                      >
+                        <User
+                          style={{
+                            width: 'min(16px, 4cqmin)',
+                            height: 'min(16px, 4cqmin)',
+                          }}
+                        />
+                        Student Names
+                      </button>
+                      <button
+                        onClick={() => handleSendToScoreboard('pin')}
+                        className="flex items-center w-full bg-slate-100 hover:bg-slate-200 text-brand-blue-dark font-bold rounded-xl transition-all active:scale-95"
+                        style={{
+                          gap: 'min(8px, 2cqmin)',
+                          padding: 'min(10px, 2.5cqmin) min(14px, 3.5cqmin)',
+                          fontSize: 'min(12px, 3.5cqmin)',
+                        }}
+                      >
+                        <Hash
+                          style={{
+                            width: 'min(16px, 4cqmin)',
+                            height: 'min(16px, 4cqmin)',
+                          }}
+                        />
+                        PINs Only
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
             )}
           </>
-        ) : (
-          <button
-            onClick={() => void handleExport()}
-            disabled={exporting || responses.length === 0}
-            className="flex items-center bg-brand-blue-primary hover:bg-brand-blue-dark disabled:bg-brand-gray-lighter text-white font-bold rounded-xl transition-all shadow-md active:scale-95 shrink-0"
-            style={{
-              gap: 'min(6px, 1.5cqmin)',
-              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3.5cqmin)',
-            }}
-          >
-            {exporting ? (
-              <Loader2
-                className="animate-spin"
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
-              />
-            ) : (
-              <Download
-                style={{
-                  width: 'min(14px, 4cqmin)',
-                  height: 'min(14px, 4cqmin)',
-                }}
-              />
-            )}
-            EXPORT
-          </button>
-        )}
-      </div>
+        }
+      />
 
       {exportError &&
         !(exportError.kind === 'schemaMismatch' && exportError.recoveryUrl) && (
@@ -1628,22 +1474,11 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
       )}
 
       {responses.length === 0 ? (
-        <div
-          className="flex flex-col items-center justify-center h-full text-brand-blue-primary/30"
-          style={{ gap: 'min(16px, 4cqmin)' }}
-        >
-          <div className="bg-brand-blue-lighter/50 p-6 rounded-full border-2 border-dashed border-brand-blue-primary/10">
-            <BarChart3
-              style={{
-                width: 'min(48px, 12cqmin)',
-                height: 'min(48px, 12cqmin)',
-              }}
-            />
-          </div>
-          <p className="font-bold" style={{ fontSize: 'min(14px, 4.5cqmin)' }}>
-            No data available yet.
-          </p>
-        </div>
+        <ScaledEmptyState
+          icon={BarChart3}
+          title="No data available yet"
+          subtitle="Results appear here once students submit."
+        />
       ) : (
         <>
           {/* Period Filter (only when responses have classPeriod data) */}
@@ -1685,35 +1520,32 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
               for legacy assignments (same precedence as the export path). */}
           <div
             className="flex border-b border-brand-blue-primary/10"
-            style={{
-              padding: 'min(8px, 2cqmin) min(16px, 4cqmin) 0',
-              gap: 'min(4px, 1cqmin)',
-            }}
+            style={{ padding: 'min(8px, 2cqmin) min(16px, 4cqmin)' }}
           >
-            {(
-              [
-                'overview',
-                'questions',
-                'students',
-                ...(plcId ? (['plc'] as const) : []),
-              ] as const
-            ).map((tab) => (
-              <button
-                key={tab}
-                onClick={() => setActiveTab(tab)}
-                className={`font-black uppercase tracking-widest rounded-t-xl transition-all ${
-                  activeTab === tab
-                    ? 'bg-white text-brand-blue-primary border-x border-t border-brand-blue-primary/10'
-                    : 'text-brand-blue-primary/40 hover:text-brand-blue-primary hover:bg-brand-blue-lighter/30'
-                }`}
-                style={{
-                  padding: 'min(10px, 2.5cqmin) min(16px, 4cqmin)',
-                  fontSize: 'min(10px, 3cqmin)',
-                }}
-              >
-                {tab}
-              </button>
-            ))}
+            <SegmentedTabs
+              ariaLabel="Quiz results sections"
+              value={activeTab}
+              onChange={setActiveTab}
+              tabs={[
+                { key: 'overview', label: 'Overview', icon: BarChart3 },
+                { key: 'questions', label: 'Questions', icon: Target },
+                {
+                  key: 'students',
+                  label: 'Students',
+                  icon: Users,
+                  count: responses.length,
+                },
+                ...(plcId
+                  ? ([
+                      {
+                        key: 'plc' as const,
+                        label: 'PLC',
+                        icon: GraduationCap,
+                      },
+                    ] as const)
+                  : []),
+              ]}
+            />
           </div>
 
           <div
@@ -1822,48 +1654,36 @@ const OverviewTab: React.FC<{
     <div className="flex flex-col" style={{ gap: 'min(20px, 5cqmin)' }}>
       {/* Top Level Scoreboard */}
       <div className="grid grid-cols-2 gap-4">
-        <div className="bg-white border-2 border-brand-blue-primary/10 rounded-2xl p-4 text-center shadow-sm relative overflow-hidden group">
-          <div className="absolute top-0 left-0 w-full h-1 bg-amber-400"></div>
-          <Trophy
-            className="text-amber-400 mx-auto mb-1 group-hover:scale-110 transition-transform"
-            style={{ width: 'min(24px, 6cqmin)', height: 'min(24px, 6cqmin)' }}
-          />
-          <p
-            className="font-black text-brand-blue-dark leading-none"
-            style={{ fontSize: 'min(28px, 9cqmin)' }}
-          >
-            {avgScore !== null ? `${avgScore}${suffix}` : '—'}
-          </p>
-          <p
-            className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
-            style={{ fontSize: 'min(10px, 3cqmin)' }}
-          >
-            Class Average
-          </p>
-        </div>
-        <div className="bg-white border-2 border-brand-blue-primary/10 rounded-2xl p-4 text-center shadow-sm relative overflow-hidden group">
-          <div className="absolute top-0 left-0 w-full h-1 bg-brand-blue-primary"></div>
-          <Users
-            className="text-brand-blue-primary mx-auto mb-1 group-hover:scale-110 transition-transform"
-            style={{ width: 'min(24px, 6cqmin)', height: 'min(24px, 6cqmin)' }}
-          />
-          <p
-            className="font-black text-brand-blue-dark leading-none"
-            style={{ fontSize: 'min(28px, 9cqmin)' }}
-          >
-            {completed.length}
-          </p>
-          <p
-            className="text-brand-blue-primary/60 font-black uppercase tracking-widest mt-1"
-            style={{ fontSize: 'min(10px, 3cqmin)' }}
-          >
-            Finished
-          </p>
-        </div>
+        <StatTile
+          tone="amber"
+          icon={
+            <Trophy
+              style={{
+                width: 'min(24px, 6cqmin)',
+                height: 'min(24px, 6cqmin)',
+              }}
+            />
+          }
+          value={avgScore !== null ? `${avgScore}${suffix}` : '—'}
+          label="Class Average"
+        />
+        <StatTile
+          tone="blue"
+          icon={
+            <Users
+              style={{
+                width: 'min(24px, 6cqmin)',
+                height: 'min(24px, 6cqmin)',
+              }}
+            />
+          }
+          value={completed.length}
+          label="Finished"
+        />
       </div>
 
       {/* Distribution Chart */}
-      <div className="bg-white border border-brand-blue-primary/10 rounded-2xl p-5 shadow-sm">
+      <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm p-5">
         <div className="flex items-center gap-2 mb-4">
           <Target className="w-4 h-4 text-brand-blue-primary" />
           <span
@@ -1956,7 +1776,7 @@ const QuestionsTab: React.FC<{
   }, [responses, questions]);
 
   return (
-    <div className="space-y-3">
+    <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm overflow-hidden">
       {questions.map((q, i) => {
         const stats = questionStats[q.id] || {
           answered: 0,
@@ -1973,45 +1793,45 @@ const QuestionsTab: React.FC<{
             : 0;
 
         return (
-          <div
+          <SessionRow
             key={q.id}
-            className="bg-white border border-brand-blue-primary/10 rounded-2xl p-4 shadow-sm hover:border-brand-blue-primary/20 transition-all"
+            trailing={
+              isWritten ? (
+                <SessionBadge tone="warn" label="Manual" />
+              ) : (
+                <span
+                  className={`font-black tabular-nums shrink-0 ${scoreColorClasses(pct).text}`}
+                  style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+                >
+                  {pct}%
+                </span>
+              )
+            }
           >
-            <div className="flex items-start justify-between mb-2">
+            <div
+              className="flex items-center"
+              style={{ gap: 'min(8px, 2cqmin)' }}
+            >
               <div
-                className="bg-brand-blue-lighter px-2 py-0.5 rounded text-brand-blue-primary font-black uppercase tracking-tighter"
+                className="bg-brand-blue-lighter px-2 py-0.5 rounded text-brand-blue-primary font-black uppercase tracking-tighter shrink-0"
                 style={{ fontSize: 'min(9px, 2.5cqmin)' }}
               >
-                Question {i + 1}
+                Q{i + 1}
               </div>
-              {q.type === 'short' || q.type === 'essay' ? (
-                <div
-                  className="font-black text-rose-700 bg-rose-50 border border-rose-200 rounded px-2 py-0.5"
-                  style={{ fontSize: 'min(10px, 3cqmin)' }}
-                  title="Written responses are graded manually by the teacher."
-                >
-                  Manual grading
-                </div>
-              ) : (
-                <div
-                  className="font-black text-brand-blue-dark"
-                  style={{ fontSize: 'min(12px, 4cqmin)' }}
-                >
-                  {pct}% Accuracy
-                </div>
-              )}
+              <p
+                className="font-bold text-brand-blue-dark leading-tight truncate"
+                style={{ fontSize: 'min(13px, 4.5cqmin)' }}
+              >
+                {q.text}
+              </p>
             </div>
 
-            <p
-              className="font-bold text-brand-blue-dark leading-tight line-clamp-2"
-              style={{ fontSize: 'min(13px, 4.5cqmin)' }}
+            <div
+              className="flex items-center mt-1.5"
+              style={{ gap: 'min(12px, 3cqmin)' }}
             >
-              {q.text}
-            </p>
-
-            <div className="flex items-center gap-4 mt-4 pt-3 border-t border-brand-blue-primary/5">
               <div
-                className="flex items-center gap-1.5 text-emerald-600 font-bold"
+                className="flex items-center gap-1.5 text-emerald-600 font-bold shrink-0"
                 style={{ fontSize: 'min(11px, 3.5cqmin)' }}
               >
                 <CheckCircle2
@@ -2024,7 +1844,7 @@ const QuestionsTab: React.FC<{
                 {isWritten ? 'Graded' : 'Correct'}
               </div>
               <div
-                className="flex items-center gap-1.5 text-brand-red-primary font-bold"
+                className="flex items-center gap-1.5 text-brand-red-primary font-bold shrink-0"
                 style={{ fontSize: 'min(11px, 3.5cqmin)' }}
               >
                 <XCircle
@@ -2036,21 +1856,14 @@ const QuestionsTab: React.FC<{
                 {stats.answered - (isWritten ? stats.graded : stats.correct)}{' '}
                 {isWritten ? 'Ungraded' : 'Missed'}
               </div>
+              <div className="flex-1 h-2 bg-brand-blue-lighter rounded-full overflow-hidden min-w-0">
+                <div
+                  className={`h-full rounded-full transition-all duration-700 ${scoreColorClasses(pct).bar}`}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
             </div>
-
-            <div className="h-2 bg-brand-blue-lighter rounded-full overflow-hidden mt-3">
-              <div
-                className={`h-full rounded-full transition-all duration-700 ${
-                  pct >= 80
-                    ? 'bg-emerald-500'
-                    : pct >= 60
-                      ? 'bg-amber-500'
-                      : 'bg-brand-red-primary'
-                }`}
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-          </div>
+          </SessionRow>
         );
       })}
     </div>
@@ -2090,7 +1903,6 @@ const StudentsTab: React.FC<{
   const [unlockingKey, setUnlockingKey] = useState<ResponseDocKey | null>(null);
   const maxPoints = questions.reduce((sum, q) => sum + (q.points ?? 1), 0);
   const gamified = isGamificationActive(session);
-  const suffix = getScoreSuffix(session);
 
   // Mirror QuizLiveMonitor.handleUnlockResultsForStudent — same toast copy
   // and same one-shot semantics (decrement warnings by 1; one more
@@ -2121,7 +1933,7 @@ const StudentsTab: React.FC<{
   );
 
   return (
-    <div className="space-y-2">
+    <div className="flex flex-col" style={{ gap: 'min(10px, 2.5cqmin)' }}>
       <button
         onClick={() => setShowResults(!showResults)}
         className="w-full flex items-center justify-between p-3 bg-white/60 border border-brand-blue-primary/10 rounded-xl hover:bg-white/80 transition-all"
@@ -2160,119 +1972,252 @@ const StudentsTab: React.FC<{
         </span>
       </button>
 
-      {showResults &&
-        responses
-          .slice()
-          .sort((a, b) => {
-            // Match the row's display gate (below): an unscoreable response
-            // renders "—", so rank it with not-started (-1) rather than letting
-            // its phantom 0 sort it in among genuine low scores. Computed inline
-            // (no nested helper) so a closure isn't re-allocated per comparison.
-            const scoreA =
-              (a.status === 'completed' || a.status === 'in-progress') &&
-              canScoreResponse(a, questions)
-                ? getDisplayScore(a, questions, session)
-                : -1;
-            const scoreB =
-              (b.status === 'completed' || b.status === 'in-progress') &&
-              canScoreResponse(b, questions)
-                ? getDisplayScore(b, questions, session)
-                : -1;
-            return scoreB - scoreA;
-          })
-          .map((r) => {
-            const score = getDisplayScore(r, questions, session);
-            const earned = getEarnedPoints(r, questions, session);
-            // A finished/in-progress response is only shown with a numeric
-            // score once it can actually be graded — answer key loaded AND at
-            // least one answer maps to a loaded question. Otherwise we render a
-            // neutral placeholder instead of a misleading 0 (see
-            // `canScoreResponse`).
-            const scoreable =
-              (r.status === 'completed' || r.status === 'in-progress') &&
-              canScoreResponse(r, questions);
-            const warnings = r.tabSwitchWarnings ?? 0;
-            const resultsLockedOut = r.resultsLockedOut === true;
-            const resultsTabWarnings = r.resultsTabWarnings ?? 0;
+      {showResults && (
+        <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm overflow-hidden">
+          {responses
+            .slice()
+            .sort((a, b) => {
+              // Match the row's display gate (below): an unscoreable response
+              // renders "—", so rank it with not-started (-1) rather than letting
+              // its phantom 0 sort it in among genuine low scores. Computed inline
+              // (no nested helper) so a closure isn't re-allocated per comparison.
+              const scoreA =
+                (a.status === 'completed' || a.status === 'in-progress') &&
+                canScoreResponse(a, questions)
+                  ? getDisplayScore(a, questions, session)
+                  : -1;
+              const scoreB =
+                (b.status === 'completed' || b.status === 'in-progress') &&
+                canScoreResponse(b, questions)
+                  ? getDisplayScore(b, questions, session)
+                  : -1;
+              return scoreB - scoreA;
+            })
+            .map((r) => {
+              const score = getDisplayScore(r, questions, session);
+              const earned = getEarnedPoints(r, questions, session);
+              // A finished/in-progress response is only shown with a numeric
+              // score once it can actually be graded — answer key loaded AND at
+              // least one answer maps to a loaded question. Otherwise we render a
+              // neutral placeholder instead of a misleading 0 (see
+              // `canScoreResponse`).
+              const scoreable =
+                (r.status === 'completed' || r.status === 'in-progress') &&
+                canScoreResponse(r, questions);
+              const warnings = r.tabSwitchWarnings ?? 0;
+              const resultsLockedOut = r.resultsLockedOut === true;
+              const resultsTabWarnings = r.resultsTabWarnings ?? 0;
 
-            const displayName = resolveResponseDisplayName(
-              r,
-              pinToName,
-              byStudentUid
-            );
-            // Mono face is reserved for the literal `PIN <num>` fallback —
-            // anything else (real name, ClassLink name, or the "Student"
-            // SSO fallback) renders in the regular sans face. Mirrors the
-            // contract used by QuizLiveMonitor's StudentRow.
-            const isResolved = !r.pin || displayName !== `PIN ${r.pin}`;
-            const rowKey = getResponseDocKey(r);
-            const canDelete = Boolean(onDeleteResponse);
-            const canUnlockResults =
-              resultsLockedOut && Boolean(onUnlockResultsForStudent);
-            const isConfirming = confirmDeleteKey === rowKey;
-            const isDeleting = deletingKey === rowKey;
-            const isUnlocking = unlockingKey === rowKey;
-
-            if (isConfirming) {
-              return (
-                <div
-                  key={rowKey}
-                  className="flex items-center rounded-xl border bg-red-50 border-red-200 p-3 gap-2"
-                >
-                  <span
-                    className="flex-1 text-red-700 font-bold truncate"
-                    style={{ fontSize: 'min(12px, 4cqmin)' }}
-                  >
-                    Delete {displayName}&rsquo;s submission?
-                  </span>
-                  <button
-                    onClick={() => {
-                      setDeletingKey(rowKey);
-                      setConfirmDeleteKey(null);
-                      const pending = onDeleteResponse?.(rowKey);
-                      if (!pending) {
-                        setDeletingKey((k) => (k === rowKey ? null : k));
-                        return;
-                      }
-                      void pending
-                        .catch((err: unknown) => {
-                          console.error(
-                            '[QuizResults] failed to delete response',
-                            err
-                          );
-                          addToast(
-                            `Failed to delete ${displayName}\u2019s submission. Please try again.`,
-                            'error'
-                          );
-                        })
-                        .finally(() => {
-                          setDeletingKey((k) => (k === rowKey ? null : k));
-                        });
-                    }}
-                    disabled={isDeleting}
-                    className="bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-bold rounded-lg px-3 py-1"
-                    style={{ fontSize: 'min(11px, 3cqmin)' }}
-                  >
-                    Yes
-                  </button>
-                  <button
-                    onClick={() => setConfirmDeleteKey(null)}
-                    className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg px-3 py-1"
-                    style={{ fontSize: 'min(11px, 3cqmin)' }}
-                  >
-                    Cancel
-                  </button>
-                </div>
+              const displayName = resolveResponseDisplayName(
+                r,
+                pinToName,
+                byStudentUid
               );
-            }
+              // Mono face is reserved for the literal `PIN <num>` fallback —
+              // anything else (real name, ClassLink name, or the "Student"
+              // SSO fallback) renders in the regular sans face. Mirrors the
+              // contract used by QuizLiveMonitor's StudentRow.
+              const isResolved = !r.pin || displayName !== `PIN ${r.pin}`;
+              const rowKey = getResponseDocKey(r);
+              const canDelete = Boolean(onDeleteResponse);
+              const canUnlockResults =
+                resultsLockedOut && Boolean(onUnlockResultsForStudent);
+              const isConfirming = confirmDeleteKey === rowKey;
+              const isDeleting = deletingKey === rowKey;
+              const isUnlocking = unlockingKey === rowKey;
 
-            return (
-              <div
-                key={rowKey}
-                className="flex items-center bg-white border border-brand-blue-primary/10 rounded-xl p-3 shadow-sm hover:shadow-md transition-all"
-              >
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
+              if (isConfirming) {
+                return (
+                  <SessionRow
+                    key={rowKey}
+                    tintTone="danger"
+                    trailing={
+                      <>
+                        <button
+                          onClick={() => {
+                            setDeletingKey(rowKey);
+                            setConfirmDeleteKey(null);
+                            const pending = onDeleteResponse?.(rowKey);
+                            if (!pending) {
+                              setDeletingKey((k) => (k === rowKey ? null : k));
+                              return;
+                            }
+                            void pending
+                              .catch((err: unknown) => {
+                                console.error(
+                                  '[QuizResults] failed to delete response',
+                                  err
+                                );
+                                addToast(
+                                  `Failed to delete ${displayName}\u2019s submission. Please try again.`,
+                                  'error'
+                                );
+                              })
+                              .finally(() => {
+                                setDeletingKey((k) =>
+                                  k === rowKey ? null : k
+                                );
+                              });
+                          }}
+                          disabled={isDeleting}
+                          className="bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-bold rounded-lg px-3 py-1 shrink-0"
+                          style={{ fontSize: 'min(11px, 3cqmin)' }}
+                        >
+                          Yes
+                        </button>
+                        <button
+                          onClick={() => setConfirmDeleteKey(null)}
+                          className="bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold rounded-lg px-3 py-1 shrink-0"
+                          style={{ fontSize: 'min(11px, 3cqmin)' }}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    }
+                  >
+                    <span
+                      className="text-red-700 font-bold truncate"
+                      style={{ fontSize: 'min(12px, 4cqmin)' }}
+                    >
+                      Delete {displayName}&rsquo;s submission?
+                    </span>
+                  </SessionRow>
+                );
+              }
+
+              return (
+                <SessionRow
+                  key={rowKey}
+                  trailing={
+                    <>
+                      <div className="text-right shrink-0">
+                        {scoreable ? (
+                          <>
+                            <ScorePill
+                              score={score}
+                              display="percent"
+                              gamified={gamified}
+                              points={score}
+                            />
+                            <p
+                              className="text-brand-blue-primary/60 font-bold"
+                              style={{ fontSize: 'min(10px, 3cqmin)' }}
+                            >
+                              {earned}/{maxPoints} pts
+                              {r.status === 'in-progress' && ' (In Progress)'}
+                            </p>
+                            {/* Fresh responses now carry preSyncVersion: 0
+                             * so the server-side sync query
+                             * (`where('preSyncVersion', '==', 0)`) can find
+                             * untagged rows. The chip should only render once
+                             * a sync has actually tagged the response — i.e.
+                             * when the value is greater than zero. */}
+                            {typeof r.preSyncVersion === 'number' &&
+                              r.preSyncVersion > 0 && (
+                                <span
+                                  className="mt-0.5 inline-flex"
+                                  title="This response was started on an earlier version of the quiz. The teacher synced new content after the student began."
+                                >
+                                  <SessionBadge
+                                    tone="warn"
+                                    label={`Pre-sync v${r.preSyncVersion}`}
+                                  />
+                                </span>
+                              )}
+                          </>
+                        ) : r.status === 'completed' ||
+                          r.status === 'in-progress' ? (
+                          <p
+                            className="font-black text-brand-gray-primary"
+                            style={{ fontSize: 'min(15px, 5cqmin)' }}
+                            title="Scoring unavailable — the quiz answer key hasn't loaded yet, or this submission doesn't match the current quiz version."
+                          >
+                            &mdash;
+                          </p>
+                        ) : (
+                          <div
+                            className="bg-brand-gray-lightest text-brand-gray-primary font-black uppercase rounded px-2 py-1 tracking-tighter"
+                            style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+                          >
+                            {r.status}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Unlock-results action — only when this student is
+                        currently locked out of viewing published results.
+                        Decrements `resultsTabWarnings` by 1 and clears the
+                        flag; one more tab-switch re-locks them (zero grace
+                        warnings post-unlock, matching QuizLiveMonitor's
+                        behavior). */}
+                      {canUnlockResults && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            void handleUnlockResultsForStudent(
+                              rowKey,
+                              displayName
+                            )
+                          }
+                          disabled={isUnlocking}
+                          title="Decrement warnings by 1 and reopen the results view for this student"
+                          aria-label={`Unlock results for ${displayName}`}
+                          className="shrink-0 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-slate-900 font-bold rounded-lg px-3 py-1.5 transition-colors flex items-center gap-1"
+                          style={{ fontSize: 'min(11px, 3cqmin)' }}
+                        >
+                          {isUnlocking ? (
+                            <Loader2
+                              className="animate-spin"
+                              style={{
+                                width: 'min(14px, 4cqmin)',
+                                height: 'min(14px, 4cqmin)',
+                              }}
+                            />
+                          ) : (
+                            <Lock
+                              style={{
+                                width: 'min(14px, 4cqmin)',
+                                height: 'min(14px, 4cqmin)',
+                              }}
+                            />
+                          )}
+                          Unlock results
+                        </button>
+                      )}
+
+                      {canDelete && (
+                        <button
+                          onClick={() => setConfirmDeleteKey(rowKey)}
+                          disabled={isDeleting}
+                          title="Delete this submission"
+                          aria-label={`Delete ${displayName}'s submission`}
+                          className="shrink-0 p-1.5 rounded-lg text-brand-red-primary/50 hover:text-brand-red-primary hover:bg-brand-red-primary/10 disabled:opacity-30 transition-colors"
+                        >
+                          {isDeleting ? (
+                            <Loader2
+                              className="animate-spin"
+                              style={{
+                                width: 'min(14px, 4cqmin)',
+                                height: 'min(14px, 4cqmin)',
+                              }}
+                            />
+                          ) : (
+                            <Trash2
+                              style={{
+                                width: 'min(14px, 4cqmin)',
+                                height: 'min(14px, 4cqmin)',
+                              }}
+                            />
+                          )}
+                        </button>
+                      )}
+                    </>
+                  }
+                >
+                  <div
+                    className="flex items-center"
+                    style={{ gap: 'min(8px, 2cqmin)' }}
+                  >
                     <p
                       className={`font-bold text-brand-blue-dark truncate ${isResolved ? '' : 'font-mono'}`}
                       style={{ fontSize: 'min(13px, 4.5cqmin)' }}
@@ -2281,166 +2226,43 @@ const StudentsTab: React.FC<{
                     </p>
                     {tabWarningsEnabled && warnings > 0 && (
                       <span
-                        className="flex items-center gap-1 bg-red-100 text-red-700 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
-                        style={{ fontSize: 'min(10px, 3cqmin)' }}
                         title={`${warnings} Tab Switch Warning(s)`}
+                        className="shrink-0"
                       >
-                        <AlertTriangle
-                          style={{
-                            width: 'min(10px, 3cqmin)',
-                            height: 'min(10px, 3cqmin)',
-                          }}
+                        <SessionBadge
+                          tone="danger"
+                          icon={AlertTriangle}
+                          label={`${warnings}`}
                         />
-                        {warnings}
                       </span>
                     )}
                     {/* Results-view lockout indicator. Student crossed the
-                        `protection.tabWarningThreshold` while viewing
-                        published results — the student app redirected
-                        them out and wrote `resultsLockedOut: true`. Sits
-                        next to the in-quiz tab-switch warning badge above
-                        because both come from the same "nav warning"
-                        family but track different surfaces (live attempt
-                        vs. published results). */}
+                      `protection.tabWarningThreshold` while viewing
+                      published results — the student app redirected
+                      them out and wrote `resultsLockedOut: true`. Sits
+                      next to the in-quiz tab-switch warning badge above
+                      because both come from the same "nav warning"
+                      family but track different surfaces (live attempt
+                      vs. published results). */}
                     {resultsLockedOut && (
                       <span
                         aria-label="Results locked"
-                        className="flex items-center gap-1 bg-rose-100 text-rose-800 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
-                        style={{ fontSize: 'min(10px, 3cqmin)' }}
                         title={`Results locked after ${resultsTabWarnings} of ${resultsTabWarningThreshold} tab-switch warnings`}
+                        className="shrink-0"
                       >
-                        <Lock
-                          style={{
-                            width: 'min(10px, 3cqmin)',
-                            height: 'min(10px, 3cqmin)',
-                          }}
+                        <SessionBadge
+                          tone="warn"
+                          icon={Lock}
+                          label={`Locked (${resultsTabWarnings}/${resultsTabWarningThreshold})`}
                         />
-                        Locked ({resultsTabWarnings}/
-                        {resultsTabWarningThreshold})
                       </span>
                     )}
                   </div>
-                </div>
-
-                <div className="text-right shrink-0 ml-4 pl-4 border-l border-brand-blue-primary/5">
-                  {scoreable ? (
-                    <>
-                      <p
-                        className={`font-black ${gamified ? 'text-brand-blue-dark' : score >= 80 ? 'text-emerald-600' : score >= 60 ? 'text-amber-600' : 'text-brand-red-primary'}`}
-                        style={{ fontSize: 'min(15px, 5cqmin)' }}
-                      >
-                        {score}
-                        {suffix}
-                      </p>
-                      <p
-                        className="text-brand-blue-primary/60 font-bold"
-                        style={{ fontSize: 'min(10px, 3cqmin)' }}
-                      >
-                        {earned}/{maxPoints} pts
-                        {r.status === 'in-progress' && ' (In Progress)'}
-                      </p>
-                      {/* Fresh responses now carry preSyncVersion: 0
-                       * so the server-side sync query
-                       * (`where('preSyncVersion', '==', 0)`) can find
-                       * untagged rows. The chip should only render once
-                       * a sync has actually tagged the response — i.e.
-                       * when the value is greater than zero. */}
-                      {typeof r.preSyncVersion === 'number' &&
-                        r.preSyncVersion > 0 && (
-                          <span
-                            className="mt-0.5 inline-flex items-center rounded-full bg-amber-100 px-1.5 py-0.5 font-bold uppercase tracking-wider text-amber-700"
-                            style={{ fontSize: 'min(8px, 2.2cqmin)' }}
-                            title="This response was started on an earlier version of the quiz. The teacher synced new content after the student began."
-                          >
-                            Pre-sync v{r.preSyncVersion}
-                          </span>
-                        )}
-                    </>
-                  ) : r.status === 'completed' || r.status === 'in-progress' ? (
-                    <p
-                      className="font-black text-brand-gray-primary"
-                      style={{ fontSize: 'min(15px, 5cqmin)' }}
-                      title="Scoring unavailable — the quiz answer key hasn't loaded yet, or this submission doesn't match the current quiz version."
-                    >
-                      &mdash;
-                    </p>
-                  ) : (
-                    <div
-                      className="bg-brand-gray-lightest text-brand-gray-primary font-black uppercase rounded px-2 py-1 tracking-tighter"
-                      style={{ fontSize: 'min(9px, 2.5cqmin)' }}
-                    >
-                      {r.status}
-                    </div>
-                  )}
-                </div>
-
-                {/* Unlock-results action — only when this student is
-                    currently locked out of viewing published results.
-                    Decrements `resultsTabWarnings` by 1 and clears the
-                    flag; one more tab-switch re-locks them (zero grace
-                    warnings post-unlock, matching QuizLiveMonitor's
-                    behavior). */}
-                {canUnlockResults && (
-                  <button
-                    type="button"
-                    onClick={() =>
-                      void handleUnlockResultsForStudent(rowKey, displayName)
-                    }
-                    disabled={isUnlocking}
-                    title="Decrement warnings by 1 and reopen the results view for this student"
-                    aria-label={`Unlock results for ${displayName}`}
-                    className="ml-2 shrink-0 bg-amber-400 hover:bg-amber-300 disabled:opacity-50 text-slate-900 font-bold rounded-lg px-3 py-1.5 transition-colors flex items-center gap-1"
-                    style={{ fontSize: 'min(11px, 3cqmin)' }}
-                  >
-                    {isUnlocking ? (
-                      <Loader2
-                        className="animate-spin"
-                        style={{
-                          width: 'min(14px, 4cqmin)',
-                          height: 'min(14px, 4cqmin)',
-                        }}
-                      />
-                    ) : (
-                      <Lock
-                        style={{
-                          width: 'min(14px, 4cqmin)',
-                          height: 'min(14px, 4cqmin)',
-                        }}
-                      />
-                    )}
-                    Unlock results
-                  </button>
-                )}
-
-                {canDelete && (
-                  <button
-                    onClick={() => setConfirmDeleteKey(rowKey)}
-                    disabled={isDeleting}
-                    title="Delete this submission"
-                    aria-label={`Delete ${displayName}'s submission`}
-                    className="ml-2 shrink-0 p-1.5 rounded-lg text-brand-red-primary/50 hover:text-brand-red-primary hover:bg-brand-red-primary/10 disabled:opacity-30 transition-colors"
-                  >
-                    {isDeleting ? (
-                      <Loader2
-                        className="animate-spin"
-                        style={{
-                          width: 'min(14px, 4cqmin)',
-                          height: 'min(14px, 4cqmin)',
-                        }}
-                      />
-                    ) : (
-                      <Trash2
-                        style={{
-                          width: 'min(14px, 4cqmin)',
-                          height: 'min(14px, 4cqmin)',
-                        }}
-                      />
-                    )}
-                  </button>
-                )}
-              </div>
-            );
-          })}
+                </SessionRow>
+              );
+            })}
+        </div>
+      )}
     </div>
   );
 };

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -6,7 +6,6 @@
 import React, { useMemo, useState } from 'react';
 import {
   Download,
-  Loader2,
   ExternalLink,
   AlertTriangle,
   BarChart3,
@@ -442,7 +441,8 @@ export const Results: React.FC<ResultsProps> = ({
   if (!exportUrl) {
     overflowItems.push({
       label: 'Export',
-      icon: exporting ? Loader2 : Download,
+      icon: Download,
+      loading: exporting,
       onClick: () => void handleExport(),
       disabled: exporting || totalStudents === 0,
     });
@@ -474,7 +474,8 @@ export const Results: React.FC<ResultsProps> = ({
               <ActionButton
                 variant="primary"
                 label="Push Grades"
-                icon={pushingGrades ? Loader2 : GraduationCap}
+                icon={GraduationCap}
+                loading={pushingGrades}
                 onClick={() => void handlePushGrades()}
                 disabled={pushingGrades}
               />
@@ -486,7 +487,8 @@ export const Results: React.FC<ResultsProps> = ({
               <ActionButton
                 variant="primary"
                 label="Push to Schoology"
-                icon={pushingSchoology ? Loader2 : Send}
+                icon={Send}
+                loading={pushingSchoology}
                 onClick={() => void handlePushSchoologyGrades()}
                 disabled={pushingSchoology || completed === 0}
               />

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -5,7 +5,6 @@
 
 import React, { useMemo, useState } from 'react';
 import {
-  ArrowLeft,
   Download,
   Loader2,
   ExternalLink,
@@ -58,6 +57,19 @@ import {
 } from '@/hooks/useAssignmentPseudonyms';
 import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
 import { logError } from '@/utils/logError';
+import {
+  SessionViewHeader,
+  SegmentedTabs,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+  OverflowMenu,
+} from '@/components/common/sessionViews';
+import type { OverflowMenuItem } from '@/components/common/sessionViews';
+import { scoreColorClasses } from '@/utils/scoreColor';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 interface ResultsProps {
   session: VideoActivitySession;
@@ -411,170 +423,78 @@ export const Results: React.FC<ResultsProps> = ({
     }
   };
 
+  // Visible primary push: Classroom when this assignment is add-on-attached
+  // (and the admin gate permits), otherwise Schoology when LTI-launched. Same
+  // gating conditions/handlers as before — only the placement changes.
+  const showClassroomPush =
+    classroomAttachments.length > 0 && canAccessFeature('google-classroom');
+  const showSchoologyPush = !!ltiAttachment;
+
+  // Overflow-menu items. The Sheet/Export family (Export, Open Sheet) lives
+  // here, decluttered out of the visible header per the approved design. Each
+  // item keeps the EXACT gate/handler it had as a visible header button — only
+  // the placement changes:
+  //   • Export    — shown when `!exportUrl`; handleExport; disabled while
+  //                 exporting or with zero responses.
+  //   • Open Sheet — shown when `exportUrl` is truthy; opens the sheet in a
+  //                  new tab (was an outlined <a target="_blank"> link).
+  const overflowItems: OverflowMenuItem[] = [];
+  if (!exportUrl) {
+    overflowItems.push({
+      label: 'Export',
+      icon: exporting ? Loader2 : Download,
+      onClick: () => void handleExport(),
+      disabled: exporting || totalStudents === 0,
+    });
+  }
+  if (exportUrl) {
+    const sheetUrl = exportUrl;
+    overflowItems.push({
+      label: 'Open Sheet',
+      icon: ExternalLink,
+      onClick: () => window.open(sheetUrl, '_blank', 'noopener,noreferrer'),
+    });
+  }
+
   return (
     <div className="flex flex-col h-full font-sans">
       {/* Header */}
-      <div
-        className="flex items-center justify-between border-b border-brand-blue-primary/10 bg-brand-blue-lighter/30"
-        style={{ padding: 'min(10px, 2.5cqmin) min(16px, 4cqmin)' }}
-      >
-        <div className="flex items-center" style={{ gap: 'min(8px, 2cqmin)' }}>
-          <button
-            onClick={onBack}
-            className="text-brand-blue-primary hover:text-brand-blue-dark transition-colors"
-          >
-            <ArrowLeft
-              style={{
-                width: 'min(18px, 4.5cqmin)',
-                height: 'min(18px, 4.5cqmin)',
-              }}
-            />
-          </button>
-          <div>
-            <p
-              className="font-bold text-brand-blue-dark truncate"
-              style={{ fontSize: 'min(13px, 4cqmin)' }}
-            >
-              Results: {session.assignmentName}
-            </p>
-            <p
-              className="text-brand-blue-primary/60"
-              style={{ fontSize: 'min(10px, 3cqmin)' }}
-            >
-              {session.activityTitle} · {totalStudents} student
-              {totalStudents !== 1 ? 's' : ''} ·{' '}
-              {session.status === 'ended' ? 'Closed' : 'Active'} · {completed}{' '}
-              completed
-            </p>
-          </div>
-        </div>
-
-        <div className="flex items-center" style={{ gap: 'min(8px, 2cqmin)' }}>
-          {/* Push grades to Google Classroom — only when this assignment was
-              attached to one or more Classroom coursework items via the add-on.
-              The admin-managed `google-classroom` gate hides it for users
-              below the doc's minTier. */}
-          {classroomAttachments.length > 0 &&
-            canAccessFeature('google-classroom') && (
-              <button
+      <SessionViewHeader
+        onBack={onBack}
+        status={session.status === 'ended' ? 'ended' : 'live'}
+        title={session.assignmentName}
+        subtitle={session.activityTitle}
+        actions={
+          <>
+            {/* Push grades to Google Classroom — only when this assignment was
+                attached to one or more Classroom coursework items via the add-on.
+                The admin-managed `google-classroom` gate hides it for users
+                below the doc's minTier. */}
+            {showClassroomPush && (
+              <ActionButton
+                variant="primary"
+                label="Push Grades"
+                icon={pushingGrades ? Loader2 : GraduationCap}
                 onClick={() => void handlePushGrades()}
                 disabled={pushingGrades}
-                className="flex items-center font-bold text-white bg-brand-blue-primary hover:bg-brand-blue-dark rounded-xl transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
-                style={{
-                  gap: 'min(6px, 1.5cqmin)',
-                  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                  fontSize: 'min(11px, 3cqmin)',
-                }}
-                title="Write draft grades to this assignment's Google Classroom gradebook (matches the score shown here)."
-              >
-                {pushingGrades ? (
-                  <Loader2
-                    className="animate-spin"
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                ) : (
-                  <GraduationCap
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                )}
-                Push Grades
-              </button>
-            )}
-
-          {/* Push grades to Schoology — only when this assignment was launched
-              from a Schoology resource link (server sets `ltiAttachment` on the
-              first student launch). */}
-          {ltiAttachment && (
-            <button
-              onClick={() => void handlePushSchoologyGrades()}
-              disabled={pushingSchoology || completed === 0}
-              className="flex items-center font-bold text-white bg-brand-blue-primary hover:bg-brand-blue-dark rounded-xl transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3cqmin)',
-              }}
-              title="Write grades to this assignment's Schoology gradebook (matches the score shown here)."
-            >
-              {pushingSchoology ? (
-                <Loader2
-                  className="animate-spin"
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-              ) : (
-                <Send
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-              )}
-              Push to Schoology
-            </button>
-          )}
-
-          {/* Export button */}
-          {exportUrl ? (
-            <a
-              href={exportUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center font-bold text-emerald-700 bg-emerald-50 hover:bg-emerald-100 border border-emerald-200 rounded-xl transition-colors"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3cqmin)',
-              }}
-            >
-              <ExternalLink
-                style={{
-                  width: 'min(12px, 3cqmin)',
-                  height: 'min(12px, 3cqmin)',
-                }}
               />
-              Open Sheet
-            </a>
-          ) : (
-            <button
-              onClick={handleExport}
-              disabled={exporting || totalStudents === 0}
-              className="flex items-center font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded-xl transition-all active:scale-95 disabled:opacity-50"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3cqmin)',
-              }}
-            >
-              {exporting ? (
-                <Loader2
-                  className="animate-spin"
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-              ) : (
-                <Download
-                  style={{
-                    width: 'min(12px, 3cqmin)',
-                    height: 'min(12px, 3cqmin)',
-                  }}
-                />
-              )}
-              Export
-            </button>
-          )}
-        </div>
-      </div>
+            )}
+            {/* Push grades to Schoology — only when this assignment was launched
+                from a Schoology resource link (server sets `ltiAttachment` on the
+                first student launch). */}
+            {showSchoologyPush && (
+              <ActionButton
+                variant="primary"
+                label="Push to Schoology"
+                icon={pushingSchoology ? Loader2 : Send}
+                onClick={() => void handlePushSchoologyGrades()}
+                disabled={pushingSchoology || completed === 0}
+              />
+            )}
+            {overflowItems.length > 0 && <OverflowMenu items={overflowItems} />}
+          </>
+        }
+      />
 
       {exportError && (
         <div
@@ -599,44 +519,29 @@ export const Results: React.FC<ResultsProps> = ({
       {/* Tabs */}
       <div
         className="flex border-b border-slate-200"
-        style={{ padding: '0 min(16px, 4cqmin)' }}
+        style={{ padding: 'min(8px, 2cqmin) min(16px, 4cqmin)' }}
       >
-        {(
-          [
-            { id: 'overview', icon: <BarChart3 />, label: 'Overview' },
-            { id: 'questions', icon: <Clock />, label: 'Questions' },
-            { id: 'students', icon: <Users />, label: 'Students' },
+        <SegmentedTabs
+          ariaLabel="Video activity results sections"
+          value={activeTab}
+          onChange={setActiveTab}
+          tabs={[
+            { key: 'overview', label: 'Overview', icon: BarChart3 },
+            { key: 'questions', label: 'Questions', icon: Clock },
+            {
+              key: 'students',
+              label: 'Students',
+              icon: Users,
+              count: responses.length,
+            },
             // PLC tab intentionally hidden for Video Activity until the
             // VA-side auto-publish path lands. The Quiz path writes its
             // contributions to `/plcs/{plcId}/contributions/`; if we
             // rendered PlcTab here it would aggregate quiz responses
             // under VA question labels (cross-contamination). Re-enable
             // alongside the VA `publishPlcContribution` wiring.
-          ] as const
-        ).map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center font-bold transition-colors border-b-2 ${
-              activeTab === tab.id
-                ? 'text-brand-blue-primary border-brand-blue-primary'
-                : 'text-slate-400 border-transparent hover:text-slate-600'
-            }`}
-            style={{
-              gap: 'min(5px, 1.2cqmin)',
-              padding: 'min(8px, 2cqmin) min(12px, 3cqmin)',
-              fontSize: 'min(11px, 3cqmin)',
-            }}
-          >
-            {React.cloneElement(tab.icon, {
-              style: {
-                width: 'min(13px, 3.5cqmin)',
-                height: 'min(13px, 3.5cqmin)',
-              },
-            })}
-            {tab.label}
-          </button>
-        ))}
+          ]}
+        />
       </div>
 
       {/* Tab content */}
@@ -648,148 +553,139 @@ export const Results: React.FC<ResultsProps> = ({
         {activeTab === 'overview' && (
           <div className="space-y-3">
             <div className="grid grid-cols-3 gap-2">
-              {[
-                {
-                  label: 'Students',
-                  value: totalStudents,
-                  color: 'text-brand-blue-primary',
-                },
-                {
-                  label: 'Completed',
-                  value: completed,
-                  color: 'text-emerald-600',
-                },
-                {
-                  label: 'Avg Score',
-                  value: avgScore === null ? '—' : `${avgScore}%`,
-                  color: 'text-violet-600',
-                },
-              ].map((stat) => (
-                <div
-                  key={stat.label}
-                  className="bg-white border border-slate-100 rounded-xl text-center"
-                  style={{ padding: 'min(10px, 2.5cqmin)' }}
-                >
-                  <p
-                    className={`font-black ${stat.color}`}
-                    style={{ fontSize: 'min(22px, 7cqmin)' }}
-                  >
-                    {stat.value}
-                  </p>
-                  <p
-                    className="text-slate-500 font-medium"
-                    style={{ fontSize: 'min(10px, 3cqmin)' }}
-                  >
-                    {stat.label}
-                  </p>
-                </div>
-              ))}
+              <StatTile
+                tone="blue"
+                icon={
+                  <Users
+                    style={{
+                      width: 'min(20px, 5cqmin)',
+                      height: 'min(20px, 5cqmin)',
+                    }}
+                  />
+                }
+                value={totalStudents}
+                label="Students"
+              />
+              <StatTile
+                tone="green"
+                icon={
+                  <CheckCircle2
+                    style={{
+                      width: 'min(20px, 5cqmin)',
+                      height: 'min(20px, 5cqmin)',
+                    }}
+                  />
+                }
+                value={completed}
+                label="Completed"
+              />
+              <StatTile
+                tone="violet"
+                icon={
+                  <BarChart3
+                    style={{
+                      width: 'min(20px, 5cqmin)',
+                      height: 'min(20px, 5cqmin)',
+                    }}
+                  />
+                }
+                value={avgScore === null ? '—' : `${avgScore}%`}
+                label="Avg Score"
+              />
             </div>
 
             {totalStudents === 0 && (
-              <p
-                className="text-center text-slate-400"
-                style={{
-                  fontSize: 'min(12px, 4cqmin)',
-                  marginTop: 'min(24px, 6cqmin)',
-                }}
-              >
-                No students have joined this session yet.
-              </p>
+              <ScaledEmptyState
+                icon={Users}
+                title="No students yet"
+                subtitle="No students have joined this session yet."
+              />
             )}
           </div>
         )}
 
         {/* Questions tab */}
-        {activeTab === 'questions' && (
-          <div className="space-y-2">
-            {questions.map((q, idx) => {
-              const accuracy = getQuestionAccuracy(q.id);
-              return (
-                <div
-                  key={q.id}
-                  className="bg-white border border-slate-100 rounded-xl"
-                  style={{ padding: 'min(10px, 2.5cqmin)' }}
-                >
-                  <div
-                    className="flex items-start justify-between"
-                    style={{ gap: 'min(8px, 2cqmin)' }}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div
-                        className="flex items-center"
-                        style={{
-                          gap: 'min(6px, 1.5cqmin)',
-                          marginBottom: 'min(4px, 1cqmin)',
-                        }}
-                      >
-                        <span
-                          className="bg-brand-blue-lighter text-brand-blue-primary font-black rounded-md shrink-0"
-                          style={{
-                            fontSize: 'min(9px, 2.5cqmin)',
-                            padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
-                          }}
-                        >
-                          {formatTimestamp(q.timestamp)}
-                        </span>
+        {activeTab === 'questions' &&
+          (questions.length === 0 ? (
+            <ScaledEmptyState
+              icon={Clock}
+              title="No questions"
+              subtitle="This activity has no questions."
+            />
+          ) : (
+            <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm overflow-hidden">
+              {questions.map((q, idx) => {
+                const accuracy = getQuestionAccuracy(q.id);
+                const colors = scoreColorClasses(accuracy);
+                return (
+                  <SessionRow
+                    key={q.id}
+                    trailing={
+                      <div className="shrink-0 text-right">
                         <p
-                          className="text-slate-700 font-medium truncate"
-                          style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                          className={`font-black tabular-nums ${colors.text}`}
+                          style={{ fontSize: 'min(16px, 5cqmin)' }}
                         >
-                          {idx + 1}. {q.text}
+                          {accuracy}%
+                        </p>
+                        <p
+                          className="text-slate-400"
+                          style={{ fontSize: 'min(9px, 2.5cqmin)' }}
+                        >
+                          accuracy
                         </p>
                       </div>
-                    </div>
-                    <div className="shrink-0 text-right">
-                      <p
-                        className={`font-black ${accuracy >= 70 ? 'text-emerald-600' : accuracy >= 40 ? 'text-amber-600' : 'text-brand-red-primary'}`}
-                        style={{ fontSize: 'min(16px, 5cqmin)' }}
-                      >
-                        {accuracy}%
-                      </p>
-                      <p
-                        className="text-slate-400"
-                        style={{ fontSize: 'min(9px, 2.5cqmin)' }}
-                      >
-                        accuracy
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Accuracy bar */}
-                  <div
-                    className="bg-slate-100 rounded-full overflow-hidden"
-                    style={{
-                      height: 'min(6px, 1.5cqmin)',
-                      marginTop: 'min(6px, 1.5cqmin)',
-                    }}
+                    }
                   >
                     <div
-                      className={`h-full rounded-full transition-all ${accuracy >= 70 ? 'bg-emerald-500' : accuracy >= 40 ? 'bg-amber-500' : 'bg-brand-red-primary'}`}
-                      style={{ width: `${accuracy}%` }}
-                    />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
+                      className="flex items-center"
+                      style={{
+                        gap: 'min(6px, 1.5cqmin)',
+                        marginBottom: 'min(4px, 1cqmin)',
+                      }}
+                    >
+                      <SessionBadge
+                        tone="info"
+                        label={formatTimestamp(q.timestamp)}
+                      />
+                      <p
+                        className="text-slate-700 font-medium truncate"
+                        style={{ fontSize: 'min(12px, 3.5cqmin)' }}
+                      >
+                        {idx + 1}. {q.text}
+                      </p>
+                    </div>
+
+                    {/* Accuracy bar */}
+                    <div
+                      className="bg-slate-100 rounded-full overflow-hidden"
+                      style={{
+                        height: 'min(6px, 1.5cqmin)',
+                        marginTop: 'min(6px, 1.5cqmin)',
+                      }}
+                    >
+                      <div
+                        className={`h-full rounded-full transition-all ${colors.bar}`}
+                        style={{ width: `${accuracy}%` }}
+                      />
+                    </div>
+                  </SessionRow>
+                );
+              })}
+            </div>
+          ))}
 
         {/* Students tab */}
-        {activeTab === 'students' && (
-          <div className="space-y-2">
-            {responses.length === 0 ? (
-              <p
-                className="text-center text-slate-400"
-                style={{
-                  fontSize: 'min(12px, 4cqmin)',
-                  marginTop: 'min(24px, 6cqmin)',
-                }}
-              >
-                No students have joined this session yet.
-              </p>
-            ) : (
-              responses
+        {activeTab === 'students' &&
+          (responses.length === 0 ? (
+            <ScaledEmptyState
+              icon={Users}
+              title="No students yet"
+              subtitle="No students have joined this session yet."
+            />
+          ) : (
+            <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm overflow-hidden">
+              {responses
                 .slice()
                 .sort((a, b) => getStudentScore(b) - getStudentScore(a))
                 .map((r) => {
@@ -806,80 +702,83 @@ export const Results: React.FC<ResultsProps> = ({
                     isAnswerCorrect(a.questionId, a.answer)
                   ).length;
                   return (
-                    <div
+                    <SessionRow
                       key={r.pin}
-                      className="flex items-center bg-white border border-slate-100 rounded-xl"
-                      style={{
-                        padding: 'min(10px, 2.5cqmin)',
-                        gap: 'min(10px, 2.5cqmin)',
-                      }}
+                      trailing={
+                        <>
+                          <div
+                            className="flex items-center shrink-0"
+                            style={{ gap: 'min(6px, 1.5cqmin)' }}
+                          >
+                            {r.answers.map((a) =>
+                              isAnswerCorrect(a.questionId, a.answer) ? (
+                                <CheckCircle2
+                                  key={a.questionId}
+                                  className="text-emerald-500"
+                                  style={{
+                                    width: 'min(14px, 3.5cqmin)',
+                                    height: 'min(14px, 3.5cqmin)',
+                                  }}
+                                />
+                              ) : (
+                                <XCircle
+                                  key={a.questionId}
+                                  className="text-brand-red-primary"
+                                  style={{
+                                    width: 'min(14px, 3.5cqmin)',
+                                    height: 'min(14px, 3.5cqmin)',
+                                  }}
+                                />
+                              )
+                            )}
+                          </div>
+                          {scoreable ? (
+                            <ScorePill score={score} display="percent" />
+                          ) : (
+                            <span
+                              className="font-black tabular-nums shrink-0 text-slate-400"
+                              style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+                            >
+                              —
+                            </span>
+                          )}
+                        </>
+                      }
                     >
-                      <div className="flex-1 min-w-0">
-                        <p
-                          className="font-bold text-slate-800 truncate"
-                          style={{ fontSize: 'min(13px, 4cqmin)' }}
-                        >
-                          {/* `formatStudentName` returns '' on roster miss and legacy rows may carry '' for `r.name`; pick the first non-empty string so the falsy-fallthrough intent is explicit (no `||` chain that ESLint would flag). */}
-                          {[
-                            formatStudentName(byStudentUid.get(r.studentUid)),
-                            r.name,
-                            r.pin,
-                          ].find((s) => typeof s === 'string' && s.length > 0)}
-                        </p>
-                        <p
+                      <p
+                        className="font-bold text-slate-800 truncate"
+                        style={{ fontSize: 'min(13px, 4cqmin)' }}
+                      >
+                        {/* `formatStudentName` returns '' on roster miss and legacy rows may carry '' for `r.name`; pick the first non-empty string so the falsy-fallthrough intent is explicit (no `||` chain that ESLint would flag). */}
+                        {[
+                          formatStudentName(byStudentUid.get(r.studentUid)),
+                          r.name,
+                          r.pin,
+                        ].find((s) => typeof s === 'string' && s.length > 0)}
+                      </p>
+                      <div
+                        className="flex items-center"
+                        style={{
+                          gap: 'min(6px, 1.5cqmin)',
+                          marginTop: 'min(3px, 0.8cqmin)',
+                        }}
+                      >
+                        <SessionBadge
+                          tone={r.completedAt ? 'success' : 'warn'}
+                          label={r.completedAt ? 'Completed' : 'In progress'}
+                        />
+                        <span
                           className="text-slate-400"
                           style={{ fontSize: 'min(10px, 3cqmin)' }}
                         >
-                          {r.completedAt ? 'Completed' : 'In progress'} ·{' '}
                           {correct}/{questions.length} correct
-                        </p>
-                      </div>
-                      <div
-                        className="flex items-center shrink-0"
-                        style={{ gap: 'min(6px, 1.5cqmin)' }}
-                      >
-                        {r.answers.map((a) =>
-                          isAnswerCorrect(a.questionId, a.answer) ? (
-                            <CheckCircle2
-                              key={a.questionId}
-                              className="text-emerald-500"
-                              style={{
-                                width: 'min(14px, 3.5cqmin)',
-                                height: 'min(14px, 3.5cqmin)',
-                              }}
-                            />
-                          ) : (
-                            <XCircle
-                              key={a.questionId}
-                              className="text-brand-red-primary"
-                              style={{
-                                width: 'min(14px, 3.5cqmin)',
-                                height: 'min(14px, 3.5cqmin)',
-                              }}
-                            />
-                          )
-                        )}
-                        <span
-                          className={`font-black ml-1 ${
-                            !scoreable
-                              ? 'text-slate-400'
-                              : score >= 70
-                                ? 'text-emerald-600'
-                                : score >= 40
-                                  ? 'text-amber-600'
-                                  : 'text-brand-red-primary'
-                          }`}
-                          style={{ fontSize: 'min(14px, 4.5cqmin)' }}
-                        >
-                          {scoreable ? `${score}%` : '—'}
                         </span>
                       </div>
-                    </div>
+                    </SessionRow>
                   );
-                })
-            )}
-          </div>
-        )}
+                })}
+            </div>
+          ))}
 
         {/* PLC tab intentionally not rendered for Video Activity — see
             tab-strip comment above for the cross-contamination reason. */}

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -3,7 +3,7 @@
  * Adapted from QuizResults. Shows per-student scores and per-question accuracy.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useId, useMemo, useState } from 'react';
 import {
   Download,
   ExternalLink,
@@ -135,6 +135,8 @@ export const Results: React.FC<ResultsProps> = ({
   const [activeTab, setActiveTab] = useState<
     'overview' | 'questions' | 'students'
   >('overview');
+  // Per-instance prefix for the ARIA tab↔panel linkage.
+  const tabPanelId = useId();
 
   const questions = session.questions;
   const totalStudents = responses.length;
@@ -525,6 +527,7 @@ export const Results: React.FC<ResultsProps> = ({
       >
         <SegmentedTabs
           ariaLabel="Video activity results sections"
+          panelIdPrefix={tabPanelId}
           value={activeTab}
           onChange={setActiveTab}
           tabs={[
@@ -549,7 +552,8 @@ export const Results: React.FC<ResultsProps> = ({
       {/* Tab content */}
       <div
         role="tabpanel"
-        aria-label={`${activeTab} results`}
+        id={`${tabPanelId}-panel-${activeTab}`}
+        aria-labelledby={`${tabPanelId}-tab-${activeTab}`}
         className="flex-1 overflow-y-auto custom-scrollbar"
         style={{ padding: 'min(14px, 3.5cqmin)' }}
       >

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -691,7 +691,17 @@ export const Results: React.FC<ResultsProps> = ({
             <div className="bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm overflow-hidden">
               {responses
                 .slice()
-                .sort((a, b) => getStudentScore(b) - getStudentScore(a))
+                .sort((a, b) => {
+                  // Unscorable responses (answer key not loaded) sink to the
+                  // bottom instead of intermixing with genuine 0% students.
+                  const sa = canScoreVideoActivityResponse(questions, a.answers)
+                    ? getStudentScore(a)
+                    : -1;
+                  const sb = canScoreVideoActivityResponse(questions, b.answers)
+                    ? getStudentScore(b)
+                    : -1;
+                  return sb - sa;
+                })
                 .map((r) => {
                   const score = getStudentScore(r);
                   // When the question set hasn't loaded (or the response's

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -133,7 +133,7 @@ export const Results: React.FC<ResultsProps> = ({
   const [pushingGrades, setPushingGrades] = useState(false);
   const [pushingSchoology, setPushingSchoology] = useState(false);
   const [activeTab, setActiveTab] = useState<
-    'overview' | 'questions' | 'students' | 'plc'
+    'overview' | 'questions' | 'students'
   >('overview');
 
   const questions = session.questions;

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -707,7 +707,7 @@ export const Results: React.FC<ResultsProps> = ({
                   ).length;
                   return (
                     <SessionRow
-                      key={r.pin}
+                      key={r._responseKey ?? r.studentUid ?? r.pin}
                       trailing={
                         <>
                           <div

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -548,6 +548,8 @@ export const Results: React.FC<ResultsProps> = ({
 
       {/* Tab content */}
       <div
+        role="tabpanel"
+        aria-label={`${activeTab} results`}
         className="flex-1 overflow-y-auto custom-scrollbar"
         style={{ padding: 'min(14px, 3.5cqmin)' }}
       >

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -724,27 +724,38 @@ export const Results: React.FC<ResultsProps> = ({
                             className="flex items-center shrink-0"
                             style={{ gap: 'min(6px, 1.5cqmin)' }}
                           >
-                            {r.answers.map((a) =>
-                              isAnswerCorrect(a.questionId, a.answer) ? (
-                                <CheckCircle2
-                                  key={a.questionId}
-                                  className="text-emerald-500"
-                                  style={{
-                                    width: 'min(14px, 3.5cqmin)',
-                                    height: 'min(14px, 3.5cqmin)',
-                                  }}
-                                />
-                              ) : (
-                                <XCircle
-                                  key={a.questionId}
-                                  className="text-brand-red-primary"
-                                  style={{
-                                    width: 'min(14px, 3.5cqmin)',
-                                    height: 'min(14px, 3.5cqmin)',
-                                  }}
-                                />
+                            {/* Iterate in canonical question order (not
+                                submission order) so the icon strip matches the
+                                Live Monitor for self-paced revisits. */}
+                            {questions
+                              .map((q) =>
+                                r.answers.find((a) => a.questionId === q.id)
                               )
-                            )}
+                              .filter(
+                                (a): a is (typeof r.answers)[number] =>
+                                  a !== undefined
+                              )
+                              .map((a) =>
+                                isAnswerCorrect(a.questionId, a.answer) ? (
+                                  <CheckCircle2
+                                    key={a.questionId}
+                                    className="text-emerald-500"
+                                    style={{
+                                      width: 'min(14px, 3.5cqmin)',
+                                      height: 'min(14px, 3.5cqmin)',
+                                    }}
+                                  />
+                                ) : (
+                                  <XCircle
+                                    key={a.questionId}
+                                    className="text-brand-red-primary"
+                                    style={{
+                                      width: 'min(14px, 3.5cqmin)',
+                                      height: 'min(14px, 3.5cqmin)',
+                                    }}
+                                  />
+                                )
+                              )}
                           </div>
                           {scoreable ? (
                             <ScorePill score={score} display="percent" />

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -471,7 +471,7 @@ export const VideoActivityLiveMonitor: React.FC<
     <div className="flex flex-col h-full font-sans bg-slate-50">
       {/* ─── Header strip ───────────────────────────────────────────────── */}
       <SessionViewHeader
-        onBack={onBack ?? (() => undefined)}
+        onBack={onBack}
         status={isLive ? 'live' : 'paused'}
         title={session.assignmentName}
         subtitle={`${session.activityTitle} · ${questions.length} question${

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -12,11 +12,9 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   AlertTriangle,
-  ArrowLeft,
   CheckCircle2,
   Circle,
   Clock,
-  Loader2,
   Lock,
   Pause,
   Play,
@@ -39,6 +37,14 @@ import {
 } from '@/hooks/useAssignmentPseudonyms';
 import { useLtiSessionNames } from '@/hooks/useLtiSessionNames';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import {
+  SessionViewHeader,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+} from '@/components/common/sessionViews';
 import { logError } from '@/utils/logError';
 
 interface VideoActivityLiveMonitorProps {
@@ -160,250 +166,145 @@ const StudentRow: React.FC<StudentRowProps> = ({
     });
   };
 
-  return (
-    <div
-      className="flex items-center bg-white border border-slate-100 rounded-xl"
-      style={{
-        padding: 'min(10px, 2.5cqmin)',
-        gap: 'min(10px, 2.5cqmin)',
-      }}
-    >
-      <div className="flex-1 min-w-0">
-        <div
-          className="flex items-center"
-          style={{ gap: 'min(6px, 1.5cqmin)' }}
-        >
-          <p
-            className="font-bold text-slate-800 truncate"
-            style={{ fontSize: 'min(13px, 4cqmin)' }}
-          >
-            {displayName}
-          </p>
-          {response.classPeriod && (
-            <span
-              className="bg-brand-blue-lighter text-brand-blue-primary font-bold rounded-md shrink-0"
-              style={{
-                fontSize: 'min(9px, 2.5cqmin)',
-                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
-              }}
-            >
-              {response.classPeriod}
-            </span>
-          )}
-          {completed ? (
-            <span
-              className="bg-emerald-50 text-emerald-700 font-bold rounded-md shrink-0"
-              style={{
-                fontSize: 'min(9px, 2.5cqmin)',
-                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
-              }}
-            >
-              Done
-            </span>
-          ) : (
-            <span
-              className="bg-amber-50 text-amber-700 font-bold rounded-md shrink-0"
-              style={{
-                fontSize: 'min(9px, 2.5cqmin)',
-                padding: 'min(1px, 0.2cqmin) min(5px, 1.2cqmin)',
-              }}
-            >
-              In progress
-            </span>
-          )}
-          {showTabWarnings && warnings > 0 && (
-            <span
-              className="flex items-center gap-0.5 bg-red-100 text-red-700 px-1.5 py-0.5 rounded uppercase font-black shrink-0"
-              style={{ fontSize: 'min(9px, 2.5cqmin)' }}
-              title={`${warnings} Tab Switch Warning(s)`}
-            >
-              <AlertTriangle
-                style={{
-                  width: 'min(12px, 3cqmin)',
-                  height: 'min(12px, 3cqmin)',
-                }}
-              />
-              {warnings}
-            </span>
-          )}
-          {(() => {
-            if (!onUnlock) return null;
-            const isAutoSubmittedByWarnings =
-              completed && warnings >= 3 && !response.unlocked;
-            const completedCount = response.completedAttempts ?? 0;
-            const hitAttemptCap =
-              typeof attemptLimit === 'number' &&
-              attemptLimit > 0 &&
-              completedCount >= attemptLimit &&
-              !response.unlocked;
-            const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
-            if (isLocked) {
-              return (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onUnlock(displayName);
-                  }}
-                  className="flex items-center gap-0.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded uppercase font-black shrink-0 transition-colors"
-                  style={{
-                    fontSize: 'min(9px, 2.5cqmin)',
-                    padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
-                  }}
-                  title={
-                    isAutoSubmittedByWarnings
-                      ? 'Auto-submitted from tab-switch warnings — click to allow resume'
-                      : 'Attempt limit reached — click to allow resume'
-                  }
-                  aria-label={`Unlock ${displayName}'s attempt`}
-                >
-                  <Lock
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Locked
-                </button>
-              );
-            }
-            if (response.unlocked && !completed) {
-              return (
-                <span
-                  className="flex items-center gap-0.5 bg-emerald-100 text-emerald-800 rounded uppercase font-black shrink-0"
-                  style={{
-                    fontSize: 'min(9px, 2.5cqmin)',
-                    padding: 'min(2px, 0.5cqmin) min(6px, 1.5cqmin)',
-                  }}
-                  title="Unlocked — one more tab-switch will finalize the attempt"
-                >
-                  <Unlock
-                    style={{
-                      width: 'min(12px, 3cqmin)',
-                      height: 'min(12px, 3cqmin)',
-                    }}
-                  />
-                  Resumed
-                </span>
-              );
-            }
-            return null;
-          })()}
-        </div>
-        <p
-          className="text-slate-400"
-          style={{
-            fontSize: 'min(10px, 3cqmin)',
-            marginTop: 'min(2px, 0.5cqmin)',
+  // Resolve the lock/resume badge state once so the row content stays flat.
+  let lockBadge: React.ReactNode = null;
+  if (onUnlock) {
+    const isAutoSubmittedByWarnings =
+      completed && warnings >= 3 && !response.unlocked;
+    const completedCount = response.completedAttempts ?? 0;
+    const hitAttemptCap =
+      typeof attemptLimit === 'number' &&
+      attemptLimit > 0 &&
+      completedCount >= attemptLimit &&
+      !response.unlocked;
+    const isLocked = isAutoSubmittedByWarnings || hitAttemptCap;
+    if (isLocked) {
+      lockBadge = (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnlock(displayName);
           }}
-        >
-          {response.pin ? `PIN ${response.pin} · ` : null}
-          {answeredCount}/{questions.length} answered · last{' '}
-          {formatTime(latestAnsweredAt)}
-        </p>
-      </div>
-
-      <div
-        className="flex items-center shrink-0 flex-wrap justify-end"
-        style={{ gap: 'min(4px, 1cqmin)', maxWidth: '50%' }}
-      >
-        {questions.map((q) => {
-          const submitted = answerByQid.get(q.id);
-          if (submitted === undefined) {
-            return (
-              <Circle
-                key={q.id}
-                className="text-slate-300"
-                style={{
-                  width: 'min(14px, 3.5cqmin)',
-                  height: 'min(14px, 3.5cqmin)',
-                }}
-              />
-            );
+          className="inline-flex shrink-0 rounded-full transition-opacity hover:opacity-80"
+          title={
+            isAutoSubmittedByWarnings
+              ? 'Auto-submitted from tab-switch warnings — click to allow resume'
+              : 'Attempt limit reached — click to allow resume'
           }
-          const isCorrect = submitted === correctAnswerById.get(q.id);
-          return isCorrect ? (
-            <CheckCircle2
+          aria-label={`Unlock ${displayName}'s attempt`}
+        >
+          <SessionBadge tone="warn" label="Locked" icon={Lock} />
+        </button>
+      );
+    } else if (response.unlocked && !completed) {
+      lockBadge = (
+        <span
+          title="Unlocked — one more tab-switch will finalize the attempt"
+          className="inline-flex shrink-0"
+        >
+          <SessionBadge tone="success" label="Resumed" icon={Unlock} />
+        </span>
+      );
+    }
+  }
+
+  const trailing = (
+    <div
+      className="flex items-center flex-wrap justify-end"
+      style={{ gap: 'min(4px, 1cqmin)', maxWidth: 'min(220px, 50cqmin)' }}
+    >
+      {questions.map((q) => {
+        const submitted = answerByQid.get(q.id);
+        if (submitted === undefined) {
+          return (
+            <Circle
               key={q.id}
-              className="text-emerald-500"
-              style={{
-                width: 'min(14px, 3.5cqmin)',
-                height: 'min(14px, 3.5cqmin)',
-              }}
-            />
-          ) : (
-            <XCircle
-              key={q.id}
-              className="text-brand-red-primary"
+              className="text-slate-300"
               style={{
                 width: 'min(14px, 3.5cqmin)',
                 height: 'min(14px, 3.5cqmin)',
               }}
             />
           );
-        })}
+        }
+        const isCorrect = submitted === correctAnswerById.get(q.id);
+        return isCorrect ? (
+          <CheckCircle2
+            key={q.id}
+            className="text-emerald-500"
+            style={{
+              width: 'min(14px, 3.5cqmin)',
+              height: 'min(14px, 3.5cqmin)',
+            }}
+          />
+        ) : (
+          <XCircle
+            key={q.id}
+            className="text-red-500"
+            style={{
+              width: 'min(14px, 3.5cqmin)',
+              height: 'min(14px, 3.5cqmin)',
+            }}
+          />
+        );
+      })}
+      {score === null ? (
         <span
-          className={`font-black ml-1 ${
-            score === null
-              ? 'text-slate-400'
-              : score >= 70
-                ? 'text-emerald-600'
-                : score >= 40
-                  ? 'text-amber-600'
-                  : 'text-brand-red-primary'
-          }`}
+          className="font-black tabular-nums shrink-0 text-slate-400"
           style={{ fontSize: 'min(14px, 4.5cqmin)' }}
         >
-          {score === null ? '—' : `${score}%`}
+          —
         </span>
-      </div>
+      ) : (
+        <ScorePill score={score} display="percent" />
+      )}
     </div>
   );
-};
 
-/* ─── KPI tile ──────────────────────────────────────────────────────────── */
-
-interface StatTileProps {
-  label: string;
-  value: number | string;
-  icon: React.ReactNode;
-  color: 'blue' | 'amber' | 'green';
-}
-
-const StatTile: React.FC<StatTileProps> = ({ label, value, icon, color }) => {
-  const colorClasses =
-    color === 'blue'
-      ? 'text-brand-blue-primary'
-      : color === 'amber'
-        ? 'text-amber-600'
-        : 'text-emerald-600';
   return (
-    <div
-      className="bg-white border border-slate-100 rounded-xl text-center"
-      style={{ padding: 'min(10px, 2.5cqmin)' }}
+    <SessionRow
+      dot={{ tone: completed ? 'success' : 'warn' }}
+      trailing={trailing}
     >
-      <div
-        className={`flex items-center justify-center ${colorClasses}`}
-        style={{
-          gap: 'min(4px, 1cqmin)',
-          marginBottom: 'min(4px, 1cqmin)',
-        }}
-      >
-        {icon}
-        <span
-          className="font-bold uppercase tracking-wider"
-          style={{ fontSize: 'min(10px, 3cqmin)' }}
+      <div className="flex items-center" style={{ gap: 'min(6px, 1.5cqmin)' }}>
+        <p
+          className="font-bold text-slate-800 truncate"
+          style={{ fontSize: 'min(13px, 4cqmin)' }}
         >
-          {label}
-        </span>
+          {displayName}
+        </p>
+        {response.classPeriod && (
+          <SessionBadge tone="info" label={response.classPeriod} />
+        )}
+        {completed ? (
+          <SessionBadge tone="success" label="Done" />
+        ) : (
+          <SessionBadge tone="warn" label="In progress" />
+        )}
+        {showTabWarnings && warnings > 0 && (
+          <span title={`${warnings} Tab Switch Warning(s)`}>
+            <SessionBadge
+              tone="danger"
+              label={String(warnings)}
+              icon={AlertTriangle}
+            />
+          </span>
+        )}
+        {lockBadge}
       </div>
       <p
-        className={`font-black ${colorClasses}`}
-        style={{ fontSize: 'min(22px, 7cqmin)' }}
+        className="text-slate-400"
+        style={{
+          fontSize: 'min(10px, 3cqmin)',
+          marginTop: 'min(2px, 0.5cqmin)',
+        }}
       >
-        {value}
+        {response.pin ? `PIN ${response.pin} · ` : null}
+        {answeredCount}/{questions.length} answered · last{' '}
+        {formatTime(latestAnsweredAt)}
       </p>
-    </div>
+    </SessionRow>
   );
 };
 
@@ -567,152 +468,36 @@ export const VideoActivityLiveMonitor: React.FC<
   }, [responses]);
 
   return (
-    <div className="flex flex-col h-full font-sans bg-brand-blue-lighter/10">
+    <div className="flex flex-col h-full font-sans bg-slate-50">
       {/* ─── Header strip ───────────────────────────────────────────────── */}
-      <div
-        className="border-b border-brand-blue-primary/10 bg-white"
-        style={{ padding: 'min(12px, 2.5cqmin) min(16px, 4cqmin)' }}
-      >
-        <div className="flex items-center justify-between">
-          <div
-            className="flex items-center min-w-0"
-            style={{ gap: 'min(8px, 2cqmin)' }}
-          >
-            {onBack && (
-              <button
-                onClick={onBack}
-                className="flex items-center justify-center rounded-lg text-brand-blue-dark/70 hover:text-brand-blue-dark hover:bg-brand-blue-lighter/30 transition-colors shrink-0"
-                style={{
-                  width: 'min(28px, 7cqmin)',
-                  height: 'min(28px, 7cqmin)',
-                }}
-                title="Back to assignments"
-                aria-label="Back to assignments"
-              >
-                <ArrowLeft
-                  style={{
-                    width: 'min(16px, 4cqmin)',
-                    height: 'min(16px, 4cqmin)',
-                  }}
-                />
-              </button>
-            )}
-            <div
-              className={`rounded-full shrink-0 ${
-                isLive
-                  ? 'bg-brand-red-primary animate-pulse shadow-[0_0_8px_rgba(173,33,34,0.5)]'
-                  : 'bg-amber-500'
-              }`}
-              style={{
-                width: 'min(10px, 2.5cqmin)',
-                height: 'min(10px, 2.5cqmin)',
-              }}
-            />
-            <div className="flex flex-col min-w-0">
-              <div
-                className={`font-black leading-none uppercase tracking-tight ${
-                  isLive ? 'text-brand-red-primary' : 'text-amber-600'
-                }`}
-                style={{ fontSize: 'min(12px, 4cqmin)' }}
-              >
-                {isLive ? 'Live' : 'Paused'}
-              </div>
-              <span
-                className="text-brand-blue-dark font-bold truncate"
-                style={{ fontSize: 'min(11px, 3.5cqmin)' }}
-              >
-                {session.assignmentName}
-              </span>
-            </div>
-          </div>
-          <div
-            className="flex items-center shrink-0"
-            style={{ gap: 'min(6px, 1.5cqmin)' }}
-          >
+      <SessionViewHeader
+        onBack={onBack ?? (() => undefined)}
+        status={isLive ? 'live' : 'paused'}
+        title={session.assignmentName}
+        subtitle={`${session.activityTitle} · ${questions.length} question${
+          questions.length === 1 ? '' : 's'
+        }`}
+        actions={
+          <>
             {(onPause ?? onResume) && (
-              <button
+              <ActionButton
+                variant="secondary"
+                label={isLive ? 'Pause' : 'Resume'}
+                icon={isLive ? Pause : Play}
                 onClick={() => void handleTogglePause()}
                 disabled={toggling}
-                className="flex items-center bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-                style={{
-                  gap: 'min(6px, 1.5cqmin)',
-                  padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                  fontSize: 'min(11px, 3.5cqmin)',
-                }}
-                title={
-                  isLive
-                    ? 'Pause — students see a paused screen'
-                    : 'Resume — students can rejoin'
-                }
-              >
-                {toggling ? (
-                  <Loader2
-                    className="animate-spin"
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                ) : isLive ? (
-                  <Pause
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                ) : (
-                  <Play
-                    style={{
-                      width: 'min(14px, 3.5cqmin)',
-                      height: 'min(14px, 3.5cqmin)',
-                    }}
-                  />
-                )}
-                {isLive ? 'PAUSE' : 'RESUME'}
-              </button>
+              />
             )}
-            <button
+            <ActionButton
+              variant="danger"
+              label="End"
+              icon={Square}
               onClick={() => void handleEnd()}
               disabled={ending}
-              className="flex items-center bg-brand-red-primary hover:bg-brand-red-dark disabled:opacity-50 text-white font-black rounded-xl transition-all shadow-md active:scale-95"
-              style={{
-                gap: 'min(6px, 1.5cqmin)',
-                padding: 'min(6px, 1.5cqmin) min(12px, 3cqmin)',
-                fontSize: 'min(11px, 3.5cqmin)',
-              }}
-              title="End the assignment. Responses are preserved."
-            >
-              {ending ? (
-                <Loader2
-                  className="animate-spin"
-                  style={{
-                    width: 'min(14px, 3.5cqmin)',
-                    height: 'min(14px, 3.5cqmin)',
-                  }}
-                />
-              ) : (
-                <Square
-                  style={{
-                    width: 'min(14px, 3.5cqmin)',
-                    height: 'min(14px, 3.5cqmin)',
-                  }}
-                />
-              )}
-              END
-            </button>
-          </div>
-        </div>
-        <p
-          className="text-slate-500 truncate"
-          style={{
-            fontSize: 'min(10px, 3cqmin)',
-            marginTop: 'min(4px, 1cqmin)',
-          }}
-        >
-          {session.activityTitle} · {questions.length} question
-          {questions.length === 1 ? '' : 's'}
-        </p>
-      </div>
+            />
+          </>
+        }
+      />
 
       {/* ─── Body ───────────────────────────────────────────────────────── */}
       <div
@@ -733,7 +518,7 @@ export const VideoActivityLiveMonitor: React.FC<
                   }}
                 />
               }
-              color="blue"
+              tone="blue"
             />
             <StatTile
               label="Active"
@@ -746,7 +531,7 @@ export const VideoActivityLiveMonitor: React.FC<
                   }}
                 />
               }
-              color="amber"
+              tone="amber"
             />
             <StatTile
               label="Finished"
@@ -759,7 +544,7 @@ export const VideoActivityLiveMonitor: React.FC<
                   }}
                 />
               }
-              color="green"
+              tone="green"
             />
           </div>
 
@@ -817,10 +602,7 @@ export const VideoActivityLiveMonitor: React.FC<
                 subtitle="Share the assignment link from the In Progress tab."
               />
             ) : (
-              <div
-                className="flex flex-col"
-                style={{ gap: 'min(6px, 1.5cqmin)' }}
-              >
+              <div className="flex flex-col rounded-2xl bg-white/50 border border-slate-200/60 backdrop-blur-sm overflow-hidden">
                 {sortedResponses.map((r) => {
                   const rowKey = r._responseKey ?? r.studentUid;
                   return (

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -241,7 +241,7 @@ const StudentRow: React.FC<StudentRowProps> = ({
         ) : (
           <XCircle
             key={q.id}
-            className="text-red-500"
+            className="text-brand-red-primary"
             style={{
               width: 'min(14px, 3.5cqmin)',
               height: 'min(14px, 3.5cqmin)',

--- a/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+++ b/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
@@ -486,6 +486,7 @@ export const VideoActivityLiveMonitor: React.FC<
                 icon={isLive ? Pause : Play}
                 onClick={() => void handleTogglePause()}
                 disabled={toggling}
+                loading={toggling}
               />
             )}
             <ActionButton
@@ -494,6 +495,7 @@ export const VideoActivityLiveMonitor: React.FC<
               icon={Square}
               onClick={() => void handleEnd()}
               disabled={ending}
+              loading={ending}
             />
           </>
         }

--- a/components/widgets/WidgetRenderer.tsx
+++ b/components/widgets/WidgetRenderer.tsx
@@ -179,7 +179,11 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
   const SettingsComponent = WIDGET_SETTINGS_COMPONENTS[widget.type];
   const AppearanceComponent = WIDGET_APPEARANCE_COMPONENTS[widget.type];
 
-  const getWidgetSettings = () => {
+  // Memoize the JSX value itself (not a factory): DraggableWindow receives these
+  // as props, so a stable element reference is what lets its React.memo skip
+  // re-renders when neither the component type nor the widget changed. A
+  // useCallback here would be useless because the value is consumed inline.
+  const widgetSettings = useMemo(() => {
     if (SettingsComponent) {
       return (
         <Suspense fallback={<LoadingFallback />}>
@@ -192,9 +196,9 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
         Standard settings available.
       </div>
     );
-  };
+  }, [SettingsComponent, widget]);
 
-  const getWidgetAppearanceSettings = () => {
+  const widgetAppearanceSettings = useMemo(() => {
     if (AppearanceComponent) {
       return (
         <Suspense fallback={<LoadingFallback />}>
@@ -203,7 +207,7 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
       );
     }
     return null;
-  };
+  }, [AppearanceComponent, widget]);
 
   // When spotlighted we switch to position:fixed so the element escapes all
   // parent stacking contexts (will-change:transform / container-type:size on
@@ -211,15 +215,19 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
   // the widget below the backdrop overlay). position:fixed is relative to the
   // viewport, and the dashboard is always full-screen, so widget.x / widget.y
   // map 1:1 to viewport coordinates — the widget stays visually in place.
-  const customStyle: React.CSSProperties = isSpotlighted
-    ? {
-        position: 'fixed',
-        zIndex: Z_INDEX.backdrop + 1,
-        outline: '3px solid #facc15', // yellow-400 ring
-        outlineOffset: '2px',
-        boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
-      }
-    : {};
+  const customStyle: React.CSSProperties = useMemo(
+    () =>
+      isSpotlighted
+        ? {
+            position: 'fixed',
+            zIndex: Z_INDEX.backdrop + 1,
+            outline: '3px solid #facc15', // yellow-400 ring
+            outlineOffset: '2px',
+            boxShadow: '0 0 32px 8px rgba(250,204,21,0.25)',
+          }
+        : {},
+    [isSpotlighted]
+  );
 
   const scaling = WIDGET_SCALING_CONFIG[widget.type];
   const effectiveWidth = widget.maximized ? windowSize.width : widget.w;
@@ -338,8 +346,8 @@ const WidgetRendererComponent: React.FC<WidgetRendererProps> = ({
     <DraggableWindow
       widget={widget}
       title={getTitle(widget, permission)}
-      settings={getWidgetSettings()}
-      appearanceSettings={getWidgetAppearanceSettings()}
+      settings={widgetSettings}
+      appearanceSettings={widgetAppearanceSettings}
       style={customStyle}
       isSpotlighted={isSpotlighted}
       skipCloseConfirmation={

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1967,9 +1967,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       const checkBuildings = customBuildings ?? selectedBuildings;
       if (rawDockDefaults && checkBuildings.length > 0) {
         const dockDefaults = canonicalizeBuildingKeyedRecord(rawDockDefaults);
-        const allExplicitlyOff = checkBuildings.every(
-          (bid) => dockDefaults[bid] === false
-        );
+        // A missing entry (`undefined`) is treated as "no opinion → allow",
+        // NOT as "off" — so a building that the admin hasn't configured for
+        // this widget keeps the public-by-default behavior. Only an entry
+        // that is *present and explicitly* `false` counts as "off"; we deny
+        // solely when every selected building is off by that definition.
+        const allExplicitlyOff = checkBuildings.every((bid) => {
+          const setting = dockDefaults[bid];
+          return setting === false;
+        });
         if (allExplicitlyOff) return false;
       }
 

--- a/docs/monitor-results-redesign-handoff.md
+++ b/docs/monitor-results-redesign-handoff.md
@@ -1,0 +1,74 @@
+# Handoff: Quiz / Video Activity Monitor & Results — _real_ UX redesign
+
+**Read this first. The goal is a genuine experience redesign, not a reskin.**
+
+## Why this handoff exists (what went wrong)
+
+The owner (Paul) asked to "improve the monitor and results views of the quiz/VA widget … up the UI/UX of the rest of these widget experiences by ten fold."
+
+The previous attempt (PR #1971, branch `dev-paul`) delivered a **reskin**, not a redesign:
+
+- It adopted the library's visual language (glassmorphism surfaces, hairline rows, segmented-pill tabs, semantic badges) and unified score colors (80/60).
+- It extracted 8 shared atoms into `components/common/sessionViews/` and added a DEV harness.
+- **But the information architecture / layout of the monitor content is essentially unchanged.** The KPI "rounded squares" grid, the join-code bar, the question hero, and the roster are the same structures with new paint. The only structural changes were: the header (now a shared `SessionViewHeader`), the student list (bordered cards → hairline rows), and on the **Results** side, segmented-pill tabs + a header overflow menu.
+
+Net: a lot of hours and many subagents produced a polished version of the _same_ layout. Paul correctly called this out. **Do not repeat this.**
+
+### Process mistakes to avoid
+
+1. **Don't treat "improve UX 10x" as "make it match the library."** That framing caps you at a reskin. Treat it as: rethink what a teacher actually needs from these surfaces and redesign the layout/IA to serve it.
+2. **Don't pour the budget into invisible plumbing first.** Shared-atom extraction + a harness consumed effort that produced nothing Paul could see. Build user-visible value first; extract shared pieces only as they fall out naturally.
+3. **Don't let the PR review bot drive the agenda.** The prior attempt did ~22 review passes of micro-polish (focus rings, `aria-pressed`, motion-reduce, NaN guards). Triage real issues, batch the noise, and keep the focus on the redesign.
+4. **Lead with concrete visuals.** Paul is design-literate and cares deeply about UI/UX. Put actual mockups / a couple of distinct directions in front of him and get a reaction _before_ building. Don't write a long spec/plan and disappear into implementation.
+
+## The actual goal
+
+Make the **live Monitor** and **post-session Results** for Quiz and Video Activity dramatically better for a **teacher running a live class on a projector** — glanceable from across the room, calm, premium (per the Design Context in `CLAUDE.md`). This is a layout/IA/interaction-design problem, not a CSS problem.
+
+Seeds to consider (brainstorm with Paul; don't treat as final):
+
+- **Monitor = a live control surface.** From 20 feet, a teacher needs: how many kids are done vs. stuck, the join code (large, with a QR), the current question + live answer distribution, and a fast "advance." The current small KPI bubbles + dense text roster bury all of that. Consider a hero join panel (big code + QR), one bold live-progress visualization, a current-question spotlight with live distribution, and the roster as a visual **presence board** (status-colored student tiles) instead of a text list.
+- **Results = "what do I do next."** Who needs help, which questions bombed, fast paths to grade/push/export. Consider leading with the per-question and per-student signal, not a generic tab strip.
+
+These are the four files to transform:
+
+- `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
+- `components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx`
+- `components/widgets/QuizWidget/components/QuizResults.tsx`
+- `components/widgets/VideoActivityWidget/components/Results.tsx`
+
+## Hard constraints (do not break)
+
+- **Preserve all functionality and handlers.** Quiz monitor: pause/resume, end (confirm), advance, reveal/hide answer, live scoreboard (name/PIN + completion/per-question), period filter, unlock student, unlock results, remove student (confirm), score-display cycle, colors toggle, tab-warning toggle, audio mute, MC distribution, podium, self-paced vs teacher-paced. VA monitor: pause/resume, end, unlock, tab-warning toggle, per-question correctness strip. Results (both): export to Sheets, push grades to Classroom/Schoology, period filter, delete/unlock (quiz), grade written responses (quiz), schema-mismatch recovery (quiz), PLC tab (quiz).
+- **Design system:** Lexend (UI) / Patrick Hand (accent) / Roboto Mono (data); brand blue `#2d3f89`, brand red `#ad2122`; dark-mode primary (slate-900); glassmorphism is the house style. See `CLAUDE.md` → "UI Styling" and "Design Context."
+- **Container-query scaling is mandatory** on widget front-face content: `style={{ fontSize: 'min(Npx, Mcqmin)' }}`, never hardcoded Tailwind size classes (`text-sm`, `w-12`, `size={24}`). Widgets scale via container queries because they're resizable and projected. See `CLAUDE.md` → "Content Scaling with Container Queries."
+- **Product decisions already made by Paul (keep):** unified 80/60 score-color scale for both widgets (`utils/scoreColor.ts`); "Push Grades" intentionally pushes **all periods** regardless of the in-view period filter.
+- **Don't change** scoring math, grade-push payloads, Firestore reads/writes, or auth — these views are presentation over prop-driven data (`session`, `responses`, `quizData`/`config`, callbacks).
+
+## What already exists you can build on (optional — don't let it cap the design)
+
+- **Shared atoms:** `components/common/sessionViews/` — `SessionViewHeader`, `SegmentedTabs` (has `panelIdPrefix` ARIA linkage), `StatTile`, `SessionBadge`, `ScorePill`, `SessionRow`, `OverflowMenu` (portaled, full keyboard pattern), `ActionButton` (variants + `loading` + `active`). Reuse where they fit; invent new layout where they don't. The atoms are good infrastructure but they encode the _current_ layout — don't let "reuse the atoms" steer you back into the same arrangement.
+- **Score util:** `utils/scoreColor.ts` (`scoreTone`, `scoreColorClasses`; 80/60).
+- **DEV visual harness:** `components/dev/SessionViewsDevHarness.tsx` at route `/session-views-dev` (DEV-gated, needs `VITE_AUTH_BYPASS=true`), with mock sessions/responses in `components/dev/sessionViewsMocks.ts`. This is how you iterate visually across the 340/520/820px breakpoints and the waiting/live/paused/ended/results states.
+- **Reference for the look:** `components/common/library/` (the modernized library this was meant to match).
+
+## Environment / verification notes
+
+- **The app cannot boot in this environment — there is no `.env.local`** (Firebase init throws; `db` is undefined). You cannot screenshot the real app or the harness here. Verify with `pnpm run type-check`, the vitest suites, and **have Paul do the visual sweep** via `/session-views-dev`. Don't waste time trying `preview_*`/Playwright against a dead server.
+- **Repo enforces** zero TS errors, zero ESLint warnings (`--max-warnings 0`), Prettier formatting. Pre-commit hook (lint-staged) auto-formats staged files.
+- **Windows working tree is CRLF**, so repo-wide `pnpm run lint`/`format:check` is noisy on untouched files. Judge by **scoped** `pnpm exec eslint <files>` / `prettier --check <files>` on what you changed; CI runs on Linux (LF) and is the real gate.
+- pnpm; Node 24+; path alias `@/` → repo root (no `src/`).
+
+## Current state
+
+- PR **#1971** (branch `dev-paul`) contains the reskin and is review-approved. Decide with Paul whether the real redesign builds **on top of** #1971 (keeping the atoms + unified colors as a foundation) or supersedes parts of it.
+- Two follow-up task chips exist (out of scope for the redesign itself): VA Results/Monitor parity/hardening (export-URL persistence, perf memoization, test coverage, ended→"Paused" badge); and SegmentedTabs/LibraryShell/QuizMonitor a11y (roving-tabindex tablist nav, LibraryShell `panelIdPrefix`, icon-button `aria-label`s).
+
+## Suggested first move
+
+1. Read the four target files and `CLAUDE.md`'s Design Context to absorb the constraints and the current layout.
+2. Sketch 2–3 genuinely different layout/IA directions for the **monitor** (the area Paul flagged), as concrete mockups (inline visual mockups or a quick static prototype). Show Paul; get a direction.
+3. Build the chosen direction in the real components, preserving every handler, verifying via type-check + tests, and handing Paul the harness for the visual pass.
+4. Apply the same depth to Results.
+
+The bar: when Paul opens the redesigned monitor on a projector, it should feel like a different, obviously-better product — not the same layout with new colors.

--- a/docs/optimize-pass/01-accessibility-contrast.md
+++ b/docs/optimize-pass/01-accessibility-contrast.md
@@ -1,0 +1,79 @@
+# F1 — WCAG AA contrast sweep for muted text on dark surfaces
+
+**Dimension:** ux-a11y · **Impact:** 7 · **Effort:** medium · **Risk:** medium ·
+**Behavior change:** yes (visual) — **needs design sign-off from Paul before merge.**
+
+## Problem
+
+Muted slate text (`text-slate-300` / `text-slate-400` / `text-slate-500`) is used
+for real, user-facing label/metadata text on the dark dashboard surface
+(`slate-900`, `#0f172a`). On that background `text-slate-400` (`#94a3b8`) lands at
+~2.8:1 — below the WCAG AA minimum of 4.5:1 for normal text. This fails the
+project's own "Accessibility Baseline" and "Glanceable at distance" principles
+(text must be legible on a washed-out classroom projector), and it's systemic
+rather than a one-off.
+
+This is the merged form of three explore findings (the original
+ScaledEmptyState-specific and GuidedLearningResults-specific findings are
+subsumed here).
+
+## Current-state evidence
+
+- `components/common/ScaledEmptyState.tsx:33-35` — default `titleClassName` /
+  `subtitleClassName` / `iconClassName` use `text-slate-500` / `text-slate-400` /
+  `text-slate-300`. This is the **fallback UI for 60+ widgets**, so it's the
+  highest-reach instance.
+- `components/widgets/GuidedLearning/components/GuidedLearningResults.tsx:201,232,240,248,255`
+  — `text-slate-300/400` for "Total / Done / Avg Score" stat labels teachers read
+  at a glance.
+- `components/widgets/GuidedLearning/components/GuidedLearningManager.tsx:773,1013,1103,1166,1221,1341,1350`
+  — same pattern across the manager UI.
+- Broader: ~1300 `text-slate-300/400` occurrences exist repo-wide, but **many are
+  legitimate** (decorative icons, or text on _light_ admin/student surfaces). This
+  task is not a blind find-replace.
+
+## Proposed approach
+
+1. **Triage, don't bulk-replace.** Categorize each muted-text usage on a
+   **dark** surface into: (a) decorative/icon (add `aria-hidden`, leave color),
+   (b) real text on dark bg (upgrade contrast), (c) text on light bg (leave).
+2. **Start with the highest-reach, lowest-risk node:** `ScaledEmptyState`
+   defaults. Bump `text-slate-500` → `text-slate-200`, `text-slate-400` →
+   `text-slate-300`, verify ≥4.5:1 on `slate-900`. This alone fixes the empty
+   state across 60+ widgets.
+3. Then the GuidedLearning results/manager labels.
+4. Consider introducing semantic tokens (e.g. a `text-muted-on-dark` utility, or
+   a documented pair in `config/` / tailwind theme) so future code has a
+   contrast-correct default instead of reaching for raw `slate-400`. This avoids
+   re-introducing the problem.
+
+## Risks
+
+- Over-correcting text on **light** surfaces would make _those_ too low-contrast.
+  Verify each change against its actual rendered background, not globally.
+- `ScaledEmptyState` is rendered over user-chosen backgrounds in some widgets;
+  confirm the readability surface behind it still gives AA contrast.
+- Purely visual change — get Paul's design nod (brand wants "calm, restrained";
+  don't over-darken into heavy blocks).
+
+## Acceptance criteria
+
+- All _text_ (not decorative icons) on the dark dashboard surface meets ≥4.5:1
+  (normal) / ≥3:1 (large, ≥18pt or 14pt bold).
+- `ScaledEmptyState` defaults verified at AA on `slate-900`.
+- No regression on light/student/login surfaces.
+- Icon-only muted glyphs that are decorative carry `aria-hidden`.
+- A short note in CLAUDE.md (Widget Appearance Standard) on the contrast-safe
+  muted-text token, if one is introduced.
+
+## Kickoff prompt
+
+> Implement F1 from `docs/optimize-pass/01-accessibility-contrast.md`: fix
+> sub-AA muted slate text on the dark dashboard surface, starting with
+> `ScaledEmptyState` defaults (highest reach) then GuidedLearningResults/Manager
+> labels. Triage each usage by its actual background — do NOT blind-replace
+> `text-slate-400` globally, since many instances are decorative icons or sit on
+> light surfaces. Verify ≥4.5:1 on `slate-900`. This is a visual change; keep it
+> restrained per the brand's "calm/restrained" direction and surface before/after
+> swatches for review. Add a contrast-safe muted-text token if it prevents
+> regressions, and document it in CLAUDE.md.

--- a/docs/optimize-pass/02-firestore-cost.md
+++ b/docs/optimize-pass/02-firestore-cost.md
@@ -1,0 +1,125 @@
+# Firestore read/listener cost — F2, F10, F21
+
+**Dimension:** data · Firestore is a school-district cost line, so every avoidable
+read/write/listener counts.
+
+These three items all reduce Firestore cost but are independent; do them
+separately. **F2 is blocked on a data migration — read its section carefully.**
+
+---
+
+## F2 — Dual-query listener consolidation (BLOCKED — do not implement yet)
+
+**Impact:** 7 · **Effort:** medium · **Risk:** medium · **Behavior change:** no
+(if done correctly) — but **collapsing the queries now is a correctness
+regression.**
+
+### Problem
+
+`useStudentAssignments` runs **two** Firestore subscriptions per
+quiz/video-activity/guided-learning channel: a list-shape query
+(`classIds array-contains-any`) and a single-shape query (`classId in`). For a
+multi-class student this doubles active listeners and reads.
+
+### Why it's blocked
+
+The dual query guards a **genuine, incomplete data-migration straddle**, not a
+redundancy. Session documents can still carry only the legacy single `classId`
+field with no `classIds` array, and the list-shape query would never match those
+— silently dropping assignments from the student's `/my-assignments` list.
+
+Evidence:
+
+- `hooks/useStudentAssignments.ts:38-40` — header: _"Dual-query (classIds array +
+  legacy classId field) is preserved …"_
+- `hooks/useStudentAssignments.ts:442-461` — `docToSummary` _"Falls back to the
+  legacy single-class field when classIds is absent"_ → such docs are expected to
+  exist.
+- `hooks/useStudentAssignments.ts:511-512` — the two query shapes; a `classId`-only
+  doc matches only the single shape.
+- `hooks/useVideoActivitySession.ts:222-225`, `hooks/useGuidedLearningSession.ts:222-225`
+  — _"Phase 5A … classId is transitionally mirrored … so pre-Phase-5A rules keep
+  working"_ (transitional, not complete).
+- `utils/resolveAssignmentTargets.ts:11-12` — _"Legacy in-flight assignments are
+  NOT migrated; they continue reading via their existing classIds/periodNames
+  fields until they expire."_ No backfill exists.
+
+### Unblock path → then implement
+
+1. Run a backfill that writes `classIds` onto every session doc that currently
+   carries only `classId` (and stop the legacy `classId`-only write paths).
+2. Confirm via the existing `source` discriminator
+   (`utils/resolveAssignmentTargets.ts:56-58`) that the legacy `classId`-only /
+   `periodNames` read paths are no longer hit in telemetry.
+3. _Then_ collapse to the single list-shape query, dedupe listeners, keep result
+   merging + the per-status plan expansion intact, and add a vitest test asserting
+   only the list-shape plan is created when `classIds` is non-empty.
+
+### Acceptance criteria
+
+- No assignment that was previously visible disappears for any student
+  (legacy-doc regression test).
+- Listener/read count per dual-query kind halves for multi-class students.
+
+---
+
+## F10 — Cache PLC metadata instead of per-call `getDoc`
+
+**Impact:** 5 · **Effort:** medium · **Risk:** medium · **Behavior change:** no.
+
+### Problem
+
+PLC-synced quiz assignment creation fires sequential one-off `getDoc`s
+(synced-group check, shared-sheet URL), adding read roundtrips on a hot path.
+
+### Evidence
+
+- `hooks/useQuizAssignments.ts:~650-700` — `createAssignment` writes the
+  assignment+session batch, then calls `createSyncedQuizGroup` /
+  `pullSyncedQuizContent`.
+- `hooks/usePlcs.ts:443-450` — `getPlcSharedSheetUrl` issues a full `getDoc` every
+  call, no caching.
+- `hooks/usePlcAssignments.ts` — `writePlcAssignmentTemplate` may `getDoc` the
+  canonical PLC.
+
+### Approach
+
+Hydrate frequently-accessed PLC metadata (`sharedSheetUrl`, features, synced-group
+id) into `usePlcs` state once and read from there, instead of lazy per-call
+`getDoc`. Batch reads that target the same doc.
+
+### Acceptance criteria
+
+- Assignment-creation path issues no redundant `getDoc` for data already in
+  `usePlcs` state. Add a test asserting the cached path avoids the extra read.
+
+---
+
+## F21 — `usePlcs` admin `orderBy('name')` index comment is misleading
+
+**Impact:** 3 · **Effort:** trivial · **Risk:** low · **Behavior change:** no.
+
+### Problem
+
+The admin-mode subscription orders the whole `/plcs` collection by `name` with
+`limit(500)`, but the comment claims a single-field `orderBy` _"needs only the
+automatic index"_, which is not accurate for `orderBy` on a non-`__name__` field
+and can cause latency/index surprises in prod.
+
+### Evidence
+
+- `hooks/usePlcs.ts:27` — `ADMIN_PLCS_LIMIT = 500`
+- `hooks/usePlcs.ts:209-210` — the misleading comment
+- `hooks/usePlcs.ts:214-215` — `query(collection(...), orderBy('name'), limit(500))`
+
+### Approach (pick one)
+
+- (a) Confirm/add the single-field index in `firestore.indexes.json` and correct
+  the comment to match reality; **or**
+- (b) Drop the `orderBy` and sort client-side in the snapshot handler (relies only
+  on the automatic `__name__` index) — preferred for flexibility at this scale.
+
+### Acceptance criteria
+
+- Comment matches the actual index requirement, or the query no longer needs a
+  custom index. No behavior change to the admin list ordering as seen by the user.

--- a/docs/optimize-pass/03-firestore-rules.md
+++ b/docs/optimize-pass/03-firestore-rules.md
@@ -1,0 +1,83 @@
+# Firestore security-rules hardening — F6, F24
+
+**Dimension:** correctness · Both touch `firestore.rules`; do them together and run
+`pnpm run test:rules` (Firestore emulator + `tests/rules/`). They are file-disjoint
+from the F15 email-case fix already shipped in wave 1.
+
+---
+
+## F6 — Building-admin rule compares building IDs without canonicalization
+
+**Impact:** 5 · **Effort:** medium · **Risk:** medium · **Behavior change:** yes
+(it changes which building-admin edits are accepted).
+
+### Problem
+
+The building-admin update rule checks `buildingId in
+orgMember(orgId).buildingIds` using a raw `in` without canonicalizing IDs. When a
+member doc stores canonical IDs (e.g. `high`) but a legacy building doc uses the
+old format (e.g. `orono-high-school`) — or vice versa — the `in` silently fails
+and the rule **falsely denies** an edit the admin should be allowed to make.
+
+### Evidence
+
+- `firestore.rules:211` — `buildingId in orgMember(orgId).buildingIds`
+- `firestore.rules:196-202` — building create rule validates `orgId`/`id` match
+- `config/buildings.ts:88-125` — documents the legacy↔canonical ID mapping and that
+  canonicalization must happen on **all** paths. The client uses
+  `canonicalizeBuildingIds()` / `canonicalizeBuildingKeyedRecord()`, but CEL can't
+  reuse those JS functions.
+
+### Approach
+
+Mirror the alias resolution in `firestore.rules`: add a rules helper that maps a
+building id through the known legacy→canonical aliases before the membership
+check, and apply it to **both** `buildingId` and the values in
+`orgMember(orgId).buildingIds`. Keep the alias table in sync with
+`config/buildings.ts` (add a comment cross-referencing it so they don't drift).
+
+### Risks
+
+- The CEL alias map must exactly match `config/buildings.ts`; a mismatch
+  re-introduces false denials or (worse) false grants. Cover both ID formats in
+  tests.
+
+### Acceptance criteria
+
+- A building-admin whose membership is stored in either ID format can edit the
+  matching building regardless of the building doc's ID format.
+- No admin gains edit rights to a building they don't belong to.
+- `tests/rules/` cases for: canonical-member↔legacy-building, legacy-member↔
+  canonical-building, and a negative (non-member denied).
+
+---
+
+## F24 — PLC invitation email lacks a length bound
+
+**Impact:** 2 · **Effort:** trivial · **Risk:** low · **Behavior change:** no
+(rejects only pathological oversized writes).
+
+### Problem
+
+The `plc_invitations` create/update rules store the invitee email with no size
+validation, unlike other collections that bound string fields. A pathologically
+long email could bloat the doc; more importantly it's an inconsistency with the
+codebase's own validation norms.
+
+### Evidence
+
+- `firestore.rules:2098-2101` — `plc_invitations` create rule, no email length bound
+- `firestore.rules:752-776` — `rollout_requests` enforces size bounds on
+  name/role/organization (the pattern to follow)
+- `firestore.rules:809` — `admin_backgrounds` validates `email.lower()` w/o length
+
+### Approach
+
+Add `request.resource.data.inviteeEmailLower.size() <= 255` (or a tighter 100) to
+the `plc_invitations` create and update rules, matching the surrounding validation
+style.
+
+### Acceptance criteria
+
+- A normal-length invite still succeeds; an over-limit email is rejected. Add a
+  `tests/rules/` case for both.

--- a/docs/optimize-pass/04-quiz-history-correctness.md
+++ b/docs/optimize-pass/04-quiz-history-correctness.md
@@ -1,0 +1,69 @@
+# F7 — Quiz response-history deletion can clobber a PIN-mate's history
+
+**Dimension:** correctness · **Impact:** 5 · **Effort:** medium · **Risk:** medium
+· **Behavior change:** no (it narrows a destructive delete to the right owner).
+
+## Problem
+
+PIN joiners get a **deterministic** response-doc key `pin-{period}-{pin}`. Two
+students who share the same normalized `(period, PIN)` pair map to the **same**
+response doc and the same `/history` subcollection. When one is removed via
+`removeStudent()`, the code deletes the entire `/history` subcollection under that
+key — which can delete history entries that logically belong to the _other_
+student sharing the key, corrupting their draft/recovery history.
+
+The shared-secret design means collisions can't be fully prevented at the rules
+layer (acknowledged in `firestore.rules`), but the **deletion blast radius** can
+be bounded.
+
+## Current-state evidence
+
+- `hooks/useQuizSession.ts:888-907` — `deleteHistory` loops and deletes the whole
+  `/history` subcollection for the response key (chunked at 450).
+- `hooks/useQuizSession.ts:472-481` — `computeResponseKey`; comment notes the
+  collision is _"expected to be rare."_
+- `firestore.rules:2254-2257` — _"Classmate-on-classmate grief with both parties on
+  the same PIN+period is not fully preventable here (shared-secret design)."_
+- `types.ts:3256` — documents the deterministic PIN-joiner key encoding.
+
+## Proposed approach
+
+Bound the history deletion to the **removed student's own session window** instead
+of nuking the whole subcollection:
+
+1. Record the student's session start (`joinedAt`) on the response doc (if not
+   already present) and the removal time.
+2. In `deleteHistory`, delete only history docs whose `snapshotAt` / `answeredAt`
+   fall within `[joinedAt, removalTime]` for that student, leaving entries created
+   under a different student's occupancy of the same key intact.
+
+Alternative (larger, behavior-changing): migrate PIN keys to be unique per student
+(append a hash of the initial `sessionId`) so collisions can't share a doc at all —
+defer this unless product wants it; it's a bigger change with its own migration.
+
+## Risks
+
+- Timestamp-window filtering must be robust to clock skew and to history entries
+  written exactly at the boundary; prefer an explicit owner/session marker on each
+  history doc over pure time-window heuristics if one already exists or is cheap to
+  add.
+- Don't leak the _other_ student's history into the removed student's view either;
+  verify reads are already scoped.
+
+## Acceptance criteria
+
+- Removing student A under a shared `(period, PIN)` key deletes only A's history
+  entries; B's remain.
+- Single-occupant (non-colliding) keys behave exactly as before.
+- A vitest test simulating two sequential occupants of the same key asserts the
+  second removal preserves the first occupant's in-window history.
+
+## Kickoff prompt
+
+> Implement F7 from `docs/optimize-pass/04-quiz-history-correctness.md`: in
+> `hooks/useQuizSession.ts`, bound `deleteHistory` (≈888-907) to the removed
+> student's own session window so a PIN-collision doesn't delete a classmate's
+> response history. Prefer an explicit owner/session marker on history docs if
+> cheap; otherwise scope by `[joinedAt, removalTime]`. Add a vitest test with two
+> sequential occupants of one `pin-{period}-{pin}` key proving the second removal
+> preserves the first's history. Preserve single-occupant behavior exactly.

--- a/docs/optimize-pass/05-build-infra-monorepo.md
+++ b/docs/optimize-pass/05-build-infra-monorepo.md
@@ -1,0 +1,136 @@
+# Build / CI / monorepo tech-debt — F8, F11, F12, F18, F23
+
+**Dimension:** build-quality. These are independent; sequence by ROI. F11 (CI cost)
+and F18 (monorepo sharing) are the best value; F8/F12/F23 are large refactors to
+schedule deliberately.
+
+---
+
+## F11 — Type-aware ESLint needs a 6GB heap in CI
+
+**Impact:** 4 · **Effort:** medium · **Risk:** medium · **Behavior change:** no.
+
+### Problem
+
+Every CI job must cap Node heap at `--max-old-space-size=6144` to avoid OOM during
+lint, because `eslint.config.js` runs type-aware rules across **both** tsconfigs
+(root + functions) as one monolithic pass. This is slow and costly CI.
+
+### Evidence
+
+- `.github/workflows/pr-validation.yml:37`,
+  `.github/workflows/firebase-deploy.yml:40`,
+  `.github/workflows/firebase-dev-deploy.yml:25` — all set
+  `NODE_OPTIONS=--max-old-space-size=6144`.
+- `eslint.config.js:46` — loads both tsconfigs with type-aware rules enabled.
+
+### Approach
+
+Split linting so root and `functions/` use separate ESLint type-aware passes
+(separate `projectService`/`parserOptions.project` scopes), or lint `functions/`
+with its own config/command. Measure peak heap after; aim to drop the 6GB override.
+Do **not** disable type-aware rules to "fix" memory.
+
+### Acceptance criteria
+
+- `pnpm run lint` passes without the 6GB `NODE_OPTIONS` override (or a clearly
+  lower cap), with identical rule coverage. CI workflows updated.
+
+---
+
+## F18 — `functions/` can't share root types; duplicated definitions
+
+**Impact:** 3 · **Effort:** small · **Risk:** medium · **Behavior change:** no.
+
+### Problem
+
+Root `tsconfig.json` defines `@/*` → root, but `functions/tsconfig.json` has no
+equivalent, so functions can't import shared types/utils and re-declare them. E.g.
+`ClassLinkUser` is duplicated in functions instead of imported from root
+`types.ts`, risking drift.
+
+### Evidence
+
+- `tsconfig.json:21-22` — `@/*` alias for root
+- `functions/tsconfig.json` — no path alias; `rootDir` hardcoded to `src`
+- `functions/src/index.ts:76-81` — duplicates `ClassLinkUser` (exists in root `types.ts`)
+
+### Approach
+
+Add a path alias in `functions/tsconfig.json` mapping to the shared root types,
+then import the shared definition and delete the duplicate. Verify the functions
+build (`tsc`) still emits correctly with the alias (may need `tsc-alias` or a
+relative import if the emit doesn't rewrite paths — confirm before committing).
+
+### Acceptance criteria
+
+- `ClassLinkUser` (and any other duplicated shared type found) is defined once and
+  imported by functions. `pnpm run build:all` green.
+
+---
+
+## F8 — Re-enable `noUnusedLocals` / `noUnusedParameters` (large)
+
+**Impact:** 5 · **Effort:** large · **Risk:** medium · **Behavior change:** no.
+
+### Problem
+
+`tsconfig.json:38-39` disables both checks despite strict mode, letting dead
+locals/params/exports accumulate silently across the tree.
+
+### Approach
+
+Flip both to `true`, then do a dead-code sweep to clear the resulting errors
+(prefix intentionally-unused params with `_`, delete genuinely dead code). This is
+large and noisy — schedule as its own PR, ideally split per directory to keep
+review tractable. No suppressions.
+
+### Acceptance criteria
+
+- Both flags `true`; `pnpm run type-check:all` green with no new suppressions.
+
+---
+
+## F12 — Split monolithic `functions/src/index.ts` (large)
+
+**Impact:** 4 · **Effort:** large · **Risk:** medium · **Behavior change:** no.
+
+### Problem
+
+`functions/src/index.ts` is ~4336 lines exporting 42 functions/interfaces (Google
+OAuth, Spotify OAuth, LTI, analytics, …), hurting review/test/circular-import risk.
+
+### Approach
+
+Extract each logical group into its own leaf module (`googleOAuth.ts`,
+`spotifyOAuth.ts`, `lti.ts`, …) and reduce `index.ts` to a thin barrel of
+re-exports. Keep deployed function names/exports byte-identical so Firebase deploy
+targets don't change. Verify `pnpm -C functions run build` and that the exported
+function set is unchanged.
+
+### Acceptance criteria
+
+- Same set of exported Cloud Functions (names unchanged); `index.ts` is a barrel;
+  functions build green; tests still pass.
+
+---
+
+## F23 — Group the 144 flat `utils/` files (large, low priority)
+
+**Impact:** 2 · **Effort:** medium · **Risk:** low · **Behavior change:** no.
+
+### Problem
+
+`utils/` has ~144 flat files with no namespacing, hurting discovery and inviting
+duplicate helpers.
+
+### Approach
+
+Group by domain (`utils/date/`, `utils/format/`, `utils/firestore/`, …) with
+per-folder barrels, update imports (`@/utils/...`). Purely mechanical but
+wide-reaching; coordinate to avoid colliding with other in-flight branches. Lowest
+priority of this batch.
+
+### Acceptance criteria
+
+- Files grouped, imports updated, `pnpm run validate` green. No behavior change.

--- a/docs/optimize-pass/06-perf-render.md
+++ b/docs/optimize-pass/06-perf-render.md
@@ -1,0 +1,87 @@
+# Render-path performance — F9, F22
+
+**Dimension:** perf. F22 is a quick, safe win; F9 is a large, higher-risk
+architectural change to schedule deliberately. They touch different files.
+
+---
+
+## F22 — Memoize selected-group computation in `BoardCanvas`
+
+**Impact:** 2 · **Effort:** small · **Risk:** low · **Behavior change:** no.
+
+### Problem
+
+`BoardCanvas` recomputes `selectedGroupId` / `groupMembers` via
+`dashboard.widgets.find()` + `.filter()` on **every** render even when
+`selectedWidgetId` and `dashboard.widgets` are unchanged. Cheap at small widget
+counts, but scales poorly toward the ~100-widget ceiling.
+
+### Evidence
+
+- `components/layout/BoardCanvas.tsx:55-77` — the per-render `find`/`filter`.
+
+### Approach
+
+Wrap the `selectedGroupId` and `groupMembers` derivations in `useMemo` keyed on
+`[dashboard.widgets, selectedWidgetId]`. (Derived-during-render is fine per house
+rules; `useMemo` here is the "expensive derived value" case, not a `useEffect`.)
+
+### Acceptance criteria
+
+- Identical selection/group behavior; the derivation no longer recomputes when its
+  inputs are unchanged. Add/extend a test if a `BoardCanvas` harness exists nearby.
+
+---
+
+## F9 — Reduce `DashboardContext` consumer churn (large)
+
+**Impact:** 5 · **Effort:** large · **Risk:** high · **Behavior change:** no.
+
+### Problem
+
+The `DashboardContext` value object exposes ~100 properties, so **any** field
+change (e.g. a `loading` flip) re-renders every consumer of the full context. The
+hot canvas slice is already split out into `DashboardCanvasStoreContext` /
+`DashboardActionsContext`, but legacy sidebar/config consumers still read the full
+value and churn.
+
+### Evidence
+
+- `context/DashboardContext.tsx:5484-5746` — the ~100-property value object.
+- `context/dashboardCanvasStore.ts:1-50` — the existing canvas-slice store
+  (the pattern to extend).
+
+### Approach (measure first)
+
+1. **Measure before touching anything** — use the existing perf harness
+   (`tests/perf/`, React Profiler commit counts are the deterministic metric) to
+   capture a baseline of which consumers re-render on representative actions.
+   Per the repo's `perf-ux-pass` discipline, do not claim improvement without
+   before/after numbers from the same harness.
+2. Identify which components genuinely need the full legacy context vs. a narrow
+   slice. Extract stable sub-contexts (e.g. a sidebar/tool-visibility slice:
+   `visibleTools`, `dockItems`, `gradeFilter`) the same way the canvas store was
+   carved out.
+3. Re-measure; the diff must not increase Firestore/Storage/AI cost.
+
+### Risks
+
+- High blast radius — many consumers. Easy to introduce stale-render or
+  missed-update bugs. Stage it; keep each extraction behavior-identical and
+  individually reviewable.
+
+### Acceptance criteria
+
+- Measured reduction in consumer re-renders on a representative action (Profiler
+  commit-count delta from the same harness, before vs after).
+- No behavior change; `pnpm run validate` green; no added backend cost.
+
+### Kickoff prompt
+
+> Tackle F9 from `docs/optimize-pass/06-perf-render.md` using the `perf-ux-pass`
+> discipline: first commit a React-Profiler baseline of `DashboardContext`
+> consumer re-renders on representative actions, then extract a stable sidebar/
+> tool-visibility slice out of the ~100-prop context value
+> (`context/DashboardContext.tsx:5484-5746`) following the existing
+> `dashboardCanvasStore` pattern. Re-measure and prove a commit-count reduction
+> with no behavior change and no added Firestore/Storage/AI cost.

--- a/docs/optimize-pass/README.md
+++ b/docs/optimize-pass/README.md
@@ -1,0 +1,51 @@
+# Optimize-pass — deferred work backlog
+
+This folder holds **handoff docs** for optimization findings surfaced by an
+`optimize-pass` explore sweep (read-only fan-out across UX/a11y, performance,
+data-layer, correctness, and build-quality dimensions). Each doc is a
+self-contained kickoff for a later agent or contributor: it states the problem,
+cites current-state `file:line` evidence, proposes an approach, lists risks, and
+gives acceptance criteria plus a copyable kickoff prompt.
+
+## Already shipped (wave 1)
+
+Committed on `claude/codebase-improvement-areas-on8n5r` (see the
+`perf(data,widgets): … optimize-pass wave 1` commit):
+
+| ID  | Area        | Summary                                                                          |
+| --- | ----------- | -------------------------------------------------------------------------------- |
+| F3  | data        | Paginate quiz/VA/GL `deleteAssignment` response reads via `readAllDocsPaged`     |
+| F4  | data        | Paginate `useCollections` delete-all board reads; widen paging helper to `Query` |
+| F14 | data        | Replace unbounded `getDocs` in `useReconcileExpiredSubShares` with paged read    |
+| F13 | perf        | Memoize `WidgetRenderer` callbacks/`customStyle` so `DraggableWindow` memo holds |
+| F16 | ux-a11y     | `First5` external-link icon: `aria-label`, contrast, projector-size              |
+| F20 | ux-a11y     | `ClockWidget` seconds `0.7em` → `0.85em`                                         |
+| F15 | correctness | Enforce lowercase org member emails in `firestore.rules`                         |
+| F17 | build       | Align `functions/` devDeps (typescript 5.9.3, vitest 4.1.8) with root            |
+| F19 | build       | Add conservative vitest coverage thresholds (regression floor)                   |
+
+## Resolved without code change
+
+- **F5 — per-building dock-defaults "bypass": false positive (won't-fix).** The
+  reported "bypass" is the documented, tested, public-by-default contract: a
+  building missing from `dockDefaults` means "no opinion → allow", and only an
+  entry that is _present and explicitly_ `false` disables the widget. See
+  `context/AuthContext.tsx:1950-1979` and the contract tests in
+  `tests/context/AuthContext.canAccessWidgetDockDefaults.test.tsx`. Inverting this
+  to deny-by-default for unconfigured buildings would be a deliberate **product**
+  decision (it changes which widgets ~all users see), not a correctness fix —
+  do not re-file it as a bug.
+
+## Deferred batches (this folder)
+
+| Doc                              | IDs                    | Theme                                  |
+| -------------------------------- | ---------------------- | -------------------------------------- |
+| `01-accessibility-contrast.md`   | F1                     | WCAG AA contrast sweep (design review) |
+| `02-firestore-cost.md`           | F2, F10, F21           | Firestore read/listener cost           |
+| `03-firestore-rules.md`          | F6, F24                | Security-rules hardening               |
+| `04-quiz-history-correctness.md` | F7                     | Quiz PIN-collision history deletion    |
+| `05-build-infra-monorepo.md`     | F8, F11, F12, F18, F23 | Build/CI/monorepo tech-debt            |
+| `06-perf-render.md`              | F9, F22                | Render-path performance                |
+
+Each batch is independent and file-disjoint from wave 1, so they can be picked up
+in any order. Where items within a batch touch the same files, do them together.

--- a/docs/superpowers/plans/2026-06-14-quiz-va-monitor-results-redesign.md
+++ b/docs/superpowers/plans/2026-06-14-quiz-va-monitor-results-redesign.md
@@ -1,0 +1,2348 @@
+# Quiz / Video Activity — Monitor & Results Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the teacher-facing Monitor and Results views of the Quiz and Video Activity widgets up to the polish of the modernized Library view, via shared atoms + per-view restyle.
+
+**Architecture:** Build a small set of container-query-scaled shared atoms in `components/common/sessionViews/` (mirroring the library's design language), a unified `utils/scoreColor.ts` helper, and a DEV-only `/session-views-dev` harness. Then restyle the four views to consume them. No data/Firestore/scoring/grade-push logic changes — visual + header IA only, plus VA's score _color_ banding moving to the unified 80/60 scale.
+
+**Tech Stack:** React 19, TypeScript (strict), Tailwind CSS (brand tokens + container queries), Vitest + @testing-library/react, lucide-react icons. Package manager `pnpm`. Path alias `@/` → repo root (no `src/`).
+
+**Spec:** `docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md`
+
+**Conventions:**
+
+- All scaled UI uses `style={{ ... 'min(px, Ncqmin)' }}` — never hardcoded Tailwind size classes (`text-sm`, `w-12`, `size={24}`) in scaled content.
+- Run a single test file with: `pnpm exec vitest run <path>`
+- Type-check with: `pnpm run type-check`
+- Full gate before any push: `pnpm run validate`
+- Commit messages end with the required trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Work happens on branch `dev-paul` (already checked out).
+
+---
+
+## File Structure
+
+**New — shared atoms (`components/common/sessionViews/`):**
+
+- `SessionBadge.tsx` — tone-based status/info badge (`SessionTone` union).
+- `ScorePill.tsx` — score chip using the unified helper.
+- `StatTile.tsx` — KPI / overview stat tile on a glass surface.
+- `SegmentedTabs.tsx` — pill tab control (extracted from `LibraryShell`).
+- `SessionRow.tsx` — hairline list-row shell.
+- `OverflowMenu.tsx` — kebab overflow menu.
+- `ActionButton.tsx` — primary/secondary/danger button.
+- `SessionViewHeader.tsx` — shared view header (back · status pulse · title/subtitle · actions slot).
+- `index.ts` — barrel export.
+
+**New — util & harness:**
+
+- `utils/scoreColor.ts` — unified 80/60 score-color helper.
+- `components/dev/SessionViewsDevHarness.tsx` — DEV-only visual harness.
+
+**New — tests:**
+
+- `tests/utils/scoreColor.test.ts`
+- `tests/components/common/sessionViews/SessionBadge.test.tsx`
+- `tests/components/common/sessionViews/ScorePill.test.tsx`
+- `tests/components/common/sessionViews/StatTile.test.tsx`
+- `tests/components/common/sessionViews/SegmentedTabs.test.tsx`
+- `tests/components/common/sessionViews/SessionRow.test.tsx`
+- `tests/components/common/sessionViews/OverflowMenu.test.tsx`
+- `tests/components/common/sessionViews/ActionButton.test.tsx`
+- `tests/components/common/sessionViews/SessionViewHeader.test.tsx`
+
+**Modified:**
+
+- `components/common/library/LibraryShell.tsx` — consume `SegmentedTabs`.
+- `App.tsx` — register `/session-views-dev`.
+- `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
+- `components/widgets/QuizWidget/components/QuizResults.tsx`
+- `components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx`
+- `components/widgets/VideoActivityWidget/components/Results.tsx`
+
+---
+
+## Task 1: `scoreColor` util (TDD)
+
+**Files:**
+
+- Create: `utils/scoreColor.ts`
+- Test: `tests/utils/scoreColor.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/utils/scoreColor.test.ts
+import { describe, it, expect } from 'vitest';
+import { scoreTone, scoreColorClasses } from '@/utils/scoreColor';
+
+describe('scoreTone (unified 80/60 scale)', () => {
+  it('maps the threshold boundaries', () => {
+    expect(scoreTone(100)).toBe('success');
+    expect(scoreTone(80)).toBe('success');
+    expect(scoreTone(79)).toBe('warn');
+    expect(scoreTone(60)).toBe('warn');
+    expect(scoreTone(59)).toBe('danger');
+    expect(scoreTone(0)).toBe('danger');
+  });
+});
+
+describe('scoreColorClasses', () => {
+  it('returns emerald / amber / red fragments by tone', () => {
+    expect(scoreColorClasses(90).text).toBe('text-emerald-600');
+    expect(scoreColorClasses(70).text).toBe('text-amber-600');
+    expect(scoreColorClasses(30).text).toBe('text-brand-red-primary');
+    expect(scoreColorClasses(90).bar).toBe('bg-emerald-500');
+    expect(scoreColorClasses(70).band).toBe('bg-amber-50 border-amber-200');
+    expect(scoreColorClasses(30).band).toBe('bg-rose-50 border-rose-200');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/utils/scoreColor.test.ts`
+Expected: FAIL — cannot resolve `@/utils/scoreColor`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// utils/scoreColor.ts
+/**
+ * Unified score-color scale shared by the Quiz and Video Activity monitor and
+ * results views — the single source of truth for green/amber/red banding so the
+ * two widgets never drift apart again.
+ *
+ * Thresholds: >= 80 success, >= 60 warn, else danger. (Video Activity previously
+ * used 70/40; unifying to 80/60 changes only the COLOR shown — never the numeric
+ * score, accuracy math, or any grade pushed to Classroom/Schoology.)
+ */
+export type ScoreTone = 'success' | 'warn' | 'danger';
+
+export interface ScoreColorClasses {
+  /** Foreground text color, e.g. a score number. */
+  text: string;
+  /** Solid fill for a progress/accuracy bar. */
+  bar: string;
+  /** Soft background + border for a score-band card/row wash. */
+  band: string;
+}
+
+const TONE_CLASSES: Record<ScoreTone, ScoreColorClasses> = {
+  success: {
+    text: 'text-emerald-600',
+    bar: 'bg-emerald-500',
+    band: 'bg-emerald-50 border-emerald-200',
+  },
+  warn: {
+    text: 'text-amber-600',
+    bar: 'bg-amber-500',
+    band: 'bg-amber-50 border-amber-200',
+  },
+  danger: {
+    text: 'text-brand-red-primary',
+    bar: 'bg-brand-red-primary',
+    band: 'bg-rose-50 border-rose-200',
+  },
+};
+
+/** Map a 0–100 score to its tone using the unified 80/60 scale. */
+export function scoreTone(score: number): ScoreTone {
+  if (score >= 80) return 'success';
+  if (score >= 60) return 'warn';
+  return 'danger';
+}
+
+/** Tailwind class fragments (text / bar / band) for a 0–100 score. */
+export function scoreColorClasses(score: number): ScoreColorClasses {
+  return TONE_CLASSES[scoreTone(score)];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/utils/scoreColor.test.ts`
+Expected: PASS (2 suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/scoreColor.ts tests/utils/scoreColor.test.ts
+git commit -m "feat(sessionViews): unified scoreColor helper (80/60 scale)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `SessionBadge` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/SessionBadge.tsx`
+- Test: `tests/components/common/sessionViews/SessionBadge.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/SessionBadge.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionBadge } from '@/components/common/sessionViews/SessionBadge';
+
+describe('SessionBadge', () => {
+  it('renders the label with success tone classes', () => {
+    render(<SessionBadge tone="success" label="Done" />);
+    const badge = screen.getByTestId('session-badge');
+    expect(badge).toHaveTextContent('Done');
+    expect(badge.className).toContain('bg-emerald-100');
+    expect(badge.className).toContain('text-emerald-700');
+  });
+
+  it('renders a pulsing dot for success tone when dot is set', () => {
+    const { container } = render(
+      <SessionBadge tone="success" label="Live" dot />
+    );
+    const dot = container.querySelector('.animate-pulse');
+    expect(dot).not.toBeNull();
+  });
+
+  it('uses neutral classes for neutral tone', () => {
+    render(<SessionBadge tone="neutral" label="Ended" />);
+    expect(screen.getByTestId('session-badge').className).toContain(
+      'bg-slate-200'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionBadge.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/SessionBadge.tsx
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+export type SessionTone = 'success' | 'warn' | 'info' | 'neutral' | 'danger';
+
+const TONE: Record<SessionTone, { bg: string; fg: string; dot: string }> = {
+  success: {
+    bg: 'bg-emerald-100',
+    fg: 'text-emerald-700',
+    dot: 'bg-emerald-500',
+  },
+  warn: { bg: 'bg-amber-100', fg: 'text-amber-700', dot: 'bg-amber-500' },
+  info: { bg: 'bg-blue-100', fg: 'text-blue-700', dot: 'bg-blue-500' },
+  neutral: { bg: 'bg-slate-200', fg: 'text-slate-500', dot: 'bg-slate-400' },
+  danger: { bg: 'bg-red-100', fg: 'text-red-700', dot: 'bg-red-500' },
+};
+
+interface SessionBadgeProps {
+  tone: SessionTone;
+  label: string;
+  icon?: LucideIcon;
+  /** Render a leading status dot (success dots pulse). */
+  dot?: boolean;
+  /** Reserve a fixed min-width so badges align in a column. */
+  fixedWidth?: boolean;
+}
+
+/**
+ * Tone-based status/info badge matching the library's badge language:
+ * pill-shaped, uppercase, tracking-wide, fully container-query scaled.
+ */
+export const SessionBadge: React.FC<SessionBadgeProps> = ({
+  tone,
+  label,
+  icon: Icon,
+  dot = false,
+  fixedWidth = false,
+}) => {
+  const t = TONE[tone];
+  return (
+    <span
+      data-testid="session-badge"
+      className={`inline-flex items-center justify-center rounded-full font-bold uppercase tracking-wide shrink-0 ${t.bg} ${t.fg}`}
+      style={{
+        gap: 'min(4px, 1cqmin)',
+        minWidth: fixedWidth ? 'min(60px, 14cqmin)' : undefined,
+        paddingInline: 'min(8px, 2cqmin)',
+        paddingBlock: 'min(2px, 0.6cqmin)',
+        fontSize: 'min(10px, 3cqmin)',
+      }}
+    >
+      {dot && (
+        <span
+          className={`rounded-full ${t.dot} ${tone === 'success' ? 'animate-pulse' : ''}`}
+          style={{ width: 'min(6px, 1.8cqmin)', height: 'min(6px, 1.8cqmin)' }}
+        />
+      )}
+      {Icon && (
+        <Icon
+          style={{ width: 'min(12px, 4cqmin)', height: 'min(12px, 4cqmin)' }}
+        />
+      )}
+      {label}
+    </span>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionBadge.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/SessionBadge.tsx tests/components/common/sessionViews/SessionBadge.test.tsx
+git commit -m "feat(sessionViews): SessionBadge atom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `ScorePill` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/ScorePill.tsx`
+- Test: `tests/components/common/sessionViews/ScorePill.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/ScorePill.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScorePill } from '@/components/common/sessionViews/ScorePill';
+
+describe('ScorePill', () => {
+  it('renders rounded percent with the tone color', () => {
+    render(<ScorePill score={90} display="percent" />);
+    const pill = screen.getByTestId('score-pill');
+    expect(pill).toHaveTextContent('90%');
+    expect(pill.className).toContain('text-emerald-600');
+  });
+
+  it('renders count form as answered/total', () => {
+    render(<ScorePill score={0} display="count" count={3} total={5} />);
+    expect(screen.getByTestId('score-pill')).toHaveTextContent('3/5');
+  });
+
+  it('renders nothing when hidden', () => {
+    const { container } = render(<ScorePill score={90} display="hidden" />);
+    expect(container.querySelector('[data-testid="score-pill"]')).toBeNull();
+  });
+
+  it('shows points in brand-blue when gamified', () => {
+    render(<ScorePill score={42} display="percent" gamified points={1200} />);
+    const pill = screen.getByTestId('score-pill');
+    expect(pill).toHaveTextContent('1200');
+    expect(pill.className).toContain('text-brand-blue-dark');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/ScorePill.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/ScorePill.tsx
+import React from 'react';
+import { scoreColorClasses } from '@/utils/scoreColor';
+
+interface ScorePillProps {
+  /** 0–100 percentage; ignored when display is 'count' or 'hidden'. */
+  score: number;
+  display: 'percent' | 'count' | 'hidden';
+  /** Answered count, used when display is 'count'. */
+  count?: number;
+  /** Total questions, used when display is 'count'. */
+  total?: number;
+  /** Gamified sessions show raw points in brand-blue rather than a graded color. */
+  gamified?: boolean;
+  /** Raw points to show when gamified. */
+  points?: number;
+}
+
+/**
+ * Score chip colored via the unified scoreColor helper. Supports the three
+ * teacher score-display modes (percent / raw count / hidden) plus the gamified
+ * points variant used by the live scoreboard.
+ */
+export const ScorePill: React.FC<ScorePillProps> = ({
+  score,
+  display,
+  count,
+  total,
+  gamified = false,
+  points,
+}) => {
+  if (display === 'hidden') return null;
+  const colorClass = gamified
+    ? 'text-brand-blue-dark'
+    : scoreColorClasses(score).text;
+  let text: string;
+  if (gamified) text = `${points ?? 0}`;
+  else if (display === 'count') text = `${count ?? 0}/${total ?? 0}`;
+  else text = `${Math.round(score)}%`;
+  return (
+    <span
+      data-testid="score-pill"
+      className={`font-black tabular-nums shrink-0 ${colorClass}`}
+      style={{ fontSize: 'min(14px, 4.5cqmin)' }}
+    >
+      {text}
+    </span>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/ScorePill.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/ScorePill.tsx tests/components/common/sessionViews/ScorePill.test.tsx
+git commit -m "feat(sessionViews): ScorePill atom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `StatTile` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/StatTile.tsx`
+- Test: `tests/components/common/sessionViews/StatTile.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/StatTile.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Users } from 'lucide-react';
+import { StatTile } from '@/components/common/sessionViews/StatTile';
+
+describe('StatTile', () => {
+  it('renders value and label on a glass surface', () => {
+    render(<StatTile icon={<Users />} value={12} label="Joined" />);
+    const tile = screen.getByTestId('stat-tile');
+    expect(tile).toHaveTextContent('12');
+    expect(tile).toHaveTextContent('Joined');
+    expect(tile.className).toContain('bg-white/70');
+  });
+
+  it('renders as a button and fires onClick when interactive', () => {
+    const onClick = vi.fn();
+    render(
+      <StatTile
+        icon={<Users />}
+        value={3}
+        label="Active"
+        interactive
+        onClick={onClick}
+      />
+    );
+    const tile = screen.getByTestId('stat-tile');
+    expect(tile.tagName).toBe('BUTTON');
+    fireEvent.click(tile);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the selected ring when selected', () => {
+    render(
+      <StatTile
+        icon={<Users />}
+        value={3}
+        label="Active"
+        interactive
+        selected
+      />
+    );
+    expect(screen.getByTestId('stat-tile').className).toContain(
+      'ring-brand-blue-primary/40'
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/StatTile.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/StatTile.tsx
+import React from 'react';
+
+type StatTone = 'blue' | 'amber' | 'green' | 'violet';
+
+const ICON_TONE: Record<StatTone, string> = {
+  blue: 'text-brand-blue-primary',
+  amber: 'text-amber-600',
+  green: 'text-emerald-600',
+  violet: 'text-violet-600',
+};
+
+interface StatTileProps {
+  icon: React.ReactNode;
+  value: number | string;
+  label: string;
+  tone?: StatTone;
+  /** Interactive tiles get hover affordance + optional selected ring. */
+  interactive?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+  /** Expandable content (e.g. a student-name list) shown below the value. */
+  children?: React.ReactNode;
+}
+
+/**
+ * KPI / overview stat tile on a glass surface matching the library card
+ * language. Replaces the bespoke StatBox / InteractiveStatBox / StatTile copies
+ * across the monitor and results views.
+ */
+export const StatTile: React.FC<StatTileProps> = ({
+  icon,
+  value,
+  label,
+  tone = 'blue',
+  interactive = false,
+  selected = false,
+  onClick,
+  children,
+}) => {
+  const surface =
+    'bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm transition-all';
+  const interactiveClass = interactive
+    ? `cursor-pointer hover:bg-white/85 hover:shadow-md ${
+        selected ? 'ring-2 ring-brand-blue-primary/40' : ''
+      }`
+    : '';
+  const inner = (
+    <>
+      <div
+        className={`flex items-center justify-center ${ICON_TONE[tone]}`}
+        style={{ gap: 'min(4px, 1cqmin)', marginBottom: 'min(4px, 1cqmin)' }}
+      >
+        {icon}
+      </div>
+      <div
+        className={`font-black leading-none ${ICON_TONE[tone]}`}
+        style={{ fontSize: 'min(22px, 7cqmin)' }}
+      >
+        {value}
+      </div>
+      <div
+        className="font-bold uppercase tracking-wider text-slate-500"
+        style={{
+          fontSize: 'min(10px, 3cqmin)',
+          marginTop: 'min(3px, 0.8cqmin)',
+        }}
+      >
+        {label}
+      </div>
+      {children}
+    </>
+  );
+  const style: React.CSSProperties = { padding: 'min(10px, 2.5cqmin)' };
+  if (interactive) {
+    return (
+      <button
+        type="button"
+        data-testid="stat-tile"
+        onClick={onClick}
+        className={`block w-full text-center ${surface} ${interactiveClass}`}
+        style={style}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div
+      data-testid="stat-tile"
+      className={`text-center ${surface}`}
+      style={style}
+    >
+      {inner}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/StatTile.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/StatTile.tsx tests/components/common/sessionViews/StatTile.test.tsx
+git commit -m "feat(sessionViews): StatTile atom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `SegmentedTabs` atom + `LibraryShell` refactor
+
+**Files:**
+
+- Create: `components/common/sessionViews/SegmentedTabs.tsx`
+- Test: `tests/components/common/sessionViews/SegmentedTabs.test.tsx`
+- Modify: `components/common/library/LibraryShell.tsx` (replace the inline tab nav at lines ~238–297 with `<SegmentedTabs>`)
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/SegmentedTabs.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedTabs } from '@/components/common/sessionViews/SegmentedTabs';
+
+const TABS = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'students', label: 'Students', count: 4 },
+];
+
+describe('SegmentedTabs', () => {
+  it('marks the active tab with aria-selected and white surface', () => {
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    const active = screen.getByRole('tab', { name: 'Overview' });
+    expect(active).toHaveAttribute('aria-selected', 'true');
+    expect(active.className).toContain('bg-white');
+  });
+
+  it('fires onChange with the tab key', () => {
+    const onChange = vi.fn();
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Students' }));
+    expect(onChange).toHaveBeenCalledWith('students');
+  });
+
+  it('renders a count badge when count > 0', () => {
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('hides labels but keeps icons/aria when labelsHidden', () => {
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={vi.fn()}
+        labelsHidden
+      />
+    );
+    // Label text not rendered, but the accessible name (aria-label) remains.
+    expect(screen.queryByText('Overview')).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SegmentedTabs.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/SegmentedTabs.tsx
+import React from 'react';
+
+export interface SegmentedTab<K extends string = string> {
+  key: K;
+  label: string;
+  icon?: React.ComponentType<{
+    style?: React.CSSProperties;
+    className?: string;
+  }>;
+  count?: number;
+}
+
+interface SegmentedTabsProps<K extends string = string> {
+  tabs: SegmentedTab<K>[];
+  value: K;
+  onChange: (key: K) => void;
+  /** Collapse labels to icon-only (the caller measures width). */
+  labelsHidden?: boolean;
+  ariaLabel?: string;
+}
+
+/**
+ * Segmented-pill tab control extracted from LibraryShell so the library and the
+ * Quiz/VA results views share one tab component. Fully container-query scaled.
+ */
+export function SegmentedTabs<K extends string = string>({
+  tabs,
+  value,
+  onChange,
+  labelsHidden = false,
+  ariaLabel,
+}: SegmentedTabsProps<K>): React.ReactElement {
+  return (
+    <nav
+      role="tablist"
+      aria-label={ariaLabel}
+      className="flex items-center rounded-xl bg-slate-200/50 min-w-0"
+      style={{ padding: 'min(3px, 0.8cqmin)', gap: 'min(2px, 0.5cqmin)' }}
+    >
+      {tabs.map(({ key, label, icon: Icon, count }) => {
+        const selected = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            aria-label={label}
+            title={labelsHidden ? label : undefined}
+            onClick={() => onChange(key)}
+            className={`inline-flex shrink-0 items-center whitespace-nowrap rounded-lg font-bold transition-colors ${
+              selected
+                ? 'bg-white text-brand-blue-dark shadow-sm'
+                : 'text-slate-500 hover:text-slate-800'
+            }`}
+            style={{
+              gap: 'min(6px, 1.5cqmin)',
+              paddingInline: 'min(12px, 2.8cqmin)',
+              paddingBlock: 'min(6px, 1.5cqmin)',
+              fontSize: 'min(13px, 3.8cqmin)',
+            }}
+          >
+            {Icon && (
+              <Icon
+                style={{
+                  width: 'min(14px, 4cqmin)',
+                  height: 'min(14px, 4cqmin)',
+                }}
+                className="shrink-0"
+              />
+            )}
+            {!labelsHidden && <span>{label}</span>}
+            {count != null && count > 0 && (
+              <span
+                className={`inline-flex items-center justify-center rounded-full font-bold leading-none ${
+                  selected
+                    ? 'bg-brand-blue-primary text-white'
+                    : 'bg-slate-200/70 text-slate-600'
+                }`}
+                style={{
+                  paddingInline: 'min(7px, 1.8cqmin)',
+                  paddingBlock: 'min(2px, 0.5cqmin)',
+                  fontSize: 'min(10px, 3cqmin)',
+                }}
+              >
+                {count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SegmentedTabs.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Refactor `LibraryShell` to consume `SegmentedTabs`**
+
+In `components/common/library/LibraryShell.tsx`:
+
+1. Add the import near the top:
+
+```tsx
+import { SegmentedTabs } from '@/components/common/sessionViews/SegmentedTabs';
+```
+
+2. Replace the entire inline `<nav role="tablist"> ... </nav>` block (currently the first child of the chrome `<div>`, the branch rendered when `tabs.length > 0`) with:
+
+```tsx
+<SegmentedTabs
+  tabs={tabs}
+  value={tab}
+  onChange={onTabChange}
+  labelsHidden={tabLabelsHidden}
+  ariaLabel={`${widgetLabel} library tabs`}
+/>
+```
+
+Leave everything else (width measurement, `tabLabelsHidden`, the action buttons, folder panel) unchanged. The `tabs` array's element type (`TabDef`) is structurally assignable to `SegmentedTab<LibraryTab>` (icon accepts `{ size?, className?, style? }` which satisfies the narrower `{ style?, className? }`; `count` is `number | undefined`).
+
+- [ ] **Step 6: Verify the library still type-checks and its tests pass**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+Run: `pnpm exec vitest run tests/components/AssignmentArchiveCard.test.tsx tests/components/common/LibraryGrid.test.tsx tests/components/LibraryItemCard.doubleClick.test.tsx tests/components/common/library/LibraryPreviewPane.width.test.tsx`
+Expected: PASS (library suites unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/common/sessionViews/SegmentedTabs.tsx tests/components/common/sessionViews/SegmentedTabs.test.tsx components/common/library/LibraryShell.tsx
+git commit -m "feat(sessionViews): SegmentedTabs atom + LibraryShell adopts it
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `SessionRow` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/SessionRow.tsx`
+- Test: `tests/components/common/sessionViews/SessionRow.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/SessionRow.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionRow } from '@/components/common/sessionViews/SessionRow';
+
+describe('SessionRow', () => {
+  it('renders children and a hairline bottom border', () => {
+    render(
+      <SessionRow trailing={<span>99%</span>}>
+        <span>Ada Lovelace</span>
+      </SessionRow>
+    );
+    const row = screen.getByTestId('session-row');
+    expect(row).toHaveTextContent('Ada Lovelace');
+    expect(row).toHaveTextContent('99%');
+    expect(row.className).toContain('border-b');
+  });
+
+  it('applies a score-band wash when tintTone is set', () => {
+    render(
+      <SessionRow tintTone="success">
+        <span>x</span>
+      </SessionRow>
+    );
+    expect(screen.getByTestId('session-row').className).toContain(
+      'bg-emerald-50/60'
+    );
+  });
+
+  it('fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <SessionRow onClick={onClick}>
+        <span>x</span>
+      </SessionRow>
+    );
+    fireEvent.click(screen.getByTestId('session-row'));
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionRow.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/SessionRow.tsx
+import React from 'react';
+import type { ScoreTone } from '@/utils/scoreColor';
+
+type DotTone = 'success' | 'warn' | 'neutral' | 'danger';
+
+const TINT: Record<ScoreTone, string> = {
+  success: 'bg-emerald-50/60',
+  warn: 'bg-amber-50/60',
+  danger: 'bg-rose-50/60',
+};
+
+const DOT_COLOR: Record<DotTone, string> = {
+  success: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  neutral: 'bg-slate-400',
+  danger: 'bg-red-500',
+};
+
+interface SessionRowProps {
+  /** Leading status dot; pulse for live. Omit to render an empty reserved slot. */
+  dot?: { tone: DotTone; pulse?: boolean };
+  /** Subtle full-row score-band wash (teacher "colors" toggle). */
+  tintTone?: ScoreTone;
+  /** Main row content (name, badges, meta). */
+  children: React.ReactNode;
+  /** Right-aligned trailing slot (score pill, actions, overflow). */
+  trailing?: React.ReactNode;
+  onClick?: () => void;
+}
+
+/**
+ * Hairline list-row shell matching the library's list rows: gapless container
+ * (each row carries its own bottom border), a reserved status-dot slot for
+ * column alignment, an optional score-band wash, and a transient hover. Content
+ * and trailing slot are supplied by each view.
+ */
+export const SessionRow: React.FC<SessionRowProps> = ({
+  dot,
+  tintTone,
+  children,
+  trailing,
+  onClick,
+}) => {
+  return (
+    <div
+      data-testid="session-row"
+      onClick={onClick}
+      className={`flex items-center border-b border-slate-200/60 last:border-b-0 rounded-lg transition-colors ${
+        tintTone ? TINT[tintTone] : 'hover:bg-white/60'
+      } ${onClick ? 'cursor-pointer' : ''}`}
+      style={{
+        gap: 'min(10px, 2.2cqmin)',
+        paddingInline: 'min(12px, 2.6cqmin)',
+        paddingBlock: 'min(10px, 2.2cqmin)',
+      }}
+    >
+      <div
+        className="flex shrink-0 items-center justify-center"
+        style={{ width: 'min(8px, 2cqmin)' }}
+        aria-hidden="true"
+      >
+        {dot && (
+          <span
+            className={`rounded-full ${DOT_COLOR[dot.tone]} ${
+              dot.pulse ? 'animate-pulse' : ''
+            }`}
+            style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">{children}</div>
+      {trailing && (
+        <div
+          className="flex items-center shrink-0"
+          style={{ gap: 'min(8px, 2cqmin)' }}
+        >
+          {trailing}
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionRow.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/SessionRow.tsx tests/components/common/sessionViews/SessionRow.test.tsx
+git commit -m "feat(sessionViews): SessionRow hairline row shell
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: `OverflowMenu` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/OverflowMenu.tsx`
+- Test: `tests/components/common/sessionViews/OverflowMenu.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/OverflowMenu.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OverflowMenu } from '@/components/common/sessionViews/OverflowMenu';
+
+describe('OverflowMenu', () => {
+  it('opens on click and shows items', () => {
+    render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
+    expect(screen.queryByRole('menu')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Export' })
+    ).toBeInTheDocument();
+  });
+
+  it('fires the item onClick and closes', () => {
+    const onClick = vi.fn();
+    render(<OverflowMenu items={[{ label: 'Export', onClick }]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Export' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/OverflowMenu.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/OverflowMenu.tsx
+import React, { useEffect, useRef, useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface OverflowMenuItem {
+  label: string;
+  icon?: LucideIcon;
+  onClick: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+}
+
+interface OverflowMenuProps {
+  items: OverflowMenuItem[];
+  ariaLabel?: string;
+}
+
+/**
+ * Kebab overflow menu matching the library dropdown surface. Used to declutter
+ * the results-view headers — secondary actions live here.
+ */
+export const OverflowMenu: React.FC<OverflowMenuProps> = ({
+  items,
+  ariaLabel = 'More actions',
+}) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  // External-system sync (document click) — a valid useEffect use.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDown = (e: MouseEvent): void => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDown);
+    return () => document.removeEventListener('mousedown', onDown);
+  }, [open]);
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+        style={{ width: 'min(36px, 10cqmin)', height: 'min(36px, 10cqmin)' }}
+      >
+        <MoreHorizontal
+          style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
+        />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-50 min-w-[176px] overflow-hidden rounded-xl border border-slate-200 bg-white py-1 text-sm shadow-lg"
+        >
+          {items.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                onClick={() => {
+                  setOpen(false);
+                  item.onClick();
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                  item.destructive
+                    ? 'text-brand-red-dark hover:bg-brand-red-lighter/30'
+                    : 'text-slate-700 hover:bg-slate-100'
+                }`}
+              >
+                {Icon && <Icon size={16} className="shrink-0" />}
+                <span className="truncate">{item.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/OverflowMenu.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/OverflowMenu.tsx tests/components/common/sessionViews/OverflowMenu.test.tsx
+git commit -m "feat(sessionViews): OverflowMenu atom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `ActionButton` atom
+
+**Files:**
+
+- Create: `components/common/sessionViews/ActionButton.tsx`
+- Test: `tests/components/common/sessionViews/ActionButton.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/ActionButton.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Play } from 'lucide-react';
+import { ActionButton } from '@/components/common/sessionViews/ActionButton';
+
+describe('ActionButton', () => {
+  it('renders label + primary styling and fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <ActionButton
+        variant="primary"
+        label="Export"
+        icon={Play}
+        onClick={onClick}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'Export' });
+    expect(btn).toHaveTextContent('Export');
+    expect(btn.className).toContain('bg-brand-blue-primary');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('uses danger styling for the danger variant', () => {
+    render(<ActionButton variant="danger" label="End" onClick={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'End' }).className).toContain(
+      'bg-brand-red-primary'
+    );
+  });
+
+  it('hides the label text but keeps the accessible name when labelHidden', () => {
+    render(
+      <ActionButton
+        variant="secondary"
+        label="Scoreboard"
+        icon={Play}
+        onClick={vi.fn()}
+        labelHidden
+      />
+    );
+    expect(screen.queryByText('Scoreboard')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Scoreboard' })
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/ActionButton.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/ActionButton.tsx
+import React from 'react';
+import type { LucideIcon } from 'lucide-react';
+
+interface ActionButtonProps {
+  variant: 'primary' | 'secondary' | 'danger';
+  label: string;
+  icon?: LucideIcon;
+  onClick: () => void;
+  disabled?: boolean;
+  disabledReason?: string;
+  /** Collapse to icon-only (tooltip shows the label). */
+  labelHidden?: boolean;
+}
+
+const VARIANT: Record<ActionButtonProps['variant'], string> = {
+  primary: 'bg-brand-blue-primary hover:bg-brand-blue-dark text-white',
+  secondary:
+    'bg-white/70 backdrop-blur-sm hover:bg-brand-blue-lighter/40 text-brand-blue-primary border border-brand-blue-primary/20',
+  danger: 'bg-brand-red-primary hover:bg-brand-red-dark text-white',
+};
+
+/**
+ * Action button matching the library header buttons. Primary/secondary mirror
+ * LibraryShell; danger adds the brand-red destructive variant for End-session.
+ */
+export const ActionButton: React.FC<ActionButtonProps> = ({
+  variant,
+  label,
+  icon: Icon,
+  onClick,
+  disabled = false,
+  disabledReason,
+  labelHidden = false,
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    title={disabled ? disabledReason : labelHidden ? label : undefined}
+    aria-label={label}
+    className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl font-bold transition-all shadow-sm active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${VARIANT[variant]}`}
+    style={{
+      paddingInline: labelHidden ? '0' : 'min(14px, 3cqmin)',
+      paddingBlock: 'min(8px, 1.8cqmin)',
+      fontSize: 'min(14px, 4cqmin)',
+      minWidth: labelHidden ? 'min(36px, 10cqmin)' : undefined,
+      height: labelHidden ? 'min(36px, 10cqmin)' : undefined,
+    }}
+  >
+    {Icon && (
+      <Icon
+        style={{ width: 'min(16px, 4.5cqmin)', height: 'min(16px, 4.5cqmin)' }}
+        className="shrink-0"
+      />
+    )}
+    {!labelHidden && <span className="truncate">{label}</span>}
+  </button>
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/ActionButton.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/common/sessionViews/ActionButton.tsx tests/components/common/sessionViews/ActionButton.test.tsx
+git commit -m "feat(sessionViews): ActionButton atom
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `SessionViewHeader` atom + barrel export
+
+**Files:**
+
+- Create: `components/common/sessionViews/SessionViewHeader.tsx`
+- Create: `components/common/sessionViews/index.ts`
+- Test: `tests/components/common/sessionViews/SessionViewHeader.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// tests/components/common/sessionViews/SessionViewHeader.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionViewHeader } from '@/components/common/sessionViews/SessionViewHeader';
+
+describe('SessionViewHeader', () => {
+  it('renders title/subtitle and fires onBack', () => {
+    const onBack = vi.fn();
+    render(
+      <SessionViewHeader onBack={onBack} title="My Quiz" subtitle="Period 3" />
+    );
+    expect(screen.getByText('My Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Period 3')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('shows a live status pill', () => {
+    render(<SessionViewHeader onBack={vi.fn()} status="live" title="Q" />);
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('renders the actions slot', () => {
+    render(
+      <SessionViewHeader
+        onBack={vi.fn()}
+        title="Q"
+        actions={<button type="button">End</button>}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionViewHeader.test.tsx`
+Expected: FAIL — cannot resolve module.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// components/common/sessionViews/SessionViewHeader.tsx
+import React from 'react';
+import { ChevronLeft } from 'lucide-react';
+
+type ViewStatus = 'live' | 'paused' | 'ended' | 'none';
+
+interface SessionViewHeaderProps {
+  onBack: () => void;
+  status?: ViewStatus;
+  title: string;
+  subtitle?: string;
+  /** Right-aligned action buttons / overflow. */
+  actions?: React.ReactNode;
+}
+
+const STATUS: Record<
+  Exclude<ViewStatus, 'none'>,
+  { dot: string; label: string; text: string; pulse: boolean }
+> = {
+  live: {
+    dot: 'bg-brand-red-primary',
+    label: 'Live',
+    text: 'text-brand-red-primary',
+    pulse: true,
+  },
+  paused: {
+    dot: 'bg-amber-500',
+    label: 'Paused',
+    text: 'text-amber-600',
+    pulse: false,
+  },
+  ended: {
+    dot: 'bg-slate-400',
+    label: 'Ended',
+    text: 'text-slate-500',
+    pulse: false,
+  },
+};
+
+/**
+ * Shared header for the monitor and results views: glass chrome, back button,
+ * an optional live/paused/ended status pulse, title/subtitle, and a
+ * right-aligned actions slot. Matches the library header surface.
+ */
+export const SessionViewHeader: React.FC<SessionViewHeaderProps> = ({
+  onBack,
+  status = 'none',
+  title,
+  subtitle,
+  actions,
+}) => {
+  const s = status !== 'none' ? STATUS[status] : null;
+  return (
+    <div
+      className="flex items-center justify-between bg-white/60 backdrop-blur-sm border-b border-slate-200/70 shrink-0"
+      style={{
+        gap: 'min(12px, 2.5cqmin)',
+        paddingInline: 'min(16px, 3.5cqmin)',
+        paddingBlock: 'min(8px, 1.8cqmin)',
+      }}
+    >
+      <div
+        className="flex items-center min-w-0"
+        style={{ gap: 'min(10px, 2.2cqmin)' }}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back"
+          className="inline-flex shrink-0 items-center justify-center rounded-xl text-slate-500 transition-colors hover:bg-white/70 hover:text-brand-blue-primary"
+          style={{ width: 'min(32px, 8cqmin)', height: 'min(32px, 8cqmin)' }}
+        >
+          <ChevronLeft
+            style={{ width: 'min(18px, 5cqmin)', height: 'min(18px, 5cqmin)' }}
+          />
+        </button>
+        {s && (
+          <span
+            className="flex shrink-0 items-center"
+            style={{ gap: 'min(5px, 1.2cqmin)' }}
+          >
+            <span
+              className={`rounded-full ${s.dot} ${s.pulse ? 'animate-pulse' : ''}`}
+              style={{ width: 'min(8px, 2cqmin)', height: 'min(8px, 2cqmin)' }}
+            />
+            <span
+              className={`font-black uppercase tracking-tight leading-none ${s.text}`}
+              style={{ fontSize: 'min(12px, 4cqmin)' }}
+            >
+              {s.label}
+            </span>
+          </span>
+        )}
+        <div className="min-w-0">
+          <div
+            className="font-black text-slate-800 truncate"
+            style={{ fontSize: 'min(15px, 4.8cqmin)' }}
+          >
+            {title}
+          </div>
+          {subtitle && (
+            <div
+              className="font-medium text-slate-500 truncate"
+              style={{ fontSize: 'min(11px, 3.2cqmin)' }}
+            >
+              {subtitle}
+            </div>
+          )}
+        </div>
+      </div>
+      {actions && (
+        <div
+          className="flex items-center shrink-0"
+          style={{ gap: 'min(8px, 2cqmin)' }}
+        >
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Write the barrel export**
+
+```ts
+// components/common/sessionViews/index.ts
+export { SessionViewHeader } from './SessionViewHeader';
+export { SegmentedTabs } from './SegmentedTabs';
+export type { SegmentedTab } from './SegmentedTabs';
+export { StatTile } from './StatTile';
+export { SessionBadge } from './SessionBadge';
+export type { SessionTone } from './SessionBadge';
+export { ScorePill } from './ScorePill';
+export { SessionRow } from './SessionRow';
+export { OverflowMenu } from './OverflowMenu';
+export type { OverflowMenuItem } from './OverflowMenu';
+export { ActionButton } from './ActionButton';
+```
+
+- [ ] **Step 5: Run test + type-check**
+
+Run: `pnpm exec vitest run tests/components/common/sessionViews/SessionViewHeader.test.tsx`
+Expected: PASS (3 tests).
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/common/sessionViews/SessionViewHeader.tsx components/common/sessionViews/index.ts tests/components/common/sessionViews/SessionViewHeader.test.tsx
+git commit -m "feat(sessionViews): SessionViewHeader atom + barrel export
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: DEV-only `/session-views-dev` harness
+
+**Files:**
+
+- Create: `components/dev/SessionViewsDevHarness.tsx`
+- Modify: `App.tsx` (register the route, mirroring `/library-dev`)
+
+This harness renders the four **real** view components against mock data so every visual state can be checked without Firestore. The views call `useAuth` / `useDialog` / `useDashboard`, so the harness wraps them in the same provider stack the teacher app uses and relies on `VITE_AUTH_BYPASS=true` (see CLAUDE.md → "Authentication Bypass") to supply a mock admin user without Firestore listeners.
+
+- [ ] **Step 1: Read the mock-data type shapes**
+
+Read these type definitions so the mock builders satisfy every required (non-optional) field:
+
+- `types.ts` — `QuizSession`, `QuizResponse`, `QuizData`, `QuizQuestion`, `QuizConfig`, `VideoActivitySession`, `VideoActivityResponse`, `VideoActivityQuestion`.
+
+Note required fields and their types; the builders below show the shape — fill in any additional required fields TypeScript flags.
+
+- [ ] **Step 2: Write the harness**
+
+```tsx
+// components/dev/SessionViewsDevHarness.tsx
+import React, { useState } from 'react';
+import { DialogProvider } from '@/context/DialogContext';
+import { AuthProvider } from '@/context/AuthContext';
+import { CustomWidgetsProvider } from '@/context/CustomWidgetsContext';
+import { SavedWidgetsProvider } from '@/context/SavedWidgetsContext';
+import { DashboardProvider } from '@/context/DashboardContext';
+import { QuizLiveMonitor } from '@/components/widgets/QuizWidget/components/QuizLiveMonitor';
+import { QuizResults } from '@/components/widgets/QuizWidget/components/QuizResults';
+import { VideoActivityLiveMonitor } from '@/components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor';
+import { Results as VideoActivityResults } from '@/components/widgets/VideoActivityWidget/components/Results';
+import {
+  makeQuizSession,
+  makeQuizResponses,
+  makeQuizData,
+  makeQuizConfig,
+  makeVaSession,
+  makeVaResponses,
+} from './sessionViewsMocks';
+
+type ViewKey = 'quiz-monitor' | 'quiz-results' | 'va-monitor' | 'va-results';
+type StateKey = 'waiting' | 'live' | 'paused' | 'ended' | 'populated' | 'empty';
+
+const VIEWS: { key: ViewKey; label: string }[] = [
+  { key: 'quiz-monitor', label: 'Quiz Monitor' },
+  { key: 'quiz-results', label: 'Quiz Results' },
+  { key: 'va-monitor', label: 'VA Monitor' },
+  { key: 'va-results', label: 'VA Results' },
+];
+
+const WIDTHS = [340, 520, 820];
+
+const noop = async (): Promise<void> => undefined;
+
+export const SessionViewsDevHarness: React.FC = () => {
+  const [view, setView] = useState<ViewKey>('quiz-monitor');
+  const [state, setState] = useState<StateKey>('live');
+  const [width, setWidth] = useState<number>(520);
+
+  const renderView = (): React.ReactNode => {
+    if (view === 'quiz-monitor') {
+      return (
+        <QuizLiveMonitor
+          session={makeQuizSession(state)}
+          responses={state === 'waiting' ? [] : makeQuizResponses()}
+          quizData={makeQuizData()}
+          config={makeQuizConfig()}
+          rosters={[]}
+          onAdvance={noop}
+          onEnd={noop}
+          onPause={noop}
+          onResume={noop}
+          onUpdateConfig={noop}
+          onRemoveStudent={noop}
+          onUnlockStudent={noop}
+          onUnlockResultsForStudent={noop}
+          onRevealAnswer={noop}
+          onBack={() => undefined}
+        />
+      );
+    }
+    if (view === 'quiz-results') {
+      return (
+        <QuizResults
+          responses={state === 'empty' ? [] : makeQuizResponses()}
+          quiz={makeQuizData()}
+          config={makeQuizConfig()}
+          session={makeQuizSession('ended')}
+          onBack={() => undefined}
+        />
+      );
+    }
+    if (view === 'va-monitor') {
+      return (
+        <VideoActivityLiveMonitor
+          session={makeVaSession(state)}
+          responses={state === 'waiting' ? [] : makeVaResponses()}
+          onEnd={noop}
+          onPause={noop}
+          onResume={noop}
+          onUnlockStudent={noop}
+          onBack={() => undefined}
+        />
+      );
+    }
+    return (
+      <VideoActivityResults
+        session={makeVaSession('ended')}
+        responses={state === 'empty' ? [] : makeVaResponses()}
+        onBack={() => undefined}
+      />
+    );
+  };
+
+  return (
+    <DialogProvider>
+      <AuthProvider>
+        <CustomWidgetsProvider>
+          <SavedWidgetsProvider>
+            <DashboardProvider>
+              <div className="min-h-screen bg-slate-100 p-6">
+                <div className="mb-4 flex flex-wrap items-center gap-3">
+                  <select
+                    value={view}
+                    onChange={(e) => setView(e.target.value as ViewKey)}
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-bold"
+                  >
+                    {VIEWS.map((v) => (
+                      <option key={v.key} value={v.key}>
+                        {v.label}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value={state}
+                    onChange={(e) => setState(e.target.value as StateKey)}
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-bold"
+                  >
+                    {(
+                      [
+                        'waiting',
+                        'live',
+                        'paused',
+                        'ended',
+                        'populated',
+                        'empty',
+                      ] as StateKey[]
+                    ).map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="flex gap-2">
+                    {WIDTHS.map((w) => (
+                      <button
+                        key={w}
+                        type="button"
+                        onClick={() => setWidth(w)}
+                        className={`rounded-lg px-3 py-2 text-sm font-bold ${
+                          width === w
+                            ? 'bg-brand-blue-primary text-white'
+                            : 'bg-white text-slate-600 border border-slate-300'
+                        }`}
+                      >
+                        {w}px
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div
+                  className="mx-auto overflow-hidden rounded-2xl border border-slate-300 bg-white shadow-lg"
+                  style={{
+                    width,
+                    height: 640,
+                    containerType: 'size',
+                  }}
+                >
+                  {renderView()}
+                </div>
+              </div>
+            </DashboardProvider>
+          </SavedWidgetsProvider>
+        </CustomWidgetsProvider>
+      </AuthProvider>
+    </DialogProvider>
+  );
+};
+```
+
+- [ ] **Step 3: Write the mock-data module**
+
+Create `components/dev/sessionViewsMocks.ts`. Build minimal objects satisfying the types read in Step 1. Representative skeleton (extend with any other required fields TypeScript reports):
+
+```ts
+// components/dev/sessionViewsMocks.ts
+import type {
+  QuizSession,
+  QuizResponse,
+  QuizData,
+  QuizConfig,
+  VideoActivitySession,
+  VideoActivityResponse,
+} from '@/types';
+
+type MonitorState =
+  | 'waiting'
+  | 'live'
+  | 'paused'
+  | 'ended'
+  | 'populated'
+  | 'empty';
+
+export const makeQuizData = (): QuizData => ({
+  // Fill required QuizData fields per types.ts.
+  title: 'Photosynthesis Check',
+  questions: [
+    {
+      id: 'q1',
+      type: 'multiple-choice',
+      text: 'Which gas do plants absorb?',
+      options: ['Oxygen', 'Carbon dioxide', 'Nitrogen', 'Helium'],
+      correctAnswer: 'Carbon dioxide',
+      timeLimit: 30,
+    },
+    {
+      id: 'q2',
+      type: 'multiple-choice',
+      text: 'Where does photosynthesis occur?',
+      options: ['Mitochondria', 'Chloroplast', 'Nucleus', 'Ribosome'],
+      correctAnswer: 'Chloroplast',
+      timeLimit: 30,
+    },
+  ],
+});
+
+export const makeQuizSession = (state: MonitorState): QuizSession => ({
+  // Fill required QuizSession fields per types.ts.
+  id: 'sess-1',
+  code: 'AB12',
+  status:
+    state === 'paused' ? 'paused' : state === 'ended' ? 'ended' : 'active',
+  currentQuestionIndex: state === 'waiting' ? -1 : 0,
+  totalQuestions: 2,
+  sessionMode: 'teacher-paced',
+  assignmentName: 'Photosynthesis Check',
+});
+
+export const makeQuizConfig = (): QuizConfig => ({
+  // Fill required QuizConfig fields per types.ts.
+});
+
+export const makeQuizResponses = (): QuizResponse[] => [
+  // 5–8 responses spanning completed (high/mid/low score), in-progress, joined,
+  // with a tab-warning and a locked one. Fill required QuizResponse fields.
+];
+
+export const makeVaSession = (state: MonitorState): VideoActivitySession => ({
+  // Fill required VideoActivitySession fields per types.ts.
+  id: 'va-1',
+  status:
+    state === 'paused' ? 'paused' : state === 'ended' ? 'ended' : 'active',
+  assignmentName: 'Cell Division Video',
+  activityTitle: 'Cell Division',
+  questions: [
+    {
+      id: 'vq1',
+      text: 'What phase is shown?',
+      correctAnswer: 'Anaphase',
+      timestamp: 42,
+    },
+  ],
+});
+
+export const makeVaResponses = (): VideoActivityResponse[] => [
+  // 5–8 responses spanning done / in-progress with varied scores. Fill required
+  // VideoActivityResponse fields.
+];
+```
+
+> The `// Fill required ... fields` markers are explicit instructions to satisfy the type. Run `pnpm run type-check` after writing — TypeScript names every missing required field; add each until it's clean. This is faster and less error-prone than transcribing the full type defs here.
+
+- [ ] **Step 4: Register the route in `App.tsx`**
+
+Near the other DEV harness lazy imports (after the `LibraryDevHarness` constant, ~line 215):
+
+```tsx
+const SessionViewsDevHarness = import.meta.env.DEV
+  ? lazy(() =>
+      import('./components/dev/SessionViewsDevHarness').then((module) => ({
+        default: module.SessionViewsDevHarness,
+      }))
+    )
+  : null;
+```
+
+Near the other DEV route checks (after the `/library-dev` block, ~line 529):
+
+```tsx
+if (
+  import.meta.env.DEV &&
+  SessionViewsDevHarness &&
+  pathname === '/session-views-dev'
+) {
+  return (
+    <Suspense fallback={<FullPageLoader />}>
+      <SessionViewsDevHarness />
+    </Suspense>
+  );
+}
+```
+
+- [ ] **Step 5: Verify the harness loads**
+
+Run the dev server with the auth bypass:
+
+```bash
+$env:VITE_AUTH_BYPASS='true'; pnpm run dev
+```
+
+Then use the preview tools: `preview_start` (or navigate the running server) to `http://localhost:3000/session-views-dev`. Check `preview_console_logs` for errors and `preview_snapshot` to confirm a view renders. Resolve any "must be used within a Provider" error by confirming the provider stack matches the one above. (At this step the four views still look pre-redesign — that's expected; the harness just has to render them.)
+
+- [ ] **Step 6: Type-check + commit**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+```bash
+git add components/dev/SessionViewsDevHarness.tsx components/dev/sessionViewsMocks.ts App.tsx
+git commit -m "feat(dev): /session-views-dev harness for monitor/results redesign
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Restyle `QuizLiveMonitor`
+
+**Files:**
+
+- Modify: `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
+
+This is a restyle-in-place: swap bespoke chrome for the shared atoms and apply the design language, preserving **all** existing handlers, state, and sub-component logic (scoreboard, podium, MC distribution, period filter, unlock/remove, score-display cycle, colors/tab-warning toggles, mute, advance/reveal).
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import {
+  SessionViewHeader,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+} from '@/components/common/sessionViews';
+import { scoreColorClasses, scoreTone } from '@/utils/scoreColor';
+```
+
+- [ ] **Step 2: Replace the header**
+
+Replace the bespoke header block (the `border-b border-brand-red-primary/10` strip, ~lines 976–1100, including the live pulse, title, and pause/end/scoreboard buttons) with `<SessionViewHeader>`:
+
+```tsx
+<SessionViewHeader
+  onBack={onBack}
+  status={
+    session.status === 'paused'
+      ? 'paused'
+      : session.status === 'ended'
+        ? 'ended'
+        : 'live'
+  }
+  title={session.assignmentName ?? quizData.title}
+  subtitle={`Code ${session.code}`}
+  actions={
+    <>
+      {onPause && session.status !== 'ended' && (
+        <ActionButton
+          variant="secondary"
+          label={session.status === 'paused' ? 'Resume' : 'Pause'}
+          icon={session.status === 'paused' ? Play : Pause}
+          onClick={() =>
+            session.status === 'paused' ? onResume?.() : onPause()
+          }
+        />
+      )}
+      {/* keep the existing scoreboard toggle button, now as ActionButton secondary */}
+      <ActionButton
+        variant="danger"
+        label="End"
+        icon={Square}
+        onClick={handleEnd}
+      />
+    </>
+  }
+/>
+```
+
+Keep the existing `handleEnd` confirm logic and the scoreboard setup popup anchoring (the popup can remain rendered just below the header as today). Use the lucide icons already imported in the file (`Play`, `Pause`, `Square`, etc.); add any missing icon imports.
+
+- [ ] **Step 3: Replace KPI stat boxes with `StatTile`**
+
+Both `StatBox` (waiting/ended) and `InteractiveStatBox` (active) usages become `StatTile`. Map the `color` prop directly (`blue`/`amber`/`green` → StatTile `tone`). For the interactive ones, pass `interactive`, `selected={expanded}`, `onClick={onToggle}`, and render the existing expanded student-name list as `children`. Delete the now-unused `StatBox` and `InteractiveStatBox` component definitions (~lines 2321–2456) and their `themes` maps.
+
+Example (active KPI):
+
+```tsx
+<StatTile
+  icon={<Users style={{ width: 'min(18px, 5.5cqmin)', height: 'min(18px, 5.5cqmin)' }} />}
+  value={joined}
+  label="Joined"
+  tone="blue"
+  interactive
+  selected={expandedStat === 'joined'}
+  onClick={() => toggleStat('joined')}
+>
+  {expandedStat === 'joined' && (
+    /* existing student-name dropdown JSX */
+  )}
+</StatTile>
+```
+
+- [ ] **Step 4: Convert the student roster to hairline `SessionRow`s**
+
+The roster list container becomes gapless (`flex flex-col`, remove the `gap-*`/row spacing). Each `StudentRow` renders its content inside `SessionRow`:
+
+- `dot` ← live/active status (`{ tone: 'success', pulse: true }` for active answering; `'neutral'` for joined; `'success'` non-pulse for done).
+- `tintTone` ← when `effectiveColorsEnabled`, map the student's band score via `scoreTone(bandScore)` (replaces the local `scoreBandBg` helper at ~lines 2758).
+- main content ← name + existing badges, but each badge (period, done/in-progress, duplicate, tab-warnings, lock/unlock, results-locked) becomes a `<SessionBadge tone=... label=... icon=... />`.
+- `trailing` ← `<ScorePill score={pct} display={effectiveScoreDisplay} count={answeredCount} total={totalQuestions} gamified={isGamified} points={points} />` plus the existing remove (X) button and unlock controls.
+
+Preserve the confirmation-mode variant (red "Remove {name}?" Yes/No) — render it as the row content when `confirmingRemoval`, unchanged in behavior.
+
+- [ ] **Step 5: Restyle remaining surfaces to glass**
+
+Apply the card surface `bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm` to: the join-code bar, the question hero card, the answer-reveal card (keep emerald accent), the MC distribution container, the podium card, and the scoreboard setup popup. Replace `border-brand-blue-primary/10` borders with `border-slate-200/60`. Convert the progress bar fill to use `scoreColorClasses` only if it represents a score (the answered-progress bar stays emerald). Use unified `scoreColorClasses(...).text` anywhere a score is colored (e.g. the answer-reveal correct-count).
+
+- [ ] **Step 6: Verify in the harness**
+
+Run dev server with bypass (if not already running) and check each Quiz-monitor state at 340/520/820px:
+
+Use `preview_resize` + `preview_snapshot` + `preview_screenshot` for: `waiting`, `live`, `paused`, `ended`. Confirm: header status pulse correct, KPI tiles glassy, roster rows hairline with aligned columns, score pills colored on the 80/60 scale, no console errors (`preview_console_logs`).
+
+- [ ] **Step 7: Type-check + commit**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+```bash
+git add components/widgets/QuizWidget/components/QuizLiveMonitor.tsx
+git commit -m "ui(quiz): restyle live monitor with shared sessionViews atoms
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Restyle `VideoActivityLiveMonitor`
+
+**Files:**
+
+- Modify: `components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import {
+  SessionViewHeader,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+} from '@/components/common/sessionViews';
+import { scoreColorClasses } from '@/utils/scoreColor';
+```
+
+- [ ] **Step 2: Replace the header**
+
+Replace the bespoke header (~lines 572–714, the `border-b border-brand-blue-primary/10 bg-white` strip with the live/paused pulse, title, activity subtitle, and pause/end buttons) with:
+
+```tsx
+<SessionViewHeader
+  onBack={onBack}
+  status={
+    session.status === 'paused'
+      ? 'paused'
+      : session.status === 'ended'
+        ? 'ended'
+        : 'live'
+  }
+  title={session.assignmentName}
+  subtitle={`${session.activityTitle} · ${session.questions.length} questions`}
+  actions={
+    <>
+      {onPause && session.status !== 'ended' && (
+        <ActionButton
+          variant="secondary"
+          label={session.status === 'paused' ? 'Resume' : 'Pause'}
+          icon={session.status === 'paused' ? Play : Pause}
+          onClick={() =>
+            session.status === 'paused' ? onResume?.() : onPause()
+          }
+        />
+      )}
+      <ActionButton
+        variant="danger"
+        label="End"
+        icon={Square}
+        onClick={handleEnd}
+      />
+    </>
+  }
+/>
+```
+
+Preserve the existing `handleEnd` confirm flow. Add any missing lucide icon imports.
+
+- [ ] **Step 3: Replace KPI tiles + delete the local `StatTile`**
+
+Replace the three local `StatTile` usages (Joined/Active/Finished) with the shared `StatTile` (map `color` → `tone`). Delete the local `StatTile` definition (~lines 366–408).
+
+- [ ] **Step 4: Convert student rows to hairline `SessionRow`**
+
+In the `StudentRow` component (~lines 109–362):
+
+- Wrap the row in `SessionRow` with `dot` reflecting done (`{tone:'success'}`) / in-progress (`{tone:'warn'}`).
+- Period, Done / In progress, tab-warnings, and Resumed/lock badges → `<SessionBadge>`; the lock/unlock action keeps its `onUnlock` button.
+- The right-side per-question correctness strip: keep the per-question circles/checks but raise contrast — render each as a small filled chip (`CheckCircle2` emerald-500, `XCircle` red-500, empty `Circle` slate-300) inside `trailing`, followed by `<ScorePill score={scorePct} display="percent" />` (now unified 80/60 via the helper — this replaces the local 70/40 ternary at ~lines 349 and the bar color logic).
+- Keep `ScaledEmptyState` for the empty roster.
+
+- [ ] **Step 5: Restyle surfaces to glass**
+
+Replace `bg-white border border-slate-100 rounded-xl` tiles/rows backgrounds with the glass surface / hairline patterns. Remove the faint `bg-brand-blue-lighter/10` page wash if it competes with the new glass look (optional — keep if it reads well in the harness).
+
+- [ ] **Step 6: Verify in the harness**
+
+Check VA-monitor states `waiting`, `live`, `paused`, `ended` at 340/520/820px via `preview_resize` + `preview_snapshot` + `preview_screenshot`. Confirm hairline rows, unified score colors, contrast on the correctness strip, no console errors.
+
+- [ ] **Step 7: Type-check + commit**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+```bash
+git add components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx
+git commit -m "ui(video-activity): restyle live monitor with shared sessionViews atoms
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Restyle `QuizResults`
+
+**Files:**
+
+- Modify: `components/widgets/QuizWidget/components/QuizResults.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import {
+  SessionViewHeader,
+  SegmentedTabs,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+  OverflowMenu,
+} from '@/components/common/sessionViews';
+import type { OverflowMenuItem } from '@/components/common/sessionViews';
+import { scoreColorClasses } from '@/utils/scoreColor';
+```
+
+- [ ] **Step 2: Replace the header + action buttons**
+
+Replace the header block (~lines 1227–1578) with `<SessionViewHeader>`. **Visible actions: Grade Written + Push Grades** (whichever push applies — Classroom or Schoology). Everything else goes in an `OverflowMenu`:
+
+```tsx
+const overflowItems: OverflowMenuItem[] = [
+  {
+    label: hasExport ? 'Re-export Sheet' : 'Export to Sheets',
+    icon: Sheet,
+    onClick: handleExport,
+    disabled: exporting,
+  },
+  ...(exportUrl
+    ? [{ label: 'Open Sheet', icon: ExternalLink, onClick: openSheet }]
+    : []),
+  { label: 'Send to Scoreboard', icon: Trophy, onClick: openScoreboardSetup },
+  // include Push to Schoology here only if it is NOT the visible push (see below)
+];
+
+<SessionViewHeader
+  onBack={onBack}
+  title={quiz.title}
+  subtitle={periodSubtitle /* existing period/teacher subtitle, if any */}
+  actions={
+    <>
+      {hasWrittenResponses && (
+        <ActionButton
+          variant="secondary"
+          label="Grade Written"
+          icon={PenSquare}
+          onClick={() => setShowGrader(true)}
+        />
+      )}
+      {classroomAttached && canPushClassroom && (
+        <ActionButton
+          variant="primary"
+          label="Push Grades"
+          icon={Upload}
+          onClick={handlePushGrades}
+          disabled={pushingGrades}
+        />
+      )}
+      {!classroomAttached && ltiAttached && (
+        <ActionButton
+          variant="primary"
+          label="Push Grades"
+          icon={Upload}
+          onClick={handlePushSchoology}
+          disabled={pushingSchoology}
+        />
+      )}
+      <OverflowMenu items={overflowItems} />
+    </>
+  }
+/>;
+```
+
+Preserve every existing handler (`handleExport`, `handlePushGrades`, `handlePushSchoology`, scoreboard setup, schema-mismatch recovery). The export-error banner and recovery button stay below the header. Use the lucide icons already imported (add `PenSquare`/`Upload`/`Sheet`/`ExternalLink`/`Trophy` if missing). Keep the gating conditions exactly as they are today — only the placement (visible vs overflow) changes.
+
+- [ ] **Step 3: Replace the tab strip with `SegmentedTabs`**
+
+Replace the uppercase button strip (~lines 1686–1717) with:
+
+```tsx
+<SegmentedTabs
+  tabs={[
+    { key: 'overview', label: 'Overview' },
+    { key: 'questions', label: 'Questions' },
+    { key: 'students', label: 'Students', count: responses.length },
+    ...(config.plcMode ? [{ key: 'plc', label: 'PLC' }] : []),
+  ]}
+  value={activeTab}
+  onChange={setActiveTab}
+  ariaLabel="Quiz results tabs"
+/>
+```
+
+(Wrap it in the existing toolbar row alongside the period filter.)
+
+- [ ] **Step 4: Modernize `OverviewTab`**
+
+- Stat cards (Class Average, Finished) → `StatTile` (drop the `absolute ... h-1` colored top-bar). Use `tone="blue"`/`"green"`.
+- Distribution chart container → glass surface (`bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm`, replace `shadow-sm` heavy combo). Keep the bucket bars but source the fill from a fixed bucket palette (90–100 emerald, 80–89 blue, 60–79 amber, 0–59 red) — unchanged.
+
+- [ ] **Step 5: Modernize `QuestionsTab`**
+
+Convert the per-question cards to hairline rows in a gapless container (or keep light glass cards if rows feel too dense — verify in harness). The accuracy bar fill uses `scoreColorClasses(accuracyPct).bar`; the accuracy number uses `scoreColorClasses(accuracyPct).text` (replaces the local 80/60 ternary at ~line 2044 — same scale, now via the helper). The manual-grading marker → `<SessionBadge tone="danger" label="Manual" />` (or `warn`).
+
+- [ ] **Step 6: Modernize `StudentsTab`**
+
+- The list becomes gapless hairline `SessionRow`s (replace the spaced `rounded-2xl shadow-sm` cards at ~line 2272).
+- Name + badges in the content slot; tab-warning → `<SessionBadge tone="danger" .../>`, results-locked → `<SessionBadge tone="warn" .../>`, pre-sync version → `<SessionBadge tone="warn" .../>`.
+- `trailing` ← `<ScorePill score={score} display="percent" gamified={gamified} points={points} />` (replaces the local ternary at ~line 2329) plus the existing Unlock/Delete buttons (Delete keeps its confirm state).
+- Keep the "Show/Hide Results" toggle row behavior.
+
+- [ ] **Step 7: Empty state**
+
+Replace the inline "No data available yet" (~lines 1630–1646) with `ScaledEmptyState` (icon `BarChart3` or similar, already a pattern in the repo).
+
+- [ ] **Step 8: Verify in the harness**
+
+Check Quiz-results `populated` and `empty` at 340/520/820px; click through Overview/Questions/Students/PLC tabs and open the overflow menu. Confirm: header shows Grade Written + Push, Export is in the overflow, segmented tabs, hairline student rows, unified score colors, no console errors.
+
+- [ ] **Step 9: Type-check + commit**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+```bash
+git add components/widgets/QuizWidget/components/QuizResults.tsx
+git commit -m "ui(quiz): restyle results with shared sessionViews atoms + overflow header
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Restyle `Results` (Video Activity)
+
+**Files:**
+
+- Modify: `components/widgets/VideoActivityWidget/components/Results.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```tsx
+import {
+  SessionViewHeader,
+  SegmentedTabs,
+  StatTile,
+  SessionBadge,
+  ScorePill,
+  SessionRow,
+  ActionButton,
+  OverflowMenu,
+} from '@/components/common/sessionViews';
+import type { OverflowMenuItem } from '@/components/common/sessionViews';
+import { scoreColorClasses } from '@/utils/scoreColor';
+```
+
+- [ ] **Step 2: Replace the header + actions**
+
+Replace the header (~lines 417–577) with `<SessionViewHeader>`. **Visible action: Push Grades** (Classroom or Schoology, whichever applies). Export and Open Sheet go in the `OverflowMenu`. (No Grade Written — VA has no written-response grading.)
+
+```tsx
+const overflowItems: OverflowMenuItem[] = [
+  {
+    label: exportUrl ? 'Re-export Sheet' : 'Export to Sheets',
+    icon: Sheet,
+    onClick: handleExport,
+    disabled: exporting,
+  },
+  ...(exportUrl
+    ? [{ label: 'Open Sheet', icon: ExternalLink, onClick: openSheet }]
+    : []),
+];
+
+<SessionViewHeader
+  onBack={onBack}
+  title={session.assignmentName}
+  subtitle={session.activityTitle}
+  actions={
+    <>
+      {classroomAttached && canPushClassroom && (
+        <ActionButton
+          variant="primary"
+          label="Push Grades"
+          icon={Upload}
+          onClick={handlePushGrades}
+          disabled={pushingGrades}
+        />
+      )}
+      {!classroomAttached && ltiAttached && (
+        <ActionButton
+          variant="primary"
+          label="Push Grades"
+          icon={Upload}
+          onClick={handlePushSchoology}
+          disabled={pushingSchoology}
+        />
+      )}
+      <OverflowMenu items={overflowItems} />
+    </>
+  }
+/>;
+```
+
+Preserve all handlers. The export-error banner stays below the header. This also fixes the odd outlined "Open Sheet" button (now a normal overflow item).
+
+- [ ] **Step 3: Replace the tab strip with `SegmentedTabs`**
+
+```tsx
+<SegmentedTabs
+  tabs={[
+    { key: 'overview', label: 'Overview' },
+    { key: 'questions', label: 'Questions' },
+    { key: 'students', label: 'Students', count: responses.length },
+  ]}
+  value={activeTab}
+  onChange={setActiveTab}
+  ariaLabel="Video activity results tabs"
+/>
+```
+
+- [ ] **Step 4: Modernize the three tabs**
+
+- Overview: the three stat cards → `StatTile` (Students `tone="blue"`, Completed `tone="green"`, Avg Score `tone="violet"`).
+- Questions: per-question rows; accuracy bar fill `scoreColorClasses(accuracy).bar`, number `scoreColorClasses(accuracy).text` (replaces the 70/40 ternary at ~lines 745/768 — now unified 80/60). Timestamp badge → keep or `<SessionBadge tone="info" .../>`.
+- Students: gapless hairline `SessionRow`s (replace the `rounded-xl` cards at ~line 811). Status → `<SessionBadge>`; `trailing` ← `<ScorePill score={score} display="percent" />` (replaces the 70/40 ternary at ~line 866). Keep the correct/incorrect indicators.
+
+- [ ] **Step 5: Empty states**
+
+Replace the inline "No …" empty messages with `ScaledEmptyState`.
+
+- [ ] **Step 6: Verify in the harness**
+
+Check VA-results `populated` and `empty` at 340/520/820px; click Overview/Questions/Students and open the overflow. Confirm Push visible, Export in overflow, segmented tabs, hairline rows, unified 80/60 colors, no console errors.
+
+- [ ] **Step 7: Type-check + commit**
+
+Run: `pnpm run type-check`
+Expected: no errors.
+
+```bash
+git add components/widgets/VideoActivityWidget/components/Results.tsx
+git commit -m "ui(video-activity): restyle results with shared sessionViews atoms + overflow header
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Final validation pass
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full gate**
+
+Run: `pnpm run validate`
+Expected: type-check + lint (zero warnings) + format-check + tests all PASS. Fix any issues (lint `--max-warnings 0` is enforced).
+
+- [ ] **Step 2: Format any new files if needed**
+
+Run: `pnpm run format`
+Then re-run: `pnpm run format:check`
+Expected: PASS.
+
+- [ ] **Step 3: Full harness sweep**
+
+With the dev server (bypass) running, walk all four views × every state × {340, 520, 820}px using `preview_resize` + `preview_screenshot`. Confirm visual consistency with the library (glass surfaces, hairline rows, segmented tabs, unified score colors) and that every action is reachable (visible or in the overflow). Capture before/after screenshots to share with the user.
+
+- [ ] **Step 4: Confirm no behavior regressions**
+
+Spot-check that all preserved actions still fire (pause/resume, end, advance, reveal, scoreboard, period filter, unlock, remove, delete, export, push grades) — in the harness the handlers are no-ops, so verify wiring via `preview_console_logs` (no errors) and code review of the diff (handlers unchanged, only presentation moved).
+
+- [ ] **Step 5: Final commit (if any format/lint fixes were made)**
+
+```bash
+git add -A
+git commit -m "chore(sessionViews): final lint/format pass for monitor+results redesign
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Shared atoms (8) + `scoreColor` util → Tasks 1–9. ✅
+- `SegmentedTabs` extraction from `LibraryShell` → Task 5. ✅
+- Unified 80/60 score scale (incl. VA shift from 70/40) → Task 1 (helper) applied in Tasks 11–14. ✅
+- `/session-views-dev` harness, DEV-gated like `/library-dev`, mock states → Task 10. ✅
+- Per-view restyles preserving functionality → Tasks 11 (Quiz monitor), 12 (VA monitor), 13 (Quiz results), 14 (VA results). ✅
+- Results header IA: Grade Written + Push visible, Export in overflow (Quiz); Push visible, Export in overflow (VA) → Tasks 13 & 14. ✅
+- Testing: atom + util unit tests, library tests stay green, harness visual pass, `pnpm run validate` → Tasks 1–9, 5 (step 6), 15. ✅
+- Guardrails (no data/Firestore/scoring/grade-push changes) → enforced by "preserve handlers" instructions in Tasks 11–14. ✅
+
+**Type consistency:** `SessionTone` (badge, 5 tones) and `ScoreTone` (score, 3 tones) are intentionally distinct and used consistently. `SegmentedTab`/`OverflowMenuItem` types are exported from the barrel and imported where used. `StatTile` tone union (`blue|amber|green|violet`) matches the legacy `color` props it replaces. `ScorePill` display union (`percent|count|hidden`) matches the monitor's `scoreDisplay` state.
+
+**Placeholder note:** Task 10's mock builders intentionally defer per-field completion to type-check (the only honest way to satisfy large generated types without transcribing them); every other code step is complete and copy-ready.

--- a/docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md
@@ -93,7 +93,7 @@ Extract the pill-tab markup currently embedded in `LibraryShell.tsx` into the st
 
 ### QuizResults.tsx
 
-- Header → `SessionViewHeader`. Action buttons: **Export + Push Grades visible**; remaining secondary actions (Grade Written, Send to Scoreboard, Push to Schoology, Open Sheet, Re-export Sheet) move into `OverflowMenu`.
+- Header → `SessionViewHeader`. Action buttons: **Grade Written + Push Grades visible** (Push Grades = whichever push applies — Google Classroom or Schoology); remaining secondary actions (Export / Re-export Sheet, Open Sheet, Send to Scoreboard) move into `OverflowMenu`.
 - Tab strip → `SegmentedTabs` (Overview / Questions / Students / PLC).
 - Overview: stat cards → `StatTile` (drop the colored top-bar); distribution chart on a glass surface; buckets colored via `scoreColor`.
 - Questions: hairline rows; accuracy bar restyled; manual-grading marker → `SessionBadge`.
@@ -103,7 +103,7 @@ Extract the pill-tab markup currently embedded in `LibraryShell.tsx` into the st
 
 ### Results.tsx (Video Activity)
 
-- Header → `SessionViewHeader`. Actions: Push Grades + Export primary; Open Sheet / Push to Schoology secondary or in `OverflowMenu`. Fix the odd outlined "Open Sheet" button to match the system.
+- Header → `SessionViewHeader`. Actions: **Push Grades visible** (Google Classroom or Schoology, whichever applies); Export / Open Sheet move into `OverflowMenu`. (VA has no written-response grading, so there is no Grade Written button here.) Fix the odd outlined "Open Sheet" button to match the system.
 - Tab strip → `SegmentedTabs` (Overview / Questions / Students).
 - Overview: 3 stat cards → `StatTile`.
 - Questions: hairline rows; accuracy bar.

--- a/docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md
@@ -1,0 +1,159 @@
+# Quiz / Video Activity — Monitor & Results redesign
+
+**Date:** 2026-06-14
+**Status:** Approved (design); pending implementation plan
+**Author:** Paul Ivers (+ Claude)
+**Related:** PR #1932 `ui(library): modernize unified library/in-progress/archive views` (commit `84d81cd8`) — the reference design language this work extends.
+
+## Goal
+
+Bring the teacher-facing **Monitor** and **Results** views of the Quiz and Video Activity widgets up to the professional polish of the recently-modernized **Library** view. Four views in scope:
+
+- `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
+- `components/widgets/QuizWidget/components/QuizResults.tsx`
+- `components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx`
+- `components/widgets/VideoActivityWidget/components/Results.tsx`
+
+## Decisions (locked)
+
+1. **Scope/sequencing:** All four views in one pass.
+2. **Architecture:** Hybrid — extract a small set of shared atoms into `components/common/sessionViews/`, then restyle each view to consume them. No single rigid "shell" (Quiz has features VA lacks: scoreboard, podium, question-advance, MC distribution).
+3. **Score colors:** Unify to a single 80/60 scale via a shared helper. This changes only the **color banding** teachers see on Video Activity (was 70/40) — it never changes the numeric score, accuracy math, or any grade pushed to Google Classroom / Schoology.
+4. **Verification:** Build a DEV-only `/session-views-dev` harness (gated like `/library-dev`) seeded with mock sessions/responses to verify every view × state without booting Firestore.
+
+## Non-goals / guardrails
+
+- **Visual + information-architecture only.** No changes to data model, Firestore reads/writes, scoring math, or grade-push logic.
+- The **only** behavior-visible changes are: (a) VA score _coloring_ shifts to the 80/60 scale, and (b) the Results headers move overflowing secondary actions into an overflow menu.
+- Guided Learning and Mini App managers already consume the library primitives and are **out of scope**.
+- All new UI must follow the project's container-query scaling rule (`min(px, Ncqmin)`, never hardcoded Tailwind size classes in scaled content).
+
+## Design language (imported from the library primitives)
+
+Source of truth: `components/common/library/` (`LibraryShell`, `AssignmentArchiveCard`, `LibraryItemCard`, `LibraryToolbar`, `LibraryGrid`).
+
+- **Glassmorphism surfaces:** cards = `bg-white/70 border border-slate-200/60 rounded-2xl backdrop-blur-sm shadow-sm transition-shadow hover:shadow-md`. Header/chrome = `bg-white/60 backdrop-blur-sm border-b border-slate-200/70`. Recessed panels/toolbars = `bg-white/40`.
+- **Hairline list rows:** gapless container (`flex flex-col`); each row carries `border-b border-slate-200/60` + `last:border-b-0`, `rounded-lg`, transient `hover:bg-white/60`. No per-row card box, no shadow. Reserved status-dot slot (`width: min(8px, 2cqmin)`) and aligned columns (fixed-width badge, uniform action width, kebab spacer).
+- **Segmented-pill tabs:** nav = `flex items-center rounded-xl bg-slate-200/50` with inner `padding: min(3px, 0.8cqmin)`; tab button `rounded-lg font-bold`, active = `bg-white text-brand-blue-dark shadow-sm`, inactive = `text-slate-500 hover:text-slate-800`; optional count badge `rounded-full`, active `bg-brand-blue-primary text-white` / inactive `bg-slate-200/70 text-slate-600`.
+- **Semantic tone badges:** `rounded-full font-bold uppercase tracking-wide`, fixed `minWidth: min(60px, 14cqmin)` for column alignment. Tones:
+  - success `bg-emerald-100 text-emerald-700` / dot `bg-emerald-500`
+  - warn `bg-amber-100 text-amber-700` / dot `bg-amber-500`
+  - info `bg-blue-100 text-blue-700` / dot `bg-blue-500`
+  - neutral `bg-slate-200 text-slate-500` / dot `bg-slate-400`
+  - danger `bg-red-100 text-red-700` / dot `bg-red-500`
+- **Buttons:** primary = `bg-brand-blue-primary hover:bg-brand-blue-dark text-white rounded-xl font-bold shadow-sm active:scale-95`; secondary = `bg-white/70 backdrop-blur-sm border border-brand-blue-primary/20 text-brand-blue-primary hover:bg-brand-blue-lighter/40`; danger = brand-red equivalents. All `disabled:opacity-50 disabled:cursor-not-allowed`.
+- **Overflow menu:** `min-w-[176px] rounded-xl border border-slate-200 bg-white py-1 shadow-lg`; items `px-3 py-1.5 font-medium`, destructive `text-brand-red-dark hover:bg-brand-red-lighter/30`.
+- **Typography:** titles `font-black text-slate-800`; metadata `font-medium text-slate-600`; labels/badges `font-bold uppercase tracking-wide`. Sizing via `min(px, Ncqmin)` (titles ~`min(15px,4.8cqmin)`, body ~`min(12px,3.5cqmin)`, labels ~`min(10px,3cqmin)`).
+- **Empty states:** shared `ScaledEmptyState`.
+
+## Shared atoms — `components/common/sessionViews/`
+
+All atoms are fully container-query scaled and theme-consistent with the library.
+
+| File                    | Responsibility                                                                                                                                               | Key props (sketch)                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `SessionViewHeader.tsx` | Standard view header: back button, live/paused/ended status pulse + label, title/subtitle, right-aligned actions slot.                                       | `onBack`, `status?: 'live'\|'paused'\|'ended'\|'none'`, `title`, `subtitle?`, `actions?: ReactNode` |
+| `SegmentedTabs.tsx`     | The pill tab group (extracted from `LibraryShell`).                                                                                                          | `tabs: {key,label,icon?,count?}[]`, `value`, `onChange`, `labelsHidden?`                            |
+| `StatTile.tsx`          | KPI / overview stat tile. Optional interactive (expandable name list) + selected state.                                                                      | `icon`, `value`, `label`, `tone`, `interactive?`, `selected?`, `onClick?`, `children?`              |
+| `SessionBadge.tsx`      | Tone-based status/info badge (icon, dot, uppercase, fixed-width option).                                                                                     | `tone`, `label`, `icon?`, `dot?`, `fixedWidth?`                                                     |
+| `ScorePill.tsx`         | Score chip colored via the shared `scoreColor` helper.                                                                                                       | `score`, `display: 'percent'\|'count'\|'hidden'`, `count?`, `total?`, `gamified?`                   |
+| `SessionRow.tsx`        | Hairline row shell: container + reserved status-dot slot + optional score-band wash + hover + trailing action/overflow slot. Content is passed by each view. | `dot?`, `tintTone?`, `children`, `trailing?`                                                        |
+| `OverflowMenu.tsx`      | Generalized kebab menu (lifted from the inline library implementation) for header secondary actions.                                                         | `items: {label,icon?,onClick,destructive?,disabled?}[]`, `trigger?`                                 |
+| `ActionButton.tsx`      | Primary/secondary/danger button matching library treatment; label collapses to icon-only under a width threshold.                                            | `variant`, `icon?`, `label`, `onClick`, `disabled?`, `labelHidden?`                                 |
+
+### `utils/scoreColor.ts`
+
+Single source of truth for the unified scale.
+
+- `scoreTone(score: number): 'success' | 'warn' | 'danger'` — `>= 80 → success`, `>= 60 → warn`, else `danger`.
+- `scoreColorClasses(score, opts?): { text, bg, border }` — Tailwind class fragments for each tone (e.g. success `text-emerald-600` / `bg-emerald-50` / `border-emerald-200`).
+- Consumed by `ScorePill`, both monitors (row tint + score), and both results views (student scores, question accuracy, distribution buckets).
+
+## `SegmentedTabs` extraction (approved)
+
+Extract the pill-tab markup currently embedded in `LibraryShell.tsx` into the standalone `SegmentedTabs` atom, and refactor `LibraryShell` to consume it — so the library, Quiz Results, and VA Results share one tab component (zero drift). The two-stage label-collapse stays in `LibraryShell` (it owns width measurement) and is passed down via the `labelsHidden` prop. Safety net: `/library-dev` harness + existing library tests must remain green. (Fallback if regression risk proves too high: keep `LibraryShell` as-is and ship a standalone `SegmentedTabs` that mirrors its tokens — not the chosen path.)
+
+## Per-view changes (all functionality preserved)
+
+### QuizLiveMonitor.tsx
+
+- Header → `SessionViewHeader` (actions = pause/resume, end, scoreboard toggle).
+- KPIs (`StatBox`/`InteractiveStatBox`) → `StatTile`.
+- Student list → gapless hairline `SessionRow` + `SessionBadge` + `ScorePill`; score-band tint preserved as a subtle row wash via `tintTone`.
+- Glass surfaces for join-code bar, question hero, MC distribution, podium, scoreboard setup popup. Unified `scoreColor`.
+- **Preserve:** pause/resume, end, advance, reveal answer on board, scoreboard config (name/PIN, completion/per-question), period filter, unlock student, unlock results, remove student, score-display cycle, colors toggle, tab-warning toggle, audio mute, MC distribution, podium.
+
+### VideoActivityLiveMonitor.tsx
+
+- Header → `SessionViewHeader` (actions = pause/resume, end).
+- KPIs (`StatTile`-local) → shared `StatTile`.
+- Student list → hairline `SessionRow` + `SessionBadge` + `ScorePill`; per-question correctness strip restyled for higher-contrast glanceability.
+- Keeps existing `ScaledEmptyState`.
+- **Preserve:** pause/resume, end, unlock student, tab-warning toggle, per-question correctness strip, per-student answered/last-time detail.
+
+### QuizResults.tsx
+
+- Header → `SessionViewHeader`. Action buttons: **Export + Push Grades visible**; remaining secondary actions (Grade Written, Send to Scoreboard, Push to Schoology, Open Sheet, Re-export Sheet) move into `OverflowMenu`.
+- Tab strip → `SegmentedTabs` (Overview / Questions / Students / PLC).
+- Overview: stat cards → `StatTile` (drop the colored top-bar); distribution chart on a glass surface; buckets colored via `scoreColor`.
+- Questions: hairline rows; accuracy bar restyled; manual-grading marker → `SessionBadge`.
+- Students: hairline `SessionRow` list (replace spaced cards); `ScorePill`; tab-warning / results-locked → `SessionBadge`; Unlock/Delete as inline actions or row overflow.
+- Period filter restyled to match.
+- **Preserve:** export to Sheets, grade written responses, push grades (Classroom + Schoology), send to scoreboard, period filter, delete response, unlock results, schema-mismatch recovery.
+
+### Results.tsx (Video Activity)
+
+- Header → `SessionViewHeader`. Actions: Push Grades + Export primary; Open Sheet / Push to Schoology secondary or in `OverflowMenu`. Fix the odd outlined "Open Sheet" button to match the system.
+- Tab strip → `SegmentedTabs` (Overview / Questions / Students).
+- Overview: 3 stat cards → `StatTile`.
+- Questions: hairline rows; accuracy bar.
+- Students: hairline `SessionRow`; `ScorePill` (now unified 80/60); `SessionBadge`.
+- **Preserve:** export to Sheets, push grades (Classroom + Schoology), per-question accuracy, per-student detail.
+
+## Dev harness
+
+- `components/dev/SessionViewsDevHarness.tsx`, route `/session-views-dev`, registered in `App.tsx` under the same DEV-only gating as `/library-dev` and `/notebook-editor-dev`.
+- Seeds realistic mock `QuizSession` + `QuizResponse[]` and `VideoActivitySession` + `VideoActivityResponse[]`.
+- Toggles for **view × state**:
+  - Monitor: waiting · live (teacher-paced) · live (self-paced) · paused · ended.
+  - Results: overview · questions · students; empty + populated.
+- No Firestore/Drive dependency.
+
+## Testing & verification
+
+- Unit tests: `scoreColor` (threshold boundaries 0/59/60/79/80/100), and each shared atom (render + key states), mirroring `tests/components/common/library/`.
+- Existing suites stay green — especially library tests and `QuizManager`/`LibraryGrid`/`AssignmentArchiveCard` after the `LibraryShell` refactor.
+- Visual pass through `/session-views-dev` with the preview tools for every state.
+- `pnpm run validate` (type-check + lint + format-check + tests) before any push. Zero TS errors, zero lint warnings, formatted.
+
+## File manifest
+
+**New**
+
+- `components/common/sessionViews/SessionViewHeader.tsx`
+- `components/common/sessionViews/SegmentedTabs.tsx`
+- `components/common/sessionViews/StatTile.tsx`
+- `components/common/sessionViews/SessionBadge.tsx`
+- `components/common/sessionViews/ScorePill.tsx`
+- `components/common/sessionViews/SessionRow.tsx`
+- `components/common/sessionViews/OverflowMenu.tsx`
+- `components/common/sessionViews/ActionButton.tsx`
+- `utils/scoreColor.ts`
+- `components/dev/SessionViewsDevHarness.tsx`
+- Tests under `tests/components/common/sessionViews/` and `tests/utils/scoreColor.test.ts`
+
+**Modified**
+
+- `components/widgets/QuizWidget/components/QuizLiveMonitor.tsx`
+- `components/widgets/QuizWidget/components/QuizResults.tsx`
+- `components/widgets/VideoActivityWidget/components/VideoActivityLiveMonitor.tsx`
+- `components/widgets/VideoActivityWidget/components/Results.tsx`
+- `components/common/library/LibraryShell.tsx` (consume `SegmentedTabs`)
+- `App.tsx` (register `/session-views-dev`)
+
+## Risks & mitigations
+
+- **LibraryShell regression** (main risk): clean extraction; covered by `/library-dev` harness + existing library tests; behavior kept identical (label-collapse stays in the shell).
+- **VA color shift** is intentional and called out; no numeric/grade impact.
+- **Large monolithic files** (Quiz monitor ~3.3k lines, results ~2.4k): atom extraction reduces per-file size; keep existing memoization (e.g. `StudentRow` memo) intact.
+- **Header IA change** (overflow menu) is the only layout reflow; all actions remain reachable.

--- a/firestore.rules
+++ b/firestore.rules
@@ -311,10 +311,22 @@ service cloud.firestore {
         // always looks up `members/{token.email.lower()}` — can find the
         // record), required fields present, and only the invite-shape keys
         // are allowed.
+        //
+        // Email case handling (F15): every membership read keys off
+        // `request.auth.token.email.lower()` (always lowercase), so a member
+        // doc whose stored email/id is mixed-case is orphaned and matching
+        // legitimate members get permission-denied. We therefore reject any
+        // mixed-case write at the source:
+        //   - `request.resource.data.email == request.resource.data.email.lower()`
+        //     pins the stored email field to lowercase, and
+        //   - `request.resource.data.email == emailLower` ties it to the
+        //     (lowercased) doc id `emailLower`.
+        // Together these guarantee the doc id is lowercase too, so the earlier
+        // standalone `emailLower == emailLower.lower()` guard is redundant and
+        // has been dropped.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
-          emailLower == emailLower.lower() &&
-          request.resource.data.email == emailLower &&
           request.resource.data.email == request.resource.data.email.lower() &&
+          request.resource.data.email == emailLower &&
           request.resource.data.orgId == orgId &&
           request.resource.data.keys().hasAll(['email', 'orgId', 'roleId', 'buildingIds', 'status']) &&
           request.resource.data.keys().hasOnly([

--- a/functions/package.json
+++ b/functions/package.json
@@ -32,8 +32,8 @@
     "@types/cors": "^2.8.19",
     "@types/crypto-js": "^4.2.2",
     "firebase-functions-test": "^3.4.1",
-    "typescript": "^5.8.2",
-    "vitest": "^4.0.18"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.8"
   },
   "pnpm": {
     "overrides": {

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -54,11 +54,11 @@ importers:
         specifier: ^3.4.1
         version: 3.4.1(firebase-admin@13.6.0)(firebase-functions@7.2.5(firebase-admin@13.6.0))(jest@30.2.0(@types/node@25.6.0))
       typescript:
-        specifier: ^5.8.2
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.9(@types/node@25.6.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.9(@types/node@25.6.0))
 
 packages:
 
@@ -849,11 +849,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/expect@4.1.4':
-    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.4':
-    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -863,20 +863,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.4':
-    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.4':
-    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.4':
-    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -2717,20 +2717,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.4:
-    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.4
-      '@vitest/browser-preview': 4.1.4
-      '@vitest/browser-webdriverio': 4.1.4
-      '@vitest/coverage-istanbul': 4.1.4
-      '@vitest/coverage-v8': 4.1.4
-      '@vitest/ui': 4.1.4
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3768,44 +3768,44 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/expect@4.1.4':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.9(@types/node@25.6.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.9(@types/node@25.6.0))':
     dependencies:
-      '@vitest/spy': 4.1.4
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.9(@types/node@25.6.0)
 
-  '@vitest/pretty-format@4.1.4':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.4':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.4
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.4':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.4': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.4':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.4
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -5925,15 +5925,15 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
 
-  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.9(@types/node@25.6.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.9(@types/node@25.6.0)):
     dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.9(@types/node@25.6.0))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.9(@types/node@25.6.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21

--- a/hooks/useCollections.ts
+++ b/hooks/useCollections.ts
@@ -34,6 +34,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { logError } from '@/utils/logError';
+import { readAllDocsPaged } from '@/utils/firestorePaging';
 import type { Collection } from '@/types';
 
 const COLLECTIONS_SUBPATH = 'collections';
@@ -509,7 +510,9 @@ export const useCollections = (
 
         // Phase 1: re-home Boards anywhere in this tree to target's parent.
         // Chunk the `where('collectionId', 'in', ...)` queries by 30 (Firestore
-        // 'in' limit), and chunk the resulting batch writes at 400.
+        // 'in' limit), and chunk the resulting batch writes at 400. Each chunk
+        // query is read in bounded pages so a tree with thousands of boards
+        // can't pull a whole chunk's result set into memory in one read.
         const QUERY_CHUNK = 30;
         let rehomeBatch = writeBatch(db);
         let rehomeCount = 0;
@@ -520,9 +523,9 @@ export const useCollections = (
             where('collectionId', 'in', chunkIds)
           );
           phase = 'rehome-boards-read';
-          const boardSnap = await getDocs(boardsQuery);
+          const boardDocs = await readAllDocsPaged(boardsQuery);
           phase = 'rehome-boards-write';
-          for (const d of boardSnap.docs) {
+          for (const d of boardDocs) {
             if (rehomeCount >= 400) {
               await rehomeBatch.commit();
               boardsRehomed += rehomeCount;

--- a/hooks/useGuidedLearningAssignments.ts
+++ b/hooks/useGuidedLearningAssignments.ts
@@ -17,7 +17,6 @@ import {
   collection,
   deleteField,
   doc,
-  getDocs,
   onSnapshot,
   orderBy,
   query,
@@ -262,7 +261,9 @@ export const useGuidedLearningAssignments = (
       if (!userId) throw new Error('Not authenticated');
 
       // Delete response documents in batches of 500 (Firestore batch limit).
-      const responsesSnap = await getDocs(
+      // Read in bounded pages so a session with thousands of responses can't
+      // pull the whole subcollection into memory in a single unbounded read.
+      const responseDocs = await readAllDocsPaged(
         collection(
           db,
           GL_SESSIONS_COLLECTION,
@@ -271,9 +272,9 @@ export const useGuidedLearningAssignments = (
         )
       );
       const BATCH_LIMIT = 500;
-      for (let i = 0; i < responsesSnap.docs.length; i += BATCH_LIMIT) {
+      for (let i = 0; i < responseDocs.length; i += BATCH_LIMIT) {
         const batch = writeBatch(db);
-        responsesSnap.docs
+        responseDocs
           .slice(i, i + BATCH_LIMIT)
           .forEach((d) => batch.delete(d.ref));
         await batch.commit();

--- a/hooks/useQuizAssignments.ts
+++ b/hooks/useQuizAssignments.ts
@@ -1078,8 +1078,10 @@ export const useQuizAssignments = (
       const priorPlcId = priorAssignment?.plc?.id ?? null;
       const priorQuizId = priorAssignment?.quizId ?? null;
 
-      // Delete all response documents first (batched)
-      const responsesSnap = await getDocs(
+      // Delete all response documents first (batched). Read in bounded pages
+      // so a session with thousands of responses can't pull the whole
+      // subcollection into memory in a single unbounded read.
+      const responseDocs = await readAllDocsPaged(
         collection(
           db,
           QUIZ_SESSIONS_COLLECTION,
@@ -1088,9 +1090,9 @@ export const useQuizAssignments = (
         )
       );
       const BATCH_LIMIT = 500;
-      for (let i = 0; i < responsesSnap.docs.length; i += BATCH_LIMIT) {
+      for (let i = 0; i < responseDocs.length; i += BATCH_LIMIT) {
         const batch = writeBatch(db);
-        responsesSnap.docs
+        responseDocs
           .slice(i, i + BATCH_LIMIT)
           .forEach((d) => batch.delete(d.ref));
         await batch.commit();

--- a/hooks/useReconcileExpiredSubShares.test.ts
+++ b/hooks/useReconcileExpiredSubShares.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as firestore from 'firebase/firestore';
+import * as paging from '@/utils/firestorePaging';
+import { useReconcileExpiredSubShares } from './useReconcileExpiredSubShares';
+import type { GoogleDriveService } from '@/utils/googleDriveService';
+
+vi.mock('firebase/firestore');
+vi.mock('@/config/firebase', () => ({ db: {} }));
+vi.mock('@/utils/firestorePaging');
+
+interface FakeShare {
+  id: string;
+  expiresAt?: number;
+  driveGrants?: Array<{
+    email?: string;
+    fileId?: string;
+    permissionId?: string;
+  }>;
+}
+
+/** Build a QueryDocumentSnapshot stand-in for one shared_boards doc. */
+function makeShareSnap(share: FakeShare) {
+  const { id, ...data } = share;
+  return {
+    id,
+    ref: { id } as unknown as firestore.DocumentReference,
+    data: () => data,
+  };
+}
+
+function makeDriveService() {
+  return {
+    deletePermission: vi.fn().mockResolvedValue(undefined),
+  } as unknown as GoogleDriveService & {
+    deletePermission: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('useReconcileExpiredSubShares', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue('shared_boards');
+    (firestore.where as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (...args: unknown[]) => ({ __where: args })
+    );
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (...args: unknown[]) => ({ __query: args })
+    );
+    (
+      firestore.deleteDoc as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(undefined);
+  });
+
+  it('reads shares via readAllDocsPaged (bounded), never an unbounded getDocs', async () => {
+    (
+      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+
+    renderHook(() =>
+      useReconcileExpiredSubShares({
+        uid: 'teacher-1',
+        driveService: makeDriveService(),
+      })
+    );
+
+    await waitFor(() =>
+      expect(paging.readAllDocsPaged).toHaveBeenCalledTimes(1)
+    );
+    // The unbounded path must not be used by this hook anymore.
+    expect(firestore.getDocs).not.toHaveBeenCalled();
+  });
+
+  it('revokes grants for expired shares and deletes those docs, leaving active shares untouched', async () => {
+    const now = Date.now();
+    const expired = makeShareSnap({
+      id: 'expired-1',
+      expiresAt: now - 1000,
+      driveGrants: [{ email: 's@x', fileId: 'file-1', permissionId: 'perm-1' }],
+    });
+    const active = makeShareSnap({
+      id: 'active-1',
+      expiresAt: now + 60_000,
+      driveGrants: [{ email: 's@x', fileId: 'file-2', permissionId: 'perm-2' }],
+    });
+    (
+      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([expired, active]);
+    const driveService = makeDriveService();
+
+    renderHook(() =>
+      useReconcileExpiredSubShares({ uid: 'teacher-1', driveService })
+    );
+
+    await waitFor(() =>
+      expect(driveService.deletePermission).toHaveBeenCalledWith(
+        'file-1',
+        'perm-1'
+      )
+    );
+    // Active share's permission is never revoked.
+    expect(driveService.deletePermission).not.toHaveBeenCalledWith(
+      'file-2',
+      'perm-2'
+    );
+    // Only the expired share doc is deleted.
+    expect(firestore.deleteDoc).toHaveBeenCalledTimes(1);
+    expect(firestore.deleteDoc).toHaveBeenCalledWith(expired.ref);
+  });
+
+  it('does NOT revoke a permissionId still referenced by an active share', async () => {
+    const now = Date.now();
+    // Both shares share permissionId perm-shared; only one is expired.
+    const expired = makeShareSnap({
+      id: 'expired-1',
+      expiresAt: now - 1000,
+      driveGrants: [
+        { email: 's@x', fileId: 'file-1', permissionId: 'perm-shared' },
+      ],
+    });
+    const active = makeShareSnap({
+      id: 'active-1',
+      expiresAt: now + 60_000,
+      driveGrants: [
+        { email: 's@x', fileId: 'file-1', permissionId: 'perm-shared' },
+      ],
+    });
+    (
+      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([expired, active]);
+    const driveService = makeDriveService();
+
+    renderHook(() =>
+      useReconcileExpiredSubShares({ uid: 'teacher-1', driveService })
+    );
+
+    // Wait for the sweep to finish (expired doc deleted) — the shared
+    // permission must be skipped because an active share still references it.
+    await waitFor(() => expect(firestore.deleteDoc).toHaveBeenCalledTimes(1));
+    expect(driveService.deletePermission).not.toHaveBeenCalled();
+  });
+
+  it('honours the once-per-session guard for a given uid', async () => {
+    window.sessionStorage.setItem('spart_sub_reconcile_teacher-1', '1');
+    (
+      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue([]);
+
+    renderHook(() =>
+      useReconcileExpiredSubShares({
+        uid: 'teacher-1',
+        driveService: makeDriveService(),
+      })
+    );
+
+    // Give any pending microtasks a chance to run; the guard should short-circuit.
+    await Promise.resolve();
+    expect(paging.readAllDocsPaged).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useReconcileExpiredSubShares.ts
+++ b/hooks/useReconcileExpiredSubShares.ts
@@ -35,14 +35,9 @@
  */
 
 import { useEffect, useRef } from 'react';
-import {
-  collection,
-  deleteDoc,
-  getDocs,
-  query,
-  where,
-} from 'firebase/firestore';
+import { collection, deleteDoc, query, where } from 'firebase/firestore';
 import { db } from '@/config/firebase';
+import { readAllDocsPaged } from '@/utils/firestorePaging';
 import type { GoogleDriveService } from '@/utils/googleDriveService';
 
 const SESSION_KEY_PREFIX = 'spart_sub_reconcile_';
@@ -136,8 +131,12 @@ async function reconcileExpiredSubShares(
     where('originalAuthor', '==', uid),
     where('intendedMode', '==', 'substitute')
   );
-  const snap = await getDocs(allQuery);
-  if (snap.empty) return;
+  // Read in bounded pages so a teacher with a large share history can't pull
+  // the whole filtered result set into memory in a single unbounded read.
+  // We iterate every doc below (to decide expired vs. still-referenced), so a
+  // full paged read — not a capped limit() — is the right bound here.
+  const allDocs = await readAllDocsPaged(allQuery);
+  if (allDocs.length === 0) return;
 
   const now = Date.now();
   const stillReferenced = new Set<string>();
@@ -146,7 +145,7 @@ async function reconcileExpiredSubShares(
     grants: PersistedGrant[];
   }> = [];
 
-  for (const docSnap of snap.docs) {
+  for (const docSnap of allDocs) {
     const data = docSnap.data() as {
       expiresAt?: number;
       driveGrants?: PersistedGrant[];

--- a/hooks/useVideoActivityAssignments.ts
+++ b/hooks/useVideoActivityAssignments.ts
@@ -20,7 +20,6 @@ import {
   doc,
   getDoc,
   onSnapshot,
-  getDocs,
   query,
   orderBy,
   updateDoc,
@@ -526,8 +525,10 @@ export const useVideoActivityAssignments = (
     async (assignmentId) => {
       if (!userId) throw new Error('Not authenticated');
 
-      // Delete all response documents first (batched)
-      const responsesSnap = await getDocs(
+      // Delete all response documents first (batched). Read in bounded pages
+      // so a session with thousands of responses can't pull the whole
+      // subcollection into memory in a single unbounded read.
+      const responseDocs = await readAllDocsPaged(
         collection(
           db,
           VIDEO_ACTIVITY_SESSIONS_COLLECTION,
@@ -536,9 +537,9 @@ export const useVideoActivityAssignments = (
         )
       );
       const BATCH_LIMIT = 500;
-      for (let i = 0; i < responsesSnap.docs.length; i += BATCH_LIMIT) {
+      for (let i = 0; i < responseDocs.length; i += BATCH_LIMIT) {
         const batch = writeBatch(db);
-        responsesSnap.docs
+        responseDocs
           .slice(i, i + BATCH_LIMIT)
           .forEach((d) => batch.delete(d.ref));
         await batch.commit();

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Play } from 'lucide-react';
+import { ActionButton } from '@/components/common/sessionViews/ActionButton';
+
+describe('ActionButton', () => {
+  it('renders label + primary styling and fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <ActionButton
+        variant="primary"
+        label="Export"
+        icon={Play}
+        onClick={onClick}
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'Export' });
+    expect(btn).toHaveTextContent('Export');
+    expect(btn.className).toContain('bg-brand-blue-primary');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('uses danger styling for the danger variant', () => {
+    render(<ActionButton variant="danger" label="End" onClick={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'End' }).className).toContain(
+      'bg-brand-red-primary'
+    );
+  });
+
+  it('hides the label text but keeps the accessible name when labelHidden', () => {
+    render(
+      <ActionButton
+        variant="secondary"
+        label="Scoreboard"
+        icon={Play}
+        onClick={vi.fn()}
+        labelHidden
+      />
+    );
+    expect(screen.queryByText('Scoreboard')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Scoreboard' })
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -17,6 +17,8 @@ describe('ActionButton', () => {
     const btn = screen.getByRole('button', { name: 'Export' });
     expect(btn).toHaveTextContent('Export');
     expect(btn.className).toContain('bg-brand-blue-primary');
+    // Non-toggle buttons must not expose aria-pressed.
+    expect(btn).not.toHaveAttribute('aria-pressed');
     fireEvent.click(btn);
     expect(onClick).toHaveBeenCalled();
   });

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -56,9 +56,10 @@ describe('ActionButton', () => {
         loading
       />
     );
-    // Spinner present, accessible name preserved.
+    // Spinner present, accessible name preserved, and disabled so it can't double-fire.
     expect(container.querySelector('.animate-spin')).not.toBeNull();
     expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'End' })).toBeDisabled();
   });
 
   it('applies the amber on-state treatment when active', () => {

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -43,4 +43,19 @@ describe('ActionButton', () => {
       screen.getByRole('button', { name: 'Scoreboard' })
     ).toBeInTheDocument();
   });
+
+  it('shows a spinner in place of the icon when loading', () => {
+    const { container } = render(
+      <ActionButton
+        variant="danger"
+        label="End"
+        icon={Play}
+        onClick={vi.fn()}
+        loading
+      />
+    );
+    // Spinner present, accessible name preserved.
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
+  });
 });

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -58,4 +58,20 @@ describe('ActionButton', () => {
     expect(container.querySelector('.animate-spin')).not.toBeNull();
     expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
   });
+
+  it('applies the amber on-state treatment when active', () => {
+    render(
+      <ActionButton
+        variant="secondary"
+        label="Scoreboard"
+        icon={Play}
+        onClick={vi.fn()}
+        active
+      />
+    );
+    const btn = screen.getByRole('button', { name: 'Scoreboard' });
+    expect(btn.className).toContain('ring-amber-400');
+    expect(btn.className).toContain('bg-amber-100');
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/tests/components/common/sessionViews/ActionButton.test.tsx
+++ b/tests/components/common/sessionViews/ActionButton.test.tsx
@@ -19,6 +19,8 @@ describe('ActionButton', () => {
     expect(btn.className).toContain('bg-brand-blue-primary');
     // Non-toggle buttons must not expose aria-pressed.
     expect(btn).not.toHaveAttribute('aria-pressed');
+    // Keyboard focus ring present (WCAG AA).
+    expect(btn.className).toContain('focus-visible:ring-brand-blue-primary');
     fireEvent.click(btn);
     expect(onClick).toHaveBeenCalled();
   });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -21,4 +21,12 @@ describe('OverflowMenu', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole('menu')).toBeNull();
   });
+
+  it('closes on Escape', () => {
+    render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
 });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -22,6 +22,14 @@ describe('OverflowMenu', () => {
     expect(screen.queryByRole('menu')).toBeNull();
   });
 
+  it('closes on Tab so focus continues in document order', () => {
+    render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Tab' });
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
   it('closes on Escape and returns focus to the trigger', () => {
     render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
     const trigger = screen.getByRole('button', { name: 'More actions' });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OverflowMenu } from '@/components/common/sessionViews/OverflowMenu';
+
+describe('OverflowMenu', () => {
+  it('opens on click and shows items', () => {
+    render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
+    expect(screen.queryByRole('menu')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Export' })
+    ).toBeInTheDocument();
+  });
+
+  it('fires the item onClick and closes', () => {
+    const onClick = vi.fn();
+    render(<OverflowMenu items={[{ label: 'Export', onClick }]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Export' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -35,7 +35,7 @@ describe('OverflowMenu', () => {
     const trigger = screen.getByRole('button', { name: 'More actions' });
     fireEvent.click(trigger);
     expect(screen.getByRole('menu')).toBeInTheDocument();
-    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
     expect(screen.queryByRole('menu')).toBeNull();
     expect(trigger).toHaveFocus();
   });
@@ -58,13 +58,14 @@ describe('OverflowMenu', () => {
   });
 
   it('renders a spinner for a loading item', () => {
-    const { container } = render(
+    render(
       <OverflowMenu
         items={[{ label: 'Export', loading: true, onClick: vi.fn() }]}
       />
     );
     fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
-    expect(container.querySelector('.animate-spin')).not.toBeNull();
+    // Menu is portalled to document.body, so query the document, not container.
+    expect(document.querySelector('.animate-spin')).not.toBeNull();
     // A loading item is disabled so it can't double-fire.
     expect(screen.getByRole('menuitem', { name: 'Export' })).toBeDisabled();
   });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -57,5 +57,7 @@ describe('OverflowMenu', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
     expect(container.querySelector('.animate-spin')).not.toBeNull();
+    // A loading item is disabled so it can't double-fire.
+    expect(screen.getByRole('menuitem', { name: 'Export' })).toBeDisabled();
   });
 });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -68,7 +68,11 @@ describe('OverflowMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
     // Menu is portalled to document.body, so query the document, not container.
     expect(document.querySelector('.animate-spin')).not.toBeNull();
-    // A loading item is disabled so it can't double-fire.
-    expect(screen.getByRole('menuitem', { name: 'Export' })).toBeDisabled();
+    // A loading item is aria-disabled (stays focusable/announced) and its
+    // onClick is guarded so it can't double-fire.
+    expect(screen.getByRole('menuitem', { name: 'Export' })).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 });

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -22,12 +22,14 @@ describe('OverflowMenu', () => {
     expect(screen.queryByRole('menu')).toBeNull();
   });
 
-  it('closes on Tab so focus continues in document order', () => {
+  it('closes on Tab and returns focus to the trigger', () => {
     render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
-    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    const trigger = screen.getByRole('button', { name: 'More actions' });
+    fireEvent.click(trigger);
     expect(screen.getByRole('menu')).toBeInTheDocument();
     fireEvent.keyDown(screen.getByRole('menu'), { key: 'Tab' });
     expect(screen.queryByRole('menu')).toBeNull();
+    expect(trigger).toHaveFocus();
   });
 
   it('closes on Escape and returns focus to the trigger', () => {

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -22,11 +22,40 @@ describe('OverflowMenu', () => {
     expect(screen.queryByRole('menu')).toBeNull();
   });
 
-  it('closes on Escape', () => {
+  it('closes on Escape and returns focus to the trigger', () => {
     render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
-    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    const trigger = screen.getByRole('button', { name: 'More actions' });
+    fireEvent.click(trigger);
     expect(screen.getByRole('menu')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('menu')).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('focuses the first item on open and navigates with Arrow keys', () => {
+    render(
+      <OverflowMenu
+        items={[
+          { label: 'A', onClick: vi.fn() },
+          { label: 'B', onClick: vi.fn() },
+        ]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menuitem', { name: 'A' })).toHaveFocus();
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowDown' });
+    expect(screen.getByRole('menuitem', { name: 'B' })).toHaveFocus();
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'ArrowUp' });
+    expect(screen.getByRole('menuitem', { name: 'A' })).toHaveFocus();
+  });
+
+  it('renders a spinner for a loading item', () => {
+    const { container } = render(
+      <OverflowMenu
+        items={[{ label: 'Export', loading: true, onClick: vi.fn() }]}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(container.querySelector('.animate-spin')).not.toBeNull();
   });
 });

--- a/tests/components/common/sessionViews/ScorePill.test.tsx
+++ b/tests/components/common/sessionViews/ScorePill.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ScorePill } from '@/components/common/sessionViews/ScorePill';
+
+describe('ScorePill', () => {
+  it('renders rounded percent with the tone color', () => {
+    render(<ScorePill score={90} display="percent" />);
+    const pill = screen.getByTestId('score-pill');
+    expect(pill).toHaveTextContent('90%');
+    expect(pill.className).toContain('text-emerald-600');
+  });
+
+  it('renders count form as answered/total', () => {
+    render(<ScorePill score={0} display="count" count={3} total={5} />);
+    expect(screen.getByTestId('score-pill')).toHaveTextContent('3/5');
+  });
+
+  it('renders nothing when hidden', () => {
+    const { container } = render(<ScorePill score={90} display="hidden" />);
+    expect(container.querySelector('[data-testid="score-pill"]')).toBeNull();
+  });
+
+  it('shows points in brand-blue when gamified', () => {
+    render(<ScorePill score={42} display="percent" gamified points={1200} />);
+    const pill = screen.getByTestId('score-pill');
+    expect(pill).toHaveTextContent('1200');
+    expect(pill.className).toContain('text-brand-blue-dark');
+  });
+});

--- a/tests/components/common/sessionViews/ScorePill.test.tsx
+++ b/tests/components/common/sessionViews/ScorePill.test.tsx
@@ -42,4 +42,9 @@ describe('ScorePill', () => {
     );
     expect(screen.getByTestId('score-pill')).toHaveTextContent('247 pts');
   });
+
+  it('renders 0% instead of NaN% when the score is not finite', () => {
+    render(<ScorePill score={NaN} display="percent" />);
+    expect(screen.getByTestId('score-pill')).toHaveTextContent('0%');
+  });
 });

--- a/tests/components/common/sessionViews/ScorePill.test.tsx
+++ b/tests/components/common/sessionViews/ScorePill.test.tsx
@@ -29,4 +29,17 @@ describe('ScorePill', () => {
     expect(pill).toHaveTextContent('1200');
     expect(pill.className).toContain('text-brand-blue-dark');
   });
+
+  it('appends the suffix to the value (e.g. gamified points)', () => {
+    render(
+      <ScorePill
+        score={0}
+        display="percent"
+        gamified
+        points={247}
+        suffix=" pts"
+      />
+    );
+    expect(screen.getByTestId('score-pill')).toHaveTextContent('247 pts');
+  });
 });

--- a/tests/components/common/sessionViews/ScorePill.test.tsx
+++ b/tests/components/common/sessionViews/ScorePill.test.tsx
@@ -13,6 +13,9 @@ describe('ScorePill', () => {
   it('renders count form as answered/total', () => {
     render(<ScorePill score={0} display="count" count={3} total={5} />);
     expect(screen.getByTestId('score-pill')).toHaveTextContent('3/5');
+    expect(screen.getByTestId('score-pill').className).toContain(
+      'text-slate-600'
+    );
   });
 
   it('renders nothing when hidden', () => {

--- a/tests/components/common/sessionViews/SegmentedTabs.test.tsx
+++ b/tests/components/common/sessionViews/SegmentedTabs.test.tsx
@@ -62,4 +62,19 @@ describe('SegmentedTabs', () => {
     expect(screen.queryByText('Overview')).toBeNull();
     expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
   });
+
+  it('wires id + aria-controls when panelIdPrefix is set', () => {
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+        panelIdPrefix="qr"
+      />
+    );
+    const tab = screen.getByRole('tab', { name: 'Overview' });
+    expect(tab).toHaveAttribute('id', 'qr-tab-overview');
+    expect(tab).toHaveAttribute('aria-controls', 'qr-panel-overview');
+  });
 });

--- a/tests/components/common/sessionViews/SegmentedTabs.test.tsx
+++ b/tests/components/common/sessionViews/SegmentedTabs.test.tsx
@@ -9,7 +9,14 @@ const TABS = [
 
 describe('SegmentedTabs', () => {
   it('marks the active tab with aria-selected and white surface', () => {
-    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />
+    );
     const active = screen.getByRole('tab', { name: 'Overview' });
     expect(active).toHaveAttribute('aria-selected', 'true');
     expect(active.className).toContain('bg-white');
@@ -18,13 +25,27 @@ describe('SegmentedTabs', () => {
 
   it('fires onChange with the tab key', () => {
     const onChange = vi.fn();
-    render(<SegmentedTabs tabs={TABS} value="overview" onChange={onChange} />);
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={onChange}
+        ariaLabel="Sections"
+      />
+    );
     fireEvent.click(screen.getByRole('tab', { name: 'Students' }));
     expect(onChange).toHaveBeenCalledWith('students');
   });
 
   it('renders a count badge when count > 0', () => {
-    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={vi.fn()}
+        ariaLabel="Sections"
+      />
+    );
     expect(screen.getByText('4')).toBeInTheDocument();
   });
 
@@ -35,6 +56,7 @@ describe('SegmentedTabs', () => {
         value="overview"
         onChange={vi.fn()}
         labelsHidden
+        ariaLabel="Sections"
       />
     );
     expect(screen.queryByText('Overview')).toBeNull();

--- a/tests/components/common/sessionViews/SegmentedTabs.test.tsx
+++ b/tests/components/common/sessionViews/SegmentedTabs.test.tsx
@@ -13,6 +13,7 @@ describe('SegmentedTabs', () => {
     const active = screen.getByRole('tab', { name: 'Overview' });
     expect(active).toHaveAttribute('aria-selected', 'true');
     expect(active.className).toContain('bg-white');
+    expect(active.className).toContain('focus-visible:ring-brand-blue-primary');
   });
 
   it('fires onChange with the tab key', () => {

--- a/tests/components/common/sessionViews/SegmentedTabs.test.tsx
+++ b/tests/components/common/sessionViews/SegmentedTabs.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SegmentedTabs } from '@/components/common/sessionViews/SegmentedTabs';
+
+const TABS = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'students', label: 'Students', count: 4 },
+];
+
+describe('SegmentedTabs', () => {
+  it('marks the active tab with aria-selected and white surface', () => {
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    const active = screen.getByRole('tab', { name: 'Overview' });
+    expect(active).toHaveAttribute('aria-selected', 'true');
+    expect(active.className).toContain('bg-white');
+  });
+
+  it('fires onChange with the tab key', () => {
+    const onChange = vi.fn();
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Students' }));
+    expect(onChange).toHaveBeenCalledWith('students');
+  });
+
+  it('renders a count badge when count > 0', () => {
+    render(<SegmentedTabs tabs={TABS} value="overview" onChange={vi.fn()} />);
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('hides labels but keeps icons/aria when labelsHidden', () => {
+    render(
+      <SegmentedTabs
+        tabs={TABS}
+        value="overview"
+        onChange={vi.fn()}
+        labelsHidden
+      />
+    );
+    expect(screen.queryByText('Overview')).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+  });
+});

--- a/tests/components/common/sessionViews/SessionBadge.test.tsx
+++ b/tests/components/common/sessionViews/SessionBadge.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionBadge } from '@/components/common/sessionViews/SessionBadge';
+
+describe('SessionBadge', () => {
+  it('renders the label with success tone classes', () => {
+    render(<SessionBadge tone="success" label="Done" />);
+    const badge = screen.getByTestId('session-badge');
+    expect(badge).toHaveTextContent('Done');
+    expect(badge.className).toContain('bg-emerald-100');
+    expect(badge.className).toContain('text-emerald-700');
+  });
+
+  it('renders a pulsing dot for success tone when dot is set', () => {
+    const { container } = render(
+      <SessionBadge tone="success" label="Live" dot />
+    );
+    const dot = container.querySelector('.animate-pulse');
+    expect(dot).not.toBeNull();
+  });
+
+  it('uses neutral classes for neutral tone', () => {
+    render(<SessionBadge tone="neutral" label="Ended" />);
+    expect(screen.getByTestId('session-badge').className).toContain(
+      'bg-slate-200'
+    );
+  });
+});

--- a/tests/components/common/sessionViews/SessionRow.test.tsx
+++ b/tests/components/common/sessionViews/SessionRow.test.tsx
@@ -48,6 +48,7 @@ describe('SessionRow', () => {
     const row = screen.getByTestId('session-row');
     expect(row).toHaveAttribute('role', 'button');
     expect(row).toHaveAttribute('tabindex', '0');
+    expect(row.className).toContain('focus-visible:ring-brand-blue-primary');
     fireEvent.keyDown(row, { key: 'Enter' });
     fireEvent.keyDown(row, { key: ' ' });
     expect(onClick).toHaveBeenCalledTimes(2);

--- a/tests/components/common/sessionViews/SessionRow.test.tsx
+++ b/tests/components/common/sessionViews/SessionRow.test.tsx
@@ -21,9 +21,10 @@ describe('SessionRow', () => {
         <span>x</span>
       </SessionRow>
     );
-    expect(screen.getByTestId('session-row').className).toContain(
-      'bg-emerald-50/60'
-    );
+    const row = screen.getByTestId('session-row').className;
+    expect(row).toContain('bg-emerald-50/60');
+    // Tinted rows still get a hover affordance.
+    expect(row).toContain('hover:brightness-95');
   });
 
   it('fires onClick', () => {

--- a/tests/components/common/sessionViews/SessionRow.test.tsx
+++ b/tests/components/common/sessionViews/SessionRow.test.tsx
@@ -36,4 +36,30 @@ describe('SessionRow', () => {
     fireEvent.click(screen.getByTestId('session-row'));
     expect(onClick).toHaveBeenCalled();
   });
+
+  it('is keyboard-activatable (role/tabindex + Enter/Space) when onClick is set', () => {
+    const onClick = vi.fn();
+    render(
+      <SessionRow onClick={onClick}>
+        <span>x</span>
+      </SessionRow>
+    );
+    const row = screen.getByTestId('session-row');
+    expect(row).toHaveAttribute('role', 'button');
+    expect(row).toHaveAttribute('tabindex', '0');
+    fireEvent.keyDown(row, { key: 'Enter' });
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('is not interactive (no role/tabindex) without onClick', () => {
+    render(
+      <SessionRow>
+        <span>x</span>
+      </SessionRow>
+    );
+    const row = screen.getByTestId('session-row');
+    expect(row).not.toHaveAttribute('role');
+    expect(row).not.toHaveAttribute('tabindex');
+  });
 });

--- a/tests/components/common/sessionViews/SessionRow.test.tsx
+++ b/tests/components/common/sessionViews/SessionRow.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionRow } from '@/components/common/sessionViews/SessionRow';
+
+describe('SessionRow', () => {
+  it('renders children and a hairline bottom border', () => {
+    render(
+      <SessionRow trailing={<span>99%</span>}>
+        <span>Ada Lovelace</span>
+      </SessionRow>
+    );
+    const row = screen.getByTestId('session-row');
+    expect(row).toHaveTextContent('Ada Lovelace');
+    expect(row).toHaveTextContent('99%');
+    expect(row.className).toContain('border-b');
+  });
+
+  it('applies a score-band wash when tintTone is set', () => {
+    render(
+      <SessionRow tintTone="success">
+        <span>x</span>
+      </SessionRow>
+    );
+    expect(screen.getByTestId('session-row').className).toContain(
+      'bg-emerald-50/60'
+    );
+  });
+
+  it('fires onClick', () => {
+    const onClick = vi.fn();
+    render(
+      <SessionRow onClick={onClick}>
+        <span>x</span>
+      </SessionRow>
+    );
+    fireEvent.click(screen.getByTestId('session-row'));
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/tests/components/common/sessionViews/SessionViewHeader.test.tsx
+++ b/tests/components/common/sessionViews/SessionViewHeader.test.tsx
@@ -29,4 +29,10 @@ describe('SessionViewHeader', () => {
     );
     expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
   });
+
+  it('renders no back button when onBack is omitted', () => {
+    render(<SessionViewHeader title="Q" />);
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+    expect(screen.getByText('Q')).toBeInTheDocument();
+  });
 });

--- a/tests/components/common/sessionViews/SessionViewHeader.test.tsx
+++ b/tests/components/common/sessionViews/SessionViewHeader.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SessionViewHeader } from '@/components/common/sessionViews/SessionViewHeader';
+
+describe('SessionViewHeader', () => {
+  it('renders title/subtitle and fires onBack', () => {
+    const onBack = vi.fn();
+    render(
+      <SessionViewHeader onBack={onBack} title="My Quiz" subtitle="Period 3" />
+    );
+    expect(screen.getByText('My Quiz')).toBeInTheDocument();
+    expect(screen.getByText('Period 3')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('shows a live status pill', () => {
+    render(<SessionViewHeader onBack={vi.fn()} status="live" title="Q" />);
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('renders the actions slot', () => {
+    render(
+      <SessionViewHeader
+        onBack={vi.fn()}
+        title="Q"
+        actions={<button type="button">End</button>}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'End' })).toBeInTheDocument();
+  });
+});

--- a/tests/components/common/sessionViews/StatTile.test.tsx
+++ b/tests/components/common/sessionViews/StatTile.test.tsx
@@ -25,6 +25,8 @@ describe('StatTile', () => {
     );
     const tile = screen.getByTestId('stat-tile');
     expect(tile.tagName).toBe('BUTTON');
+    // Not a toggle (no `selected`) → no aria-pressed.
+    expect(tile).not.toHaveAttribute('aria-pressed');
     fireEvent.click(tile);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -39,8 +41,8 @@ describe('StatTile', () => {
         selected
       />
     );
-    expect(screen.getByTestId('stat-tile').className).toContain(
-      'ring-brand-blue-primary/40'
-    );
+    const tile = screen.getByTestId('stat-tile');
+    expect(tile.className).toContain('ring-brand-blue-primary/40');
+    expect(tile).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/tests/components/common/sessionViews/StatTile.test.tsx
+++ b/tests/components/common/sessionViews/StatTile.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Users } from 'lucide-react';
+import { StatTile } from '@/components/common/sessionViews/StatTile';
+
+describe('StatTile', () => {
+  it('renders value and label on a glass surface', () => {
+    render(<StatTile icon={<Users />} value={12} label="Joined" />);
+    const tile = screen.getByTestId('stat-tile');
+    expect(tile).toHaveTextContent('12');
+    expect(tile).toHaveTextContent('Joined');
+    expect(tile.className).toContain('bg-white/70');
+  });
+
+  it('renders as a button and fires onClick when interactive', () => {
+    const onClick = vi.fn();
+    render(
+      <StatTile
+        icon={<Users />}
+        value={3}
+        label="Active"
+        interactive
+        onClick={onClick}
+      />
+    );
+    const tile = screen.getByTestId('stat-tile');
+    expect(tile.tagName).toBe('BUTTON');
+    fireEvent.click(tile);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the selected ring when selected', () => {
+    render(
+      <StatTile
+        icon={<Users />}
+        value={3}
+        label="Active"
+        interactive
+        selected
+      />
+    );
+    expect(screen.getByTestId('stat-tile').className).toContain(
+      'ring-brand-blue-primary/40'
+    );
+  });
+});

--- a/tests/components/widgets/QuizResults.regenerate.test.tsx
+++ b/tests/components/widgets/QuizResults.regenerate.test.tsx
@@ -179,7 +179,9 @@ describe('QuizResults — Re-export Sheet 404 regenerate-sheet recovery', () => 
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /re-export sheet/i }));
+    // Re-export Sheet now lives in the overflow menu: open the kebab first.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /re-export sheet/i }));
 
     await waitFor(() => {
       expect(mockExportResultsToSheet).toHaveBeenCalledTimes(2);
@@ -234,7 +236,9 @@ describe('QuizResults — Re-export Sheet rebuild branch (no delta)', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /re-export sheet/i }));
+    // Re-export Sheet now lives in the overflow menu: open the kebab first.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /re-export sheet/i }));
 
     // Rebuild branch fires regeneratePlcSheet, NOT exportResultsToSheet —
     // the latter would append duplicate rows. Verify both: regenerate

--- a/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
+++ b/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
@@ -171,7 +171,11 @@ describe('QuizResults — PLC schema mismatch recovery', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
+    // Export now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: /export to sheets/i })
+    );
 
     // The banner has to call out *what* differs so the teacher / admin can
     // tell at a glance whether the gap is a column-count drift or a single
@@ -204,7 +208,11 @@ describe('QuizResults — PLC schema mismatch recovery', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
+    // Export now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: /export to sheets/i })
+    );
 
     await waitFor(() => {
       expect(
@@ -243,7 +251,11 @@ describe('QuizResults — PLC schema mismatch recovery', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^export$/i }));
+    // Export now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: /export to sheets/i })
+    );
 
     await waitFor(() => {
       expect(

--- a/tests/components/widgets/QuizResults.soloReExport.test.tsx
+++ b/tests/components/widgets/QuizResults.soloReExport.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { QuizConfig, QuizData, QuizResponse } from '@/types';
 
 // Locks in the solo Re-Export Sheet affordance — without it, teachers had no
@@ -144,17 +144,49 @@ describe('QuizResults — solo Re-Export Sheet button', () => {
       />
     );
 
+    // The Re-Export and Open Sheet actions now live in the overflow (kebab)
+    // menu — open it before asserting they're present.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+
     expect(
-      screen.getByRole('button', {
+      screen.getByRole('menuitem', {
         name: /re-export sheet \(creates a new sheet\)/i,
       })
     ).toBeInTheDocument();
-    // OPEN SHEET is rendered alongside it so the teacher can still navigate
+    // OPEN SHEET is offered alongside it so the teacher can still navigate
     // to (or recover) the previous sheet if needed.
-    expect(screen.getByRole('link', { name: /open sheet/i })).toHaveAttribute(
-      'href',
-      'https://docs.google.com/spreadsheets/d/OLD/edit'
+    expect(
+      screen.getByRole('menuitem', { name: /open sheet/i })
+    ).toBeInTheDocument();
+  });
+
+  it('clicking Open Sheet opens the export URL in a new tab', () => {
+    const exportUrl = 'https://docs.google.com/spreadsheets/d/OLD/edit';
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    render(
+      <QuizResults
+        quiz={makeQuiz()}
+        responses={[makeResponse('01')]}
+        config={soloConfig()}
+        onBack={vi.fn()}
+        plcId={null}
+        syncGroupId={null}
+        initialExportUrl={exportUrl}
+      />
     );
+
+    // Open Sheet now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /open sheet/i }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      exportUrl,
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    openSpy.mockRestore();
   });
 
   it('clicking Re-Export calls exportResultsToSheet with plcMode false and shows a re-export toast', async () => {
@@ -178,9 +210,13 @@ describe('QuizResults — solo Re-Export Sheet button', () => {
       />
     );
 
-    screen
-      .getByRole('button', { name: /re-export sheet \(creates a new sheet\)/i })
-      .click();
+    // Re-Export now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', {
+        name: /re-export sheet \(creates a new sheet\)/i,
+      })
+    );
 
     await waitFor(() => {
       expect(mockExportResultsToSheet).toHaveBeenCalledTimes(1);
@@ -224,8 +260,12 @@ describe('QuizResults — solo Re-Export Sheet button', () => {
       />
     );
 
-    // First-export path uses the plain "EXPORT" button (not Re-Export).
-    screen.getByRole('button', { name: /^export$/i }).click();
+    // First-export path uses the plain "Export to Sheets" overflow item (not
+    // Re-Export): open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', { name: /export to sheets/i })
+    );
 
     await waitFor(() => {
       expect(mockExportResultsToSheet).toHaveBeenCalledTimes(1);
@@ -259,9 +299,13 @@ describe('QuizResults — solo Re-Export Sheet button', () => {
       />
     );
 
-    screen
-      .getByRole('button', { name: /re-export sheet \(creates a new sheet\)/i })
-      .click();
+    // Re-Export now lives in the overflow menu: open the kebab, then click it.
+    fireEvent.click(screen.getByRole('button', { name: /more actions/i }));
+    fireEvent.click(
+      screen.getByRole('menuitem', {
+        name: /re-export sheet \(creates a new sheet\)/i,
+      })
+    );
 
     await waitFor(() => {
       const errorCalls = addToast.mock.calls.filter(

--- a/tests/components/widgets/QuizResults.soloReExport.test.tsx
+++ b/tests/components/widgets/QuizResults.soloReExport.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { QuizConfig, QuizData, QuizResponse } from '@/types';
 
@@ -108,6 +108,11 @@ describe('QuizResults — solo Re-Export Sheet button', () => {
   beforeEach(() => {
     addToast.mockClear();
     mockExportResultsToSheet.mockClear();
+  });
+
+  afterEach(() => {
+    // Restore any vi.spyOn (e.g. window.open) even if a test throws first.
+    vi.restoreAllMocks();
   });
 
   it('does not render the Re-Export button before the first export (initialExportUrl is null)', () => {

--- a/tests/components/widgets/QuizResults.unlock.test.tsx
+++ b/tests/components/widgets/QuizResults.unlock.test.tsx
@@ -129,9 +129,9 @@ describe('QuizResults — Students tab results-lockout unlock control', () => {
       />
     );
 
-    // Default tab is overview — switch to Students. The tab buttons render
-    // their lowercase key as label, so the accessible name is "students".
-    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+    // Default tab is overview — switch to Students. The SegmentedTabs control
+    // renders each tab with role="tab" and the label as its accessible name.
+    fireEvent.click(screen.getByRole('tab', { name: /^students$/i }));
 
     // Students tab gates the per-student rows behind a Show/Hide toggle so a
     // teacher doesn't accidentally project scores. Reveal them so the
@@ -188,7 +188,7 @@ describe('QuizResults — Students tab results-lockout unlock control', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /^students$/i }));
     fireEvent.click(screen.getByRole('button', { name: /show results/i }));
 
     const unlockButton = await screen.findByRole('button', {
@@ -224,7 +224,7 @@ describe('QuizResults — Students tab results-lockout unlock control', () => {
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^students$/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /^students$/i }));
     fireEvent.click(screen.getByRole('button', { name: /show results/i }));
 
     // The student row mounts (verify by looking for the score), but neither

--- a/tests/context/AuthContext.canAccessWidgetDockDefaults.test.tsx
+++ b/tests/context/AuthContext.canAccessWidgetDockDefaults.test.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+import type { FeaturePermission } from '@/types';
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+  // Silences "No 'X' export defined on the firebase/firestore mock" stderr
+  // noise from the returning-user probe at AuthContext.tsx:~1217.
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn((c: unknown) => c),
+  limit: vi.fn(() => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface DocRef {
+  __path?: string;
+}
+interface CollectionRef {
+  __path?: string;
+}
+
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+function setupGetDoc(opts: {
+  adminEmail: string | null;
+  selectedBuildings: string[];
+}): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as DocRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => true,
+        data: () => ({ selectedBuildings: opts.selectedBuildings }),
+      } as unknown as DocSnap);
+    }
+    const isAdminLookup =
+      opts.adminEmail !== null &&
+      path === `admins/${opts.adminEmail.toLowerCase()}`;
+    return Promise.resolve({
+      exists: () => isAdminLookup,
+      data: () => (isAdminLookup ? {} : undefined),
+    } as unknown as DocSnap);
+  });
+}
+
+function deliverFeaturePermissions(perms: FeaturePermission[]): void {
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as CollectionRef).__path ?? '';
+    if (path === 'feature_permissions') {
+      const snapshot = {
+        forEach: (cb: (doc: { data: () => unknown }) => void) => {
+          perms.forEach((p) => cb({ data: () => p }));
+        },
+      };
+      (onNext as unknown as (s: typeof snapshot) => void)(snapshot);
+    }
+    // `global_permissions` and any other listener: deliver an empty snapshot.
+    return () => undefined;
+  });
+}
+
+async function mountAs(opts: {
+  email: string;
+  isAdmin: boolean;
+  selectedBuildings: string[];
+  perms: FeaturePermission[];
+}): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc({
+    adminEmail: opts.isAdmin ? opts.email : null,
+    selectedBuildings: opts.selectedBuildings,
+  });
+  deliverFeaturePermissions(opts.perms);
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(opts.email);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(ctxHolder.current).not.toBeNull();
+    expect(ctxHolder.current?.isAdmin).not.toBeNull();
+    expect(ctxHolder.current?.profileLoaded).toBe(true);
+    expect(ctxHolder.current?.featurePermissions.length).toBe(
+      opts.perms.length
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+});
+
+describe('AuthContext — canAccessWidget per-building dockDefaults gate', () => {
+  // The documented contract (AuthContext.tsx canAccessWidget comment):
+  //   - missing dockDefaults → no opinion, allow
+  //   - user has no selected buildings → no opinion, allow
+  //   - building entry missing or true → allow
+  //   - only deny when *every* selected building is explicitly `false`
+  const basePermission: FeaturePermission = {
+    widgetType: 'time-tool',
+    accessLevel: 'public',
+    betaUsers: [],
+    enabled: true,
+  };
+
+  function withDockDefaults(
+    dockDefaults: Record<string, boolean>
+  ): FeaturePermission {
+    return {
+      ...basePermission,
+      config: { dockDefaults },
+    };
+  }
+
+  it('denies when every selected building is explicitly false (all-off)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ middle: false, high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(false);
+  });
+
+  it('allows when buildings are mixed (some true, some false)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ middle: true, high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('allows when a selected building is missing from dockDefaults (partial config defaults to enabled)', async () => {
+    // The gate must NOT treat a missing entry as "off": a building the admin
+    // has not configured keeps public-by-default access. Here `high` is off
+    // but `middle` is unconfigured, so access is granted via `middle`.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('allows when every selected building is missing from dockDefaults', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ schumann: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('allows when every selected building is explicitly true (all-enabled)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ middle: true, high: true })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('allows when dockDefaults is absent entirely (no opinion)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['middle', 'high'],
+      perms: [basePermission],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('allows when the user has no selected buildings (no opinion)', async () => {
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: [],
+      perms: [withDockDefaults({ middle: false, high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('canonicalizes legacy dockDefaults keys against canonical selections', async () => {
+    // Legacy admin write keyed by `orono-high-school` must match the
+    // canonical `high` selection so the all-off gate still fires.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: ['high'],
+      perms: [withDockDefaults({ 'orono-high-school': false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(false);
+  });
+
+  it('admin bypass wins over an all-off dockDefaults gate', async () => {
+    await mountAs({
+      email: 'admin@example.com',
+      isAdmin: true,
+      selectedBuildings: ['middle', 'high'],
+      perms: [withDockDefaults({ middle: false, high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool')).toBe(true);
+  });
+
+  it('honors customBuildings override for the in-flight selection', async () => {
+    // AuthContext has no selected buildings, but the wizard passes an
+    // in-flight selection that is fully off → deny.
+    await mountAs({
+      email: 'teacher@example.com',
+      isAdmin: false,
+      selectedBuildings: [],
+      perms: [withDockDefaults({ middle: false, high: false })],
+    });
+    expect(getCtx().canAccessWidget('time-tool', ['middle', 'high'])).toBe(
+      false
+    );
+  });
+});

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1249,6 +1249,95 @@ describe('organizations/invitations — fully locked from every client role (Pha
   });
 });
 
+describe('organizations/members — email case normalization (F15)', () => {
+  // Every membership read keys off `request.auth.token.email.lower()`, which is
+  // always lowercase. If a member doc were stored with a mixed-case email/id it
+  // would be orphaned and the matching member would get permission-denied. The
+  // create rule rejects mixed-case writes at the source; these tests pin that
+  // behavior down end-to-end.
+  const validMember = (email: string) => ({
+    email,
+    orgId: ORG_ID,
+    roleId: 'teacher',
+    status: 'invited',
+    buildingIds: ['high'],
+  });
+
+  // An auth context whose token email is mixed-case; `.lower()` in the rules
+  // normalizes it to the lowercase member-doc id when reading.
+  const asMixedCaseTeacher = () =>
+    testEnv
+      .authenticatedContext('mixedcase-uid', {
+        email: 'New.Teacher@Orono.K12.MN.US',
+      })
+      .firestore();
+
+  it('a lowercase-stored member can self-read via a mixed-case auth email (lower() normalizes both sides)', async () => {
+    // Seed the canonical lowercase member doc directly.
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          'organizations/orono/members/new.teacher@orono.k12.mn.us'
+        ),
+        validMember('new.teacher@orono.k12.mn.us')
+      );
+    });
+
+    // The self-read branch compares `request.auth.token.email.lower()` to the
+    // (lowercase) doc id, so a mixed-case token email still resolves.
+    await assertSucceeds(
+      getDoc(
+        doc(
+          asMixedCaseTeacher(),
+          `organizations/${ORG_ID}/members/new.teacher@orono.k12.mn.us`
+        )
+      )
+    );
+  });
+
+  it('domain admin can create a member whose email + doc id are both lowercase', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/lower.case@orono.k12.mn.us`
+        ),
+        validMember('lower.case@orono.k12.mn.us')
+      )
+    );
+  });
+
+  it('domain admin cannot create a member with a mixed-case email field (rejected, not normalized)', async () => {
+    // Doc id is lowercase but the payload email field carries mixed-case —
+    // `request.resource.data.email == request.resource.data.email.lower()`
+    // rejects it.
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/case.member@orono.k12.mn.us`
+        ),
+        validMember('Case.Member@orono.k12.mn.us')
+      )
+    );
+  });
+
+  it('domain admin cannot create a member with a mixed-case doc id even if the email field is lowercase', async () => {
+    // `request.resource.data.email == emailLower` ties the lowercase payload
+    // email to the doc id, so a mixed-case id cannot match.
+    await assertFails(
+      setDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/Mixed.Id@orono.k12.mn.us`
+        ),
+        validMember('mixed.id@orono.k12.mn.us')
+      )
+    );
+  });
+});
+
 describe('organizations/members — uid write restricted to Cloud Functions (Phase 4)', () => {
   // Phase 4 first-sign-in links a member's uid to their Google auth uid. This
   // MUST go through the `claimOrganizationInvite` callable — the Admin SDK

--- a/tests/utils/scoreColor.test.ts
+++ b/tests/utils/scoreColor.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { scoreTone, scoreColorClasses } from '@/utils/scoreColor';
+
+describe('scoreTone (unified 80/60 scale)', () => {
+  it('maps the threshold boundaries', () => {
+    expect(scoreTone(100)).toBe('success');
+    expect(scoreTone(80)).toBe('success');
+    expect(scoreTone(79)).toBe('warn');
+    expect(scoreTone(60)).toBe('warn');
+    expect(scoreTone(59)).toBe('danger');
+    expect(scoreTone(0)).toBe('danger');
+  });
+});
+
+describe('scoreColorClasses', () => {
+  it('returns emerald / amber / red fragments by tone', () => {
+    expect(scoreColorClasses(90).text).toBe('text-emerald-600');
+    expect(scoreColorClasses(70).text).toBe('text-amber-600');
+    expect(scoreColorClasses(30).text).toBe('text-brand-red-primary');
+    expect(scoreColorClasses(90).bar).toBe('bg-emerald-500');
+    expect(scoreColorClasses(70).band).toBe('bg-amber-50 border-amber-200');
+    expect(scoreColorClasses(30).band).toBe('bg-rose-50 border-rose-200');
+  });
+});

--- a/utils/firestorePaging.test.ts
+++ b/utils/firestorePaging.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as firestore from 'firebase/firestore';
+import { readAllDocsPaged, FIRESTORE_PAGE_SIZE } from './firestorePaging';
+
+vi.mock('firebase/firestore');
+
+type MockDoc = { id: string };
+
+/**
+ * Build a fake page snapshot whose `.docs` array has the requested length.
+ * `readAllDocsPaged` only reads `pageSnap.docs` (length + last element as the
+ * cursor), so minimal stand-in docs are sufficient.
+ */
+function makeSnap(docs: MockDoc[]): { docs: MockDoc[] } {
+  return { docs };
+}
+
+describe('readAllDocsPaged', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // `query`/`orderBy`/`startAfter`/`limit`/`documentId` are only used to
+    // assemble the page query; return opaque tokens so the loop can run.
+    (firestore.query as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (...args: unknown[]) => ({ __query: args })
+    );
+    (firestore.orderBy as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      'orderBy'
+    );
+    (
+      firestore.startAfter as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue('startAfter');
+    (firestore.limit as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (n: number) => ({ __limit: n })
+    );
+    (
+      firestore.documentId as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue('documentId');
+  });
+
+  it('reads a single page when the result fits under the page size', async () => {
+    const docs: MockDoc[] = [{ id: 'a' }, { id: 'b' }];
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(makeSnap(docs));
+
+    const result = await readAllDocsPaged(
+      {} as firestore.Query,
+      /* pageSize */ 10
+    );
+
+    expect(firestore.getDocs).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+    // No cursor used on the first (and only) page.
+    expect(firestore.startAfter).not.toHaveBeenCalled();
+  });
+
+  it('pages a large result set in bounded chunks and visits every doc', async () => {
+    const pageSize = 3;
+    // 7 docs => pages of 3, 3, 1 (last page short => loop terminates).
+    const all: MockDoc[] = Array.from({ length: 7 }, (_, i) => ({
+      id: `d${i}`,
+    }));
+    const getDocs = firestore.getDocs as unknown as ReturnType<typeof vi.fn>;
+    getDocs
+      .mockResolvedValueOnce(makeSnap(all.slice(0, 3)))
+      .mockResolvedValueOnce(makeSnap(all.slice(3, 6)))
+      .mockResolvedValueOnce(makeSnap(all.slice(6, 7)));
+
+    const result = await readAllDocsPaged({} as firestore.Query, pageSize);
+
+    // One getDocs per page — proves reads are chunked, not one unbounded read.
+    expect(getDocs).toHaveBeenCalledTimes(3);
+    // Every doc is still visited and accumulated in order.
+    expect(result.map((d) => (d as unknown as MockDoc).id)).toEqual(
+      all.map((d) => d.id)
+    );
+    // Each page request is capped at the page size.
+    expect(firestore.limit).toHaveBeenCalledWith(pageSize);
+    // Pages after the first advance the cursor with startAfter.
+    expect(firestore.startAfter).toHaveBeenCalledTimes(2);
+  });
+
+  it('terminates exactly when a full final page is followed by an empty page', async () => {
+    const pageSize = 2;
+    const all: MockDoc[] = [{ id: 'x' }, { id: 'y' }, { id: 'z' }, { id: 'w' }];
+    const getDocs = firestore.getDocs as unknown as ReturnType<typeof vi.fn>;
+    getDocs
+      .mockResolvedValueOnce(makeSnap(all.slice(0, 2)))
+      .mockResolvedValueOnce(makeSnap(all.slice(2, 4)))
+      .mockResolvedValueOnce(makeSnap([]));
+
+    const result = await readAllDocsPaged({} as firestore.Query, pageSize);
+
+    expect(getDocs).toHaveBeenCalledTimes(3);
+    expect(result).toHaveLength(4);
+  });
+
+  it('rejects a non-positive page size rather than looping forever', async () => {
+    await expect(
+      readAllDocsPaged({} as firestore.Query, 0)
+    ).rejects.toBeInstanceOf(RangeError);
+  });
+
+  it('defaults to FIRESTORE_PAGE_SIZE when no page size is supplied', async () => {
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce(makeSnap([{ id: 'only' }]));
+
+    await readAllDocsPaged({} as firestore.Query);
+
+    expect(firestore.limit).toHaveBeenCalledWith(FIRESTORE_PAGE_SIZE);
+  });
+});

--- a/utils/firestorePaging.ts
+++ b/utils/firestorePaging.ts
@@ -1,5 +1,4 @@
 import {
-  collection,
   documentId,
   getDocs,
   limit,
@@ -22,13 +21,17 @@ import {
 export const FIRESTORE_PAGE_SIZE = 500;
 
 /**
- * Read every doc in a (sub)collection in bounded pages, returning the
- * accumulated snapshots. Shared by the quiz / video-activity / guided-learning
- * score-publish paths so grading still sees the full response set while no
- * single Firestore query is unbounded.
+ * Read every doc matched by a (sub)collection reference OR an already-filtered
+ * query in bounded pages, returning the accumulated snapshots. Shared by the
+ * quiz / video-activity / guided-learning score-publish paths (which pass a
+ * plain collection ref) and the collection delete-all cascade (which passes a
+ * `where(...)`-filtered query) so the full result set is still visited while
+ * no single Firestore query is unbounded. A `CollectionReference` is itself a
+ * `Query`, so existing callers are unaffected; the `orderBy(documentId())` +
+ * `startAfter` cursor composes onto whatever filters the caller already set.
  */
 export async function readAllDocsPaged(
-  coll: ReturnType<typeof collection>,
+  coll: Query<DocumentData>,
   pageSize: number = FIRESTORE_PAGE_SIZE
 ): Promise<QueryDocumentSnapshot<DocumentData>[]> {
   if (!(pageSize >= 1)) {

--- a/utils/scoreColor.ts
+++ b/utils/scoreColor.ts
@@ -1,0 +1,49 @@
+/**
+ * Unified score-color scale shared by the Quiz and Video Activity monitor and
+ * results views — the single source of truth for green/amber/red banding so the
+ * two widgets never drift apart again.
+ *
+ * Thresholds: >= 80 success, >= 60 warn, else danger. (Video Activity previously
+ * used 70/40; unifying to 80/60 changes only the COLOR shown — never the numeric
+ * score, accuracy math, or any grade pushed to Classroom/Schoology.)
+ */
+export type ScoreTone = 'success' | 'warn' | 'danger';
+
+export interface ScoreColorClasses {
+  /** Foreground text color, e.g. a score number. */
+  text: string;
+  /** Solid fill for a progress/accuracy bar. */
+  bar: string;
+  /** Soft background + border for a score-band card/row wash. */
+  band: string;
+}
+
+const TONE_CLASSES: Record<ScoreTone, ScoreColorClasses> = {
+  success: {
+    text: 'text-emerald-600',
+    bar: 'bg-emerald-500',
+    band: 'bg-emerald-50 border-emerald-200',
+  },
+  warn: {
+    text: 'text-amber-600',
+    bar: 'bg-amber-500',
+    band: 'bg-amber-50 border-amber-200',
+  },
+  danger: {
+    text: 'text-brand-red-primary',
+    bar: 'bg-brand-red-primary',
+    band: 'bg-rose-50 border-rose-200',
+  },
+};
+
+/** Map a 0–100 score to its tone using the unified 80/60 scale. */
+export function scoreTone(score: number): ScoreTone {
+  if (score >= 80) return 'success';
+  if (score >= 60) return 'warn';
+  return 'danger';
+}
+
+/** Tailwind class fragments (text / bar / band) for a 0–100 score. */
+export function scoreColorClasses(score: number): ScoreColorClasses {
+  return TONE_CLASSES[scoreTone(score)];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,19 @@ export default mergeConfig(
         '.claude/worktrees/**',
         '.pnpm-store/**',
       ],
-      coverage: { exclude: ['locales/**'] },
+      coverage: {
+        exclude: ['locales/**'],
+        // Conservative regression floor — intentionally well below current
+        // coverage so CI doesn't break today. Ratchet these up over time as
+        // coverage improves; they exist to catch silent regressions, not to
+        // act as a stretch goal.
+        thresholds: {
+          lines: 30,
+          functions: 30,
+          statements: 30,
+          branches: 30,
+        },
+      },
     },
   })
 );


### PR DESCRIPTION
## Summary

Levels up the teacher-facing **Monitor** and **Results** views of the Quiz and Video Activity widgets to the polish of the modernized Library view, via a small set of shared, container-query-scaled atoms.

**New shared primitives** (`components/common/sessionViews/`): `SessionViewHeader`, `SegmentedTabs`, `StatTile`, `SessionBadge`, `ScorePill`, `SessionRow`, `OverflowMenu`, `ActionButton` — each with unit tests. `SegmentedTabs` is extracted from `LibraryShell` (now consumed by both the library and these views — one tab component, no drift).

**New util** `utils/scoreColor.ts` — a single unified 80/60 green/amber/red score-color scale used across both widgets (Video Activity's banding moves from 70/40 to 80/60; **color only** — no change to numeric scores, accuracy math, or grades pushed to Classroom/Schoology).

**Restyled, behavior-preserving** (only presentation + header action placement changed):
- `QuizLiveMonitor`, `VideoActivityLiveMonitor` — glass header with live/paused pulse, `StatTile` KPIs, hairline `SessionRow` rosters, semantic badges, unified score pills.
- `QuizResults`, `VideoActivity Results` — `SegmentedTabs` tabs, `StatTile` overview, hairline question/student rows. Results headers surface the high-value actions (Quiz: Grade Written + Push Grades; VA: Push Grades) and move Export / Open Sheet / Re-export / Send-to-Scoreboard into an overflow menu.

**DEV tooling:** a DEV-only `/session-views-dev` harness (gated like `/library-dev`) that renders all four views against mock sessions/responses for visual iteration without Firestore.

Design spec and implementation plan: `docs/superpowers/specs/2026-06-14-quiz-va-monitor-results-redesign-design.md`, `docs/superpowers/plans/2026-06-14-quiz-va-monitor-results-redesign.md`.

## Test plan

- [x] `pnpm run type-check:all` clean (root + functions)
- [x] Full unit suite green (4695 tests) incl. new atom/util tests + the existing quiz/VA suites
- [x] eslint + prettier clean on all changed files
- [ ] Visual sweep via `/session-views-dev` (run `VITE_AUTH_BYPASS=true pnpm run dev`) across all 4 views × states × 340/520/820px widths
- [ ] Smoke-test a real live quiz + video activity session end-to-end (monitor → results, export, grade push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)