### PR TITLE
fix(deps): override qs to >=6.15.2 in functions to clear GHSA-q8mj-m7cp-5q26

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -39,7 +39,8 @@
     "overrides": {
       "body-parser": "^2.2.1",
       "lodash": "^4.17.23",
-      "protobufjs": "^7.5.6"
+      "protobufjs": "^7.5.6",
+      "qs": "^6.15.2"
     }
   },
   "private": true

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   body-parser: ^2.2.1
   lodash: ^4.17.23
   protobufjs: ^7.5.6
+  qs: ^6.15.2
 
 importers:
 
@@ -2292,12 +2293,8 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -3963,7 +3960,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -4251,7 +4248,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -4286,7 +4283,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -5463,11 +5460,7 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## Summary

Resolves the MEDIUM `qs` DoS advisory **GHSA-q8mj-m7cp-5q26** in the `functions/` workspace (tracked in the `dependency-audit` scheduled-task journal, detected 2026-05-26).

`qs` >=6.11.1 <=6.15.1 has a remotely triggerable DoS: `qs.stringify` crashes with a `TypeError` on `null`/`undefined` entries in comma-format arrays when `encodeValuesOnly` is set. In `functions/` it reached the dep graph via:

- `@google-cloud/functions-framework@5.0.0 > body-parser > qs` → resolved the vulnerable `qs@6.14.2`
- `@google-cloud/functions-framework@5.0.0 > express > qs` → resolved the vulnerable `qs@6.15.0`

## Change

Added `"qs": "^6.15.2"` to the `pnpm.overrides` block in `functions/package.json`. The caret bounds the resolution to `>=6.15.2 <7.0.0` — the patched range, within the `6.x` major that express 4/5 and body-parser expect — and matches the convention of the other overrides in the block (`body-parser`, `lodash`, `protobufjs`). Lockfile regenerated via `pnpm -C functions install`.

## Verification

- **Before:** `pnpm -C functions why qs` → vulnerable resolutions (`6.14.2`, `6.15.0`); `pnpm -C functions audit` reports GHSA-q8mj-m7cp-5q26.
- **After:** `pnpm -C functions why qs` → single `qs@6.15.2`; `pnpm -C functions audit` grep count for the advisory is `0`.
- `prettier --check functions/package.json` — clean
- `pnpm -C functions type-check` — 0 errors
- `pnpm -C functions build` — `tsc` succeeds
- `pnpm -C functions test` — 29 files / 532 tests all pass

## Notes

- The root-side instance of this same advisory (via `@google/genai > @modelcontextprotocol/sdk > express > qs`) is unrelated to this change and remains covered by the separate MEDIUM MCP SDK item in the journal.
- Override-only approach avoids bumping the direct dependency's version while guaranteeing the patched `qs` across all transitive paths.
- Branch is rebased directly on `dev-paul`, so the diff is exactly the two `functions/` files.

https://claude.ai/code/session_01GppS6wEy3C8fmDZz9C5MMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GppS6wEy3C8fmDZz9C5MMJ)_