### PR TITLE
fix(migration): add range guards to proportionsValid in migrateWidgetToProportional

### DIFF
--- a/tests/utils/migrateProportionalLayout.test.ts
+++ b/tests/utils/migrateProportionalLayout.test.ts
@@ -264,6 +264,110 @@ describe('migrateWidgetToProportional', () => {
     expect(out.version).toBe(5);
     expect(out.config).toBe(w.config); // structural identity preserved
   });
+
+  // Happy-path arithmetic tests: verify known pixel → proportional values.
+  it('converts known pixel coordinates to correct proportional values on 1920×1080', () => {
+    const vpW = 1920;
+    const vpH = 1080;
+    const { safeW, safeH } = getSafeViewport(vpW, vpH);
+    const w = baseWidget({ x: 200, y: 100, w: 400, h: 300 });
+    const out = migrateWidgetToProportional(w, vpW, vpH);
+    expect(out.xProp).toBeCloseTo((200 - PADDING) / safeW, 6);
+    expect(out.yProp).toBeCloseTo((100 - PADDING) / safeH, 6);
+    expect(out.wProp).toBeCloseTo(400 / safeW, 6);
+    expect(out.hProp).toBeCloseTo(300 / safeH, 6);
+    expect(out.aspectRatio).toBeCloseTo(400 / 300, 6);
+  });
+
+  it('round-trips pixel → proportion → pixel correctly (same viewport)', () => {
+    // Verifies that migrateWidgetToProportional + hydrateWidgetPixels
+    // (fill mode, same viewport) recovers the original pixel coordinates
+    // exactly (within rounding).
+    const vpW = 1920;
+    const vpH = 1080;
+    const pixelX = 200;
+    const pixelY = 100;
+    const pixelW = 400;
+    const pixelH = 300;
+    const w = baseWidget({ x: pixelX, y: pixelY, w: pixelW, h: pixelH });
+    const migrated = migrateWidgetToProportional(w, vpW, vpH);
+    const hydrated = hydrateWidgetPixels(migrated, vpW, vpH, 'fill');
+    expect(hydrated.x).toBe(pixelX);
+    expect(hydrated.y).toBe(pixelY);
+    expect(hydrated.w).toBe(pixelW);
+    expect(hydrated.h).toBe(pixelH);
+  });
+
+  // Regression test for the proportionsValid early-return bug:
+  // When xProp/yProp contain pixel values (e.g. from a partial migration)
+  // and wProp/hProp are valid proportions, widgetNeedsProportionalMigration
+  // correctly flags the widget (Math.abs(300) > 1.5). However, the old
+  // migrateWidgetToProportional only checked Number.isFinite on all four
+  // fields — pixel values like 300 are finite, so the early-return path
+  // would skip re-deriving xProp/yProp and leave the widget at the wrong
+  // on-screen position.
+  it('fixes pixel-valued xProp/yProp even when wProp/hProp are already valid proportions', () => {
+    const vpW = 1920;
+    const vpH = 1080;
+    const { safeW, safeH } = getSafeViewport(vpW, vpH);
+    // Simulate a partial migration: position props are still pixel values,
+    // but size props look like valid proportions. This state is reachable
+    // when a migration was interrupted or applied only partially.
+    const w = baseWidget({
+      x: 300,
+      y: 150,
+      w: 400,
+      h: 200,
+      xProp: 300, // pixel value masquerading as proportion
+      yProp: 150, // pixel value masquerading as proportion
+      wProp: 0.15, // already a valid proportion
+      hProp: 0.18, // already a valid proportion
+      // aspectRatio intentionally absent to force full re-migration path
+    });
+    // The guard must have flagged this widget first:
+    expect(widgetNeedsProportionalMigration(w)).toBe(true);
+
+    const out = migrateWidgetToProportional(w, vpW, vpH);
+
+    // After migration, all proportional fields must be in proportion range
+    expect(Math.abs(out.xProp as number)).toBeLessThanOrEqual(1.5);
+    expect(Math.abs(out.yProp as number)).toBeLessThanOrEqual(1.5);
+    expect((out.wProp as number) <= 1.5).toBe(true);
+    expect((out.hProp as number) <= 1.5).toBe(true);
+
+    // The corrected position props must reflect the pixel x/y, not the
+    // stale pixel-valued xProp/yProp.
+    expect(out.xProp).toBeCloseTo((300 - PADDING) / safeW, 6);
+    expect(out.yProp).toBeCloseTo((150 - PADDING) / safeH, 6);
+
+    // The widget must no longer need migration:
+    expect(widgetNeedsProportionalMigration(out)).toBe(false);
+  });
+
+  it('fixes pixel-valued wProp/hProp even when xProp/yProp are already valid proportions', () => {
+    const vpW = 1920;
+    const vpH = 1080;
+    const { safeW, safeH } = getSafeViewport(vpW, vpH);
+    const w = baseWidget({
+      x: 100,
+      y: 100,
+      w: 400,
+      h: 300,
+      xProp: 0.05, // valid proportion
+      yProp: 0.09, // valid proportion
+      wProp: 400, // pixel value masquerading as proportion
+      hProp: 300, // pixel value masquerading as proportion
+    });
+    expect(widgetNeedsProportionalMigration(w)).toBe(true);
+
+    const out = migrateWidgetToProportional(w, vpW, vpH);
+
+    expect((out.wProp as number) <= 1.5).toBe(true);
+    expect((out.hProp as number) <= 1.5).toBe(true);
+    expect(out.wProp).toBeCloseTo(400 / safeW, 6);
+    expect(out.hProp).toBeCloseTo(300 / safeH, 6);
+    expect(widgetNeedsProportionalMigration(out)).toBe(false);
+  });
 });
 
 describe('migrateDashboardWidgets idempotency', () => {

--- a/utils/migrateProportionalLayout.ts
+++ b/utils/migrateProportionalLayout.ts
@@ -75,11 +75,31 @@ export const migrateWidgetToProportional = (
   // when the saved viewport is missing/untrusted we fall back to
   // REFERENCE_VIEWPORT, producing wrong proportions for a widget that was
   // originally authored on a different-sized viewport.
+  //
+  // The range check mirrors widgetNeedsProportionalMigration exactly:
+  // wProp/hProp must not exceed 1.5 (pixel-valued), and Math.abs of
+  // xProp/yProp must not exceed 1.5 (catches both positive and negative
+  // pixel coordinates that leaked into the proportional fields).
+  // A finite-only check is insufficient — e.g. xProp=300 is finite but
+  // is a pixel value, not a proportion; without the range guard the
+  // function would early-return without correcting the bad position fields.
+  //
+  // Destructure first so downstream comparisons see `number`, not
+  // `number | undefined`, satisfying TypeScript's control-flow analysis.
+  const { xProp, yProp, wProp, hProp } = widget;
   const proportionsValid =
-    Number.isFinite(widget.xProp) &&
-    Number.isFinite(widget.yProp) &&
-    Number.isFinite(widget.wProp) &&
-    Number.isFinite(widget.hProp);
+    typeof xProp === 'number' &&
+    typeof yProp === 'number' &&
+    typeof wProp === 'number' &&
+    typeof hProp === 'number' &&
+    Number.isFinite(xProp) &&
+    Number.isFinite(yProp) &&
+    Number.isFinite(wProp) &&
+    Number.isFinite(hProp) &&
+    wProp <= 1.5 &&
+    hProp <= 1.5 &&
+    Math.abs(xProp) <= 1.5 &&
+    Math.abs(yProp) <= 1.5;
   if (proportionsValid) {
     return {
       ...widget,


### PR DESCRIPTION
## Root Cause

`migrateWidgetToProportional` (`utils/migrateProportionalLayout.ts`) checked `Number.isFinite` on all four proportional fields before taking the "already migrated" early-return path. But `Number.isFinite(300)` is `true` — pixel values are finite. A widget in a partial-migration state (e.g. `xProp: 300, yProp: 150` from an interrupted migration, alongside valid `wProp: 0.15, hProp: 0.18`) would pass the `proportionsValid` check and return unchanged, leaving raw pixel coordinates in the proportional position fields.

`widgetNeedsProportionalMigration` already had the correct guard (`Math.abs(xProp) > 1.5` / `wProp > 1.5`). The two functions were mismatched: the guard correctly flagged the widget, but the migration function would immediately early-return without fixing it.

When these widgets were later hydrated back to pixels, `xProp: 300` was treated as a proportion (meaning 300× the safe viewport width), placing widgets wildly off-screen.

## Fix

Extended `proportionsValid` to include the same range checks used by `widgetNeedsProportionalMigration`:

```typescript
wProp <= 1.5 &&
hProp <= 1.5 &&
Math.abs(xProp) <= 1.5 &&
Math.abs(yProp) <= 1.5
```

Any field containing a pixel value (> 1.5) now falls through to the full re-migration path. Also added `typeof === 'number'` before `Number.isFinite` to satisfy TypeScript's control-flow analysis on `number | undefined` fields.

## Band-Aid Rejected

Only fixing the guard (`widgetNeedsProportionalMigration`) to not flag such widgets — that would hide the invalid state in Firestore rather than correcting it. The migration function must fix the root cause.

## Regression Tests

Added 2 regression tests and 2 happy-path arithmetic tests (`tests/utils/migrateProportionalLayout.test.ts`). 25 tests total (up from 21):

- `fixes pixel-valued xProp/yProp even when wProp/hProp are already valid proportions`: **FAIL before** (out.xProp = 300, fails `<= 1.5` assertion); **PASS after**
- `fixes pixel-valued wProp/hProp even when xProp/yProp are already valid proportions`: **FAIL before**; **PASS after**
- `converts known pixel coordinates to correct proportional values on 1920×1080`: happy-path arithmetic verification
- `round-trips pixel → proportion → pixel correctly (same viewport)`: end-to-end round-trip

## Risk Tag

**contained** — change is isolated to a single `proportionsValid` expression in `migrateProportionalLayout.ts`. The migration only runs on widgets flagged by `widgetNeedsProportionalMigration`, which already excluded healthy widgets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2yQ8dSA7nPUQdnvEUuKNa)_