### PR TITLE
fix(videoActivityGrading): deduplicate question IDs in videoActivityMaxPoints + migration coverage

### DIFF
--- a/tests/utils/migrateProportionalLayout.test.ts
+++ b/tests/utils/migrateProportionalLayout.test.ts
@@ -298,6 +298,82 @@ describe('migrateWidgetToProportional', () => {
     expect(hydrated.h).toBe(pixelH);
   });
 
+  // Backlog-requested arithmetic test: the specific coordinate set cited in
+  // the PR #1976 backlog note. These exercise the division formula with a
+  // different aspect ratio (2:1) and non-trivial pixel coordinates so that
+  // a swap of safeW/safeH, or using raw vpW/vpH in place of the safe
+  // dimensions, would produce a wrong — and therefore failing — assertion.
+  it('converts (x=300, y=150, w=280, h=140) on 1920×1080 to exact proportional values', () => {
+    const vpW = 1920;
+    const vpH = 1080;
+    // safeW = vpW - PADDING*2, safeH = vpH - PADDING*2
+    const { safeW, safeH } = getSafeViewport(vpW, vpH);
+    const w = baseWidget({ x: 300, y: 150, w: 280, h: 140 });
+    const out = migrateWidgetToProportional(w, vpW, vpH);
+
+    // Position: pixel origin is offset by PADDING from the safe-board origin.
+    const expectedXProp = (300 - PADDING) / safeW;
+    const expectedYProp = (150 - PADDING) / safeH;
+    // Size: proportioned against the full safe dimension (no padding offset).
+    const expectedWProp = 280 / safeW;
+    const expectedHProp = 140 / safeH;
+    const expectedAspect = 280 / 140; // 2.0
+
+    expect(out.xProp).toBeCloseTo(expectedXProp, 6);
+    expect(out.yProp).toBeCloseTo(expectedYProp, 6);
+    expect(out.wProp).toBeCloseTo(expectedWProp, 6);
+    expect(out.hProp).toBeCloseTo(expectedHProp, 6);
+    expect(out.aspectRatio).toBeCloseTo(expectedAspect, 6);
+
+    // Sanity-check the derived numeric values to nail the arithmetic to
+    // the specific numbers the backlog item describes. With PADDING=16:
+    //   safeW = 1920 - 32 = 1888, safeH = 1080 - 32 = 1048
+    //   xProp = (300 - 16) / 1888 = 284 / 1888
+    //   yProp = (150 - 16) / 1048 = 134 / 1048
+    //   wProp = 280 / 1888
+    //   hProp = 140 / 1048
+    expect(out.xProp).toBeCloseTo(284 / 1888, 6);
+    expect(out.yProp).toBeCloseTo(134 / 1048, 6);
+    expect(out.wProp).toBeCloseTo(280 / 1888, 6);
+    expect(out.hProp).toBeCloseTo(140 / 1048, 6);
+  });
+
+  it('converts (x=300, y=150, w=280, h=140) on 1366×768 to exact proportional values', () => {
+    // Second viewport to ensure the formula is not accidentally hardcoded
+    // for 1920×1080. Any implementation that uses vpW/vpH literally instead
+    // of the safe dimensions, or swaps W and H, will fail here too.
+    const vpW = 1366;
+    const vpH = 768;
+    const { safeW, safeH } = getSafeViewport(vpW, vpH);
+    const w = baseWidget({ x: 300, y: 150, w: 280, h: 140 });
+    const out = migrateWidgetToProportional(w, vpW, vpH);
+
+    expect(out.xProp).toBeCloseTo((300 - PADDING) / safeW, 6);
+    expect(out.yProp).toBeCloseTo((150 - PADDING) / safeH, 6);
+    expect(out.wProp).toBeCloseTo(280 / safeW, 6);
+    expect(out.hProp).toBeCloseTo(140 / safeH, 6);
+    expect(out.aspectRatio).toBeCloseTo(2, 6);
+    // Proportions on a smaller viewport are larger than on 1920×1080,
+    // so wProp here must be strictly greater than wProp on 1920×1080.
+    const { safeW: refSafeW } = getSafeViewport(1920, 1080);
+    expect(280 / safeW).toBeGreaterThan(280 / refSafeW);
+  });
+
+  it('round-trips (x=300, y=150, w=280, h=140) on 1920×1080 through hydration', () => {
+    // End-to-end: migrate pixel→proportional then hydrate proportional→pixel.
+    // The recovered coordinates must equal the originals (within ±1px from
+    // Math.round).
+    const vpW = 1920;
+    const vpH = 1080;
+    const w = baseWidget({ x: 300, y: 150, w: 280, h: 140 });
+    const migrated = migrateWidgetToProportional(w, vpW, vpH);
+    const hydrated = hydrateWidgetPixels(migrated, vpW, vpH, 'fill');
+    expect(hydrated.x).toBe(300);
+    expect(hydrated.y).toBe(150);
+    expect(hydrated.w).toBe(280);
+    expect(hydrated.h).toBe(140);
+  });
+
   // Regression test for the proportionsValid early-return bug:
   // When xProp/yProp contain pixel values (e.g. from a partial migration)
   // and wProp/hProp are valid proportions, widgetNeedsProportionalMigration

--- a/tests/utils/videoActivityMaxPoints.test.ts
+++ b/tests/utils/videoActivityMaxPoints.test.ts
@@ -7,16 +7,18 @@ import type { VideoActivityQuestion } from '@/types';
  * deep-link line-item denominator and the VA Results push denominator (both call
  * this), so a Schoology grade can't post against the wrong scale.
  */
-const q = (points?: number): VideoActivityQuestion =>
-  ({ id: 'x', type: 'MC', points }) as unknown as VideoActivityQuestion;
+const q = (points?: number, id = 'x'): VideoActivityQuestion =>
+  ({ id, type: 'MC', points }) as unknown as VideoActivityQuestion;
 
 describe('videoActivityMaxPoints', () => {
   it('sums per-question points', () => {
-    expect(videoActivityMaxPoints([q(2), q(3), q(5)])).toBe(10);
+    expect(videoActivityMaxPoints([q(2, 'a'), q(3, 'b'), q(5, 'c')])).toBe(10);
   });
 
   it('defaults a missing/undefined points to 1', () => {
-    expect(videoActivityMaxPoints([q(), q(), q(4)])).toBe(6);
+    expect(
+      videoActivityMaxPoints([q(undefined, 'a'), q(undefined, 'b'), q(4, 'c')])
+    ).toBe(6);
   });
 
   it('falls back to 100 when there are no questions', () => {
@@ -25,5 +27,16 @@ describe('videoActivityMaxPoints', () => {
 
   it('falls back to 100 when the summed points are 0', () => {
     expect(videoActivityMaxPoints([q(0)])).toBe(100);
+  });
+
+  it('deduplicates questions with the same id (Drive-sync duplicate guard)', () => {
+    // Drive-sync or arrayUnion races can write the same question ID twice.
+    // videoActivityMaxPoints is frozen into the Schoology scoreMaximum at
+    // attach time and reused at push time; if duplicates inflate it, the
+    // pushed fraction is wrong (e.g. 2/4 instead of the correct 2/2).
+    // computeVideoActivityScorePct already deduplicates via a Set<string>;
+    // this function must do the same so the denominator stays consistent.
+    const dup = q(2); // id === 'x' on both entries
+    expect(videoActivityMaxPoints([dup, dup])).toBe(2);
   });
 });

--- a/utils/videoActivityGrading.ts
+++ b/utils/videoActivityGrading.ts
@@ -167,11 +167,26 @@ export function computeVideoActivityScorePct(
  * different denominator and post the wrong fraction. Sharing one helper makes
  * that drift impossible (it previously lived as an inline `reduce(...) || 100`
  * copied across the picker and the Results view).
+ *
+ * Deduplicates by question id — Drive-sync or arrayUnion races can write the
+ * same question id twice. Without the guard the denominator is inflated
+ * (e.g. 4 instead of 2) while `computeVideoActivityScorePct` (which already
+ * deduplicates via a Set<string>) stays correct, producing a fraction > 1 that
+ * rounds to a wrong LMS grade. Mirrors the dedup fence in
+ * `computeVideoActivityScorePct` so the numerator and denominator stay on the
+ * same counting basis.
  */
 export function videoActivityMaxPoints(
   questions: VideoActivityQuestion[]
 ): number {
-  return questions.reduce((sum, q) => sum + (q.points ?? 1), 0) || 100;
+  const seen = new Set<string>();
+  let total = 0;
+  for (const q of questions) {
+    if (seen.has(q.id)) continue;
+    seen.add(q.id);
+    total += q.points ?? 1;
+  }
+  return total || 100;
 }
 
 /**


### PR DESCRIPTION
## Root cause

`videoActivityMaxPoints()` used a plain `reduce()` without deduplicating by question ID. `computeVideoActivityScorePct()` (numerator) was already deduplicating via a `Set<string>` to handle Drive-sync / `arrayUnion` races that can write the same question ID twice. The denominator had no such guard — so:

- numerator: counts each unique ID once ✓
- denominator: counts every occurrence → **inflated** (e.g. 4 instead of 2)
- LMS grade posted: `score / inflated_max` → fraction > 1 → rounds to wrong grade

## Fix summary

`utils/videoActivityGrading.ts` — mirror the dedup fence from `computeVideoActivityScorePct` into `videoActivityMaxPoints`:

```diff
-  return questions.reduce((sum, q) => sum + (q.points ?? 1), 0) || 100;
+  const seen = new Set<string>();
+  let total = 0;
+  for (const q of questions) {
+    if (seen.has(q.id)) continue;
+    seen.add(q.id);
+    total += q.points ?? 1;
+  }
+  return total || 100;
```

## Rejected band-aid

Deduplicating at call sites — this would have to be repeated across the grade picker and Results view; the helper exists precisely to avoid this drift.

## Regression test

New test in `tests/utils/videoActivityMaxPoints.test.ts`:

```
'deduplicates questions with the same id (Drive-sync duplicate guard)'
videoActivityMaxPoints([dup, dup])  // dup.id='x', dup.points=2
→ expected 2, old code returned 4 (FAIL before, PASS after)
```

Full suite: 5 tests pass (was 4).

## Bonus: migrateProportionalLayout coverage (commit 1)

The arithmetic in `migrateProportionalLayout.ts` is correct — no bug. However the backlog noted a coverage gap: no test for the specific case `(x=300, y=150, w=280, h=140)` on a real viewport. Three new tests added to pin the formula against concrete constants, covering 1920×1080, 1366×768, and a round-trip hydration check.

## Risk

**Contained.** Single utility function + tests. The fix only fires when duplicate question IDs are present (Drive-sync race condition). No API or schema changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_015gQT5dXu8DsCVoNhFDGFJ1)_