### PR TITLE
Optimize-pass safe batch: F7, F10, F21, F22, F24 (+ F1/F6 proposals)

### DIFF
--- a/components/layout/BoardCanvas.tsx
+++ b/components/layout/BoardCanvas.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from 'react';
+import { type FC, memo, useMemo } from 'react';
 import type {
   Dashboard,
   LiveSession,
@@ -58,19 +58,29 @@ const GroupBoundingBoxLayer: FC<{ dashboard: Dashboard }> = ({ dashboard }) => {
   );
   const zoom = useDashboardCanvasSelector((s) => s.zoom);
 
-  const selectedGroupId = selectedWidgetId
-    ? dashboard.widgets.find((w) => w.id === selectedWidgetId)?.groupId
-    : undefined;
+  const widgets = dashboard.widgets;
 
-  const groupMembers = selectedGroupId
-    ? dashboard.widgets.filter(
-        (w) =>
-          w.groupId === selectedGroupId &&
-          !w.minimized &&
-          !w.isLocked &&
-          !w.isPinned
-      )
-    : [];
+  const selectedGroupId = useMemo(
+    () =>
+      selectedWidgetId
+        ? widgets.find((w) => w.id === selectedWidgetId)?.groupId
+        : undefined,
+    [widgets, selectedWidgetId]
+  );
+
+  const groupMembers = useMemo(
+    () =>
+      selectedGroupId
+        ? widgets.filter(
+            (w) =>
+              w.groupId === selectedGroupId &&
+              !w.minimized &&
+              !w.isLocked &&
+              !w.isPinned
+          )
+        : [],
+    [widgets, selectedGroupId]
+  );
 
   if (!selectedGroupId || groupMembers.length === 0) return null;
   return <GroupBoundingBox groupWidgets={groupMembers} zoom={zoom} />;

--- a/docs/optimize-pass/PROPOSAL-F1-contrast.md
+++ b/docs/optimize-pass/PROPOSAL-F1-contrast.md
@@ -1,0 +1,174 @@
+# PROPOSAL F1 — WCAG AA contrast for muted slate text on the dark dashboard
+
+**Status:** proposal-written · **Gated:** needs Paul's design sign-off (purely visual change)
+**Source finding:** `docs/optimize-pass/01-accessibility-contrast.md`
+**Scope of this proposal:** `ScaledEmptyState` defaults + GuidedLearning results/manager labels **on dark surfaces only**. No source file is modified by this proposal.
+
+---
+
+## TL;DR (decision-ready)
+
+- I recomputed every muted value against the real `slate-900` (#0f172a) background using the WCAG 2.x relative-luminance formula (verified: black/white = 21.00:1, #777/#fff = 4.48:1).
+- **The upstream doc's headline number is wrong.** It claims `text-slate-400` lands at "~2.8:1" on `slate-900`. The actual ratio is **6.96:1 — it already PASSES AA** for normal text. The genuine AA failure on dark is **`text-slate-500` (3.75:1)**, used for the `ScaledEmptyState` _title_ and the GL "Building library" pill.
+- Recommended restrained upgrade: **`slate-500 → slate-200`** (3.75 → 14.48) and **`slate-400 → slate-300`** (6.96 → 12.02) for real text on dark. Decorative icons get `aria-hidden`, color unchanged. Light/student/login surfaces are untouched.
+- Swatch pairs to eyeball: title `#64748b → #e2e8f0`, subtitle/labels `#94a3b8 → #cbd5e1`.
+
+---
+
+## 1. Contrast table (computed, WCAG 2.x formula)
+
+Background = dark dashboard surface `slate-900` **#0f172a**. Thresholds: **4.5:1** normal text, **3:1** large text (≥18px, or ≥14px **bold**).
+
+Many of the target labels actually render on a `bg-white/5` card (the GuidedLearning stat cards), so that effective background (**#1b2335** = white@5% over #0f172a) is shown too.
+
+| Class       | Hex       | Ratio on #0f172a | Normal (4.5:1) | Large (3:1) | Ratio on `bg-white/5` #1b2335 | Normal  | Large   |
+| ----------- | --------- | ---------------- | -------------- | ----------- | ----------------------------- | ------- | ------- |
+| `slate-500` | `#64748b` | **3.75:1**       | ❌ FAIL        | ✅ PASS     | **3.30:1**                    | ❌ FAIL | ✅ PASS |
+| `slate-400` | `#94a3b8` | **6.96:1**       | ✅ PASS        | ✅ PASS     | **6.12:1**                    | ✅ PASS | ✅ PASS |
+| `slate-300` | `#cbd5e1` | **12.02:1**      | ✅ PASS        | ✅ PASS     | **10.57:1**                   | ✅ PASS | ✅ PASS |
+| `slate-200` | `#e2e8f0` | **14.48:1**      | ✅ PASS        | ✅ PASS     | **12.73:1**                   | ✅ PASS | ✅ PASS |
+
+**Correction to the explore doc:** `01-accessibility-contrast.md` (lines 11, 26) asserts `text-slate-400` ≈ 2.8:1 and that it "fails 4.5:1." That is incorrect on `#0f172a` — slate-400 is 6.96:1 and passes. The only class that genuinely fails AA for normal text on the dark surface is **`slate-500`**. The acceptance criteria still hold; the at-risk set is just narrower than the doc implies.
+
+---
+
+## 2. Proposed restrained upgrade (dark surfaces only)
+
+Brand direction is "calm / restrained" — so the upgrade is the minimal one Tailwind-step pair that clears AA with margin and keeps the muted _hierarchy_ (title brighter than subtitle):
+
+| Role                                  | Old         | New         | Old ratio (#0f172a) | New ratio (#0f172a) | Result   |
+| ------------------------------------- | ----------- | ----------- | ------------------- | ------------------- | -------- |
+| Primary muted text (title / pill)     | `slate-500` | `slate-200` | 3.75:1 ❌           | **14.48:1**         | AA + AAA |
+| Secondary muted text (subtitle/label) | `slate-400` | `slate-300` | 6.96:1 ✅ (low)     | **12.02:1**         | AA + AAA |
+
+Two notes on the slate-400 → slate-300 bump:
+
+- slate-400 **already passes** 4.5:1, so this row is a _glanceability_ improvement (brand principle 3: "legible on a washed-out classroom projector"), not a compliance fix. It is the safer, restrained choice because it keeps a one-step gap below the new title color (200 vs 300) and preserves visual hierarchy. **Paul may elect to leave slate-400 as-is** and only fix the slate-500 failures — see Decision section.
+- We deliberately do **not** go brighter than slate-200 (white would flatten the muted hierarchy and read as "heavy block," against the brand).
+
+**Decorative icons are NOT recolored.** They get `aria-hidden` so a screen reader skips them; their slate color is irrelevant to text-contrast AA. (Several are already `aria-hidden`.)
+
+**Light / student / login surfaces are out of scope** and must not be touched — brightening muted text _on white_ would _reduce_ its contrast.
+
+---
+
+## 3. Exact proposed diff (DO NOT APPLY — review gate)
+
+### 3a. `components/common/ScaledEmptyState.tsx` — defaults (highest reach: fallback UI for 60+ widgets)
+
+The title is `font-black` 14px (qualifies as "large," so slate-500 technically clears 3:1) — but as the most-seen muted text in the product it should clear the **normal** 4.5:1 bar comfortably. The subtitle is 12px non-bold = normal text.
+
+```diff
+-  iconClassName = 'text-slate-300',
+-  titleClassName = 'text-slate-500',
+-  subtitleClassName = 'text-slate-400',
++  iconClassName = 'text-slate-300',
++  titleClassName = 'text-slate-200',
++  subtitleClassName = 'text-slate-300',
+```
+
+- `titleClassName`: `slate-500 → slate-200` (3.75 → 14.48) — fixes the real AA gap.
+- `subtitleClassName`: `slate-400 → slate-300` (6.96 → 12.02) — restrained glanceability bump.
+- `iconClassName`: **unchanged** (`slate-300`). The icon is decorative; see icon note below.
+
+> Icon note for the implementer: the `<Icon>` wrapper (lines 42–50) is decorative (the title already names the empty state). When this lands, add `aria-hidden` to the icon wrapper rather than recoloring it. This proposal does **not** change the icon color.
+
+### 3b. `components/widgets/GuidedLearning/components/GuidedLearningResults.tsx` — stat labels on `bg-white/5` cards
+
+Real, glanceable label text on a dark card. (Lines 201 and 222 are a hover-affordance back button and a spinner respectively — **not changed here**; 201 already animates to white on hover, 222 is a decorative `Loader2`.)
+
+```diff
+@@ Total stat label (line ~232)
+-              <div className="text-slate-400 text-xs mt-0.5 flex items-center justify-center gap-1">
++              <div className="text-slate-300 text-xs mt-0.5 flex items-center justify-center gap-1">
+                 <Users className="w-3 h-3" /> Total
+@@ Done stat label (line ~240)
+-              <div className="text-slate-400 text-xs mt-0.5 flex items-center justify-center gap-1">
++              <div className="text-slate-300 text-xs mt-0.5 flex items-center justify-center gap-1">
+                 <CheckCircle2 className="w-3 h-3" /> Done
+@@ Avg Score stat label (line ~248)
+-              <div className="text-slate-400 text-xs mt-0.5">Avg Score</div>
++              <div className="text-slate-300 text-xs mt-0.5">Avg Score</div>
+@@ "Question Results" heading (line ~255)
+-              <h3 className="text-slate-300 text-xs font-semibold uppercase tracking-wider mb-2">
++              <h3 className="text-slate-200 text-xs font-semibold uppercase tracking-wider mb-2">
+```
+
+- 232 / 240 / 248: `slate-400 → slate-300` (12px normal text, 6.12 → 10.57 on the card). The inline `Users` / `CheckCircle2` icons are decorative — implementer should add `aria-hidden`.
+- 255: this heading is already `slate-300` (passes). Bumping to `slate-200` keeps it as the brightest label in the block (section heading > stat label). **Optional** — listed for completeness; safe to skip if Paul prefers the smaller diff.
+
+### 3c. `components/widgets/GuidedLearning/components/GuidedLearningManager.tsx` — triage of the doc's line list
+
+The explore doc lists `773, 1013, 1103, 1166, 1221, 1341, 1350`. After inspecting the actual code, **most of these should NOT be recolored.** Triage:
+
+| Line | Current                                   | Category                                           | Action                                         |
+| ---- | ----------------------------------------- | -------------------------------------------------- | ---------------------------------------------- |
+| 773  | `<BookOpen … text-slate-400 aria-hidden>` | Decorative icon, already `aria-hidden`             | **No change** (correct as-is)                  |
+| 1013 | spinner container `text-slate-500`        | Colors a `Loader2` icon, not text                  | **No change** (decorative)                     |
+| 1103 | spinner container `text-slate-500`        | Colors a `Loader2` icon, not text                  | **No change** (decorative)                     |
+| 1166 | `<BookOpen … text-slate-400 aria-hidden>` | Decorative icon, already `aria-hidden`             | **No change** (correct as-is)                  |
+| 1221 | "Building library" pill `text-slate-500`  | **Real text on dark** (uppercase bold 11px)        | **Change** `slate-500 → slate-200` (see below) |
+| 1341 | "No preview image" `text-slate-400`       | Text on **light** card (`bg-slate-50`, white pane) | **No change** — out of scope (light surface)   |
+| 1350 | "Mode:" `text-slate-500`                  | Text on **light** card (white pane)                | **No change** — out of scope (light surface)   |
+
+Confirmed light-surface context for 1341/1350: the enclosing `GuidedLearningPreviewPane` body is `text-slate-700` (line 1332) inside `LibraryPreviewPane`, which is `bg-white` (`components/common/library/LibraryPreviewPane.tsx:114`). Brightening muted text there would _reduce_ contrast — leave it.
+
+The single real change in this file:
+
+```diff
+@@ "Building library" filter pill (line ~1221)
+-                  <span className="inline-flex items-center gap-1 text-[11px] font-bold uppercase tracking-widest text-slate-500">
++                  <span className="inline-flex items-center gap-1 text-[11px] font-bold uppercase tracking-widest text-slate-200">
+                     <Building2 size={12} />
+```
+
+- 11px bold uppercase = "large" by WCAG, so slate-500 (3.75:1) technically clears 3:1 — but it's a status label a teacher reads, and slate-200 (14.48:1) makes it crisp on a projector. The `Building2` icon is decorative; implementer should add `aria-hidden`.
+
+**Net:** of the 7 manager lines the doc listed, only **1** (line 1221) is a genuine text-on-dark fix; 4 are decorative icons/spinners and 2 are light-surface text.
+
+---
+
+## 4. Contrast-safe muted-text token
+
+**Recommendation: introduce a documented token, lightweight.** Raw `slate-400`/`slate-500` keep getting reached for as "muted text" and `slate-500` is sub-AA on dark — a named default prevents regressions.
+
+Lowest-friction option that fits this codebase (Tailwind + the existing "Widget Appearance Standard" in CLAUDE.md): add two semantic utility classes in the Tailwind theme / a base layer, e.g.
+
+- `text-muted-on-dark` → `slate-300` (12.02:1) — for muted text on the dark dashboard.
+- `text-strong-muted-on-dark` → `slate-200` (14.48:1) — for the brighter muted tier (titles, status pills).
+
+Where: define alongside the brand color extensions in `tailwind.config.js`, and steer new widget code to these instead of raw `slate-400/500`. Introducing the token is **not required** to ship the fixes in §3 — it's a follow-up that makes the fix durable. If Paul wants the smallest possible change now, ship §3 with raw classes and defer the token.
+
+**Proposed one-line CLAUDE.md addition** (under "Widget Appearance Standard"), only if the token is adopted:
+
+> - Muted text on the **dark** dashboard surface must use `text-muted-on-dark` (slate-300, 12:1) or `text-strong-muted-on-dark` (slate-200, 14.5:1) — never raw `text-slate-400/500`, which is sub-AA (3.75:1) on `slate-900`. Decorative muted icons get `aria-hidden` instead of a contrast bump.
+
+---
+
+## 5. Decision needed from Paul
+
+This is a purely **visual** change. Brand direction is "calm / restrained" — the proposed upgrade is the minimal Tailwind-step pair that clears AA while keeping the muted hierarchy (title brighter than subtitle/label). Eyeball the before/after swatches (plain hex):
+
+| Role                          | Before (hex)        | After (hex)         | Why                                   |
+| ----------------------------- | ------------------- | ------------------- | ------------------------------------- |
+| Empty-state **title**         | `#64748b` slate-500 | `#e2e8f0` slate-200 | Real AA fix (3.75 → 14.48 on #0f172a) |
+| Empty-state **subtitle**      | `#94a3b8` slate-400 | `#cbd5e1` slate-300 | Glanceability bump (already passed)   |
+| GL stat labels (Total/Done/…) | `#94a3b8` slate-400 | `#cbd5e1` slate-300 | Glanceability bump (already passed)   |
+| GL "Question Results" heading | `#cbd5e1` slate-300 | `#e2e8f0` slate-200 | Optional — keep heading brightest     |
+| GL "Building library" pill    | `#64748b` slate-500 | `#e2e8f0` slate-200 | Real fix on dark (3.75 → 14.48)       |
+
+**Three decisions:**
+
+1. **Required fix vs. comfort bump.** Approve the _required_ slate-500 fixes (title + Building-library pill) — those are genuine AA failures. The slate-400 → slate-300 bumps are optional glanceability; approve them or tell me to leave slate-400 as-is for a smaller, more restrained diff.
+2. **Token or not.** Adopt `text-muted-on-dark` / `text-strong-muted-on-dark` (§4) + the CLAUDE.md line, or defer and ship raw classes now.
+3. **"Question Results" heading (§3b, line 255).** Already passes AA — bump to slate-200 for hierarchy, or leave it.
+
+Once you pick, F1 implementation can apply §3 (plus `aria-hidden` on the decorative icons called out inline) with no further design input.
+
+---
+
+### Out-of-scope guardrails for the implementer (carried from the source finding)
+
+- Triage by **actual rendered background**, not a global find-replace. ~1300 `text-slate-300/400` occurrences exist repo-wide; most are decorative icons or text on _light_ admin/student surfaces and must stay.
+- Do not touch light / student / login surfaces (would _reduce_ their contrast).
+- Confirm `ScaledEmptyState`'s readability surface still gives AA when rendered over a user-chosen background image.

--- a/docs/optimize-pass/PROPOSAL-F6-building-id-canonicalization.md
+++ b/docs/optimize-pass/PROPOSAL-F6-building-id-canonicalization.md
@@ -1,0 +1,260 @@
+# PROPOSAL F6 — Canonicalize building IDs in the building-admin update rule
+
+**Area:** firestore.rules · **Dimension:** correctness · **Impact:** 5 ·
+**Effort:** medium · **Risk:** medium · **Behavior change:** YES (it changes which
+building-admin edits are accepted).
+
+**Status:** proposal-written. This document is a review proposal only. It does
+**not** modify `firestore.rules`, `config/buildings.ts`, or any test. Do not apply
+the diff below until the "Decision needed from Paul" section is signed off.
+
+---
+
+## 1. Problem recap
+
+The building-admin branch of the `/organizations/{orgId}/buildings/{buildingId}`
+update rule gates the edit on:
+
+```
+firestore.rules:211
+  buildingId in orgMember(orgId).buildingIds
+```
+
+This is a raw CEL `in` over two strings with **no canonicalization**. The app has
+two ID spaces for the same building (see `config/buildings.ts:88-114`):
+
+- **Legacy long form** — e.g. `orono-high-school`, written historically by the
+  Sidebar / user profiles / Feature Permissions.
+- **Canonical short form** — e.g. `high`, written by the Organization Buildings
+  admin panel to `members.buildingIds` and to the building doc id.
+
+When the two spaces drift — a member doc stored with canonical `high` but a
+building doc still keyed `orono-high-school` (or the reverse) — the raw `in`
+silently returns false and the rule **falsely denies** an edit the building admin
+is legitimately entitled to make. (No false _grant_ happens today, because `in`
+only matches on exact equality — but see Risks: a wrong alias map would.)
+
+The client already resolves this with `canonicalBuildingId()` /
+`canonicalizeBuildingIds()` (`config/buildings.ts:124-169`), but CEL cannot call
+JS, so the alias table has to be mirrored into the rules file.
+
+### Where the IDs come from
+
+| Path                           | ID format stored                              | Source                                                                       |
+| ------------------------------ | --------------------------------------------- | ---------------------------------------------------------------------------- |
+| `buildingId` (path segment)    | doc id — canonical _or_ legacy, per data age  | `firestore.rules:189`, create rule pins `data.id == buildingId` at `196-202` |
+| `orgMember(orgId).buildingIds` | array — canonical _or_ legacy, per member age | `firestore.rules:115-117`, `211`                                             |
+
+Because either side can independently be in either format, canonicalizing **both**
+sides before the `in` is required — canonicalizing only one side still misses the
+canonical-member ↔ legacy-building and legacy-member ↔ canonical-building crosses.
+
+---
+
+## 2. Alias pairs (extracted verbatim from `config/buildings.ts:109-114`)
+
+`BUILDING_ID_ALIASES` is the single source of truth. The CEL map below MUST be a
+byte-for-byte mirror of it.
+
+| Legacy ID (key)             | Canonical ID (value) |
+| --------------------------- | -------------------- |
+| `orono-high-school`         | `high`               |
+| `orono-middle-school`       | `middle`             |
+| `orono-intermediate-school` | `intermediate`       |
+| `schumann-elementary`       | `schumann`           |
+
+Notes carried over from `config/buildings.ts`:
+
+- `canonicalBuildingId(id)` returns `BUILDING_ID_ALIASES[id] ?? id` — i.e. an ID
+  that is already canonical, or simply unknown, is returned **unchanged**. The CEL
+  helper must replicate exactly this "pass through on miss" behavior.
+- The seed buildings `orono-community-education` and `orono-discovery-center`
+  (`config/buildings.ts:67-85`) have **no** alias entry — they are their own
+  canonical IDs and must pass through unchanged. Do not invent aliases for them.
+
+---
+
+## 3. Proposed CEL helper + rule edit (DIFF — DO NOT APPLY)
+
+Two changes, both inside the top-level `match /databases/{database}/documents`
+block:
+
+1. Add a `canonicalBuildingId(id)` rules function next to the other org helpers
+   (e.g. just after `orgMember(orgId)` at `firestore.rules:117`).
+2. Rewrite the membership check at `firestore.rules:211` so **both** `buildingId`
+   and every entry of `orgMember(orgId).buildingIds` are canonicalized before the
+   `in`.
+
+CEL has no array `.map()`, so the right-hand side is canonicalized by mapping the
+member array through a comprehension. Firestore rules support list
+comprehensions, so `[canonicalBuildingId(b) for b in <list>]` is expressible; if
+the deployed CEL dialect rejects the comprehension form during
+`firebase deploy --only firestore:rules` dry-run, fall back to the membership
+expansion shown in the **Alternative** block below.
+
+```diff
+--- a/firestore.rules
++++ b/firestore.rules
+@@ functions block, after orgMember(orgId)
+     // Returns the caller's /organizations/{orgId}/members/{email} doc data.
+     // Callers must guard with isOrgMember(orgId) first; otherwise get() fails.
+     function orgMember(orgId) {
+       return get(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower())).data;
+     }
++
++    // Maps a legacy long-form building ID to its canonical short form.
++    // MUST stay byte-for-byte in sync with BUILDING_ID_ALIASES in
++    // config/buildings.ts:109-114 — CEL cannot reuse the JS map, so any
++    // building renamed/aliased there has to be mirrored here. A mismatch
++    // silently re-introduces false denials, or (if a wrong pair is added)
++    // false GRANTS to a building the admin does not manage.
++    //
++    // Mirrors canonicalBuildingId() in config/buildings.ts:124 — unknown or
++    // already-canonical IDs pass through unchanged.
++    function canonicalBuildingId(id) {
++      return id == 'orono-high-school' ? 'high'
++           : id == 'orono-middle-school' ? 'middle'
++           : id == 'orono-intermediate-school' ? 'intermediate'
++           : id == 'schumann-elementary' ? 'schumann'
++           : id;
++    }
+@@ match /buildings/{buildingId} — allow update, building-admin branch
+         allow update: if isSuperAdmin() ||
+             ((isDomainAdmin(orgId) ||
+               (isBuildingAdmin(orgId) &&
+-               buildingId in orgMember(orgId).buildingIds)) &&
++               // Canonicalize BOTH sides before the membership test so a
++               // building admin whose member doc and the building doc are in
++               // different ID formats (legacy vs canonical) is not falsely
++               // denied. See config/buildings.ts:88-114 and PROPOSAL-F6.
++               canonicalBuildingId(buildingId) in
++                 orgMember(orgId).buildingIds
++                   .map(b, canonicalBuildingId(b)))) &&
+              request.resource.data.id == resource.data.id &&
+              request.resource.data.orgId == resource.data.orgId &&
+              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+                'name', 'address', 'grades', 'type', 'adminEmails'
+              ]));
+```
+
+> **Note on `.map()` syntax:** Firestore Rules CEL exposes the list macro as
+> `list.map(item, transform)`. If `firebase validate`/deploy rejects it in this
+> dialect, use the comprehension `[canonicalBuildingId(b) for b in
+orgMember(orgId).buildingIds]` instead. Both must be confirmed against the
+> emulator (`pnpm run test:rules`) and a `firebase deploy --only
+firestore:rules` dry-run before merge — see Risks.
+
+### Alternative if list transforms are unavailable in the deployed dialect
+
+If neither `.map()` nor a comprehension validates, canonicalize only the
+**buildingId** side and test it against the member array _expanded to include the
+legacy form of each canonical entry_ — i.e. test that the canonical buildingId is
+in the member list OR that the buildingId's legacy alias is. Concretely, replace
+the membership test with a fixed OR over the four known pairs plus the raw match:
+
+```
+(buildingId in orgMember(orgId).buildingIds) ||
+(canonicalBuildingId(buildingId) in orgMember(orgId).buildingIds)
+```
+
+This handles legacy-building ↔ canonical-member and the already-matching cases,
+but NOT canonical-building ↔ legacy-member. To cover that fourth cross without a
+list transform you must also expand the member side via a helper that checks each
+legacy key, which is verbose; prefer the `.map()`/comprehension form above and
+only fall back here if the dialect forces it. Flag this limitation to Paul if the
+fallback is taken.
+
+---
+
+## 4. Risks
+
+- **Alias-map drift is the core hazard.** The CEL `canonicalBuildingId` is a hand
+  copy of `BUILDING_ID_ALIASES` (`config/buildings.ts:109-114`). If the two ever
+  diverge:
+  - **Missing/incorrect-to-pass-through pair** → reintroduces the exact false
+    _denial_ this proposal fixes.
+  - **Wrong pair added** (e.g. aliasing a building to one the admin actually
+    manages) → a false _GRANT_: a building admin could edit a building they do
+    not belong to. This is strictly worse than the status quo. The cross-
+    referencing comment in the diff (pointing at `config/buildings.ts:109-114`)
+    is mandatory, not optional, to reduce drift risk.
+- **CEL dialect / list-macro support.** `.map()` and comprehensions must be
+  validated against both the emulator and a real deploy dry-run. A rule that
+  passes the emulator but fails `firebase deploy` would block all rules deploys,
+  not just this collection. Do a `firebase deploy --only firestore:rules` dry-run
+  in CI or locally before merge.
+- **No effect on domain-admin / super-admin paths.** The change is scoped to the
+  `isBuildingAdmin` branch only; domain and super admins are unaffected. Verify
+  the existing passing tests (`firestore-rules-organizations.test.ts:491-555`)
+  still pass unchanged.
+- **Future retirement.** When the backfill script
+  (`scripts/backfill-user-building-ids.js`, referenced at
+  `config/buildings.ts:105-107`) has rewritten all stored data to canonical IDs,
+  this CEL helper can be deleted alongside `BUILDING_ID_ALIASES`. Add a TODO so
+  the two are retired together.
+
+---
+
+## 5. Tests to add (`tests/rules/firestore-rules-organizations.test.ts`)
+
+Add to the existing `describe('organizations/buildings — writes', ...)` block
+(`tests/rules/firestore-rules-organizations.test.ts:411`), reusing the existing
+`asBuildingAdmin()` / `asDomainAdmin()` actors and the `beforeEach` seed. The
+current seed gives the building admin `buildingIds: ['high']` (canonical) and
+seeds a `high` building doc, so the new cases need their own seeded fixtures via
+`testEnv.withSecurityRulesDisabled(...)` to set up the cross-format pairs.
+
+Three cases, matching the acceptance criteria in `03-firestore-rules.md`:
+
+1. **canonical-member ↔ legacy-building → ALLOW.**
+   Member `buildingIds: ['high']` (canonical, already in the default seed); seed
+   an additional building doc at id `orono-high-school` (legacy) with
+   `id: 'orono-high-school'`, `orgId: ORG_ID`. The building admin updates a
+   whitelisted field (e.g. `{ address: '...' }`) on
+   `organizations/${ORG_ID}/buildings/orono-high-school` → `assertSucceeds`.
+
+2. **legacy-member ↔ canonical-building → ALLOW.**
+   Seed a second building-admin member whose `buildingIds: ['orono-high-school']`
+   (legacy) and authenticate as them; update a whitelisted field on the canonical
+   `organizations/${ORG_ID}/buildings/high` doc → `assertSucceeds`.
+
+3. **non-member negative → DENY.**
+   A building admin whose `buildingIds` contains neither `high` nor any alias of
+   it (e.g. `buildingIds: ['middle']`, or the existing out-of-scope actor)
+   attempts to update `organizations/${ORG_ID}/buildings/high` (and, for
+   thoroughness, the legacy `orono-high-school` doc) → `assertFails` for both.
+   This guards against the helper accidentally widening access (the "false grant"
+   risk above).
+
+Regression guard: the existing cases at
+`firestore-rules-organizations.test.ts:491-531` (canonical-member ↔
+canonical-building allow; out-of-scope deny) must continue to pass unchanged —
+the new helper must not alter the already-matching path.
+
+Run with `pnpm run test:rules` (boots the Firestore emulator; the emulator does
+not run in this CI sandbox per the team's known test gotchas, so this must be run
+in an environment that has the emulator available).
+
+---
+
+## 6. Decision needed from Paul
+
+This rule change **alters which building-admin edits Firestore accepts**: edits
+that are currently _denied_ due to ID-format drift will start _succeeding_. That
+is the intended fix, but it is a behavior change to a security boundary, so it
+needs explicit sign-off before merge.
+
+Specifically, please confirm:
+
+1. **Approve the behavior change** — building admins should be able to edit "their"
+   building regardless of whether the member doc and building doc use legacy or
+   canonical IDs. (Status quo silently denies these.)
+2. **Approve the hardcoded CEL alias map** as the mirror of
+   `config/buildings.ts:109-114`, accepting the drift-maintenance burden (the two
+   tables must be updated together; a mismatch risks a false grant).
+3. **Confirm the CEL list-transform approach** (`.map()` / comprehension) is
+   acceptable, or direct me to the fallback in §3 if your deploy dialect rejects
+   it. This needs a real `firebase deploy --only firestore:rules` dry-run, which
+   I cannot run from this sandbox.
+
+No code is changed until these three are approved.

--- a/firestore.rules
+++ b/firestore.rules
@@ -2109,6 +2109,8 @@ service cloud.firestore {
       // can verify by id without a query.
       allow create, update: if request.auth != null
         && request.resource.data.invitedByUid == request.auth.uid
+        && request.resource.data.inviteeEmailLower is string
+        && request.resource.data.inviteeEmailLower.size() <= 255
         && get(/databases/$(database)/documents/plcs/$(request.resource.data.plcId)).data.leadUid == request.auth.uid
         && inviteId == plcInviteDocId(request.resource.data.plcId, request.resource.data.inviteeEmailLower);
 

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -1,9 +1,8 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   collection,
   query,
   where,
-  orderBy,
   limit,
   onSnapshot,
   doc,
@@ -22,8 +21,9 @@ const PLCS_COLLECTION = 'plcs';
 // naturally bounded by membership, but the admin picker reads ALL PLCs, so
 // bound it to avoid streaming an unbounded collection (and the Firestore read
 // cost that comes with it). 500 is comfortably above the real-world PLC count
-// for a single district; `orderBy('name')` makes the truncation deterministic
-// (the first 500 alphabetically) rather than an arbitrary subset.
+// for a single district. The query relies only on the automatic `__name__`
+// index (no custom `orderBy`); the snapshot handler sorts by name client-side
+// for the visible alphabetical order — see the `list.sort` below.
 const ADMIN_PLCS_LIMIT = 500;
 // Mirrors the constant in `usePlcInvitations` — kept here so `deletePlc` can
 // sweep outstanding invites in the same batch as the PLC doc.
@@ -71,10 +71,29 @@ interface UsePlcsResult {
   /**
    * One-off read of a PLC's sharedSheetUrl. Used at assignment-create
    * time when we need the current value without waiting for the next
-   * snapshot tick (the snapshot is trustworthy but we want a strong-read
-   * for the "already created?" check to avoid racing two teachers).
+   * snapshot tick.
+   *
+   * State-first with a `getDoc` fallback (F10): when the PLC is already
+   * in the live `usePlcs` subscription AND its snapshotted `sharedSheetUrl`
+   * is non-null, we return that cached value and skip the network read —
+   * the snapshot is the authoritative, real-time-synced copy, so a present
+   * non-null value can be trusted. We fall back to a `getDoc` only when the
+   * PLC is absent from state (subscription not yet hydrated, or an
+   * admin-only doc the member-scoped listen never sees) OR state reports a
+   * null/absent URL — in the latter case the `getDoc` re-confirms with a
+   * strong read so the "already created?" race check can't be defeated by a
+   * locally-stale "still empty" snapshot.
    */
   getPlcSharedSheetUrl: (plcId: string) => Promise<string | null>;
+  /**
+   * Synchronous selector returning the live-subscribed PLC metadata for
+   * `plcId`, or `undefined` when the PLC isn't in the current subscription
+   * (not yet hydrated, or out of scope for this read mode). Lets callers on
+   * a hot path read `sharedSheetUrl` / `features` / etc. straight from the
+   * real-time-synced state instead of issuing a per-call `getDoc`. Always
+   * pair with a `getDoc` fallback when `undefined` is returned.
+   */
+  getPlcFromState: (plcId: string) => Plc | undefined;
   /**
    * Any member: toggle the PLC dashboard `features` map. Always writes the
    * full canonical map (defaults merged in) so partial historical writes
@@ -192,6 +211,17 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  // Latest `plcs` snapshot reachable from the stable `getPlcSharedSheetUrl`
+  // / `getPlcFromState` callbacks without re-creating them every render.
+  // Updated via `useEffect` (not during render) to keep the
+  // `react-hooks/refs` lint happy — same pattern as `assignmentsRef` in
+  // useQuizAssignments.ts. By the time a consumer calls one of those
+  // selectors the effect has run and the ref reflects the live state.
+  const plcsRef = useRef<Plc[]>(plcs);
+  useEffect(() => {
+    plcsRef.current = plcs;
+  }, [plcs]);
+
   useEffect(() => {
     if (!enabled || !user || isAuthBypass) {
       // Defer so we don't trip react-hooks/set-state-in-effect. Same pattern as
@@ -204,16 +234,14 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       return () => clearTimeout(timer);
     }
 
-    // Admin mode reads the whole collection (unfiltered apart from a bounded
-    // `orderBy('name') + limit`); member mode scopes to PLCs the current user
-    // belongs to. Single-field `orderBy('name')` needs only the automatic
-    // index, so no composite index is required.
+    // Admin mode reads the whole collection (bounded only by `limit`); member
+    // mode scopes to PLCs the current user belongs to. The admin query
+    // deliberately omits `orderBy('name')` so it relies only on the automatic
+    // `__name__` index — the snapshot handler sorts the results by name
+    // client-side (see `list.sort` below), preserving the visible alphabetical
+    // order without requiring a custom single-field index.
     const q = asAdmin
-      ? query(
-          collection(db, PLCS_COLLECTION),
-          orderBy('name'),
-          limit(ADMIN_PLCS_LIMIT)
-        )
+      ? query(collection(db, PLCS_COLLECTION), limit(ADMIN_PLCS_LIMIT))
       : query(
           collection(db, PLCS_COLLECTION),
           where('memberUids', 'array-contains', user.uid)
@@ -440,14 +468,37 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
     [user]
   );
 
+  // Synchronous selector over the live `plcs` subscription. Reads from the
+  // ref (not `plcs` directly) so the callback identity stays stable across
+  // snapshot ticks. `undefined` ⇒ the PLC isn't in scope for this read mode
+  // / hasn't hydrated yet; callers must fall back to a `getDoc` in that case.
+  const getPlcFromState = useCallback(
+    (plcId: string): Plc | undefined =>
+      plcsRef.current.find((p) => p.id === plcId),
+    []
+  );
+
   const getPlcSharedSheetUrl = useCallback(
     async (plcId: string): Promise<string | null> => {
+      // State-first (F10): if the live subscription already carries this PLC
+      // with a populated `sharedSheetUrl`, trust the real-time-synced value
+      // and skip the network read. A present non-null URL can only have come
+      // from a committed write, so it's safe for the "already created?"
+      // check. We deliberately do NOT short-circuit on a state value of
+      // `null`/absent — a locally-stale "still empty" snapshot must not let a
+      // racing teammate's just-created sheet go unnoticed, so we re-confirm
+      // with a strong `getDoc` in that case (and whenever the PLC is missing
+      // from state entirely, e.g. before the subscription hydrates).
+      const cached = getPlcFromState(plcId)?.sharedSheetUrl;
+      if (typeof cached === 'string' && cached.length > 0) {
+        return cached;
+      }
       const snap = await getDoc(doc(db, PLCS_COLLECTION, plcId));
       if (!snap.exists()) return null;
       const raw = (snap.data() as { sharedSheetUrl?: unknown }).sharedSheetUrl;
       return typeof raw === 'string' && raw.length > 0 ? raw : null;
     },
-    []
+    [getPlcFromState]
   );
 
   // Any current member: write the canonical features map. We always send
@@ -485,6 +536,7 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       setPlcSharedSheetUrl,
       clearPlcSharedSheetUrl,
       getPlcSharedSheetUrl,
+      getPlcFromState,
       updatePlcFeatures,
     }),
     [
@@ -499,6 +551,7 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       setPlcSharedSheetUrl,
       clearPlcSharedSheetUrl,
       getPlcSharedSheetUrl,
+      getPlcFromState,
       updatePlcFeatures,
     ]
   );

--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -186,6 +186,62 @@ export function shouldSnapshotHistory(
   return now - lastSnapshotAt >= throttleMs;
 }
 
+/**
+ * Lower-bound guard margin (ms) for the removed student's history-deletion
+ * window on a SHARED anonymous-PIN key. The PIN response key is deterministic
+ * (`pin-{period}-{pin}`), so two students sharing a normalized (period, PIN)
+ * map to the SAME `/history` subcollection. The window bound (below) uses
+ * `answeredAt` — a client `Date.now()` produced by the student's own device,
+ * the same clock domain as the entries in `answers[]`. The margin absorbs
+ * intra-attempt clock jitter and snapshot "boundary entries" (a snapshot whose
+ * `answeredAt` is the prior answer's timestamp, which can sit slightly outside
+ * the live answers' range). It is applied ONLY to the lower bound: the upper
+ * bound is `removalTime` ("now", after every write the removed occupant could
+ * have made), so padding the top would only risk reaching forward into a
+ * fast-following PIN-mate's drafts (F7 over-reach). 60 s comfortably covers a
+ * re-typed essay across a couple of autosave/lockout round-trips.
+ *
+ * NOTE: this windowed scoping is a best-effort PIN-mate protection and is used
+ * ONLY for shared `pin-…` keys. Provably single-occupant keys (SSO `auth.uid`,
+ * which can never be shared) take the wholesale sweep in `removeStudent` — that
+ * avoids the floor undershooting the occupant's OWN early drafts, which would
+ * otherwise leave a readable orphan for a rejoiner.
+ */
+export const HISTORY_WINDOW_GUARD_MS = 60_000;
+
+/**
+ * Decide whether a single history-snapshot doc belongs to the student being
+ * removed, given that student's session window. Used by `removeStudent` to
+ * scope the `/history` cleanup on a SHARED `pin-{period}-{pin}` key to the
+ * removed occupant instead of nuking the whole subcollection — which would
+ * destroy a PIN-mate's history too (F7).
+ *
+ * A doc is in-window when its `answeredAt` falls within
+ * `[windowStart - guard, windowEnd]`. The lower bound is guard-padded (clock
+ * jitter / boundary entries); the upper bound is NOT — `windowEnd` is the
+ * `removalTime` ("now"), already past every write the removed occupant could
+ * have made, so padding it would only reach forward into a fast-following
+ * PIN-mate's drafts. `answeredAt` is the only per-occupant, client-clock
+ * timestamp on the history doc (`snapshotAt` is server time and is NOT mixed
+ * in here to avoid cross-clock comparison).
+ *
+ * Docs with a missing / non-finite `answeredAt` are treated as in-window
+ * (deleted): they predate the field or are malformed, can't be attributed to
+ * a PIN-mate, and leaving them readable would let a rejoiner on the same key
+ * read prior drafts — the leak this cleanup exists to prevent.
+ */
+export function isHistoryDocInRemovalWindow(
+  answeredAt: unknown,
+  windowStart: number,
+  windowEnd: number,
+  guardMs: number = HISTORY_WINDOW_GUARD_MS
+): boolean {
+  if (typeof answeredAt !== 'number' || !Number.isFinite(answeredAt)) {
+    return true;
+  }
+  return answeredAt >= windowStart - guardMs && answeredAt <= windowEnd;
+}
+
 /** Unbiased Fisher-Yates in-place shuffle (returns new array) */
 function fisherYatesShuffle<T>(arr: T[]): T[] {
   const result = [...arr];
@@ -873,6 +929,11 @@ export const useQuizSessionTeacher = (
             )
           : null;
 
+      // Single removal timestamp, reused as both the upper bound of the
+      // history-deletion window and the archive doc's `archivedAt` below,
+      // so the window end and the recorded removal time agree.
+      const removalTime = Date.now();
+
       // Clean up the answer-history subcollection BEFORE deleting the
       // parent response. Firestore does not cascade subcollection
       // deletes, so without this the snapshots orphan — and because the
@@ -885,7 +946,49 @@ export const useQuizSessionTeacher = (
       // stay under the 500-op Firestore batch limit; these are independent
       // of the atomic archive+delete batch below, so a partial failure
       // just leaves a smaller orphan tail that a retry sweeps.
-      const historyDocs = (
+      //
+      // F7: the `pin-{period}-{pin}` key is SHARED across every student with
+      // the same normalized (period, PIN), so this one subcollection can hold
+      // history from more than one student. Deleting it wholesale would
+      // destroy a PIN-mate's recoverable drafts. Scope the delete to the
+      // removed student's own session window instead — but ONLY for the shared
+      // PIN keyspace, and only when an occupant is loaded:
+      //
+      //   - SSO/studentRole keys are the auth `uid` itself, which is per-user
+      //     and can NEVER be shared, so the subcollection is provably
+      //     single-occupant. Window-scoping such a key is not just unnecessary,
+      //     it is HARMFUL: the floor (earliest LIVE answer) undershoots the
+      //     occupant's OWN early history whenever they revise an answer more
+      //     than the guard margin after first entering it, leaving that early
+      //     draft as a readable orphan for a same-key rejoiner. We therefore
+      //     wholesale-sweep these (and the doc-already-gone fallback case,
+      //     where we have no occupant to attribute history to) — eliminating
+      //     the leak for the common case.
+      //
+      //   - Shared `pin-…` keys keep the best-effort windowed scoping to
+      //     protect a PIN-mate's drafts. The floor is the earliest `answeredAt`
+      //     in the removed student's LIVE `answers` (reset to `[]` on rejoin,
+      //     so they fingerprint the CURRENT occupant on the client's own clock;
+      //     the doc's `joinedAt` is immutable/STALE from whichever PIN-mate
+      //     created the doc and is therefore NOT a usable floor). The no-answers
+      //     case (joined-but-never-answered, whose own history is empty anyway)
+      //     floors at `removalTime`, leaving any pre-existing history for the
+      //     prior occupant. The ceiling is `removalTime` with no upper guard
+      //     (see `isHistoryDocInRemovalWindow`).
+      //
+      // Each history doc carries `answeredAt` on the SAME client clock as the
+      // occupant's answers (it is a prior `answers[i].answeredAt`), so the
+      // comparison stays within one clock domain. `snapshotAt` (server time) is
+      // deliberately NOT mixed in.
+      const isSharedPinKey = responseKey.startsWith('pin-');
+      const answerTimes = (target?.answers ?? [])
+        .map((a) => a.answeredAt)
+        .filter(
+          (t): t is number => typeof t === 'number' && Number.isFinite(t)
+        );
+      const windowStart =
+        answerTimes.length > 0 ? Math.min(...answerTimes) : removalTime;
+      const allHistoryDocs = (
         await getDocs(
           collection(
             db,
@@ -897,6 +1000,19 @@ export const useQuizSessionTeacher = (
           )
         )
       ).docs;
+      // Wholesale sweep when the key is provably single-occupant (non-PIN) or
+      // when no occupant is loaded (doc already gone); otherwise scope the
+      // delete to the removed student's window on the shared PIN key.
+      const historyDocs =
+        target && isSharedPinKey
+          ? allHistoryDocs.filter((d) =>
+              isHistoryDocInRemovalWindow(
+                (d.data() as { answeredAt?: unknown }).answeredAt,
+                windowStart,
+                removalTime
+              )
+            )
+          : allHistoryDocs;
       const HISTORY_DELETE_CHUNK = 450;
       for (let i = 0; i < historyDocs.length; i += HISTORY_DELETE_CHUNK) {
         const historyBatch = writeBatch(db);
@@ -947,8 +1063,10 @@ export const useQuizSessionTeacher = (
         // update and rejected, breaking the entire removeStudent
         // batch. Querying by `originalResponseKey` (a field on the
         // archive doc) or by `archived_responses` collection-group +
-        // path filter recovers per-student history.
-        const archivedAt = Date.now();
+        // path filter recovers per-student history. Reuse `removalTime`
+        // (the history-window ceiling) so the archive id and the window
+        // share one clock reading.
+        const archivedAt = removalTime;
         const archiveRef = doc(
           db,
           QUIZ_SESSIONS_COLLECTION,

--- a/tests/hooks/usePlcs.test.ts
+++ b/tests/hooks/usePlcs.test.ts
@@ -22,6 +22,8 @@ import {
 import { act, renderHook } from '@testing-library/react';
 import {
   collection,
+  doc,
+  getDoc,
   limit,
   onSnapshot,
   orderBy,
@@ -65,6 +67,8 @@ const mockQuery = query as Mock;
 const mockWhere = where as Mock;
 const mockOrderBy = orderBy as Mock;
 const mockLimit = limit as Mock;
+const mockDoc = doc as Mock;
+const mockGetDoc = getDoc as Mock;
 
 const USER_UID = 'user-1';
 
@@ -111,18 +115,16 @@ describe('usePlcs - subscription wiring', () => {
     expect(mockOnSnapshot).toHaveBeenCalledTimes(1);
   });
 
-  it('admin mode bounds the whole-collection listen with orderBy + limit', () => {
+  it('admin mode bounds the whole-collection listen with limit only (no orderBy)', () => {
     renderHook(() => usePlcs({ asAdmin: true }));
 
     // The unbounded admin listen is capped so it can't stream the entire
-    // collection. `orderBy('name')` makes the truncation deterministic.
-    expect(mockOrderBy).toHaveBeenCalledWith('name');
+    // collection. We deliberately omit `orderBy('name')` so the query relies
+    // only on the automatic `__name__` index — the snapshot handler sorts by
+    // name client-side (asserted in the parse-and-sort test below).
+    expect(mockOrderBy).not.toHaveBeenCalled();
     expect(mockLimit).toHaveBeenCalledWith(500);
-    expect(mockQuery).toHaveBeenCalledWith(
-      'plcs',
-      { __orderBy: { field: 'name', dir: undefined } },
-      { __limit: 500 }
-    );
+    expect(mockQuery).toHaveBeenCalledWith('plcs', { __limit: 500 });
   });
 
   it('skips the listener when signed out', () => {
@@ -224,5 +226,142 @@ describe('usePlcs - subscription wiring', () => {
   it('defaults error to null before any snapshot resolves', () => {
     const { result } = renderHook(() => usePlcs({ asAdmin: true }));
     expect(result.current.error).toBeNull();
+  });
+});
+
+describe('usePlcs - getPlcSharedSheetUrl state-first caching (F10)', () => {
+  /**
+   * Render the hook and push a snapshot containing the given PLC docs so the
+   * live `plcs` state (and the mirrored ref the selectors read) is hydrated.
+   * Returns the hook result handle for the caller to exercise.
+   */
+  function renderWithHydratedPlcs(
+    docs: Array<{ id: string; data: Record<string, unknown> }>
+  ) {
+    let cb: (snap: unknown) => void = () => {
+      throw new Error('snapshot callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, onNext) => {
+      cb = onNext;
+      return () => undefined;
+    });
+
+    const view = renderHook(() => usePlcs({ asAdmin: true }));
+
+    act(() => {
+      cb({
+        forEach: (fn: (d: { id: string; data: () => unknown }) => void) => {
+          docs.forEach((d) => fn({ id: d.id, data: () => d.data }));
+        },
+      });
+    });
+
+    return view;
+  }
+
+  it('returns the cached sharedSheetUrl from live state WITHOUT a getDoc', async () => {
+    const { result } = renderWithHydratedPlcs([
+      {
+        id: 'plc-1',
+        data: {
+          name: 'Algebra PLC',
+          leadUid: 'lead-1',
+          memberUids: ['lead-1'],
+          memberEmails: { 'lead-1': 'a@x.com' },
+          sharedSheetUrl: 'https://docs.google.com/spreadsheets/d/abc',
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    ]);
+
+    // The snapshot already carried a populated sharedSheetUrl, so the
+    // assignment-create "already created?" check must be served from state.
+    let url: string | null = null;
+    await act(async () => {
+      url = await result.current.getPlcSharedSheetUrl('plc-1');
+    });
+
+    expect(url).toBe('https://docs.google.com/spreadsheets/d/abc');
+    // The whole point of F10: no redundant network read for data already in
+    // the live subscription.
+    expect(mockGetDoc).not.toHaveBeenCalled();
+  });
+
+  it('falls back to getDoc when the PLC is not in state (subscription not hydrated)', async () => {
+    // No snapshot pushed → `plcs` state stays empty, so the selector misses.
+    const { result } = renderHook(() => usePlcs({ asAdmin: true }));
+
+    mockDoc.mockReturnValue({ __ref: 'plcs/plc-missing' });
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ sharedSheetUrl: 'https://docs.google.com/strong-read' }),
+    });
+
+    let url: string | null = null;
+    await act(async () => {
+      url = await result.current.getPlcSharedSheetUrl('plc-missing');
+    });
+
+    // Safety guarantee: a PLC absent from state must still resolve via the
+    // authoritative strong read, never regress to a missing value.
+    expect(mockGetDoc).toHaveBeenCalledTimes(1);
+    expect(url).toBe('https://docs.google.com/strong-read');
+  });
+
+  it('falls back to getDoc when state reports a null/absent sharedSheetUrl (strong-read race guard)', async () => {
+    const { result } = renderWithHydratedPlcs([
+      {
+        id: 'plc-2',
+        data: {
+          name: 'Biology PLC',
+          leadUid: 'lead-2',
+          memberUids: ['lead-2'],
+          memberEmails: { 'lead-2': 'b@x.com' },
+          // sharedSheetUrl absent → parsed as null in state.
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    ]);
+
+    mockDoc.mockReturnValue({ __ref: 'plcs/plc-2' });
+    // A racing teammate populated the URL after our last snapshot tick — the
+    // strong read must surface it rather than trusting the stale "empty"
+    // state value.
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ sharedSheetUrl: 'https://docs.google.com/raced' }),
+    });
+
+    let url: string | null = null;
+    await act(async () => {
+      url = await result.current.getPlcSharedSheetUrl('plc-2');
+    });
+
+    expect(mockGetDoc).toHaveBeenCalledTimes(1);
+    expect(url).toBe('https://docs.google.com/raced');
+  });
+
+  it('getPlcFromState returns the live PLC, or undefined when absent', () => {
+    const { result } = renderWithHydratedPlcs([
+      {
+        id: 'plc-3',
+        data: {
+          name: 'Chemistry PLC',
+          leadUid: 'lead-3',
+          memberUids: ['lead-3'],
+          memberEmails: { 'lead-3': 'c@x.com' },
+          sharedSheetUrl: 'https://docs.google.com/spreadsheets/d/xyz',
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      },
+    ]);
+
+    expect(result.current.getPlcFromState('plc-3')?.sharedSheetUrl).toBe(
+      'https://docs.google.com/spreadsheets/d/xyz'
+    );
+    expect(result.current.getPlcFromState('nope')).toBeUndefined();
   });
 });

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -10,6 +10,8 @@ import {
   isUnsafeBlankDraft,
   isUnsafeStatusDowngrade,
   shouldSnapshotHistory,
+  isHistoryDocInRemovalWindow,
+  HISTORY_WINDOW_GUARD_MS,
 } from '@/hooks/useQuizSession';
 import { auth } from '@/config/firebase';
 import type {
@@ -686,6 +688,58 @@ describe('shouldSnapshotHistory (#5 throttle)', () => {
         THROTTLE
       )
     ).toBe(false);
+  });
+});
+
+describe('isHistoryDocInRemovalWindow (F7 PIN-mate history scoping)', () => {
+  // Use a tiny guard so the math stays readable; production uses
+  // HISTORY_WINDOW_GUARD_MS (60s).
+  const GUARD = 10;
+
+  it('keeps a doc inside the window', () => {
+    expect(isHistoryDocInRemovalWindow(500, 100, 1000, GUARD)).toBe(true);
+  });
+
+  it('keeps a doc on the (guard-padded) lower boundary', () => {
+    // answeredAt just below windowStart but within the guard margin.
+    expect(isHistoryDocInRemovalWindow(95, 100, 1000, GUARD)).toBe(true);
+  });
+
+  it('keeps a doc on the (unpadded) upper boundary', () => {
+    // The upper bound is `removalTime` ("now"), so it is NOT guard-padded —
+    // exactly `windowEnd` is the last in-window value.
+    expect(isHistoryDocInRemovalWindow(1000, 100, 1000, GUARD)).toBe(true);
+  });
+
+  it('excludes a doc just past the (unpadded) upper boundary', () => {
+    // No upper guard: padding the top would reach forward into a
+    // fast-following PIN-mate's drafts (F7 over-reach).
+    expect(isHistoryDocInRemovalWindow(1001, 100, 1000, GUARD)).toBe(false);
+  });
+
+  it('excludes a PIN-mate doc that predates the window (below start - guard)', () => {
+    // A different student answered long before this student joined.
+    expect(isHistoryDocInRemovalWindow(50, 100, 1000, GUARD)).toBe(false);
+  });
+
+  it('excludes a PIN-mate doc that postdates the window (above end)', () => {
+    expect(isHistoryDocInRemovalWindow(2000, 100, 1000, GUARD)).toBe(false);
+  });
+
+  it('treats a missing/non-finite answeredAt as in-window (deleted) so it cannot leak to a rejoiner', () => {
+    expect(isHistoryDocInRemovalWindow(undefined, 100, 1000, GUARD)).toBe(true);
+    expect(isHistoryDocInRemovalWindow(NaN, 100, 1000, GUARD)).toBe(true);
+    expect(isHistoryDocInRemovalWindow('500', 100, 1000, GUARD)).toBe(true);
+  });
+
+  it('exposes a non-trivial default guard margin', () => {
+    // Sanity: the default guard is large enough to absorb intra-attempt
+    // jitter (tens of seconds) but the helper still uses it when omitted.
+    expect(HISTORY_WINDOW_GUARD_MS).toBeGreaterThanOrEqual(1000);
+    // answeredAt exactly windowStart - default guard is still in-window.
+    expect(
+      isHistoryDocInRemovalWindow(100 - HISTORY_WINDOW_GUARD_MS, 100, 1000)
+    ).toBe(true);
   });
 });
 
@@ -2024,6 +2078,368 @@ describe('useQuizSessionTeacher — removeStudent / revealAnswer / hideAnswer', 
       'history',
       'h2',
     ]);
+  });
+
+  it('scopes the history sweep to the removed occupant under a shared PIN key — preserving a PIN-mate sequential occupant (F7)', async () => {
+    // The `pin-{period}-{pin}` response key is deterministic and SHARED:
+    // every student with the same normalized (period, PIN) maps to the same
+    // response doc + `/history` subcollection. Two students occupy the key
+    // sequentially over the session — first occupant A, then occupant B (the
+    // doc is reset in place on B's rejoin, so its `joinedAt` stays A's).
+    // Removing B must delete ONLY B's history snapshots; A's must survive so
+    // the wholesale sweep can't clobber a PIN-mate's recoverable drafts.
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    // Realistic ms timestamps. A was active ~1000s before B took over the
+    // shared key, comfortably beyond the guard margin.
+    const A_ANSWERED_AT = 1_000_000_000;
+    const B_ANSWERED_AT = 1_000_000_000 + 1_000_000; // +1000s
+
+    const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+    // Drive the responses listener so `target` resolves to occupant B, the
+    // CURRENT holder of the shared doc. `joinedAt` is the STALE value from
+    // occupant A (immutable across the in-place rejoin reset) — the fix must
+    // NOT use it as the floor when B has live answers.
+    act(() => {
+      env.responsesCallback?.({
+        docs: [
+          {
+            id: 'pin-period_1-9999',
+            ref: {
+              __type: 'doc',
+              path: [
+                'quiz_sessions',
+                'sess-1',
+                'responses',
+                'pin-period_1-9999',
+              ],
+            },
+            data: () => ({
+              studentUid: 'anon-b-uid',
+              status: 'in-progress',
+              joinedAt: A_ANSWERED_AT - 50_000, // stale, from occupant A
+              answers: [
+                {
+                  questionId: 'q1',
+                  answer: 'B current',
+                  answeredAt: B_ANSWERED_AT,
+                },
+              ],
+            }),
+          },
+        ],
+      } as never);
+    });
+
+    // History subcollection holds BOTH students' snapshots: A's (early,
+    // out-of-window) and B's (recent, in-window).
+    const historyDocs = [
+      {
+        ref: {
+          __type: 'doc',
+          path: [
+            'quiz_sessions',
+            'sess-1',
+            'responses',
+            'pin-period_1-9999',
+            'history',
+            'a-hist', // occupant A
+          ],
+        },
+        data: () => ({
+          questionId: 'q1',
+          answer: 'A draft',
+          answeredAt: A_ANSWERED_AT,
+          status: 'draft',
+        }),
+      },
+      {
+        ref: {
+          __type: 'doc',
+          path: [
+            'quiz_sessions',
+            'sess-1',
+            'responses',
+            'pin-period_1-9999',
+            'history',
+            'b-hist', // occupant B (the one being removed)
+          ],
+        },
+        data: () => ({
+          questionId: 'q1',
+          answer: 'B draft',
+          answeredAt: B_ANSWERED_AT,
+          status: 'draft',
+        }),
+      },
+    ];
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValueOnce({ docs: historyDocs, empty: false });
+
+    await act(async () => {
+      await result.current.removeStudent('pin-period_1-9999');
+    });
+
+    const deletedPaths = env.batch.delete.mock.calls.map(
+      (c) => (c[0] as { path: string[] }).path
+    );
+
+    // B's history doc IS deleted...
+    expect(deletedPaths).toContainEqual([
+      'quiz_sessions',
+      'sess-1',
+      'responses',
+      'pin-period_1-9999',
+      'history',
+      'b-hist',
+    ]);
+    // ...but A's (the PIN-mate's) history is PRESERVED — the bug F7 fixes.
+    expect(deletedPaths).not.toContainEqual([
+      'quiz_sessions',
+      'sess-1',
+      'responses',
+      'pin-period_1-9999',
+      'history',
+      'a-hist',
+    ]);
+    // The parent response doc is still deleted, freeing the key for a rejoin.
+    expect(deletedPaths).toContainEqual([
+      'quiz_sessions',
+      'sess-1',
+      'responses',
+      'pin-period_1-9999',
+    ]);
+    // And B's partial work is archived before deletion.
+    expect(env.batch.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('wholesale-sweeps a provably single-occupant (SSO) key so an early revised draft cannot leak to a rejoiner (F7 floor undershoot)', async () => {
+    // F7 leak boundary. The SSO/studentRole key is the auth `uid` itself, which
+    // is per-user and can NEVER be shared, so the `/history` subcollection is
+    // provably single-occupant. A clock-only window floored at the earliest
+    // LIVE answer UNDERSHOOTS the occupant's OWN early history whenever they
+    // revise an answer more than the guard margin after first entering it:
+    // their first draft's `answeredAt` falls below `windowStart - guard` and
+    // would survive as a readable orphan for a same-key rejoiner (the exact
+    // leak the cleanup exists to prevent). The fix routes single-occupant keys
+    // to the wholesale sweep, deleting ALL of their history regardless of when
+    // it was entered.
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    // Pin `removalTime` so the early-draft boundary is deterministic.
+    const NOW = 1_700_000_000_000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+
+    try {
+      const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+      // Occupant B's LIVE answer is the REVISED value, entered well after the
+      // first draft — so the window floor (earliest live answer) sits above
+      // the early draft's timestamp.
+      const REVISED_AT = NOW - 5_000;
+      act(() => {
+        env.responsesCallback?.({
+          docs: [
+            {
+              id: 'sso-uid-b',
+              ref: {
+                __type: 'doc',
+                path: ['quiz_sessions', 'sess-1', 'responses', 'sso-uid-b'],
+              },
+              data: () => ({
+                studentUid: 'sso-uid-b',
+                status: 'in-progress',
+                joinedAt: NOW - 120_000,
+                answers: [
+                  {
+                    questionId: 'q1',
+                    answer: 'revised',
+                    answeredAt: REVISED_AT,
+                  },
+                ],
+              }),
+            },
+          ],
+        } as never);
+      });
+
+      // The early draft predates `windowStart - HISTORY_WINDOW_GUARD_MS`, i.e.
+      // it would be EXCLUDED by the window filter — the leak. The wholesale
+      // sweep must delete it anyway.
+      const earlyDraftAt = REVISED_AT - HISTORY_WINDOW_GUARD_MS - 1;
+      const historyDocs = [
+        {
+          ref: {
+            __type: 'doc',
+            path: [
+              'quiz_sessions',
+              'sess-1',
+              'responses',
+              'sso-uid-b',
+              'history',
+              'early-draft',
+            ],
+          },
+          data: () => ({
+            questionId: 'q1',
+            answer: 'first try',
+            answeredAt: earlyDraftAt,
+            status: 'draft',
+          }),
+        },
+      ];
+      (
+        firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({ docs: historyDocs, empty: false });
+
+      await act(async () => {
+        await result.current.removeStudent('sso-uid-b');
+      });
+
+      const deletedPaths = env.batch.delete.mock.calls.map(
+        (c) => (c[0] as { path: string[] }).path
+      );
+      // The early revised draft IS deleted — no orphan survives for a rejoiner.
+      expect(deletedPaths).toContainEqual([
+        'quiz_sessions',
+        'sess-1',
+        'responses',
+        'sso-uid-b',
+        'history',
+        'early-draft',
+      ]);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+
+  it('preserves a fast-following PIN-mate draft entered after removal time on a shared PIN key (F7 upper-boundary over-reach)', async () => {
+    // F7 over-reach boundary. On a SHARED `pin-…` key the window ceiling is
+    // `removalTime` ("now"), already past every write the removed occupant
+    // could have made. Padding the top would reach FORWARD into a PIN-mate who
+    // started typing in the moments around the teacher's removal click, nuking
+    // their drafts — the very bug F7 fixes, at the window edge. With the upper
+    // guard removed, a doc whose `answeredAt` is just past `removalTime` is
+    // left intact.
+    (auth as unknown as { currentUser: { uid: string } | null }).currentUser = {
+      uid: 'teacher-1',
+    };
+
+    const NOW = 1_700_000_000_000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(NOW);
+
+    try {
+      const { result } = renderHook(() => useQuizSessionTeacher('sess-1'));
+
+      // Removed occupant B's live answer sits just below removalTime.
+      act(() => {
+        env.responsesCallback?.({
+          docs: [
+            {
+              id: 'pin-period_1-1234',
+              ref: {
+                __type: 'doc',
+                path: [
+                  'quiz_sessions',
+                  'sess-1',
+                  'responses',
+                  'pin-period_1-1234',
+                ],
+              },
+              data: () => ({
+                studentUid: 'anon-b-uid',
+                status: 'in-progress',
+                joinedAt: NOW - 60_000,
+                answers: [
+                  { questionId: 'q1', answer: 'B', answeredAt: NOW - 1_000 },
+                ],
+              }),
+            },
+          ],
+        } as never);
+      });
+
+      const historyDocs = [
+        {
+          ref: {
+            __type: 'doc',
+            path: [
+              'quiz_sessions',
+              'sess-1',
+              'responses',
+              'pin-period_1-1234',
+              'history',
+              'b-hist',
+            ],
+          },
+          data: () => ({
+            questionId: 'q1',
+            answer: 'B draft',
+            answeredAt: NOW - 1_000,
+            status: 'draft',
+          }),
+        },
+        {
+          // PIN-mate C's draft entered 1ms AFTER removalTime — a student who
+          // started typing as the teacher removed B.
+          ref: {
+            __type: 'doc',
+            path: [
+              'quiz_sessions',
+              'sess-1',
+              'responses',
+              'pin-period_1-1234',
+              'history',
+              'c-hist',
+            ],
+          },
+          data: () => ({
+            questionId: 'q1',
+            answer: 'C draft',
+            answeredAt: NOW + 1,
+            status: 'draft',
+          }),
+        },
+      ];
+      (
+        firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+      ).mockResolvedValueOnce({ docs: historyDocs, empty: false });
+
+      await act(async () => {
+        await result.current.removeStudent('pin-period_1-1234');
+      });
+
+      const deletedPaths = env.batch.delete.mock.calls.map(
+        (c) => (c[0] as { path: string[] }).path
+      );
+      // B's own draft IS deleted...
+      expect(deletedPaths).toContainEqual([
+        'quiz_sessions',
+        'sess-1',
+        'responses',
+        'pin-period_1-1234',
+        'history',
+        'b-hist',
+      ]);
+      // ...but the fast-following PIN-mate's draft (just past removalTime) is
+      // PRESERVED — no upper-guard over-reach.
+      expect(deletedPaths).not.toContainEqual([
+        'quiz_sessions',
+        'sess-1',
+        'responses',
+        'pin-period_1-1234',
+        'history',
+        'c-hist',
+      ]);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it('skips the ledger delete (and still commits) when the response has no attempt-ledger doc', async () => {

--- a/tests/rules/plcInvitations.test.ts
+++ b/tests/rules/plcInvitations.test.ts
@@ -1,0 +1,148 @@
+// Firestore security rules regression coverage for `plc_invitations/{inviteId}`.
+// Pins the create-side hardening added for finding F24: the invitee email
+// (`inviteeEmailLower`) must be a string bounded to <= 255 chars, mirroring the
+// size validation other collections apply (rollout_requests, admin_backgrounds).
+// Without the bound a PLC lead could write an unbounded string into the invite,
+// so this suite asserts:
+//   - A normal-length invite from the PLC lead still succeeds.
+//   - An over-limit invitee email is rejected, even from the lead.
+//
+// The create rule additionally requires `invitedByUid` to equal the caller,
+// the parent PLC's `leadUid` to equal the caller, and the doc id to match the
+// deterministic `plcId + '_' + inviteeEmailLower` format — all preserved here
+// so the size bound is the only thing under test for the negative case.
+//
+// Requires a running Firestore emulator — invoke via `pnpm run test:rules`.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-plc-invitations-rules';
+const PLC_ID = 'plc-invitations-test';
+
+const LEAD_UID = 'lead-uid-plci';
+const LEAD_EMAIL = 'lead@example.com';
+const NON_LEAD_UID = 'member-uid-plci';
+const NON_LEAD_EMAIL = 'member@example.com';
+
+const INVITEE_EMAIL = 'invitee@example.com';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asLead = () =>
+  testEnv.authenticatedContext(LEAD_UID, { email: LEAD_EMAIL }).firestore();
+
+const asNonLead = () =>
+  testEnv
+    .authenticatedContext(NON_LEAD_UID, { email: NON_LEAD_EMAIL })
+    .firestore();
+
+// Mirrors `plcInviteDocId(plcId, emailLower)` in firestore.rules — the create
+// rule forces the doc id to this deterministic format.
+const inviteDocId = (plcId: string, emailLower: string) =>
+  `${plcId}_${emailLower}`;
+
+// The invite shape the app writes (see hooks/usePlcInvitations.ts `sendInvite`).
+const validInvite = (overrides: Record<string, unknown> = {}) => ({
+  plcId: PLC_ID,
+  plcName: 'Test PLC',
+  inviteeEmailLower: INVITEE_EMAIL,
+  invitedByUid: LEAD_UID,
+  invitedByName: 'Lead Teacher',
+  invitedAt: 1000,
+  status: 'pending',
+  ...overrides,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  // Seed the parent PLC so the create rule's leadUid get() resolves.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), `plcs/${PLC_ID}`), {
+      name: 'Test PLC',
+      leadUid: LEAD_UID,
+      memberUids: [LEAD_UID],
+      memberEmails: { [LEAD_UID]: LEAD_EMAIL },
+      createdAt: 1,
+      updatedAt: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Create — inviteeEmailLower size bound (F24)
+// ---------------------------------------------------------------------------
+
+describe('plc_invitations — create (email length bound)', () => {
+  it('PLC lead can create an invite with a normal-length email', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asLead(), `plc_invitations/${inviteDocId(PLC_ID, INVITEE_EMAIL)}`),
+        validInvite()
+      )
+    );
+  });
+
+  it('rejects an invite whose inviteeEmailLower exceeds 255 chars', async () => {
+    // 246-char local part + "@example.com" (12) = 258 chars > 255.
+    const overLimitEmail = `${'a'.repeat(246)}@example.com`;
+    await assertFails(
+      setDoc(
+        doc(asLead(), `plc_invitations/${inviteDocId(PLC_ID, overLimitEmail)}`),
+        validInvite({ inviteeEmailLower: overLimitEmail })
+      )
+    );
+  });
+
+  it('accepts an invite whose inviteeEmailLower is exactly 255 chars', async () => {
+    // 243-char local part + "@example.com" (12) = 255 chars (boundary).
+    const boundaryEmail = `${'a'.repeat(243)}@example.com`;
+    await assertSucceeds(
+      setDoc(
+        doc(asLead(), `plc_invitations/${inviteDocId(PLC_ID, boundaryEmail)}`),
+        validInvite({ inviteeEmailLower: boundaryEmail })
+      )
+    );
+  });
+
+  it('a non-lead cannot create an invite (authz unchanged by the bound)', async () => {
+    await assertFails(
+      setDoc(
+        doc(
+          asNonLead(),
+          `plc_invitations/${inviteDocId(PLC_ID, INVITEE_EMAIL)}`
+        ),
+        validInvite({ invitedByUid: NON_LEAD_UID })
+      )
+    );
+  });
+});


### PR DESCRIPTION
## Optimize-pass — safe batch + gated proposals

Completes the implementable, low-risk slice of the `docs/optimize-pass/` deferred backlog, plus review-ready proposals for the two design/behavior-gated items. Built by a multi-agent orchestration: file-disjoint implementers → two critical reviewers → routed fixers. Review caught and fixed two real correctness bugs in the first F7 pass.

### ✅ Implemented (verified locally)

| Item | Change | Files |
|------|--------|-------|
| **F7** | Scope quiz `removeStudent` history-delete to the removed occupant so a shared `pin-{period}-{pin}` collision can't wipe a PIN-mate's recoverable drafts. Single-occupant SSO keys take the wholesale sweep (no self-leak to a rejoiner); shared PIN keys delete only the removed occupant's window `[start-guard, removalTime]`. | `hooks/useQuizSession.ts` + tests |
| **F10** | `getPlcSharedSheetUrl` is state-first (live `usePlcs` subscription) with a `getDoc` fallback; new `getPlcFromState` selector. Strong-read race guard preserved. | `hooks/usePlcs.ts` + tests |
| **F21** | Drop `orderBy('name')` from the admin `/plcs` query (relies on automatic `__name__` index); existing client-side sort keeps order identical. | `hooks/usePlcs.ts` |
| **F22** | `useMemo` the `BoardCanvas` selected-group `find()/filter()` derivation. Behavior identical. | `components/layout/BoardCanvas.tsx` |
| **F24** | Bound `plc_invitations` invitee email to `<= 255` (`is string` guard) matching `rollout_requests`/`admin_backgrounds`. | `firestore.rules` + new `tests/rules/plcInvitations.test.ts` |

### 🔶 Proposals — awaiting your sign-off (no source/rules changed)

- **F1 — WCAG contrast** (`docs/optimize-pass/PROPOSAL-F1-contrast.md`): **corrects the upstream doc** — `slate-400` is already AA-pass (6.96:1); only `slate-500` (3.75:1) genuinely fails. Proposes a restrained `slate-500→slate-200` upgrade scoped to real text on dark, with exact diffs. Visual change → needs your design nod.
- **F6 — building-id canonicalization in rules** (`docs/optimize-pass/PROPOSAL-F6-building-id-canonicalization.md`): proposes a CEL `canonicalBuildingId` helper at `firestore.rules:211`. Security-boundary behavior change (which building-admin edits are accepted) → needs approval; CEL list-transform support must be confirmed against a deploy dry-run.

### ⏭️ Skipped / deferred (with rationale)

- **F2** — *blocked upstream*: data-migration straddle ("do not implement yet").
- **F11, F18, F8, F12, F23, F9** — deferred to dedicated follow-up PRs. All are "schedule deliberately" per the docs and carry CI/deploy risks not fully gateable on a merge-bound PR (F18: functions cross-rootDir import has a deploy-runtime failure mode; F11: marginal benefit on 16 GB runners + lint-coverage risk; F8/F12/F23: large refactors; F9: high-risk context split needing the perf harness).

### ✔️ Verification

Local (all green): `lint --max-warnings 0` · `prettier --check` · `type-check:all` · `test:all` (**4952 root + 532 functions**) · `build:all`.
CI-only gates (run by this PR's suite): **rules** (Java emulator — exercises the new `plcInvitations` test) and **e2e** (Playwright — untouched happy-paths).

> Note: local checkout is CRLF (`core.autocrlf=true`); committed blobs are LF (verified 0 CR in staged blobs), so CI's `format:check`/`lint` see clean LF.
