### PR TITLE
fix(widgets/random): guard group-rename onBlur against stale Escape-cancel closure

### DIFF
--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Regression tests for RandomGroups / GroupDropZone.
+ *
+ * Bug: onBlur/Escape stale-closure in group rename input
+ * -------------------------------------------------------
+ * When the user pressed Escape to cancel a group rename, React queued the
+ * state updates from cancel() (setEditingName(false), setDraft(groupName))
+ * but the DOM blur event fired synchronously BEFORE those updates were
+ * applied.  The onBlur={commit} handler ran with a stale draft closure that
+ * still held the edited text, so pressing Escape persisted the value the
+ * user intended to discard.
+ *
+ * Fix: `cancelledRef.current = true` is set at the very start of cancel()
+ * (a ref write, synchronous and immediate), and commit() bails out early
+ * when it sees that flag.
+ */
+
+import React from 'react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RandomGroups } from './RandomGroups';
+import type { RandomGroup } from '@/types';
+
+// dnd-kit needs minimal stubs so components render without a real drag context.
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({ isOver: false, setNodeRef: vi.fn() }),
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    isDragging: false,
+  }),
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const makeGroups = (data: Record<string, string[]>): RandomGroup[] =>
+  Object.entries(data).map(([id, names]) => ({ id, names }));
+
+describe('GroupDropZone — rename input', () => {
+  const groups = makeGroups({ g1: ['Alice', 'Bob'], g2: ['Carol'] });
+  const sharedGroups = [{ id: 'g1', name: 'Team Alpha', color: null }];
+
+  let onRenameGroup: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onRenameGroup = vi.fn();
+  });
+
+  function renderEditable(extraProps = {}) {
+    return render(
+      <RandomGroups
+        displayResult={groups}
+        sharedGroups={sharedGroups}
+        editable
+        onRenameGroup={onRenameGroup}
+        onToggleLock={vi.fn()}
+        {...extraProps}
+      />
+    );
+  }
+
+  it('renders the group name and pencil icon', () => {
+    renderEditable();
+    expect(screen.getByText('Team Alpha')).toBeInTheDocument();
+  });
+
+  it('opens the rename input when the pencil button is clicked', () => {
+    renderEditable();
+    const pencil = screen.getByRole('button', { name: /Rename Team Alpha/i });
+    fireEvent.click(pencil);
+    expect(
+      screen.getByRole('textbox', { name: /Rename Team Alpha/i })
+    ).toBeInTheDocument();
+  });
+
+  it('commits the new name on Enter', () => {
+    renderEditable();
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    fireEvent.change(input, { target: { value: 'Team Beta' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Team Beta');
+  });
+
+  it('commits the new name on blur (without cancel)', () => {
+    renderEditable();
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    fireEvent.change(input, { target: { value: 'Team Gamma' } });
+    fireEvent.blur(input);
+    expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Team Gamma');
+  });
+
+  // ─── Regression: Escape + onBlur stale-closure ────────────────────────────
+  //
+  // BEFORE the fix:
+  //   1. User types "Bad Name" into the input.
+  //   2. User presses Escape (intending to cancel).
+  //   3. cancel() queues state updates (setEditingName(false), setDraft(orig)).
+  //   4. Removing focus from the now-unmounting input fires a synchronous blur.
+  //   5. onBlur={commit} fires — draft closure still holds "Bad Name" (state
+  //      not yet flushed) → onRenameGroup("g1", "Bad Name") is called. WRONG.
+  //
+  // AFTER the fix:
+  //   cancel() sets cancelledRef.current = true synchronously before touching
+  //   state. commit() checks this flag first and returns early, so the blur
+  //   that fires during unmount is a no-op. onRenameGroup is never called.
+  it('REGRESSION: does NOT call onRenameGroup when Escape is pressed to cancel a rename', () => {
+    renderEditable();
+
+    // Open the rename input.
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+
+    // Type a new (unwanted) name.
+    fireEvent.change(input, { target: { value: 'Unwanted Name' } });
+
+    // Simulate the browser's Escape-then-blur sequence inside a single act()
+    // so React processes them in order before flushing the state batch:
+    //   1. keyDown schedules cancel() → sets cancelledRef + queues state updates
+    //   2. blur fires (still in same synchronous sequence, before React commits)
+    //      → calls commit() with the stale draft — on the ORIGINAL code this
+    //      persists 'Unwanted Name'; with the fix it sees cancelledRef and exits.
+    //
+    // jsdom does not fire blur automatically when a DOM node is removed, so we
+    // replicate the browser's synchronous blur-during-unmount by firing both
+    // events inside the same act() — matching the DraggableWindow #1965 pattern.
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      // blur fires while the input is still mounted (React defers the state
+      // flush until act() exits), replicating the browser's focus-manager order.
+      fireEvent.blur(input);
+    });
+
+    // The rename must NOT have been persisted.
+    expect(onRenameGroup).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRenameGroup when the value is unchanged and blur fires', () => {
+    renderEditable();
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    // No change — blur without editing.
+    fireEvent.blur(input);
+    expect(onRenameGroup).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call onRenameGroup when the trimmed value is empty', () => {
+    renderEditable();
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.blur(input);
+    expect(onRenameGroup).not.toHaveBeenCalled();
+  });
+
+  it('allows a subsequent rename after a cancelled one', () => {
+    renderEditable();
+
+    // First rename attempt — cancel it.
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    let input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    fireEvent.change(input, { target: { value: 'Nope' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onRenameGroup).not.toHaveBeenCalled();
+
+    // Second rename attempt — commit it.
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    input = screen.getByRole('textbox', {
+      name: /Rename Team Alpha/i,
+    });
+    fireEvent.change(input, { target: { value: 'Good Name' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onRenameGroup).toHaveBeenCalledTimes(1);
+    expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Good Name');
+  });
+});

--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -39,12 +39,12 @@ const makeGroups = (data: Record<string, string[]>): RandomGroup[] =>
 
 describe('GroupDropZone — rename input', () => {
   const groups = makeGroups({ g1: ['Alice', 'Bob'], g2: ['Carol'] });
-  const sharedGroups = [{ id: 'g1', name: 'Team Alpha', color: null }];
+  const sharedGroups = [{ id: 'g1', name: 'Team Alpha' }];
 
-  let onRenameGroup: ReturnType<typeof vi.fn>;
+  let onRenameGroup: (groupId: string, newName: string) => void;
 
   beforeEach(() => {
-    onRenameGroup = vi.fn();
+    onRenameGroup = vi.fn() as (groupId: string, newName: string) => void;
   });
 
   function renderEditable(extraProps = {}) {

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -120,6 +120,9 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const colorPickerRef = useRef<HTMLDivElement>(null);
   const paletteButtonRef = useRef<HTMLButtonElement>(null);
+  // Tracks whether Escape was pressed so the synchronous blur event that fires
+  // when the input unmounts does not re-invoke commit() with a stale draft.
+  const cancelledRef = useRef(false);
   const renameEnabled = editable && !!onRename;
   const colorEnabled = editable && !!onChangeColor;
 
@@ -134,6 +137,9 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
 
   useEffect(() => {
     if (editingName) {
+      // A new rename session is starting — clear any leftover cancel flag from
+      // a previous Escape press so commit() is not suppressed this session.
+      cancelledRef.current = false;
       inputRef.current?.focus();
       inputRef.current?.select();
     }
@@ -174,6 +180,13 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
   }, [colorPickerOpen]);
 
   const commit = () => {
+    // If Escape was pressed, cancel() already ran and set cancelledRef — bail
+    // out here so the blur event that fires when the input unmounts does not
+    // persist the value the user intended to discard.
+    if (cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
     setEditingName(false);
     const trimmed = draft.trim();
     if (trimmed && trimmed !== groupName) {
@@ -184,6 +197,10 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
   };
 
   const cancel = () => {
+    // Set the flag BEFORE updating state so that the synchronous blur event
+    // (fired when React removes the focused <input> from the DOM) sees it and
+    // skips commit().
+    cancelledRef.current = true;
     setEditingName(false);
     setDraft(groupName);
   };


### PR DESCRIPTION
## Root Cause

`GroupDropZone.cancel()` in `components/widgets/random/RandomGroups.tsx` called `setEditingName(false)` before setting any guard. React batches the state update; when it commits, the focused `<input>` is removed from the DOM. Browsers fire `blur` synchronously during DOM removal. The `onBlur={commit}` handler at that moment is the stale closure from the previous render — it still holds `draft = 'Edited Name'` (the text the user typed) rather than the reverted value. So pressing Escape to cancel a group rename persisted the unwanted name.

## Fix

Set `cancelledRef.current = true` synchronously at the top of `cancel()`, before any `setState`. `commit()` checks the flag on entry and short-circuits. The flag is a ref (not state), so the write is immediate and is visible to the stale `commit` closure when it fires during blur.

Same pattern as `DraggableWindow.isCancellingTitleRef` (#1965).

## Band-Aid Rejected

Adding `e.preventDefault()` to the Escape keyDown event — browsers only prevent the `blur` from focus-related actions, not from DOM removal. The blur from unmounting always fires regardless of `preventDefault`.

## Regression Test

`components/widgets/random/RandomGroups.test.tsx` — new file, 8 tests.

The critical test uses `act(() => { fireEvent.keyDown(Escape); fireEvent.blur(); })` to replicate the browser's synchronous blur-during-unmount order (jsdom does not fire blur automatically on DOM removal):

- **FAIL before fix**: `onRenameGroup` called with `['g1', 'Unwanted Name']`
- **PASS after fix**: `onRenameGroup` not called

## Risk Tag

**contained** — change is isolated to `GroupDropZone` in `RandomGroups.tsx`. No shared utilities or context modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2yQ8dSA7nPUQdnvEUuKNa)_