### PR TITLE
perf(dashboard): split tool visibility into its own context (F9)

### DIFF
--- a/components/auth/NewUserSetup.tsx
+++ b/components/auth/NewUserSetup.tsx
@@ -13,6 +13,7 @@ import { db, isAuthBypass } from '@/config/firebase';
 import { canonicalizeBuildingIds } from '@/config/buildings';
 import { useAuth } from '@/context/useAuth';
 import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { TOOLS } from '@/config/tools';
 import {
@@ -111,7 +112,8 @@ const STEPS = [
 
 export const NewUserSetup: React.FC = () => {
   const { user, setSelectedBuildings, completeSetup } = useAuth();
-  const { setGlobalStyle, reorderDockItems } = useDashboard();
+  const { setGlobalStyle } = useDashboard();
+  const { reorderDockItems } = useToolVisibility();
 
   const [step, setStep] = useState(0);
   const [selectedBuildings, setLocalBuildings] = useState<string[]>([]);

--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -28,6 +28,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { useAuth } from '@/context/useAuth';
 import { useCustomWidgets } from '@/context/useCustomWidgets';
 import { useSavedWidgets } from '@/context/useSavedWidgets';
@@ -87,11 +88,16 @@ export const Dock: React.FC = () => {
     addWidget,
     removeWidget,
     removeWidgets,
+    activeDashboard,
+    updateWidget,
+    addToast,
+    setPendingQuizShareId,
+    setPendingAssignmentShareId,
+  } = useDashboard();
+  const {
     visibleTools,
     dockItems,
     reorderDockItems,
-    activeDashboard,
-    updateWidget,
     toggleToolVisibility,
     reorderLibrary,
     libraryOrder,
@@ -101,10 +107,7 @@ export const Dock: React.FC = () => {
     addItemToFolder,
     moveItemOutOfFolder,
     reorderFolderItems,
-    addToast,
-    setPendingQuizShareId,
-    setPendingAssignmentShareId,
-  } = useDashboard();
+  } = useToolVisibility();
   const {
     canAccessWidget,
     canAccessFeature,

--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -36,7 +36,7 @@ import { TOOLS } from '@/config/tools';
 import { WidgetType, GlobalStyle, InternalToolType } from '@/types';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useDialog } from '@/context/useDialog';
-import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 
 // O(1) Lookup Map for TOOLS optimization.
@@ -170,7 +170,7 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
     ref
   ) => {
     const { showConfirm } = useDialog();
-    const { resetDockToDefaults } = useDashboard();
+    const { resetDockToDefaults } = useToolVisibility();
 
     const sensors = useSensors(
       useSensor(PointerSensor, {

--- a/components/layout/sidebar/SidebarWidgets.tsx
+++ b/components/layout/sidebar/SidebarWidgets.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Filter, CheckSquare } from 'lucide-react';
 import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { useAuth } from '@/context/useAuth';
 import { TOOLS } from '@/config/tools';
 import { getWidgetGradeLevels } from '@/config/widgetGradeLevels';
@@ -14,13 +15,9 @@ export const SidebarWidgets: React.FC<SidebarWidgetsProps> = ({
   isVisible,
 }) => {
   const { t } = useTranslation();
-  const {
-    visibleTools,
-    toggleToolVisibility,
-    setAllToolsVisibility,
-    gradeFilter,
-    setGradeFilter,
-  } = useDashboard();
+  const { gradeFilter, setGradeFilter } = useDashboard();
+  const { visibleTools, toggleToolVisibility, setAllToolsVisibility } =
+    useToolVisibility();
   const { featurePermissions } = useAuth();
 
   // Grade filter options for consistent validation and rendering

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -111,7 +111,6 @@ const mockDashboard: DashboardContextValue = {
   dashboards: [],
   activeDashboard: null,
   toasts: [],
-  visibleTools: [],
   loading: false,
   isSaving: false,
   gradeFilter: 'all',
@@ -161,9 +160,6 @@ const mockDashboard: DashboardContextValue = {
   setActiveCollectionId: () => {
     // No-op
   },
-  resetDockToDefaults: () => {
-    // No-op
-  },
   addWidget: () => {
     // No-op
   },
@@ -209,23 +205,6 @@ const mockDashboard: DashboardContextValue = {
   setGlobalStyle: () => {
     // No-op
   },
-  toggleToolVisibility: () => {
-    // No-op
-  },
-  setAllToolsVisibility: () => {
-    // No-op
-  },
-  reorderTools: () => {
-    // No-op
-  },
-  libraryOrder: [],
-  reorderLibrary: () => {
-    // No-op
-  },
-  dockItems: [],
-  reorderDockItems: () => {
-    // No-op
-  },
   updateDashboardSettings: () => {
     // No-op
   },
@@ -258,31 +237,6 @@ const mockDashboard: DashboardContextValue = {
   setGroupBuildMode: () => {
     // No-op
   },
-  addFolder: () => {
-    // No-op
-  },
-  createFolderWithItems: () => {
-    // No-op
-  },
-  renameFolder: () => {
-    // No-op
-  },
-  deleteFolder: () => {
-    // No-op
-  },
-  addItemToFolder: () => {
-    // No-op
-  },
-  removeItemFromFolder: () => {
-    // No-op
-  },
-  moveItemOutOfFolder: () => {
-    // No-op
-  },
-  reorderFolderItems: () => {
-    // No-op
-  },
-
   clearAllStickers: () => {
     // No-op
   },

--- a/components/subs/SubsDashboardProvider.tsx
+++ b/components/subs/SubsDashboardProvider.tsx
@@ -40,7 +40,6 @@ import type {
   Toast,
   GradeFilter,
   GlobalStyle,
-  InternalToolType,
   AddWidgetOverrides,
   ClassRoster,
   WidgetConfig,
@@ -226,12 +225,9 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
 
       // === Safe defaults =================================================
       toasts: EMPTY_ARRAY as Toast[],
-      visibleTools: EMPTY_ARRAY as (WidgetType | InternalToolType)[],
-      dockItems: EMPTY_ARRAY as DashboardContextValue['dockItems'],
       loading: false,
       isSaving: false,
       gradeFilter: 'all' as GradeFilter,
-      libraryOrder: EMPTY_ARRAY as (WidgetType | InternalToolType)[],
       annotationActive: false,
       annotationState: DEFAULT_ANNOTATION_STATE,
       zoom: 1,
@@ -278,7 +274,6 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       pinBoard: NOOP_ASYNC as (boardId: string) => Promise<void>,
       unpinBoard: NOOP_ASYNC as (boardId: string) => Promise<void>,
       setActiveCollectionId: NOOP,
-      resetDockToDefaults: NOOP,
       setGradeFilter: NOOP,
 
       // Widget CRUD — disallowed for subs. The read-only flag already
@@ -307,11 +302,6 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       resetWidgetSize: NOOP,
       setBackground: NOOP,
       setGlobalStyle: NOOP as (style: Partial<GlobalStyle>) => void,
-      toggleToolVisibility: NOOP,
-      setAllToolsVisibility: NOOP,
-      reorderTools: NOOP,
-      reorderLibrary: NOOP,
-      reorderDockItems: NOOP,
       updateDashboardSettings: NOOP as (
         settings: Partial<Dashboard['settings']>
       ) => void,
@@ -391,16 +381,6 @@ export const SubsDashboardProvider: React.FC<SubsDashboardProviderProps> = ({
       setActiveRoster: NOOP,
       setAbsentStudents:
         NOOP_ASYNC as DashboardContextValue['setAbsentStudents'],
-
-      // Folder CRUD — subs don't see the dock so this never runs.
-      addFolder: NOOP,
-      createFolderWithItems: NOOP,
-      renameFolder: NOOP,
-      deleteFolder: NOOP,
-      addItemToFolder: NOOP,
-      removeItemFromFolder: NOOP,
-      moveItemOutOfFolder: NOOP,
-      reorderFolderItems: NOOP,
     };
   }, [activeDashboard, updateWidget, bringToFront]);
 

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -93,6 +93,7 @@ import {
   DashboardCanvasStoreContext,
   type DashboardActions,
 } from './dashboardCanvasStore';
+import { ToolVisibilityContext } from './ToolVisibilityContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '@/utils/ai_security';
 import { getAdminBuildingConfig as getAdminBuildingConfigPure } from '@/utils/adminBuildingConfig';
 import { AnnotationState } from './DashboardContextValue';
@@ -5488,8 +5489,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       dashboards,
       activeDashboard,
       toasts,
-      visibleTools,
-      dockItems,
       loading,
       isSaving,
       gradeFilter,
@@ -5509,7 +5508,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pinBoard,
       unpinBoard,
       setActiveCollectionId,
-      resetDockToDefaults,
       addWidget,
       addWidgets,
       removeWidget,
@@ -5526,8 +5524,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       updateDashboardSettings,
       updateDashboard,
       setGlobalStyle,
-      toggleToolVisibility,
-      setAllToolsVisibility,
       selectedWidgetId,
       setSelectedWidgetId,
       groupWidgets,
@@ -5537,10 +5533,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       setSelectedWidgetIds,
       groupBuildMode,
       setGroupBuildMode,
-      reorderTools,
-      reorderLibrary,
-      reorderDockItems,
-      libraryOrder,
       clearAllStickers,
       clearAllWidgets,
       rosters,
@@ -5550,14 +5542,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       deleteRoster,
       setActiveRoster,
       setAbsentStudents,
-      addFolder,
-      createFolderWithItems,
-      renameFolder,
-      deleteFolder,
-      addItemToFolder,
-      removeItemFromFolder,
-      moveItemOutOfFolder,
-      reorderFolderItems,
       shareDashboard: handleShareDashboard,
       shareSubstituteDashboard: handleShareSubstituteDashboard,
       loadSharedDashboard: handleLoadSharedDashboard,
@@ -5614,8 +5598,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       dashboards,
       activeDashboard,
       toasts,
-      visibleTools,
-      dockItems,
       loading,
       isSaving,
       gradeFilter,
@@ -5635,7 +5617,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       pinBoard,
       unpinBoard,
       setActiveCollectionId,
-      resetDockToDefaults,
       addWidget,
       addWidgets,
       removeWidget,
@@ -5652,8 +5633,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       updateDashboardSettings,
       updateDashboard,
       setGlobalStyle,
-      toggleToolVisibility,
-      setAllToolsVisibility,
       selectedWidgetId,
       setSelectedWidgetId,
       groupWidgets,
@@ -5663,10 +5642,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       setSelectedWidgetIds,
       groupBuildMode,
       setGroupBuildMode,
-      reorderTools,
-      reorderLibrary,
-      reorderDockItems,
-      libraryOrder,
       clearAllStickers,
       clearAllWidgets,
       rosters,
@@ -5676,14 +5651,6 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       deleteRoster,
       setActiveRoster,
       setAbsentStudents,
-      addFolder,
-      createFolderWithItems,
-      renameFolder,
-      deleteFolder,
-      addItemToFolder,
-      removeItemFromFolder,
-      moveItemOutOfFolder,
-      reorderFolderItems,
       handleShareDashboard,
       handleShareSubstituteDashboard,
       handleLoadSharedDashboard,
@@ -5735,13 +5702,63 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     ]
   );
 
+  // F9 — tool-visibility slice. Split out of `contextValue` so a tool toggle
+  // (or dock/library reorder) recreates ONLY this object, re-rendering its few
+  // consumers (Dock / NewUserSetup / WidgetLibrary / SidebarWidgets) instead of
+  // every `useDashboard()` consumer. State + persistence effects stay in this
+  // provider; this memo just exposes the same 17 callbacks/values from a
+  // narrower context. Deps mirror exactly the tool-vis fields the deleted
+  // entries used to contribute to `contextValue`'s dep array.
+  const toolVisibilityValue = useMemo(
+    () => ({
+      visibleTools,
+      dockItems,
+      libraryOrder,
+      toggleToolVisibility,
+      setAllToolsVisibility,
+      reorderTools,
+      reorderLibrary,
+      reorderDockItems,
+      resetDockToDefaults,
+      addFolder,
+      createFolderWithItems,
+      renameFolder,
+      deleteFolder,
+      addItemToFolder,
+      removeItemFromFolder,
+      moveItemOutOfFolder,
+      reorderFolderItems,
+    }),
+    [
+      visibleTools,
+      dockItems,
+      libraryOrder,
+      toggleToolVisibility,
+      setAllToolsVisibility,
+      reorderTools,
+      reorderLibrary,
+      reorderDockItems,
+      resetDockToDefaults,
+      addFolder,
+      createFolderWithItems,
+      renameFolder,
+      deleteFolder,
+      addItemToFolder,
+      removeItemFromFolder,
+      moveItemOutOfFolder,
+      reorderFolderItems,
+    ]
+  );
+
   return (
     <DashboardContext.Provider value={contextValue}>
-      <DashboardActionsContext.Provider value={stableActions}>
-        <DashboardCanvasStoreContext.Provider value={canvasStore}>
-          {children}
-        </DashboardCanvasStoreContext.Provider>
-      </DashboardActionsContext.Provider>
+      <ToolVisibilityContext.Provider value={toolVisibilityValue}>
+        <DashboardActionsContext.Provider value={stableActions}>
+          <DashboardCanvasStoreContext.Provider value={canvasStore}>
+            {children}
+          </DashboardCanvasStoreContext.Provider>
+        </DashboardActionsContext.Provider>
+      </ToolVisibilityContext.Provider>
     </DashboardContext.Provider>
   );
 };

--- a/context/DashboardContextValue.ts
+++ b/context/DashboardContextValue.ts
@@ -6,8 +6,6 @@ import {
   Dashboard,
   GradeFilter,
   ClassRoster,
-  DockItem,
-  InternalToolType,
   WidgetConfig,
   GlobalStyle,
   Student,
@@ -129,8 +127,6 @@ export interface DashboardContextValue {
   dashboards: Dashboard[];
   activeDashboard: Dashboard | null;
   toasts: Toast[];
-  visibleTools: (WidgetType | InternalToolType)[];
-  dockItems: DockItem[];
   loading: boolean;
   isSaving: boolean;
   gradeFilter: GradeFilter;
@@ -173,7 +169,6 @@ export interface DashboardContextValue {
     options?: { silent?: boolean }
   ) => Promise<void>;
   setActiveCollectionId: (collectionId: string | null) => void;
-  resetDockToDefaults: () => void;
   addWidget: (type: WidgetType, overrides?: AddWidgetOverrides) => void;
   addWidgets: (
     widgetsToAdd: {
@@ -200,12 +195,6 @@ export interface DashboardContextValue {
   resetWidgetSize: (id: string) => void;
   setBackground: (bg: string) => void;
   setGlobalStyle: (style: Partial<GlobalStyle>) => void;
-  toggleToolVisibility: (type: WidgetType | InternalToolType) => void;
-  setAllToolsVisibility: (visible: boolean) => void;
-  reorderTools: (tools: (WidgetType | InternalToolType)[]) => void;
-  reorderLibrary: (tools: (WidgetType | InternalToolType)[]) => void;
-  reorderDockItems: (items: DockItem[]) => void;
-  libraryOrder: (WidgetType | InternalToolType)[];
   updateDashboardSettings: (
     settings: Partial<Dashboard['settings']>,
     opts?: { immediate?: boolean }
@@ -387,32 +376,6 @@ export interface DashboardContextValue {
   deleteRoster: (id: string) => Promise<void>;
   setActiveRoster: (id: string | null) => void;
   setAbsentStudents: (rosterId: string, studentIds: string[]) => Promise<void>;
-
-  // Folder system
-  addFolder: (name: string) => void;
-  createFolderWithItems: (
-    name: string,
-    items: (WidgetType | InternalToolType)[]
-  ) => void;
-  renameFolder: (id: string, name: string) => void;
-  deleteFolder: (id: string) => void;
-  addItemToFolder: (
-    folderId: string,
-    type: WidgetType | InternalToolType
-  ) => void;
-  removeItemFromFolder: (
-    folderId: string,
-    type: WidgetType | InternalToolType
-  ) => void;
-  moveItemOutOfFolder: (
-    folderId: string,
-    type: WidgetType | InternalToolType,
-    index: number
-  ) => void;
-  reorderFolderItems: (
-    folderId: string,
-    newItems: (WidgetType | InternalToolType)[]
-  ) => void;
 }
 
 export const DashboardContext = createContext<

--- a/context/ToolVisibilityContextValue.ts
+++ b/context/ToolVisibilityContextValue.ts
@@ -1,0 +1,60 @@
+import { createContext } from 'react';
+import { WidgetType, DockItem, InternalToolType } from '@/types';
+
+/**
+ * Tool-visibility slice of the dashboard, split out of `DashboardContextValue`
+ * into its own context (F9). DashboardContext builds one big memoized value
+ * whose `useMemo` deps include `visibleTools` / `dockItems` / `libraryOrder`,
+ * so toggling a tool recreates that object and re-renders ALL ~189
+ * `useDashboard()` consumers. Tool visibility is read by only a handful of
+ * surfaces (Dock, NewUserSetup, WidgetLibrary, SidebarWidgets), so isolating
+ * it here means a tool toggle recreates only THIS value (~3 consumers) while
+ * widget/canvas mutations no longer churn the dock.
+ *
+ * The provider is `DashboardProvider` — it owns all the underlying state
+ * (`visibleTools`, `dockItems`, `libraryOrder`) and persistence effects and
+ * supplies BOTH contexts. `useToolVisibility()` therefore throws the same
+ * "within DashboardProvider" error as `useDashboard()` when no provider is
+ * mounted. Alternate hosts that mount a bare `DashboardContext.Provider`
+ * (SubsDashboardProvider, StudentContexts) do NOT mount this context, but they
+ * also never render a tool-visibility consumer, so the throw is unreachable
+ * there.
+ */
+export interface ToolVisibilityContextValue {
+  visibleTools: (WidgetType | InternalToolType)[];
+  dockItems: DockItem[];
+  libraryOrder: (WidgetType | InternalToolType)[];
+  toggleToolVisibility: (type: WidgetType | InternalToolType) => void;
+  setAllToolsVisibility: (visible: boolean) => void;
+  reorderTools: (tools: (WidgetType | InternalToolType)[]) => void;
+  reorderLibrary: (tools: (WidgetType | InternalToolType)[]) => void;
+  reorderDockItems: (items: DockItem[]) => void;
+  resetDockToDefaults: () => void;
+  addFolder: (name: string) => void;
+  createFolderWithItems: (
+    name: string,
+    items: (WidgetType | InternalToolType)[]
+  ) => void;
+  renameFolder: (id: string, name: string) => void;
+  deleteFolder: (id: string) => void;
+  addItemToFolder: (
+    folderId: string,
+    type: WidgetType | InternalToolType
+  ) => void;
+  removeItemFromFolder: (
+    folderId: string,
+    type: WidgetType | InternalToolType
+  ) => void;
+  moveItemOutOfFolder: (
+    folderId: string,
+    type: WidgetType | InternalToolType,
+    index: number
+  ) => void;
+  reorderFolderItems: (
+    folderId: string,
+    newItems: (WidgetType | InternalToolType)[]
+  ) => void;
+}
+
+export const ToolVisibilityContext =
+  createContext<ToolVisibilityContextValue | null>(null);

--- a/context/toolVisibility.test.tsx
+++ b/context/toolVisibility.test.tsx
@@ -28,7 +28,7 @@
 
 import React, { useEffect } from 'react';
 import { render, waitFor, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardProvider } from './DashboardContext';
 import { useDashboard } from './useDashboard';
 import { useToolVisibility } from './useToolVisibility';
@@ -229,6 +229,12 @@ const captured: Captured = { dashboard: null, toolVis: null };
 const CaptureProbe: React.FC = () => {
   const dashboard = useDashboard();
   const toolVis = useToolVisibility();
+  // Capture into the module-level holder from a post-commit effect, NOT the
+  // render body: the `react-hooks/immutability` rule fires on any module-level
+  // mutation inside a render function (see tests/context/
+  // AuthContext.quizMonitorPrefs.test.tsx for the same pattern). Tests read
+  // captured.* inside act() after the commit settles, so a post-commit write is
+  // exactly when the value is needed.
   useEffect(() => {
     captured.dashboard = dashboard;
     captured.toolVis = toolVis;
@@ -333,6 +339,10 @@ beforeEach(() => {
   captured.dashboard = null;
   captured.toolVis = null;
   localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('tool-visibility isolation — useDashboard() consumers stay put', () => {
@@ -538,10 +548,10 @@ describe('useToolVisibility provider guard', () => {
       return null;
     };
     // Silence React's error boundary console noise for the expected throw.
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    // The global afterEach (vi.restoreAllMocks) restores this spy.
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
     expect(() => render(<ThrowProbe />)).toThrow(
       'useToolVisibility must be used within DashboardProvider'
     );
-    spy.mockRestore();
   });
 });

--- a/context/toolVisibility.test.tsx
+++ b/context/toolVisibility.test.tsx
@@ -1,0 +1,547 @@
+/**
+ * Contract tests for the tool-visibility context split (F9) against the REAL
+ * DashboardProvider (context/ToolVisibilityContextValue.ts +
+ * context/useToolVisibility.ts).
+ *
+ * DashboardProvider builds two memoized values from the same underlying state:
+ * the big `contextValue` (DashboardContext) and the narrow `toolVisibilityValue`
+ * (ToolVisibilityContext). Splitting tool visibility out means:
+ *
+ *   1. Tool-visibility isolation — a `useDashboard()` consumer does NOT
+ *      re-render when only tool visibility changes (toggle / reorder). Before
+ *      the split, visibleTools/dockItems/libraryOrder were in contextValue's
+ *      useMemo deps, so a toggle recreated that value and fanned out to every
+ *      consumer; now it recreates only toolVisibilityValue.
+ *   2. Canvas isolation — a `useToolVisibility()` consumer does NOT re-render
+ *      when only widget/canvas state changes (addWidget / updateWidget). The
+ *      tool-vis value's deps are exactly the 17 tool-vis fields, none of which
+ *      a widget mutation touches.
+ *   3. Correctness — tool-visibility mutations still produce the right state
+ *      AND the same localStorage persistence (classroom_visible_tools /
+ *      classroom_dock_items) they did before the split.
+ *
+ * Render-count probes mirror dashboardCanvasStore.test.tsx's ShellProbe: each
+ * probe bumps a per-id counter in its render body, and we assert ZERO delta on
+ * the untouched probe across the mutation under test. The mocking strategy is
+ * copied verbatim from dashboardCanvasStore.test.tsx (same neighbor harness).
+ */
+
+import React, { useEffect } from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DashboardProvider } from './DashboardContext';
+import { useDashboard } from './useDashboard';
+import { useToolVisibility } from './useToolVisibility';
+import { Dashboard, WidgetData, WidgetType, DockItem } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors context/dashboardCanvasStore.test.tsx)
+// ---------------------------------------------------------------------------
+
+// ONE stable value object (mirrors tests/perf/dashboardPerf.test.tsx). A fresh
+// object per call would hand the provider unstable user/featurePermissions, so
+// getDefaultDockTools — and through it resetDockToDefaults, a dep of the
+// toolVisibilityValue memo — would churn identity on every provider render.
+// That would recreate the tool-vis value on a plain widget mutation and mask
+// the canvas-isolation guarantee under test.
+vi.mock('./useAuth', () => {
+  const stableAuthValue = {
+    user: {
+      uid: 'test-user',
+      displayName: 'Test User',
+      email: 'test@example.com',
+    },
+    isAdmin: false,
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    refreshGoogleToken: vi.fn(),
+    remoteControlEnabled: true,
+    profileLoaded: true,
+    setupCompleted: true,
+  };
+  return { useAuth: () => stableAuthValue };
+});
+
+type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
+let capturedSnapshotCb: SnapshotCb | null = null;
+
+// Each hook mock returns a STABLE singleton — the real hooks memoize their
+// result, so their identity survives an unrelated provider re-render. A fresh
+// object per call would make useFirestore/rosters/collections/share* churn
+// identity on EVERY provider render, recomputing the big contextValue (those
+// feed its callbacks' deps) even on a pure tool-vis change — which would mask
+// the isolation guarantee under test. Same rationale as the useAuth mock above
+// and tests/perf/dashboardPerf.test.tsx.
+vi.mock('../hooks/useFirestore', () => {
+  const value = {
+    saveDashboard: vi.fn().mockResolvedValue(Date.now()),
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    subscribeToDashboards: vi.fn((cb: SnapshotCb) => {
+      capturedSnapshotCb = cb;
+      return () => {
+        // cleanup
+      };
+    }),
+    shareDashboard: vi.fn(),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+    rosters: [],
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    activeRosterId: null,
+  };
+  return { useFirestore: () => value };
+});
+
+vi.mock('../hooks/useRosters', () => {
+  const value = {
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  };
+  return { useRosters: () => value };
+});
+
+vi.mock('../hooks/useCollections', () => {
+  const value = {
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  };
+  return { useCollections: () => value };
+});
+
+vi.mock('../hooks/useSharedCollection', () => {
+  const value = {
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  };
+  return { useSharedCollection: () => value };
+});
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Probes
+// ---------------------------------------------------------------------------
+
+// Render-invocation counts keyed by probe label. A Map (mutated via .set, as
+// in dashboardCanvasStore.test.tsx's ShellProbe) sidesteps the
+// react-hooks/immutability rule that forbids reassigning an outer scalar from a
+// render body.
+const probeRenders = new Map<string, number>();
+const bumpProbe = (label: string): void => {
+  probeRenders.set(label, (probeRenders.get(label) ?? 0) + 1);
+};
+const probeCount = (label: string): number => probeRenders.get(label) ?? 0;
+
+/**
+ * Legacy DashboardContext consumer. Reads two fields that SURVIVE the F9 split
+ * (updateWidget callback + activeDashboard) so the subscription is real and not
+ * tree-shaken. Bumps a render counter in the body — the ruler for "did a
+ * tool-visibility change leak a re-render into a plain useDashboard() consumer?"
+ *
+ * Wrapped in React.memo with no props (mirrors the perf harness's
+ * BystanderProbe) so the ONLY thing that can re-render it is a DashboardContext
+ * value-identity change — a re-render of the DashboardProvider itself is bailed
+ * out by memo, isolating the metric to the context fan-out under test.
+ */
+const DashboardProbe: React.FC = React.memo(() => {
+  const { updateWidget, activeDashboard } = useDashboard();
+  bumpProbe('dashboard');
+  void updateWidget;
+  void activeDashboard;
+  return null;
+});
+DashboardProbe.displayName = 'DashboardProbe';
+
+/**
+ * Tool-visibility consumer. Reads visibleTools + toggleToolVisibility so its
+ * subscription is real. Bumps a render counter — the ruler for "did a widget /
+ * canvas mutation leak a re-render into a useToolVisibility() consumer?"
+ *
+ * Also React.memo-wrapped so only a ToolVisibilityContext value-identity change
+ * (not a provider re-render) can re-render it.
+ */
+const ToolVisProbe: React.FC = React.memo(() => {
+  const { visibleTools, toggleToolVisibility } = useToolVisibility();
+  bumpProbe('toolVis');
+  void visibleTools;
+  void toggleToolVisibility;
+  return null;
+});
+ToolVisProbe.displayName = 'ToolVisProbe';
+
+// ---------------------------------------------------------------------------
+// Capture harness — grab both context values so tests can drive mutations.
+// ---------------------------------------------------------------------------
+
+interface Captured {
+  dashboard: ReturnType<typeof useDashboard> | null;
+  toolVis: ReturnType<typeof useToolVisibility> | null;
+}
+
+const captured: Captured = { dashboard: null, toolVis: null };
+
+const CaptureProbe: React.FC = () => {
+  const dashboard = useDashboard();
+  const toolVis = useToolVisibility();
+  useEffect(() => {
+    captured.dashboard = dashboard;
+    captured.toolVis = toolVis;
+  });
+  return null;
+};
+
+function getDashboard(): ReturnType<typeof useDashboard> {
+  if (!captured.dashboard) throw new Error('Dashboard context not captured');
+  return captured.dashboard;
+}
+
+function getToolVis(): ReturnType<typeof useToolVisibility> {
+  if (!captured.toolVis)
+    throw new Error('Tool-visibility context not captured');
+  return captured.toolVis;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWidget(id: string, z: number): WidgetData {
+  return {
+    id,
+    type: 'text',
+    x: 0,
+    y: 0,
+    w: 1,
+    h: 1,
+    z,
+    flipped: false,
+    config: { text: 'test' } as WidgetData['config'],
+  };
+}
+
+function makeDashboard(widgets: WidgetData[]): Dashboard {
+  return {
+    id: 'dash-1',
+    name: 'Test Board',
+    background: 'bg-slate-900',
+    widgets,
+    createdAt: 1000,
+    updatedAt: 1000,
+  };
+}
+
+async function pushSnapshot(dashboards: Dashboard[]): Promise<void> {
+  if (!capturedSnapshotCb) throw new Error('Provider not mounted');
+  const cb = capturedSnapshotCb;
+  await act(async () => {
+    cb(dashboards, false);
+    await Promise.resolve();
+  });
+}
+
+/**
+ * Wait for the provider's async dock-init/hydration effects to finish seeding
+ * the dock. Those effects fire after mount (getDoc hydration → setDockHydrated
+ * → init effect seeds dockItems), and each setVisibleTools/setDockItems churns
+ * the tool-vis value. The isolation tests must capture their render-count
+ * baseline AFTER that settles, otherwise a late seed render lands inside the
+ * measurement window and shows up as a phantom +1 against the mutation under
+ * test. The empty-dock recovery effect seeds ~all accessible tools (empty
+ * selectedBuildings = "show all"), so a non-empty, stable dock is the signal
+ * that init is done.
+ */
+async function settleDock(): Promise<void> {
+  await waitFor(() => {
+    expect(getToolVis().dockItems.length).toBeGreaterThan(0);
+  });
+  // One more flush so any trailing state update from the seed commits before we
+  // snapshot the render counts.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function setup(): void {
+  render(
+    <DashboardProvider>
+      <CaptureProbe />
+      <DashboardProbe />
+      <ToolVisProbe />
+    </DashboardProvider>
+  );
+}
+
+const TWO_WIDGETS = (): WidgetData[] => [
+  makeWidget('w-1', 1),
+  makeWidget('w-2', 2),
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedSnapshotCb = null;
+  probeRenders.clear();
+  captured.dashboard = null;
+  captured.toolVis = null;
+  localStorage.clear();
+});
+
+describe('tool-visibility isolation — useDashboard() consumers stay put', () => {
+  it('does not re-render a useDashboard() consumer on toggleToolVisibility', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+    await settleDock();
+
+    const baseline = probeCount('dashboard');
+    act(() => {
+      getToolVis().toggleToolVisibility('clock');
+    });
+
+    // The tool-vis value churned, but the DashboardContext value identity did
+    // not — so the plain useDashboard() consumer did not re-render.
+    expect(probeCount('dashboard')).toBe(baseline);
+  });
+
+  it('does not re-render a useDashboard() consumer on reorderDockItems', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+    await settleDock();
+
+    const baseline = probeCount('dashboard');
+    const reordered: DockItem[] = [
+      { type: 'tool', toolType: 'text' },
+      { type: 'tool', toolType: 'clock' },
+    ];
+    act(() => {
+      getToolVis().reorderDockItems(reordered);
+    });
+
+    expect(probeCount('dashboard')).toBe(baseline);
+  });
+
+  // reorderLibrary is the ONE tool-vis action that is NOT isolated from the
+  // dashboard — by design it dual-writes the new order onto the active
+  // dashboard's `libraryOrder` (so a board carries its own library ordering
+  // through share/export). It therefore legitimately churns `contextValue` and
+  // re-renders useDashboard() consumers; that's correct behavior, not a leak.
+  // The dedicated assertion below pins the dual-write is preserved post-split.
+  it('reorderLibrary dual-writes order onto the active dashboard', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+    await settleDock();
+
+    const order: WidgetType[] = ['text', 'clock', 'poll'];
+    act(() => {
+      getToolVis().reorderLibrary(order);
+    });
+
+    await waitFor(() => {
+      expect(getToolVis().libraryOrder).toEqual(order);
+    });
+    // The same order must be mirrored onto the active dashboard (the field
+    // moved to ToolVisibilityContext, but the action body keeps the
+    // setDashboards write intact — this is the F9 must-preserve invariant).
+    expect(getDashboard().activeDashboard?.libraryOrder).toEqual(order);
+  });
+});
+
+describe('canvas isolation — useToolVisibility() consumers stay put', () => {
+  it('does not re-render a useToolVisibility() consumer on addWidget', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+    await settleDock();
+
+    const baseline = probeCount('toolVis');
+    act(() => {
+      getDashboard().addWidget('text');
+    });
+
+    await waitFor(() => {
+      expect(getDashboard().activeDashboard?.widgets.length).toBe(3);
+    });
+
+    // A widget add churns DashboardContext but never touches the tool-vis
+    // value's deps, so the tool-vis consumer did not re-render.
+    expect(probeCount('toolVis')).toBe(baseline);
+  });
+
+  it('does not re-render a useToolVisibility() consumer on updateWidget', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+    await settleDock();
+
+    const baseline = probeCount('toolVis');
+    act(() => {
+      getDashboard().updateWidget('w-1', {
+        config: { text: 'edited' } as WidgetData['config'],
+      });
+    });
+
+    await waitFor(() => {
+      const w = getDashboard().activeDashboard?.widgets.find(
+        (x) => x.id === 'w-1'
+      );
+      expect((w?.config as { text?: string }).text).toBe('edited');
+    });
+
+    expect(probeCount('toolVis')).toBe(baseline);
+  });
+});
+
+describe('correctness — tool-visibility state + persistence', () => {
+  // The mock env (empty selectedBuildings + empty featurePermissions) makes the
+  // provider's dock-init effect seed ALL accessible tools, so 'clock' may
+  // already be visible at start. These tests therefore assert the toggle FLIPS
+  // presence (direction-agnostic) and that both localStorage keys stay in sync
+  // with state — the same contract the perf harness relies on.
+  const dockHasClock = (items: DockItem[]): boolean =>
+    items.some((i) => i.type === 'tool' && i.toolType === 'clock');
+
+  it('toggleToolVisibility flips state and writes both localStorage keys', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+
+    const visibleBefore = getToolVis().visibleTools.includes('clock');
+
+    act(() => {
+      getToolVis().toggleToolVisibility('clock');
+    });
+
+    await waitFor(() => {
+      expect(getToolVis().visibleTools.includes('clock')).toBe(!visibleBefore);
+    });
+
+    // dockItems mirrors visibleTools for 'clock', and BOTH localStorage keys
+    // are written — exactly the persistence behavior the action had pre-split.
+    expect(dockHasClock(getToolVis().dockItems)).toBe(!visibleBefore);
+
+    const visibleRaw = localStorage.getItem('classroom_visible_tools');
+    const dockRaw = localStorage.getItem('classroom_dock_items');
+    expect(visibleRaw).not.toBeNull();
+    expect(dockRaw).not.toBeNull();
+    expect(
+      (JSON.parse(visibleRaw as string) as string[]).includes('clock')
+    ).toBe(!visibleBefore);
+    expect(dockHasClock(JSON.parse(dockRaw as string) as DockItem[])).toBe(
+      !visibleBefore
+    );
+
+    // Toggling again restores the original presence (and persists it).
+    act(() => {
+      getToolVis().toggleToolVisibility('clock');
+    });
+    await waitFor(() => {
+      expect(getToolVis().visibleTools.includes('clock')).toBe(visibleBefore);
+    });
+    expect(
+      (
+        JSON.parse(
+          localStorage.getItem('classroom_visible_tools') as string
+        ) as string[]
+      ).includes('clock')
+    ).toBe(visibleBefore);
+  });
+
+  it('reorderDockItems sets state and persists classroom_dock_items', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+
+    // A bespoke, non-empty dock so the empty-dock recovery effect doesn't fire
+    // and re-seed underneath us (that effect only refills when length === 0).
+    const reordered: DockItem[] = [
+      { type: 'tool', toolType: 'text' },
+      { type: 'tool', toolType: 'clock' },
+    ];
+    act(() => {
+      getToolVis().reorderDockItems(reordered);
+    });
+
+    await waitFor(() => {
+      expect(getToolVis().dockItems).toEqual(reordered);
+    });
+    expect(
+      JSON.parse(localStorage.getItem('classroom_dock_items') as string)
+    ).toEqual(reordered);
+  });
+
+  it('reorderLibrary sets state and persists spartboard_library_order', async () => {
+    setup();
+    await pushSnapshot([makeDashboard(TWO_WIDGETS())]);
+
+    const order: WidgetType[] = ['text', 'clock', 'poll'];
+    act(() => {
+      getToolVis().reorderLibrary(order);
+    });
+
+    await waitFor(() => {
+      expect(getToolVis().libraryOrder).toEqual(order);
+    });
+    expect(
+      JSON.parse(localStorage.getItem('spartboard_library_order') as string)
+    ).toEqual(order);
+  });
+});
+
+describe('useToolVisibility provider guard', () => {
+  it('throws a clear error when used outside DashboardProvider', () => {
+    const ThrowProbe: React.FC = () => {
+      useToolVisibility();
+      return null;
+    };
+    // Silence React's error boundary console noise for the expected throw.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(() => render(<ThrowProbe />)).toThrow(
+      'useToolVisibility must be used within DashboardProvider'
+    );
+    spy.mockRestore();
+  });
+});

--- a/context/useToolVisibility.ts
+++ b/context/useToolVisibility.ts
@@ -4,6 +4,8 @@ import { ToolVisibilityContext } from './ToolVisibilityContextValue';
 export const useToolVisibility = () => {
   const context = useContext(ToolVisibilityContext);
   if (!context)
-    throw new Error('useToolVisibility must be used within DashboardProvider');
+    throw new Error(
+      'useToolVisibility must be used within DashboardProvider, which provides ToolVisibilityContext (bare hosts like SubsDashboardProvider and student apps do not mount it)'
+    );
   return context;
 };

--- a/context/useToolVisibility.ts
+++ b/context/useToolVisibility.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { ToolVisibilityContext } from './ToolVisibilityContextValue';
+
+export const useToolVisibility = () => {
+  const context = useContext(ToolVisibilityContext);
+  if (!context)
+    throw new Error('useToolVisibility must be used within DashboardProvider');
+  return context;
+};

--- a/tests/components/layout/Dock.test.tsx
+++ b/tests/components/layout/Dock.test.tsx
@@ -31,6 +31,11 @@ vi.mock('@/context/useDashboard', () => ({
   useDashboard: vi.fn(),
 }));
 
+// F9 — Dock now reads tool-visibility fields from a separate context.
+vi.mock('@/context/useToolVisibility', () => ({
+  useToolVisibility: vi.fn(),
+}));
+
 vi.mock('@/context/useAuth', () => ({
   useAuth: vi.fn(),
 }));
@@ -199,6 +204,7 @@ vi.mock('@dnd-kit/sortable', () => ({
 // ── Imports after mocks ────────────────────────────────────────────────────
 
 import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { useAuth } from '@/context/useAuth';
 import { useCustomWidgets } from '@/context/useCustomWidgets';
 import { useSavedWidgets } from '@/context/useSavedWidgets';
@@ -226,24 +232,28 @@ function setupMocks({
     addWidget: vi.fn(),
     removeWidget: vi.fn(),
     removeWidgets: vi.fn(),
-    visibleTools: [],
-    dockItems,
-    reorderDockItems: vi.fn(),
     activeDashboard: null,
     updateWidget: vi.fn(),
+    addToast: vi.fn(),
+    setPendingQuizShareId: vi.fn(),
+    setPendingAssignmentShareId: vi.fn(),
+  } as unknown as ReturnType<typeof useDashboard>);
+
+  // F9 — tool-visibility fields now live on their own context.
+  vi.mocked(useToolVisibility).mockReturnValue({
+    visibleTools: [],
+    dockItems,
+    libraryOrder: [],
+    reorderDockItems: vi.fn(),
     toggleToolVisibility: vi.fn(),
     reorderLibrary: vi.fn(),
-    libraryOrder: [],
     addFolder: vi.fn(),
     renameFolder: vi.fn(),
     deleteFolder: vi.fn(),
     addItemToFolder: vi.fn(),
     moveItemOutOfFolder: vi.fn(),
     reorderFolderItems: vi.fn(),
-    addToast: vi.fn(),
-    setPendingQuizShareId: vi.fn(),
-    setPendingAssignmentShareId: vi.fn(),
-  } as unknown as ReturnType<typeof useDashboard>);
+  } as unknown as ReturnType<typeof useToolVisibility>);
 
   vi.mocked(useAuth).mockReturnValue({
     canAccessWidget,

--- a/tests/escapeInteraction.test.tsx
+++ b/tests/escapeInteraction.test.tsx
@@ -183,8 +183,6 @@ describe('Global Escape Interaction', () => {
     removeToast: vi.fn(),
     loading: false,
     isSaving: false,
-    visibleTools: [],
-    dockItems: [],
     gradeFilter: 'all',
     zoom: 1,
     setZoom: vi.fn(),

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -627,6 +627,13 @@ const BYSTANDER_IDS = [
 const BoardHarness: React.FC = () => {
   const ctx = useDashboard();
   const toolVis = useToolVisibility();
+  // Capture into the module-level holders from a post-commit effect, NOT the
+  // render body: ctxRef/toolVisRef are module-level objects (not useRef()
+  // values), so writing them during render trips the `react-hooks/immutability`
+  // rule (it fires on any module-level mutation inside a render function — see
+  // tests/context/AuthContext.quizMonitorPrefs.test.tsx). getCtx()/getToolVis()
+  // are read inside act() after the commit settles, so a post-commit write is
+  // when the value is needed.
   useEffect(() => {
     ctxRef.current = ctx;
     toolVisRef.current = toolVis;

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -73,6 +73,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { DashboardProvider } from '@/context/DashboardContext';
 import { useDashboard } from '@/context/useDashboard';
+import { useToolVisibility } from '@/context/useToolVisibility';
 import { BoardCanvas } from '@/components/layout/BoardCanvas';
 import type {
   Dashboard,
@@ -177,8 +178,13 @@ vi.mock('@/context/useAuth', () => {
 type SnapshotCb = (dashboards: Dashboard[], hasPendingWrites: boolean) => void;
 let capturedSnapshotCb: SnapshotCb | null = null;
 
-vi.mock('@/hooks/useFirestore', () => ({
-  useFirestore: () => ({
+// Stable singleton (same rationale as the other hook mocks). The real
+// useFirestore memoizes its result; a fresh object per call would make
+// saveDashboardFirestore / subscribeToDashboards / etc. churn identity every
+// provider render, which recomputes the big contextValue (those feed its
+// callbacks' deps) even on a pure tool-vis toggle — masking the F9 split.
+vi.mock('@/hooks/useFirestore', () => {
+  const value = {
     saveDashboard: vi.fn().mockResolvedValue(Date.now()),
     saveDashboards: vi.fn().mockResolvedValue(undefined),
     deleteDashboard: vi.fn().mockResolvedValue(undefined),
@@ -190,11 +196,20 @@ vi.mock('@/hooks/useFirestore', () => ({
     }),
     shareDashboard: vi.fn(),
     loadSharedDashboard: vi.fn().mockResolvedValue(null),
-  }),
-}));
+  };
+  return { useFirestore: () => value };
+});
 
-vi.mock('@/hooks/useRosters', () => ({
-  useRosters: () => ({
+// Stable singletons (same rationale as the useAuth mock above). The real
+// useRosters / useCollections / useSharedCollection hooks memoize their result,
+// so their identity survives an unrelated provider re-render. A fresh object
+// per call would make rosters/collectionsApi/share* churn identity on EVERY
+// provider render, recomputing the big contextValue even when only tool
+// visibility changed — which would defeat the F9 split's measurement (the
+// bystander probes would re-render on a toggle via collectionsApi churn, not a
+// genuine tool-vis fan-out).
+vi.mock('@/hooks/useRosters', () => {
+  const value = {
     rosters: [],
     activeRosterId: null,
     addRoster: vi.fn(),
@@ -202,11 +217,12 @@ vi.mock('@/hooks/useRosters', () => ({
     deleteRoster: vi.fn(),
     setActiveRoster: vi.fn(),
     setAbsentStudents: vi.fn(),
-  }),
-}));
+  };
+  return { useRosters: () => value };
+});
 
-vi.mock('@/hooks/useCollections', () => ({
-  useCollections: () => ({
+vi.mock('@/hooks/useCollections', () => {
+  const value = {
     collections: [],
     loading: false,
     error: null,
@@ -217,11 +233,12 @@ vi.mock('@/hooks/useCollections', () => ({
     reorderSiblings: vi.fn(),
     setCollectionMetadata: vi.fn(),
     setCollectionDefaultBoard: vi.fn(),
-  }),
-}));
+  };
+  return { useCollections: () => value };
+});
 
-vi.mock('@/hooks/useSharedCollection', () => ({
-  useSharedCollection: () => ({
+vi.mock('@/hooks/useSharedCollection', () => {
+  const value = {
     shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
     shareSubstituteCollection: vi
       .fn()
@@ -230,8 +247,9 @@ vi.mock('@/hooks/useSharedCollection', () => ({
       .fn()
       .mockResolvedValue({ ok: false, reason: 'not-found' }),
     loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
-  }),
-}));
+  };
+  return { useSharedCollection: () => value };
+});
 
 vi.mock('firebase/firestore', async (importOriginal) => {
   // Real module reference so any unmocked Firestore function still resolves
@@ -545,6 +563,21 @@ function getCtx(): ReturnType<typeof useDashboard> {
   return ctxRef.current;
 }
 
+// F9 — tool visibility now lives on its own context (ToolVisibilityContext),
+// captured separately so the toggleToolVisibility scenario can drive it after
+// the split. The BystanderProbe deliberately keeps reading the legacy
+// useDashboard() value (NOT this), so it still measures the DashboardContext
+// fan-out the split is meant to silence.
+const toolVisRef: { current: ReturnType<typeof useToolVisibility> | null } = {
+  current: null,
+};
+
+function getToolVis(): ReturnType<typeof useToolVisibility> {
+  if (!toolVisRef.current)
+    throw new Error('Tool-visibility context not captured');
+  return toolVisRef.current;
+}
+
 /**
  * Bystander consumer probe. Stands in for the ~189 widget-content/settings
  * components that call the legacy `useDashboard()` for an unrelated field and
@@ -593,8 +626,10 @@ const BYSTANDER_IDS = [
  */
 const BoardHarness: React.FC = () => {
   const ctx = useDashboard();
+  const toolVis = useToolVisibility();
   useEffect(() => {
     ctxRef.current = ctx;
+    toolVisRef.current = toolVis;
   });
   if (!ctx.activeDashboard) return null;
   return (
@@ -817,27 +852,28 @@ describe('dashboard canvas performance baseline', () => {
     ).toBe(false);
 
     // (7) toggleToolVisibility — flip one tool's dock visibility through the
-    // real context action, the same control mechanism (getCtx().<action>) the
-    // addWidget/removeWidget/minimize scenarios use. 'clock' is a real
+    // real context action. Post-F9 this action lives on ToolVisibilityContext
+    // (captured via getToolVis()), NOT DashboardContext. 'clock' is a real
     // WidgetType (config/tools.ts); the harness seeds an empty dock, so the
-    // toggle ADDS it — mutating both visibleTools and dockItems, which are in
-    // the contextValue useMemo deps (context/DashboardContext.tsx), recreating
-    // the value object's identity. On CURRENT (pre-F9) code that fans out to
-    // EVERY useDashboard() consumer, so the 5 bystander probes all re-render.
-    // This bystanderRenders count is the "before" baseline the F9 split drives
-    // to 0; the shells, by contrast, read the isolated canvas store and stay
-    // put.
+    // toggle ADDS it — mutating visibleTools and dockItems, which are now in
+    // the toolVisibilityValue useMemo deps (context/DashboardContext.tsx).
+    // Because that value is a SEPARATE context, recreating it does NOT churn
+    // DashboardContext's value identity, so the 5 bystander probes (which read
+    // legacy useDashboard()) stay put — bystanderRenders drops to 0. The
+    // shells likewise read the isolated canvas store and never re-render here.
     const toolToToggle: WidgetType = 'clock';
-    const visibleBefore = getCtx().visibleTools.includes(toolToToggle);
+    const visibleBefore = getToolVis().visibleTools.includes(toolToToggle);
     rec.start();
     act(() => {
-      getCtx().toggleToolVisibility(toolToToggle);
+      getToolVis().toggleToolVisibility(toolToToggle);
     });
     await settle();
     rec.record('toggleToolVisibility');
     // Behavioral validity: the toggle actually flipped the tool's visibility,
-    // so contextValue genuinely churned (not a no-op).
-    expect(getCtx().visibleTools.includes(toolToToggle)).toBe(!visibleBefore);
+    // so toolVisibilityValue genuinely churned (not a no-op).
+    expect(getToolVis().visibleTools.includes(toolToToggle)).toBe(
+      !visibleBefore
+    );
 
     // The harness only asserts that metrics were produced — no duration
     // thresholds (CI machines vary; this must never be flaky).
@@ -893,28 +929,20 @@ describe('dashboard canvas performance baseline', () => {
     const sanityAddWidgetProbeDelta = metricFor('addWidget').bystanderRenders;
     expect(sanityAddWidgetProbeDelta).toBeGreaterThan(0);
 
-    // PRIMARY: on current (pre-F9) code, toggling a tool recreates
-    // contextValue and fans out to every useDashboard() consumer, so all 5
-    // bystander probes re-render. This non-zero number is the 'before'
-    // baseline the context split must drive to 0. A 0 here would mean the
-    // instrument is NOT capturing the churn (probe memoized off the wrong
-    // hook, or the toggle was a no-op) — investigate before trusting it.
+    // PRIMARY (post-F9): tool visibility lives on its own context, so toggling
+    // a tool recreates ONLY toolVisibilityValue — DashboardContext's value
+    // identity is untouched. The 5 bystander probes read legacy useDashboard()
+    // (the DashboardContext value), so NONE of them re-render: bystanderRenders
+    // is 0 and the per-probe breakdown is empty. This is the F9 win the harness
+    // exists to prove. The sanity check above (addWidget DOES churn the probes)
+    // confirms the instrument still detects real DashboardContext fan-out, so a
+    // 0 here is a genuine isolation result, not a dead probe.
     const toggle = metricFor('toggleToolVisibility');
-    expect(toggle.bystanderRenders).toBeGreaterThan(0);
-    // Each of the 5 probes is an independent consumer of the same churning
-    // value, so on current code all 5 re-render exactly once per toggle.
-    expect(toggle.bystanderRenders).toBe(5);
-    expect(Object.keys(toggle.bystanderRendersById).sort()).toEqual([
-      'bystander-1',
-      'bystander-2',
-      'bystander-3',
-      'bystander-4',
-      'bystander-5',
-    ]);
+    expect(toggle.bystanderRenders).toBe(0);
+    expect(toggle.bystanderRendersById).toEqual({});
     // The toggle must NOT have re-rendered any widget shell — shells read the
-    // isolated canvas store, not the churning DashboardContext value, so the
-    // tool-visibility churn is invisible to them. (This is the contrast that
-    // makes the bystander probe necessary in the first place.)
+    // isolated canvas store, not the tool-visibility context, so the
+    // tool-visibility churn is invisible to them too.
     expect(shellDiff('toggleToolVisibility')).toEqual([]);
   });
 });
@@ -940,10 +968,11 @@ afterAll(() => {
           'rendered (widgets added mid-test are keyed "added-widget"). ' +
           'bystanderRenders/bystanderRendersById count how many of the 5 ' +
           'legacy-DashboardContext consumer probes re-rendered per scenario — ' +
-          'this is the F9 context-split ruler: the toggleToolVisibility ' +
-          'scenario should read 5 today (every consumer re-renders on a tool ' +
-          'toggle) and drop to 0 once tool visibility moves to its own ' +
-          'context. ' +
+          'this is the F9 context-split ruler: post-split the ' +
+          'toggleToolVisibility scenario reads 0 (tool visibility lives on its ' +
+          'own ToolVisibilityContext, so a toggle no longer churns the ' +
+          'DashboardContext value the probes subscribe to), while addWidget ' +
+          'still churns the probes (sanity that the instrument is live). ' +
           'actualDurationMs is machine-dependent and indicative only — ' +
           'compare medians of 3 runs.',
         skipped:

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -84,42 +84,59 @@ import type {
 
 // ─── Shared fixtures (hoisted so vi.mock factories can use them) ────────────
 
-const { STUB_WIDGET_TYPES, shellRenderCounts, countShellRender } = vi.hoisted(
-  () => {
-    // Render-invocation counts of the DraggableWindow shell, keyed by widget
-    // id. Widgets added mid-test get random UUIDs, so those are normalized to
-    // a stable label to keep the results JSON identical run-to-run.
-    const counts = new Map<string, number>();
-    return {
-      shellRenderCounts: counts,
-      countShellRender: (widgetId: string) => {
-        const key = /^w-\d+$/.test(widgetId) ? widgetId : 'added-widget';
-        counts.set(key, (counts.get(key) ?? 0) + 1);
-      },
-      // 15 widgets across 8 distinct types — all on the standard (non-position-
-      // aware) drag path, which is what every widget except the 3 catalyst types
-      // uses. All are registered skipScaling so the container-query branch of
-      // WidgetRenderer is exercised (the majority path per WidgetRegistry).
-      STUB_WIDGET_TYPES: [
-        'clock',
-        'text',
-        'checklist',
-        'poll',
-        'weather',
-        'schedule',
-        'dice',
-        'scoreboard',
-        'clock',
-        'text',
-        'checklist',
-        'poll',
-        'weather',
-        'schedule',
-        'dice',
-      ] as const,
-    };
-  }
-);
+const {
+  STUB_WIDGET_TYPES,
+  shellRenderCounts,
+  countShellRender,
+  bystanderRenderCounts,
+  countBystanderRender,
+} = vi.hoisted(() => {
+  // Render-invocation counts of the DraggableWindow shell, keyed by widget
+  // id. Widgets added mid-test get random UUIDs, so those are normalized to
+  // a stable label to keep the results JSON identical run-to-run.
+  const counts = new Map<string, number>();
+  // Render-invocation counts of the BystanderProbe consumers, keyed by probe
+  // id ('bystander-1'..'bystander-5'). These probes subscribe to the legacy
+  // DashboardContext value (the one whose identity churns on every tool
+  // toggle) and stand in for the ~189 real useDashboard() consumers that have
+  // nothing to do with tool visibility. The shell counter above can't measure
+  // this: shells read the isolated canvas store, so they intentionally do NOT
+  // re-render on a tool toggle — a separate counter is required to prove the
+  // context fan-out.
+  const bystanderCounts = new Map<string, number>();
+  return {
+    shellRenderCounts: counts,
+    countShellRender: (widgetId: string) => {
+      const key = /^w-\d+$/.test(widgetId) ? widgetId : 'added-widget';
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    },
+    bystanderRenderCounts: bystanderCounts,
+    countBystanderRender: (probeId: string) => {
+      bystanderCounts.set(probeId, (bystanderCounts.get(probeId) ?? 0) + 1);
+    },
+    // 15 widgets across 8 distinct types — all on the standard (non-position-
+    // aware) drag path, which is what every widget except the 3 catalyst types
+    // uses. All are registered skipScaling so the container-query branch of
+    // WidgetRenderer is exercised (the majority path per WidgetRegistry).
+    STUB_WIDGET_TYPES: [
+      'clock',
+      'text',
+      'checklist',
+      'poll',
+      'weather',
+      'schedule',
+      'dice',
+      'scoreboard',
+      'clock',
+      'text',
+      'checklist',
+      'poll',
+      'weather',
+      'schedule',
+      'dice',
+    ] as const,
+  };
+});
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -366,6 +383,13 @@ interface ScenarioMetric {
   actualDurationMs: number;
   totalShellRenders: number;
   shellRendersByWidget: Record<string, number>;
+  // Bystander-consumer fan-out: how many of the 5 legacy-context probes
+  // re-rendered during the scenario (sum), plus the per-probe breakdown. This
+  // is the PRIMARY metric for the F9 context split — it should be > 0 (ideally
+  // 5) on the toggleToolVisibility scenario today and drop to 0 once tool
+  // visibility moves into its own context.
+  bystanderRenders: number;
+  bystanderRendersById: Record<string, number>;
 }
 
 const metrics: ScenarioMetric[] = [];
@@ -382,10 +406,24 @@ function shellRenderDeltas(
   return deltas;
 }
 
+/** Per-probe delta of bystanderRenderCounts since the given baseline snapshot. */
+function bystanderRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...bystanderRenderCounts.keys()].sort()) {
+    const delta =
+      (bystanderRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
 function createRecorder() {
   let commits = 0;
   let duration = 0;
   let shellBaseline: ReadonlyMap<string, number> = new Map();
+  let bystanderBaseline: ReadonlyMap<string, number> = new Map();
   const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
     commits += 1;
     duration += actualDuration;
@@ -396,9 +434,11 @@ function createRecorder() {
       commits = 0;
       duration = 0;
       shellBaseline = new Map(shellRenderCounts);
+      bystanderBaseline = new Map(bystanderRenderCounts);
     },
     record(scenario: string) {
       const shellRendersByWidget = shellRenderDeltas(shellBaseline);
+      const bystanderRendersById = bystanderRenderDeltas(bystanderBaseline);
       metrics.push({
         scenario,
         commits,
@@ -408,6 +448,11 @@ function createRecorder() {
           0
         ),
         shellRendersByWidget,
+        bystanderRenders: Object.values(bystanderRendersById).reduce(
+          (sum, n) => sum + n,
+          0
+        ),
+        bystanderRendersById,
       });
     },
   };
@@ -501,10 +546,50 @@ function getCtx(): ReturnType<typeof useDashboard> {
 }
 
 /**
+ * Bystander consumer probe. Stands in for the ~189 widget-content/settings
+ * components that call the legacy `useDashboard()` for an unrelated field and
+ * have nothing to do with tool visibility.
+ *
+ * It subscribes to the REAL legacy DashboardContext (via `useDashboard()`),
+ * not the isolated canvas store — so it re-renders whenever the provider's
+ * memoized contextValue identity changes, which is exactly what a tool toggle
+ * does today (visibleTools/dockItems are in that value's useMemo deps). It
+ * reads `updateWidget` (a callback that survives the F9 split) and
+ * `activeDashboard` so a tree-shaker can't elide the subscription; it does
+ * NOT touch `useDashboardCanvasSelector`/`useDashboardActions`, so it faithfully
+ * represents the churning-context consumers the split aims to quiet.
+ *
+ * Wrapped in React.memo with a stable `id` prop so the ONLY thing that can
+ * drive a re-render is context-value churn — parent (BoardHarness) re-renders
+ * are bailed out by memo, isolating the metric to the fan-out under test.
+ */
+const BystanderProbe: React.FC<{ id: string }> = React.memo(({ id }) => {
+  const { updateWidget, activeDashboard } = useDashboard();
+  countBystanderRender(id);
+  // Reference both reads so the subscription is real and not optimized away.
+  void updateWidget;
+  void activeDashboard;
+  return null;
+});
+BystanderProbe.displayName = 'BystanderProbe';
+
+const BYSTANDER_IDS = [
+  'bystander-1',
+  'bystander-2',
+  'bystander-3',
+  'bystander-4',
+  'bystander-5',
+] as const;
+
+/**
  * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
  * BoardCanvas: context state and callbacks flow down as props, while
  * DraggableWindow/WidgetRenderer read the stable actions context and the
  * canvas hot-slice selectors directly (context/dashboardCanvasStore.ts).
+ *
+ * The 5 BystanderProbe consumers are mounted alongside BoardCanvas, under the
+ * same <DashboardProvider> and inside the same <Profiler>, so their
+ * context-driven re-renders are captured by the recorder.
  */
 const BoardHarness: React.FC = () => {
   const ctx = useDashboard();
@@ -513,28 +598,33 @@ const BoardHarness: React.FC = () => {
   });
   if (!ctx.activeDashboard) return null;
   return (
-    <BoardCanvas
-      dashboard={ctx.activeDashboard}
-      isActive
-      isMinimized={false}
-      animationClass=""
-      session={null}
-      students={EMPTY_STUDENTS}
-      emptyStudents={EMPTY_STUDENTS}
-      updateSessionConfig={noopAsync}
-      updateSessionBackground={noopAsync}
-      startSession={startSessionStub}
-      endSession={noopAsync}
-      removeStudent={noopAsync}
-      toggleFreezeStudent={noopAsync}
-      toggleGlobalFreeze={noopAsync}
-      updateWidget={ctx.updateWidget}
-      removeWidget={ctx.removeWidget}
-      duplicateWidget={ctx.duplicateWidget}
-      bringToFront={ctx.bringToFront}
-      addToast={ctx.addToast}
-      updateDashboardSettings={ctx.updateDashboardSettings}
-    />
+    <>
+      {BYSTANDER_IDS.map((id) => (
+        <BystanderProbe key={id} id={id} />
+      ))}
+      <BoardCanvas
+        dashboard={ctx.activeDashboard}
+        isActive
+        isMinimized={false}
+        animationClass=""
+        session={null}
+        students={EMPTY_STUDENTS}
+        emptyStudents={EMPTY_STUDENTS}
+        updateSessionConfig={noopAsync}
+        updateSessionBackground={noopAsync}
+        startSession={startSessionStub}
+        endSession={noopAsync}
+        removeStudent={noopAsync}
+        toggleFreezeStudent={noopAsync}
+        toggleGlobalFreeze={noopAsync}
+        updateWidget={ctx.updateWidget}
+        removeWidget={ctx.removeWidget}
+        duplicateWidget={ctx.duplicateWidget}
+        bringToFront={ctx.bringToFront}
+        addToast={ctx.addToast}
+        updateDashboardSettings={ctx.updateDashboardSettings}
+      />
+    </>
   );
 };
 
@@ -726,13 +816,37 @@ describe('dashboard canvas performance baseline', () => {
       getCtx().activeDashboard?.widgets.find((w) => w.id === 'w-3')?.minimized
     ).toBe(false);
 
+    // (7) toggleToolVisibility — flip one tool's dock visibility through the
+    // real context action, the same control mechanism (getCtx().<action>) the
+    // addWidget/removeWidget/minimize scenarios use. 'clock' is a real
+    // WidgetType (config/tools.ts); the harness seeds an empty dock, so the
+    // toggle ADDS it — mutating both visibleTools and dockItems, which are in
+    // the contextValue useMemo deps (context/DashboardContext.tsx), recreating
+    // the value object's identity. On CURRENT (pre-F9) code that fans out to
+    // EVERY useDashboard() consumer, so the 5 bystander probes all re-render.
+    // This bystanderRenders count is the "before" baseline the F9 split drives
+    // to 0; the shells, by contrast, read the isolated canvas store and stay
+    // put.
+    const toolToToggle: WidgetType = 'clock';
+    const visibleBefore = getCtx().visibleTools.includes(toolToToggle);
+    rec.start();
+    act(() => {
+      getCtx().toggleToolVisibility(toolToToggle);
+    });
+    await settle();
+    rec.record('toggleToolVisibility');
+    // Behavioral validity: the toggle actually flipped the tool's visibility,
+    // so contextValue genuinely churned (not a no-op).
+    expect(getCtx().visibleTools.includes(toolToToggle)).toBe(!visibleBefore);
+
     // The harness only asserts that metrics were produced — no duration
     // thresholds (CI machines vary; this must never be flaky).
-    expect(metrics).toHaveLength(12);
+    expect(metrics).toHaveLength(13);
     for (const m of metrics) {
       expect(m.commits).toBeGreaterThanOrEqual(0);
       expect(m.actualDurationMs).toBeGreaterThanOrEqual(0);
       expect(m.totalShellRenders).toBeGreaterThanOrEqual(0);
+      expect(m.bystanderRenders).toBeGreaterThanOrEqual(0);
     }
     // The mount must have rendered all 15 shells at least once each.
     const mount = metrics.find((m) => m.scenario === 'mount15');
@@ -764,6 +878,44 @@ describe('dashboard canvas performance baseline', () => {
     // Minimize/restore touch only the targeted widget's shell.
     expect(shellDiff('minimize')).toEqual(['w-3']);
     expect(shellDiff('restore')).toEqual(['w-3']);
+
+    // ── Bystander fan-out (the F9 'before' baseline) ──────────────────────
+    const metricFor = (scenario: string): ScenarioMetric => {
+      const m = metrics.find((x) => x.scenario === scenario);
+      if (!m) throw new Error(`scenario ${scenario} not recorded`);
+      return m;
+    };
+
+    // SANITY: the probe is wired correctly — a real DashboardContext change
+    // (addWidget mutates dashboards/activeDashboard → contextValue identity)
+    // makes the bystander probes re-render. If THIS were 0, the probe isn't
+    // subscribed to the churning context and every other reading is worthless.
+    const sanityAddWidgetProbeDelta = metricFor('addWidget').bystanderRenders;
+    expect(sanityAddWidgetProbeDelta).toBeGreaterThan(0);
+
+    // PRIMARY: on current (pre-F9) code, toggling a tool recreates
+    // contextValue and fans out to every useDashboard() consumer, so all 5
+    // bystander probes re-render. This non-zero number is the 'before'
+    // baseline the context split must drive to 0. A 0 here would mean the
+    // instrument is NOT capturing the churn (probe memoized off the wrong
+    // hook, or the toggle was a no-op) — investigate before trusting it.
+    const toggle = metricFor('toggleToolVisibility');
+    expect(toggle.bystanderRenders).toBeGreaterThan(0);
+    // Each of the 5 probes is an independent consumer of the same churning
+    // value, so on current code all 5 re-render exactly once per toggle.
+    expect(toggle.bystanderRenders).toBe(5);
+    expect(Object.keys(toggle.bystanderRendersById).sort()).toEqual([
+      'bystander-1',
+      'bystander-2',
+      'bystander-3',
+      'bystander-4',
+      'bystander-5',
+    ]);
+    // The toggle must NOT have re-rendered any widget shell — shells read the
+    // isolated canvas store, not the churning DashboardContext value, so the
+    // tool-visibility churn is invisible to them. (This is the contrast that
+    // makes the bystander probe necessary in the first place.)
+    expect(shellDiff('toggleToolVisibility')).toEqual([]);
   });
 });
 
@@ -786,6 +938,12 @@ afterAll(() => {
           'totalShellRenders sums DraggableWindow render invocations across ' +
           'all widgets per scenario; shellRendersByWidget shows which shells ' +
           'rendered (widgets added mid-test are keyed "added-widget"). ' +
+          'bystanderRenders/bystanderRendersById count how many of the 5 ' +
+          'legacy-DashboardContext consumer probes re-rendered per scenario — ' +
+          'this is the F9 context-split ruler: the toggleToolVisibility ' +
+          'scenario should read 5 today (every consumer re-renders on a tool ' +
+          'toggle) and drop to 0 once tool visibility moves to its own ' +
+          'context. ' +
           'actualDurationMs is machine-dependent and indicative only — ' +
           'compare medians of 3 runs.',
         skipped:

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-06-16T23:53:17.765Z",
+  "generatedAt": "2026-06-17T01:04:04.194Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: the toggleToolVisibility scenario should read 5 today (every consumer re-renders on a tool toggle) and drop to 0 once tool visibility moves to its own context. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
-      "commits": 4,
-      "actualDurationMs": 152.111,
+      "commits": 3,
+      "actualDurationMs": 483.293,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -26,19 +26,19 @@
         "w-8": 1,
         "w-9": 1
       },
-      "bystanderRenders": 10,
+      "bystanderRenders": 5,
       "bystanderRendersById": {
-        "bystander-1": 2,
-        "bystander-2": 2,
-        "bystander-3": 2,
-        "bystander-4": 2,
-        "bystander-5": 2
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 2.312,
+      "actualDurationMs": 21.447,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -63,8 +63,8 @@
     },
     {
       "scenario": "drag.release",
-      "commits": 2,
-      "actualDurationMs": 3.209,
+      "commits": 3,
+      "actualDurationMs": 8.299,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -81,7 +81,7 @@
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 1.029,
+      "actualDurationMs": 2.299,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
@@ -98,8 +98,8 @@
     },
     {
       "scenario": "resize.release",
-      "commits": 2,
-      "actualDurationMs": 3.57,
+      "commits": 3,
+      "actualDurationMs": 6.236,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -116,7 +116,7 @@
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 10.936,
+      "actualDurationMs": 21.812,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -136,8 +136,8 @@
     },
     {
       "scenario": "addWidget",
-      "commits": 2,
-      "actualDurationMs": 6.174,
+      "commits": 3,
+      "actualDurationMs": 13.46,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -154,7 +154,7 @@
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 0.999,
+      "actualDurationMs": 2.305,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -169,7 +169,7 @@
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 1.955,
+      "actualDurationMs": 2.922,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -186,7 +186,7 @@
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 2.048,
+      "actualDurationMs": 4.434,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -202,18 +202,12 @@
     },
     {
       "scenario": "toggleToolVisibility",
-      "commits": 2,
-      "actualDurationMs": 0.688,
+      "commits": 1,
+      "actualDurationMs": 1.32,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
-      "bystanderRenders": 5,
-      "bystanderRendersById": {
-        "bystander-1": 1,
-        "bystander-2": 1,
-        "bystander-3": 1,
-        "bystander-4": 1,
-        "bystander-5": 1
-      }
+      "bystanderRenders": 0,
+      "bystanderRendersById": {}
     }
   ]
 }

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-06-16T06:20:00.168Z",
+  "generatedAt": "2026-06-16T23:53:17.765Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: the toggleToolVisibility scenario should read 5 today (every consumer re-renders on a tool toggle) and drop to 0 once tool visibility moves to its own context. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
       "commits": 4,
-      "actualDurationMs": 395.816,
+      "actualDurationMs": 152.111,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -25,15 +25,31 @@
         "w-7": 1,
         "w-8": 1,
         "w-9": 1
+      },
+      "bystanderRenders": 10,
+      "bystanderRendersById": {
+        "bystander-1": 2,
+        "bystander-2": 2,
+        "bystander-3": 2,
+        "bystander-4": 2,
+        "bystander-5": 2
       }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 5.475,
+      "actualDurationMs": 2.312,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
@@ -41,44 +57,66 @@
       "commits": 0,
       "actualDurationMs": 0,
       "totalShellRenders": 0,
-      "shellRendersByWidget": {}
+      "shellRendersByWidget": {},
+      "bystanderRenders": 0,
+      "bystanderRendersById": {}
     },
     {
       "scenario": "drag.release",
       "commits": 2,
-      "actualDurationMs": 3.777,
+      "actualDurationMs": 3.209,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 9.602,
+      "actualDurationMs": 1.029,
       "totalShellRenders": 0,
-      "shellRendersByWidget": {}
+      "shellRendersByWidget": {},
+      "bystanderRenders": 0,
+      "bystanderRendersById": {}
     },
     {
       "scenario": "resize.move30",
       "commits": 0,
       "actualDurationMs": 0,
       "totalShellRenders": 0,
-      "shellRendersByWidget": {}
+      "shellRendersByWidget": {},
+      "bystanderRenders": 0,
+      "bystanderRendersById": {}
     },
     {
       "scenario": "resize.release",
       "commits": 2,
-      "actualDurationMs": 14.486,
+      "actualDurationMs": 3.57,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 20.183,
+      "actualDurationMs": 10.936,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -86,40 +124,95 @@
         "w-3": 1,
         "w-4": 1,
         "w-6": 1
+      },
+      "bystanderRenders": 25,
+      "bystanderRendersById": {
+        "bystander-1": 5,
+        "bystander-2": 5,
+        "bystander-3": 5,
+        "bystander-4": 5,
+        "bystander-5": 5
       }
     },
     {
       "scenario": "addWidget",
       "commits": 2,
-      "actualDurationMs": 31.092,
+      "actualDurationMs": 6.174,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 1.093,
+      "actualDurationMs": 0.999,
       "totalShellRenders": 0,
-      "shellRendersByWidget": {}
+      "shellRendersByWidget": {},
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
+      }
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 16.43,
+      "actualDurationMs": 1.955,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 12.377,
+      "actualDurationMs": 2.048,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
+      }
+    },
+    {
+      "scenario": "toggleToolVisibility",
+      "commits": 2,
+      "actualDurationMs": 0.688,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {},
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
       }
     }
   ]


### PR DESCRIPTION
## What & why

F9 from the optimize-pass backlog. `DashboardContext` built a single memoized value whose `useMemo` deps included `visibleTools` / `dockItems` / `libraryOrder`, so toggling one tool's visibility recreated the whole value and re-rendered **every** `useDashboard()` consumer (~189 components, including all widget content + settings panels).

This extracts the 17-member tool-visibility slice into a sibling `ToolVisibilityContext` + `useToolVisibility()` hook. `DashboardProvider` keeps all state and persistence effects unchanged and now supplies **both** contexts via two memoized values. The result is symmetric:

- **Tool toggle** → recreates only `toolVisibilityValue` (4 consumers: Dock, NewUserSetup, WidgetLibrary, SidebarWidgets).
- **Widget/canvas mutation** → recreates only the dashboard value; the dock no longer re-renders.

Lightweight two-context split — no `useSyncExternalStore`. That machinery only earns its keep with many divergent per-instance subscribers (already covered by the canvas store); tool visibility has ~4 consumers, so a second plain context is the right-sized tool.

## Measured result

Built on the Phase 0 perf instrument (a 5-probe `useDashboard()` bystander + a `toggleToolVisibility` scenario in `dashboardPerf.test.tsx`):

| scenario | before | after |
|---|---|---|
| `toggleToolVisibility` — bystander re-renders | **5** | **0** |
| `addWidget` — bystander re-renders (sanity, must stay live) | 5 | 5 |

- `addWidget` staying at 5 proves the instrument isn't a dead probe.
- **Falsifiability:** temporarily re-adding `visibleTools` to the dep array fails *both* the contract test and the perf assertion; restoring makes them pass.
- **Production fidelity:** every remaining `contextValue` dep sourced from a hook (`collectionsApi`, `driveService`, `rosters`, `sharedCollection` callbacks) is referentially stable across renders (memoized / `useCallback`, token- or userId-keyed), so the split is effective in production — not just under the stabilized test mocks.

## Invariants preserved

- `reorderLibrary`'s dual-write onto `activeDashboard.libraryOrder` is intact (pinned by a contract test).
- No state or persistence/hydration effect moved — the diff is the import, the memo split, the provider nesting, and the consumer migrations.
- Host-safety: the two bare-`DashboardContext.Provider` hosts (Subs, Student) never render a tool-visibility consumer, so `useToolVisibility()`'s throw is unreachable there.

## Tests

New `context/toolVisibility.test.tsx`: isolation in both directions, persistence of all three localStorage keys, the `reorderLibrary` dual-write, and the provider guard. `type-check:all`, `eslint --max-warnings 0`, and the perf/contract/canvas-store suites all pass.

## How it was built

Implemented + reviewed by a multi-agent workflow — three adversarial review lenses (correctness/host-safety, perf-contract/measurement-validity, type/test-quality), all **ship** with zero blocking findings — plus a follow-up production-fidelity verification of the hook memoization the measurement depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)