### PR TITLE
fix(ClockWidget): replace cqh/cqw font-size with cqmin for consistent scaling

### DIFF
--- a/components/widgets/ClockWidget/Widget.test.tsx
+++ b/components/widgets/ClockWidget/Widget.test.tsx
@@ -179,4 +179,28 @@ describe('ClockWidget', () => {
     expect(ampm.className).toContain('opacity-70');
     expect(ampm.className).not.toContain('opacity-40');
   });
+
+  // Regression: font-size formulas must use cqmin (not cqh or cqw separately).
+  // cqh/cqw formulas like `min(82cqh, 20cqw)` break at non-default aspect ratios:
+  // a very tall narrow clock (200×400) gives `min(328px, 40px) = 40px` (10% of
+  // height — near-invisible); a very wide clock (800×100) gives `min(82px, 160px)
+  // = 82px` (82% of height — overflows into the date row). cqmin scales both axes
+  // symmetrically: `40cqmin` = 40% of the smaller dimension in all orientations.
+  it('time display uses cqmin units for font scaling (not cqh/cqw)', () => {
+    renderWidget(createWidget({ showSeconds: true }));
+
+    const fontSize = screen.getByTestId('clock-time-container').style.fontSize;
+    expect(fontSize).not.toMatch(/cqh/);
+    expect(fontSize).not.toMatch(/cqw/);
+    expect(fontSize).toMatch(/cqmin/);
+  });
+
+  it('date label uses cqmin units for font scaling (not cqh/cqw)', () => {
+    renderWidget(createWidget());
+
+    const fontSize = screen.getByTestId('clock-date').style.fontSize;
+    expect(fontSize).not.toMatch(/cqh/);
+    expect(fontSize).not.toMatch(/cqw/);
+    expect(fontSize).toMatch(/cqmin/);
+  });
 });

--- a/components/widgets/ClockWidget/Widget.test.tsx
+++ b/components/widgets/ClockWidget/Widget.test.tsx
@@ -195,6 +195,15 @@ describe('ClockWidget', () => {
     expect(fontSize).toMatch(/cqmin/);
   });
 
+  it('time display uses cqmin units in no-seconds path', () => {
+    renderWidget(createWidget({ showSeconds: false }));
+
+    const fontSize = screen.getByTestId('clock-time-container').style.fontSize;
+    expect(fontSize).not.toMatch(/cqh/);
+    expect(fontSize).not.toMatch(/cqw/);
+    expect(fontSize).toMatch(/cqmin/);
+  });
+
   it('date label uses cqmin units for font scaling (not cqh/cqw)', () => {
     renderWidget(createWidget());
 

--- a/components/widgets/ClockWidget/Widget.tsx
+++ b/components/widgets/ClockWidget/Widget.tsx
@@ -59,9 +59,10 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       padding="p-0"
       content={
         <div
-          className={`flex flex-col items-center justify-center h-full w-full gap-[1cqmin] transition-all duration-500 ${
+          className={`flex flex-col items-center justify-center h-full w-full transition-all duration-500 ${
             clockStyle === 'lcd' ? 'bg-black/5' : ''
           }`}
+          style={{ gap: '1cqmin' }}
         >
           <div
             data-testid="clock-time-container"

--- a/components/widgets/ClockWidget/Widget.tsx
+++ b/components/widgets/ClockWidget/Widget.tsx
@@ -59,7 +59,7 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       padding="p-0"
       content={
         <div
-          className={`flex flex-col items-center justify-center h-full w-full gap-[0.5cqh] transition-all duration-500 ${
+          className={`flex flex-col items-center justify-center h-full w-full gap-[1cqmin] transition-all duration-500 ${
             clockStyle === 'lcd' ? 'bg-black/5' : ''
           }`}
         >
@@ -67,7 +67,7 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
             data-testid="clock-time-container"
             className={`flex items-baseline leading-none transition-all ${getFontClass()} ${getStyleClasses()}`}
             style={{
-              fontSize: showSeconds ? 'min(82cqh, 20cqw)' : 'min(82cqh, 25cqw)',
+              fontSize: showSeconds ? '40cqmin' : '50cqmin',
               color: themeColor,
               textShadow: glow
                 ? `0 0 0.1em ${themeColor}, 0 0 0.25em ${themeColor}66`
@@ -121,8 +121,9 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           </div>
 
           <div
+            data-testid="clock-date"
             className={`opacity-80 uppercase tracking-[0.2em] text-slate-900 ${getFontClass()}`}
-            style={{ fontSize: 'min(12cqh, 80cqw)', fontWeight: 900 }}
+            style={{ fontSize: '12cqmin', fontWeight: 900 }}
           >
             {time.toLocaleDateString(i18n.language, {
               weekday: 'long',


### PR DESCRIPTION
## Root cause

`ClockWidget` computed font sizes using `min(82cqh, 20cqw)` — two independent container-query axes. At non-default aspect ratios this breaks badly:

- **Very tall narrow clock (200×400):** `min(328px, 40px) = 40px` — 10% of height, near-invisible
- **Very wide clock (800×100):** `min(82px, 160px) = 82px` — 82% of height, overflows into date row

`cqmin` is `min(cqw, cqh)` computed by the browser and scales both axes symmetrically at any shape.

## Fix summary

Three changes in `components/widgets/ClockWidget/Widget.tsx`:

| Before | After |
|--------|-------|
| `gap-[0.5cqh]` | `gap-[1cqmin]` |
| `fontSize: showSeconds ? 'min(82cqh, 20cqw)' : 'min(82cqh, 25cqw)'` | `fontSize: showSeconds ? '40cqmin' : '50cqmin'` |
| `fontSize: 'min(12cqh, 80cqw)'` (date) | `fontSize: '12cqmin'` |

Values calibrated to match the default 280×140 widget exactly (cqmin = 1.4 px → 56/70/16.8 px), while fixing the aspect-ratio regression.

`data-testid="clock-date"` also added to the date div to make it testable.

## Rejected band-aid

`min(Xpx, Ycqmin)` was considered for the date label (px cap) but rejected because jsdom's CSS parser returns empty string for `min()` with container query units, which would break the regression test's `toMatch(/cqmin/)` assertion.

## Regression tests

Two new tests in `components/widgets/ClockWidget/Widget.test.tsx`:

```
'time display uses cqmin units for font scaling (not cqh/cqw)'
'date label uses cqmin units for font scaling (not cqh/cqw)'
```

Both fail on the original code (wrong units / missing testid) and pass after the fix.

## Before / after evidence

At default 280×140: pixel sizes unchanged (56 / 70 / 16.8 px).
At 200×400 (portrait): cqmin = 2 px → 80 / 100 / 24 px (was: 328/40 px — broken).
At 800×100 (landscape): cqmin = 1 px → 40 / 50 / 12 px (was: 82/160 px — overflow).

## Risk

**Contained.** Single widget, CSS-only, no state or API changes. All 13 ClockWidget tests pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_015gQT5dXu8DsCVoNhFDGFJ1)_