### PR TITLE
fix(i18n): translate sidebar.boards.rootBoards in DE, ES, and FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -100,7 +100,7 @@
       "enterName": "Gib einen Namen für deine neue Tafel ein.",
       "boardName": "Tafelname",
       "activeCollection": "Aktive Sammlung",
-      "rootBoards": "Boards",
+      "rootBoards": "Tafeln",
       "manageAll": "Alle Tafeln verwalten",
       "create": "Erstellen",
       "enterBoardData": "Tafeldaten hier einfügen:",

--- a/locales/es.json
+++ b/locales/es.json
@@ -103,7 +103,7 @@
       "enterBoardData": "Pega los datos de tu tablero aquí:",
       "imported": "Importado",
       "activeCollection": "Colección activa",
-      "rootBoards": "Boards",
+      "rootBoards": "Tableros",
       "manageAll": "Administrar todos los tableros"
     },
     "classes": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -100,7 +100,7 @@
       "enterName": "Entrez un nom pour votre nouveau tableau.",
       "boardName": "Nom du tableau",
       "activeCollection": "Collection active",
-      "rootBoards": "Boards",
+      "rootBoards": "Tableaux",
       "manageAll": "Gérer tous les tableaux",
       "create": "Créer",
       "enterBoardData": "Collez vos données de tableau ici :",

--- a/tests/i18n/sidebarBoardsRootLocales.test.ts
+++ b/tests/i18n/sidebarBoardsRootLocales.test.ts
@@ -1,21 +1,4 @@
-/**
- * Regression test for sidebar.boards.rootBoards verbatim-EN placeholder bug.
- *
- * The sidebar.boards.rootBoards key was set to the English string 'Boards' in
- * DE, ES, and FR locales. This causes the breadcrumb label shown in
- * SidebarBoardsActive.tsx (line: t('sidebar.boards.rootBoards', ...)) to display
- * the English word "Boards" to German, Spanish, and French users instead of the
- * correct translated term.
- *
- * Evidence: every other key that translates "Boards" in each locale uses the
- * correct term (DE='Tafeln', ES='Tableros', FR='Tableaux') — e.g.
- * boardsModal.allBoards, boardsModal.boards, boardNav.boardList.
- *
- * This test:
- * 1. Checks that all 4 locales carry the sidebar.boards.rootBoards key.
- * 2. Checks that DE, ES, and FR each use their established locale-native
- *    translation, NOT the verbatim English string.
- */
+// Regression: sidebar.boards.rootBoards was stored as verbatim EN 'Boards' in DE/ES/FR — fixes PR #1983.
 
 import { describe, it, expect } from 'vitest';
 import en from '@/locales/en.json';

--- a/tests/i18n/sidebarBoardsRootLocales.test.ts
+++ b/tests/i18n/sidebarBoardsRootLocales.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for sidebar.boards.rootBoards verbatim-EN placeholder bug.
+ *
+ * The sidebar.boards.rootBoards key was set to the English string 'Boards' in
+ * DE, ES, and FR locales. This causes the breadcrumb label shown in
+ * SidebarBoardsActive.tsx (line: t('sidebar.boards.rootBoards', ...)) to display
+ * the English word "Boards" to German, Spanish, and French users instead of the
+ * correct translated term.
+ *
+ * Evidence: every other key that translates "Boards" in each locale uses the
+ * correct term (DE='Tafeln', ES='Tableros', FR='Tableaux') — e.g.
+ * boardsModal.allBoards, boardsModal.boards, boardNav.boardList.
+ *
+ * This test:
+ * 1. Checks that all 4 locales carry the sidebar.boards.rootBoards key.
+ * 2. Checks that DE, ES, and FR each use their established locale-native
+ *    translation, NOT the verbatim English string.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+type LocaleFile = typeof en;
+
+const EN_VALUE = en.sidebar.boards.rootBoards; // 'Boards'
+
+describe('EN locale — sidebar.boards.rootBoards baseline', () => {
+  it('has the sidebar.boards.rootBoards key', () => {
+    expect(en.sidebar.boards).toHaveProperty('rootBoards');
+  });
+  it('EN value is "Boards"', () => {
+    expect(EN_VALUE).toBe('Boards');
+  });
+});
+
+describe.each([
+  {
+    code: 'de',
+    locale: de as unknown as LocaleFile,
+    expectedValue: 'Tafeln',
+  },
+  {
+    code: 'es',
+    locale: es as unknown as LocaleFile,
+    expectedValue: 'Tableros',
+  },
+  {
+    code: 'fr',
+    locale: fr as unknown as LocaleFile,
+    expectedValue: 'Tableaux',
+  },
+])(
+  '$code locale — sidebar.boards.rootBoards translation',
+  ({ code, locale, expectedValue }) => {
+    it(`${code}: has the sidebar.boards.rootBoards key`, () => {
+      expect(
+        locale.sidebar.boards,
+        `${code}.sidebar.boards.rootBoards is missing`
+      ).toHaveProperty('rootBoards');
+    });
+
+    it(`${code}: value is not the verbatim English string`, () => {
+      const value = locale.sidebar.boards.rootBoards;
+      expect(
+        value,
+        `${code}.sidebar.boards.rootBoards is still the verbatim EN string '${EN_VALUE}' — should be '${expectedValue}'`
+      ).not.toBe(EN_VALUE);
+    });
+
+    it(`${code}: value is the locale-native translation`, () => {
+      const value = locale.sidebar.boards.rootBoards;
+      expect(
+        value,
+        `${code}.sidebar.boards.rootBoards should be '${expectedValue}' but got '${value}'`
+      ).toBe(expectedValue);
+    });
+  }
+);


### PR DESCRIPTION
## Root Cause

`sidebar.boards.rootBoards` was added to `locales/en.json` when the Boards sidebar was built but was never translated in the other three locale files. All three non-EN locale files had the verbatim English string `"Boards"` stored as the value.

**Why it was silent:** `SidebarBoardsActive.tsx` calls `t('sidebar.boards.rootBoards', { defaultValue: 'Boards' })`. `i18next.defaultValue` only fires when the key is **absent** — not when a wrong stored value is present. Because the key existed in DE/ES/FR (with the English value), the fallback never triggered and DE/ES/FR teachers always saw "Boards" in the sidebar breadcrumb for the Boards panel.

This is the same pattern documented in the memory doc (`boardBreadcrumb.openManager` / `collectionSwitcher.title` fixed in #1936, `boardsModal`/`shareCollection` placeholders fixed in #1951/#1964).

## Fix Summary

| Locale | Before (verbatim EN) | After (correct translation) |
|--------|---------------------|-----------------------------|
| `de`   | `"Boards"`          | `"Tafeln"`                  |
| `es`   | `"Boards"`          | `"Tableros"`                |
| `fr`   | `"Boards"`          | `"Tableaux"`                |

## Rejected Band-Aid

Adding a `defaultValue` to the `t()` call would have silenced the symptom without fixing the locale files — DE/ES/FR teachers would still see English. The correct fix is to store accurate translations.

## Regression Test

`tests/i18n/sidebarBoardsRootLocales.test.ts` (11 tests):
- Key is present in all 4 locales
- Value is NOT the EN string `"Boards"` for DE, ES, FR
- Value matches the expected locale-native translation exactly

**Before fix:** 6 tests fail (all DE/ES/FR presence + value checks)  
**After fix:** 11/11 pass

## Risk Tag

**Contained** — locale JSON only, no component changes.

## Test Plan
- [ ] Run `pnpm exec vitest run tests/i18n/sidebarBoardsRootLocales.test.ts` — all 11 pass
- [ ] Run `pnpm run validate` — all checks green

---
_Generated by [Claude Code](https://claude.ai/code/session_01GACCHe7f5VJd6ghXxzTRjr)_