### PR TITLE
test(lti/ags): add trailing-slash regression coverage for scoresUrl

### DIFF
--- a/functions/src/lti/ags.test.ts
+++ b/functions/src/lti/ags.test.ts
@@ -28,6 +28,36 @@ describe('scoresUrl', () => {
       'https://x/lineitems/1/lineitem/scores?type_id=5'
     );
   });
+
+  // Regression guard: the trailing-slash strip is the ONLY protection against a
+  // Schoology-issued lineitem URL that ends in `/` producing a 404-prone double
+  // slash (`.../lineitem//scores`). Without the strip these cases all yield the
+  // wrong URL and every AGS grade push for that student would 404.
+  it('strips a single trailing slash before inserting /scores', () => {
+    expect(scoresUrl('https://x/lineitems/1/lineitem/')).toBe(
+      'https://x/lineitems/1/lineitem/scores'
+    );
+  });
+
+  it('strips multiple consecutive trailing slashes', () => {
+    expect(scoresUrl('https://x/lineitems/1/lineitem///')).toBe(
+      'https://x/lineitems/1/lineitem/scores'
+    );
+  });
+
+  it('strips a trailing slash that precedes a query string', () => {
+    // e.g. Schoology returns "https://platform/lineitem/?type_id=5"
+    expect(scoresUrl('https://x/lineitems/1/lineitem/?type_id=5')).toBe(
+      'https://x/lineitems/1/lineitem/scores?type_id=5'
+    );
+  });
+
+  it('is a no-op when there is no trailing slash (baseline)', () => {
+    // Ensures the strip doesn't corrupt clean URLs.
+    expect(scoresUrl('https://x/lineitems/1/lineitem')).toBe(
+      'https://x/lineitems/1/lineitem/scores'
+    );
+  });
 });
 
 describe('getAgsAccessToken', () => {


### PR DESCRIPTION
## Coverage Gap

`scoresUrl` (`functions/src/lti/ags.ts`) strips trailing slashes from the lineitem URL path before appending `/scores`. This strip is the **only protection** preventing a Schoology-issued lineitem URL like `https://platform/lineitem/` from generating a double-slash endpoint `…/lineitem//scores` — which would 404 on every AGS grade push for that student.

The production code was correct. However, removing the strip (`.replace(/\/+$/, '')`) would leave all 528 existing tests green — zero regression protection for this critical guard.

## Fix

Added 4 assertions to the existing `describe('scoresUrl')` block in `functions/src/lti/ags.test.ts`:

- Single trailing slash stripped: `…/lineitem/` → `…/lineitem/scores`
- Multiple consecutive trailing slashes: `…/lineitem///` → `…/lineitem/scores`
- Trailing slash + query string: `…/lineitem/?type_id=5` → `…/lineitem/scores?type_id=5` (verifies the strip operates on the path, not the query)
- No-op baseline: confirms clean URLs are not corrupted

No production code changed. Test count: 528 → 532.

## Risk Tag

**contained** — test-only addition to `functions/src/lti/ags.test.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2yQ8dSA7nPUQdnvEUuKNa)_