### PR TITLE
fix(widgets/schedule): decouple row sizing from width so widening reveals content

### DIFF
--- a/components/widgets/Schedule/ScheduleWidget.tsx
+++ b/components/widgets/Schedule/ScheduleWidget.tsx
@@ -27,11 +27,12 @@ import {
   parseScheduleTime,
   computeEffectiveTimes,
   getItemDurationSeconds,
+  scheduleSize,
 } from '@/components/widgets/Schedule/utils';
 import { ScheduleRow } from '@/components/widgets/Schedule/components/ScheduleRow';
 import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
 
-const GAP_STYLE = 'min(10px, 2cqmin)';
+const GAP_STYLE = scheduleSize(2, 10);
 
 export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -522,7 +523,7 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
       content={
         <div
           className={`h-full w-full flex flex-col overflow-hidden ${getFontClass()}`}
-          style={{ padding: 'min(12px, 2.5cqmin)' }}
+          style={{ padding: scheduleSize(2.5, 12) }}
         >
           <div
             ref={scrollContainerRef}

--- a/components/widgets/Schedule/components/ScheduleRow.tsx
+++ b/components/widgets/Schedule/components/ScheduleRow.tsx
@@ -5,6 +5,7 @@ import { Circle, CheckCircle2, Timer } from 'lucide-react';
 import {
   formatCountdown,
   formatScheduleTime,
+  scheduleSize,
 } from '@/components/widgets/Schedule/utils';
 import { hexToRgba } from '@/utils/styles';
 
@@ -36,11 +37,11 @@ export const CountdownDisplay: React.FC<CountdownDisplayProps> = ({
   const progress = total > 0 ? rem / total : 0;
 
   return (
-    <div className="flex flex-col w-full" style={{ gap: 'min(4px, 0.8cqmin)' }}>
+    <div className="flex flex-col w-full" style={{ gap: scheduleSize(0.8, 4) }}>
       <span
         className="text-indigo-400"
         style={{
-          fontSize: 'min(24px, 6cqmin)',
+          fontSize: scheduleSize(6, 24),
           fontVariantNumeric: 'tabular-nums',
           opacity: isIdle ? 0.6 : 1,
         }}
@@ -49,7 +50,7 @@ export const CountdownDisplay: React.FC<CountdownDisplayProps> = ({
       </span>
       <div
         className="w-full rounded-full overflow-hidden bg-slate-200"
-        style={{ height: 'min(5px, 1.2cqmin)' }}
+        style={{ height: scheduleSize(1.2, 5) }}
       >
         <div
           className="h-full rounded-full bg-indigo-400"
@@ -216,8 +217,13 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
   // tall enough. Auto-scroll keeps the active item in view.
   const rowStyle = {
     flex: '0 0 auto',
-    minHeight: 'min(72px, 18cqmin)',
+    minHeight: scheduleSize(18, 72),
     backgroundColor: bgColor,
+    // Active rows get a thicker accent border; width set inline so it can use
+    // the same clamp()-based sizing (Tailwind arbitrary values can't hold the
+    // commas/spaces a clamp() expression needs). border-style:solid comes from
+    // Tailwind's preflight, so only the width + color need setting here.
+    borderWidth: isActive ? scheduleSize(1.5, 6) : '1px',
   };
 
   // Timer-start icon: strictly mode-aware so the button only appears when
@@ -241,8 +247,8 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
     <div
       className={`w-full flex items-center rounded-2xl transition-all relative snap-start overflow-hidden ${
         isActive
-          ? 'border-[min(6px,1.5cqmin)] border-brand-blue-primary shadow-md z-10'
-          : 'border border-slate-200 shadow-sm'
+          ? 'border-brand-blue-primary shadow-md z-10'
+          : 'border-slate-200 shadow-sm'
       }`}
       style={rowStyle}
     >
@@ -250,9 +256,9 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
         <div
           className="absolute top-0 right-0 bg-brand-blue-primary text-white font-black uppercase tracking-widest z-20"
           style={{
-            fontSize: `min(${Math.round(10 * textScale)}px, ${(2.5 * textScale).toFixed(2)}cqmin)`,
-            padding: 'min(4px, 1cqmin) min(8px, 2cqmin)',
-            borderBottomLeftRadius: 'min(12px, 3cqmin)',
+            fontSize: scheduleSize(2.5 * textScale, 10 * textScale),
+            padding: `${scheduleSize(1, 4)} ${scheduleSize(2, 8)}`,
+            borderBottomLeftRadius: scheduleSize(3, 12),
           }}
         >
           Now
@@ -261,22 +267,22 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
       <button
         onClick={() => onToggle(index)}
         className="flex items-center flex-1 min-w-0 h-full"
-        style={{ gap: 'min(16px, 3cqmin)', padding: 'min(16px, 3cqmin)' }}
+        style={{ gap: scheduleSize(3, 16), padding: scheduleSize(3, 16) }}
       >
         {item.done ? (
           <CheckCircle2
             className="text-green-500 shrink-0"
             style={{
-              width: 'min(32px, 8cqmin)',
-              height: 'min(32px, 8cqmin)',
+              width: scheduleSize(8, 32),
+              height: scheduleSize(8, 32),
             }}
           />
         ) : (
           <Circle
             className="text-indigo-300 shrink-0"
             style={{
-              width: 'min(32px, 8cqmin)',
-              height: 'min(32px, 8cqmin)',
+              width: scheduleSize(8, 32),
+              height: scheduleSize(8, 32),
             }}
           />
         )}
@@ -289,9 +295,9 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
             />
           ) : (
             <span
-              className={`font-black leading-none ${item.done ? 'text-slate-400' : 'text-indigo-400'}`}
+              className={`font-black leading-none whitespace-nowrap ${item.done ? 'text-slate-400' : 'text-indigo-400'}`}
               style={{
-                fontSize: `min(${Math.round(24 * textScale)}px, ${(6 * textScale).toFixed(2)}cqmin)`,
+                fontSize: scheduleSize(6 * textScale, 24 * textScale),
                 color: !item.done ? fontColor : undefined,
               }}
             >
@@ -301,7 +307,7 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
           <span
             className={`font-black leading-tight truncate w-full text-left ${item.done ? 'text-slate-400 line-through' : 'text-slate-700'}`}
             style={{
-              fontSize: `min(${Math.round(36 * textScale)}px, ${(10 * textScale).toFixed(2)}cqmin)`,
+              fontSize: scheduleSize(10 * textScale, 36 * textScale),
               color: !item.done ? fontColor : undefined,
             }}
           >
@@ -314,8 +320,8 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
           onClick={() => onStartTimer?.(item)}
           className="shrink-0 text-indigo-300 hover:text-indigo-500 hover:bg-indigo-50 rounded-lg transition-colors"
           style={{
-            padding: 'min(4px, 1cqmin)',
-            marginRight: 'min(12px, 2.5cqmin)',
+            padding: scheduleSize(1, 4),
+            marginRight: scheduleSize(2.5, 12),
           }}
           title={timerLaunchLabel}
           aria-label={timerLaunchLabel}
@@ -323,8 +329,8 @@ export const ScheduleRow = React.memo<ScheduleRowProps>(function ScheduleRow({
           <Timer
             className="shrink-0"
             style={{
-              width: 'min(28px, 7cqmin)',
-              height: 'min(28px, 7cqmin)',
+              width: scheduleSize(7, 28),
+              height: scheduleSize(7, 28),
             }}
           />
         </button>

--- a/components/widgets/Schedule/utils.ts
+++ b/components/widgets/Schedule/utils.ts
@@ -1,5 +1,29 @@
 import { DailySchedule, ScheduleItem } from '@/types';
 
+/**
+ * Build a container-query size expression for Schedule widget content.
+ *
+ * The widget content area is a `container-type: size` container, so sizing can
+ * react to width (`cqw`) and height (`cqh`) independently. We want:
+ *
+ *   • Autoscale *down* with the smaller dimension — a short OR narrow widget
+ *     shrinks text/rows so more content fits — but never below a floor.
+ *   • Width growth alone must NOT enlarge anything: widening past a comfortable
+ *     point should reveal more of each row (longer titles), not zoom it.
+ *   • Making the widget taller still grows the content (the wanted scaling).
+ *
+ * Mechanism: `clamp(floor, min(coeff·cqw, coeff·HEIGHT_CAP·cqh), maxPx)`.
+ * The `cqw` term only binds when the widget is narrow (so narrowing shrinks);
+ * the `cqh` cap binds at normal/wide aspect ratios (so widening can't grow the
+ * size). `coeff`/`maxPx` mirror the previous `min(maxPx, coeff·cqmin)` values
+ * (already multiplied by any text-size preset scale).
+ */
+const SCHEDULE_HEIGHT_CAP = 0.45; // height-cap coefficient (× coeff), applied to cqh
+const SCHEDULE_SIZE_FLOOR = 0.45; // floor as a fraction of maxPx
+
+export const scheduleSize = (coeff: number, maxPx: number): string =>
+  `clamp(${(maxPx * SCHEDULE_SIZE_FLOOR).toFixed(2)}px, min(${coeff.toFixed(2)}cqw, ${(coeff * SCHEDULE_HEIGHT_CAP).toFixed(2)}cqh), ${maxPx.toFixed(2)}px)`;
+
 /** Returns today's date as YYYY-MM-DD in the user's local timezone. */
 export const getTodayStr = (): string => {
   const d = new Date();


### PR DESCRIPTION
## What

The Schedule widget sized rows with `min(maxPx, K·cqmin)`, tying every size to the **smaller** dimension. In a tall/narrow widget that's the width — so making the widget *wider* zoomed every row bigger instead of revealing more of each title.

This replaces that with a shared `scheduleSize()` helper:

```
clamp(floor, min(K·cqw, K·0.45·cqh), maxPx)
```

Resulting behavior:

| Resize | Behavior |
|---|---|
| **Narrower / shorter** | Text and rows autoscale **down** to a floor (a "min cap") so more content fits. |
| **Wider only** | Size holds steady; the extra width **reveals more of each title** instead of zooming. |
| **Taller** | Size grows (the wanted scaling). |

The `cqw` term only binds when the widget is narrow (so narrowing shrinks); the `cqh` cap binds at normal/wide aspect ratios (so widening can't enlarge anything).

## Also

- Active-row border width moved to an inline style (a `clamp()` expression can't live in a Tailwind arbitrary class).
- Added `whitespace-nowrap` to the time so it never wraps to two lines at larger sizes.

## Tuning knobs

In `scheduleSize` (`components/widgets/Schedule/utils.ts`):
- `SCHEDULE_HEIGHT_CAP = 0.45` — lower = stops growing sooner on widen; higher = bigger before it caps.
- `SCHEDULE_SIZE_FLOOR = 0.45` — minimum size (fraction of max) when narrow/short.

## Verification

- Tuned and measured against a faithful container-query harness across all three resize directions (widening 260→380→480px holds task text at 21.6px while titles go from truncated to fully shown).
- `pnpm run type-check` ✅, ESLint ✅, Prettier ✅, 28/28 Schedule unit tests ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
