### PR TITLE
fix(ci): run functions tests in both deploy workflows

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run unit tests
-        run: pnpm test
+        run: pnpm run test:all
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY || 'test-key' }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN || 'test.firebaseapp.com' }}

--- a/.github/workflows/firebase-dev-deploy.yml
+++ b/.github/workflows/firebase-dev-deploy.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
-      - run: pnpm run test
+      - run: pnpm run test:all
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}

--- a/tests/ci.functionsTestCoverage.test.ts
+++ b/tests/ci.functionsTestCoverage.test.ts
@@ -32,18 +32,25 @@ function readWorkflow(name: string): string {
 }
 
 /**
- * Returns true when the YAML content includes a step that runs the functions
- * test suite.  Accepts either:
+ * Returns true when the YAML content includes an uncommented step that runs
+ * the functions test suite.  Accepts either:
  *   - `pnpm run test:all`   (the canonical combined runner)
  *   - `pnpm test:all`       (shorthand)
  *   - `pnpm -C functions`   (direct functions invocation)
+ *
+ * Lines starting with '#' are skipped to avoid false positives from
+ * commented-out commands or descriptive prose.
  */
 function includesFunctionsTests(yaml: string): boolean {
-  return (
-    yaml.includes('pnpm run test:all') ||
-    yaml.includes('pnpm test:all') ||
-    yaml.includes('pnpm -C functions')
-  );
+  return yaml.split('\n').some((line) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('#')) return false;
+    return (
+      trimmed.includes('pnpm run test:all') ||
+      trimmed.includes('pnpm test:all') ||
+      trimmed.includes('pnpm -C functions')
+    );
+  });
 }
 
 describe('CI workflow: functions tests must run in deploy pipelines', () => {

--- a/tests/ci.functionsTestCoverage.test.ts
+++ b/tests/ci.functionsTestCoverage.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test: deploy workflows must run the functions test suite.
+ *
+ * Bug: `firebase-deploy.yml` (production) and `firebase-dev-deploy.yml` (dev
+ * preview) ran only `pnpm test` (root tests) in their test steps, skipping
+ * `pnpm -C functions test` entirely. Because the PR-validation workflow uses
+ * `pnpm run test:all` (which covers both root AND functions), broken functions
+ * tests could pass PR validation and still be deployed — they just happened
+ * not to break on any recently-merged PR. A direct push to `main` or a
+ * `workflow_dispatch` (which bypasses the PR flow completely) would deploy
+ * functions with broken tests immediately.
+ *
+ * Fix: each deploy workflow's test step must invoke `pnpm run test:all` (or
+ * otherwise ensure `pnpm -C functions run test` is executed) so functions
+ * regressions block deployment the same way they block PR merges.
+ *
+ * This test reads the YAML files as plain text and asserts the presence of the
+ * functions test invocation, providing a fast, hermetic CI-config guard that
+ * doesn't require running the workflows themselves.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workflowsDir = resolve(__dirname, '../.github/workflows');
+
+function readWorkflow(name: string): string {
+  return readFileSync(resolve(workflowsDir, name), 'utf-8');
+}
+
+/**
+ * Returns true when the YAML content includes a step that runs the functions
+ * test suite.  Accepts either:
+ *   - `pnpm run test:all`   (the canonical combined runner)
+ *   - `pnpm test:all`       (shorthand)
+ *   - `pnpm -C functions`   (direct functions invocation)
+ */
+function includesFunctionsTests(yaml: string): boolean {
+  return (
+    yaml.includes('pnpm run test:all') ||
+    yaml.includes('pnpm test:all') ||
+    yaml.includes('pnpm -C functions')
+  );
+}
+
+describe('CI workflow: functions tests must run in deploy pipelines', () => {
+  it('firebase-deploy.yml (production) runs the functions test suite', () => {
+    const yaml = readWorkflow('firebase-deploy.yml');
+    expect(includesFunctionsTests(yaml)).toBe(true);
+  });
+
+  it('firebase-dev-deploy.yml (dev preview) runs the functions test suite', () => {
+    const yaml = readWorkflow('firebase-dev-deploy.yml');
+    expect(includesFunctionsTests(yaml)).toBe(true);
+  });
+
+  it('pr-validation.yml already runs the functions test suite (baseline)', () => {
+    // This is the reference that was already correct — pin it so a future
+    // "simplification" of pr-validation.yml can't silently regress it.
+    const yaml = readWorkflow('pr-validation.yml');
+    expect(includesFunctionsTests(yaml)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Both `firebase-deploy.yml` (production) and `firebase-dev-deploy.yml` (dev preview) ran only `pnpm test` (root tests), silently skipping the Cloud Functions suite.

The `pr-validation.yml` already used `pnpm run test:all` correctly — creating a gap: a direct push to `main` or a `workflow_dispatch` (both of which bypass the PR flow) could deploy broken Cloud Functions code without any test gate.

- `firebase-deploy.yml` line 22: `pnpm test` → `pnpm run test:all`
- `firebase-dev-deploy.yml` line 43: `pnpm run test` → `pnpm run test:all`

## Regression test

`tests/ci.functionsTestCoverage.test.ts` reads each deploy workflow YAML as plain text and asserts the functions suite is invoked. Fails 2/3 before fix, passes 3/3 after.

## Test plan

- [ ] `pnpm run test:all` passes locally (475 root + 532 functions = 1007 tests green)
- [ ] CI Code Quality Checks pass
- [ ] CI Unit Tests pass (includes new `ci.functionsTestCoverage.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gQT5dXu8DsCVoNhFDGFJ1

---
_Generated by [Claude Code](https://claude.ai/code/session_015gQT5dXu8DsCVoNhFDGFJ1)_