### PR TITLE
perf(widgets): migrate 9 content widgets to stable useDashboardActions()

### DIFF
--- a/components/widgets/CustomWidget/Widget.tsx
+++ b/components/widgets/CustomWidget/Widget.tsx
@@ -14,7 +14,7 @@ import {
   CustomGridDefinition,
   CustomWidgetDoc,
 } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { WidgetBlockState, WidgetAction } from './types';
 import {
   blockReducer,
@@ -68,7 +68,7 @@ export const CustomWidgetWidget: React.FC<{ widget: WidgetData }> = ({
 }) => {
   const config = widget.config as CustomWidgetConfig;
   const { customWidgetId } = config;
-  const { addToast } = useDashboard();
+  const { addToast } = useDashboardActions();
 
   // Live Firestore doc for the custom widget definition
   const [widgetDoc, setWidgetDoc] = React.useState<CustomWidgetDoc | null>(

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -125,6 +125,13 @@ const mockDashboardContext = {
   addToast: mockAddToast,
 };
 
+vi.mock('@/context/dashboardCanvasStore', () => ({
+  useDashboardActions: () => mockDashboardContext,
+}));
+
+// EmbedSettings (rendered in the EmbedSettings describe block) still reads the
+// full legacy context; keep it stubbed so those cases don't hit the real
+// provider.
 vi.mock('@/context/useDashboard', () => ({
   useDashboard: () => mockDashboardContext,
 }));

--- a/components/widgets/Embed/Widget.tsx
+++ b/components/widgets/Embed/Widget.tsx
@@ -19,7 +19,7 @@ import {
   extractGoogleFileId,
 } from '@/utils/urlHelpers';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { generateMiniAppCode } from '@/utils/ai';
 import { useEmbedConfig } from './hooks/useEmbedConfig';
 import { TRUSTED_EMBED_HOSTNAMES } from './trustedHostnames';
@@ -36,7 +36,7 @@ const TOOLBAR_GAP = 6;
 const ESTIMATED_TOOLBAR_HEIGHT = 44;
 
 export const EmbedWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { addWidget, addToast, updateWidget } = useDashboard();
+  const { addWidget, addToast, updateWidget } = useDashboardActions();
   const { canAccessFeature } = useAuth();
   const buildingId = useWidgetBuildingId(widget);
   const { config: globalConfig } = useEmbedConfig(buildingId);

--- a/components/widgets/HotspotImage/Widget.tsx
+++ b/components/widgets/HotspotImage/Widget.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { WidgetData, HotspotImageConfig } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -15,7 +15,7 @@ const ICON_MAP = {
 export const HotspotImageWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as HotspotImageConfig;
   const [activePinId, setActivePinId] = React.useState<string | null>(null);
 

--- a/components/widgets/MathToolInstance/Widget.tsx
+++ b/components/widgets/MathToolInstance/Widget.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, lazy, useRef } from 'react';
 import { WidgetData, MathToolConfig } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { CSS_PPI } from '../math-tools/mathToolUtils';
 import { StickerPieceSVG } from '../math-tools/StickerPieces';
 import { WidgetLayout } from '../WidgetLayout';
@@ -133,7 +133,7 @@ function ToolContent({
 export const MathToolInstanceWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as MathToolConfig;
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/components/widgets/MathTools/Widget.tsx
+++ b/components/widgets/MathTools/Widget.tsx
@@ -6,7 +6,7 @@ import {
   GradeLevel,
   MathToolsGlobalConfig,
 } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
 import {
   MATH_TOOL_META,
@@ -21,7 +21,7 @@ import { GRADE_LABELS, PALETTE_SECTIONS } from './constants';
 export const MathToolsWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { addWidget } = useDashboard();
+  const { addWidget } = useDashboardActions();
   const { featurePermissions } = useAuth();
   const config = widget.config as MathToolsConfig;
   const ppi = config.dpiCalibration ?? CSS_PPI;

--- a/components/widgets/NumberLine/Widget.test.tsx
+++ b/components/widgets/NumberLine/Widget.test.tsx
@@ -32,20 +32,10 @@ const baseWidget: WidgetData = {
   },
 };
 
+// NumberLineWidget only consumes updateWidget from useDashboardActions(); the
+// mock mirrors exactly that to make the dependency explicit.
 const defaultDashboardMock = {
-  activeDashboard: { id: 'dash-1', widgets: [] },
-  dashboards: [],
   updateWidget: vi.fn(),
-  addWidget: vi.fn(),
-  removeWidget: vi.fn(),
-  setDashboards: vi.fn(),
-  setActiveDashboardId: vi.fn(),
-  updateDashboardSettings: vi.fn(),
-  hasWriteAccess: true,
-  syncStatus: 'synced' as const,
-  duplicateDashboard: vi.fn(),
-  globalPermissions: [],
-  lastLocalUpdateRef: { current: 0 },
 } as unknown as ReturnType<typeof DashboardCanvasStore.useDashboardActions>;
 
 describe('NumberLineWidget', () => {

--- a/components/widgets/NumberLine/Widget.test.tsx
+++ b/components/widgets/NumberLine/Widget.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { NumberLineWidget } from './Widget';
 import { WidgetData } from '@/types';
-import * as DashboardContext from '@/context/useDashboard';
+import * as DashboardCanvasStore from '@/context/dashboardCanvasStore';
 
 // Mock ResizeObserver
 class ResizeObserverMock {
@@ -46,11 +46,11 @@ const defaultDashboardMock = {
   duplicateDashboard: vi.fn(),
   globalPermissions: [],
   lastLocalUpdateRef: { current: 0 },
-} as unknown as ReturnType<typeof DashboardContext.useDashboard>;
+} as unknown as ReturnType<typeof DashboardCanvasStore.useDashboardActions>;
 
 describe('NumberLineWidget', () => {
   it('renders correctly without crashing', () => {
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
     render(<NumberLineWidget widget={baseWidget} />);
@@ -60,7 +60,7 @@ describe('NumberLineWidget', () => {
   });
 
   it('renders endpoints correctly even if step does not perfectly align', () => {
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
 
@@ -87,7 +87,7 @@ describe('NumberLineWidget', () => {
   });
 
   it('formats fractions correctly including negative numbers', () => {
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
 
@@ -125,7 +125,7 @@ describe('NumberLineWidget', () => {
     // strict equality — the affected ticks fall back to decimal labels ("0.3", "0.6",
     // "0.7") instead of fractional ones ("3/10", "6/10", "7/10"). The fix must use
     // an epsilon check so every tenth is consistently formatted as a fraction.
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
 
@@ -164,7 +164,7 @@ describe('NumberLineWidget', () => {
     // val.toString() label path renders the raw FP artifact for the
     // 'integers' display mode — the same bug that was already fixed for
     // 'fractions' mode. This test confirms the fix covers all display modes.
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
 
@@ -198,7 +198,7 @@ describe('NumberLineWidget', () => {
   });
 
   it('caps number of ticks if range is too large compared to step', () => {
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue(
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue(
       defaultDashboardMock
     );
 
@@ -235,7 +235,7 @@ describe('NumberLineWidget', () => {
     //   parseFloat(val.toFixed(10))
     // This is separate from the tick-label fix (which already uses toFixed(4) for display).
     const updateWidgetMock = vi.fn();
-    vi.spyOn(DashboardContext, 'useDashboard').mockReturnValue({
+    vi.spyOn(DashboardCanvasStore, 'useDashboardActions').mockReturnValue({
       ...defaultDashboardMock,
       updateWidget: updateWidgetMock,
     });

--- a/components/widgets/NumberLine/Widget.tsx
+++ b/components/widgets/NumberLine/Widget.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useMemo, useEffect } from 'react';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { WidgetData, NumberLineConfig, NumberLineMarker } from '@/types';
 import { WidgetLayout } from '../WidgetLayout';
 import { WIDGET_PALETTE } from '@/config/colors';
@@ -44,7 +44,7 @@ function fractionLabel(num: number, denom: number): string {
 export const NumberLineWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as NumberLineConfig;
   const containerRef = useRef<HTMLDivElement>(null);
   const [svgWidth, setSvgWidth] = useState(700);

--- a/components/widgets/StarterPack/Widget.tsx
+++ b/components/widgets/StarterPack/Widget.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useAuth } from '@/context/useAuth';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { useStarterPacks } from '@/hooks/useStarterPacks';
 import { WidgetComponentProps, StarterPack } from '@/types';
 import * as LucideIcons from 'lucide-react';
@@ -10,7 +10,7 @@ import { playCleanUp, getAudioCtx } from './audioUtils';
 
 export const StarterPackWidget = ({ isStudentView }: WidgetComponentProps) => {
   const { user } = useAuth();
-  const { addWidget, deleteAllWidgets } = useDashboard();
+  const { addWidget, deleteAllWidgets } = useDashboardActions();
   const { publicPacks, userPacks, loading, executePack } = useStarterPacks(
     user?.uid
   );

--- a/components/widgets/SyntaxFramer/Widget.tsx
+++ b/components/widgets/SyntaxFramer/Widget.tsx
@@ -17,7 +17,7 @@ import {
   sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { beginWidgetDrag, endWidgetDrag } from '@/utils/widgetDragFlag';
 import { Z_INDEX } from '@/config/zIndex';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
@@ -144,7 +144,7 @@ export const SyntaxFramerWidget: React.FC<WidgetComponentProps> = ({
   widget,
 }) => {
   const config = widget.config as SyntaxFramerConfig;
-  const { updateWidget } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const { tokens = [], mode = 'text', alignment = 'center' } = config;
 
   const sensors = useSensors(

--- a/components/widgets/TrafficLightWidget/Widget.test.tsx
+++ b/components/widgets/TrafficLightWidget/Widget.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { WidgetData, TrafficConfig } from '@/types';
 import { TrafficLightWidget } from './Widget';
 
-vi.mock('@/context/useDashboard');
+vi.mock('@/context/dashboardCanvasStore');
 
 const mockUpdateWidget = vi.fn();
 
-const mockDashboardContext = {
+const mockDashboardActions = {
   updateWidget: mockUpdateWidget,
 };
 
@@ -20,9 +20,9 @@ const renderWidget = (widget: WidgetData) => {
 describe('TrafficLightWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
-      mockDashboardContext
-    );
+    (
+      useDashboardActions as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue(mockDashboardActions);
   });
 
   const createWidget = (active?: string): WidgetData => ({

--- a/components/widgets/TrafficLightWidget/Widget.test.tsx
+++ b/components/widgets/TrafficLightWidget/Widget.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { useDashboardActions } from '@/context/dashboardCanvasStore';
+import {
+  useDashboardActions,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { WidgetData, TrafficConfig } from '@/types';
 import { TrafficLightWidget } from './Widget';
@@ -20,9 +23,9 @@ const renderWidget = (widget: WidgetData) => {
 describe('TrafficLightWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (
-      useDashboardActions as unknown as ReturnType<typeof vi.fn>
-    ).mockReturnValue(mockDashboardActions);
+    vi.mocked(useDashboardActions).mockReturnValue(
+      mockDashboardActions as unknown as DashboardActions
+    );
   });
 
   const createWidget = (active?: string): WidgetData => ({

--- a/components/widgets/TrafficLightWidget/Widget.tsx
+++ b/components/widgets/TrafficLightWidget/Widget.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { WidgetData, TrafficConfig } from '@/types';
 
 import { WidgetLayout } from '../WidgetLayout';
@@ -7,7 +7,7 @@ import { WidgetLayout } from '../WidgetLayout';
 export const TrafficLightWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as TrafficConfig;
 
   const current = config.active ?? 'none';

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -5391,6 +5391,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // dispatches to the freshest closure — no stale-closure hazard even for
   // actions whose useCallback deps churn.
   const liveActions: DashboardActions = {
+    addWidget,
     updateWidget,
     updateWidgets,
     removeWidget,
@@ -5412,6 +5413,8 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
   // Empty deps is the point: identity fixed for the provider's lifetime.
   const stableActions = useMemo<DashboardActions>(
     () => ({
+      addWidget: (type, overrides) =>
+        liveActionsRef.current.addWidget(type, overrides),
       updateWidget: (id, updates, opts) =>
         liveActionsRef.current.updateWidget(id, updates, opts),
       updateWidgets: (updates) => liveActionsRef.current.updateWidgets(updates),

--- a/context/dashboardCanvasStore.ts
+++ b/context/dashboardCanvasStore.ts
@@ -130,6 +130,7 @@ export function createDashboardCanvasStore(
  */
 export type DashboardActions = Pick<
   DashboardContextValue,
+  | 'addWidget'
   | 'updateWidget'
   | 'updateWidgets'
   | 'removeWidget'

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -73,6 +73,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { DashboardProvider } from '@/context/DashboardContext';
 import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { useToolVisibility } from '@/context/useToolVisibility';
 import { BoardCanvas } from '@/components/layout/BoardCanvas';
 import type {
@@ -91,6 +92,8 @@ const {
   countShellRender,
   bystanderRenderCounts,
   countBystanderRender,
+  actionsProbeRenderCounts,
+  countActionsProbeRender,
 } = vi.hoisted(() => {
   // Render-invocation counts of the DraggableWindow shell, keyed by widget
   // id. Widgets added mid-test get random UUIDs, so those are normalized to
@@ -105,6 +108,15 @@ const {
   // re-render on a tool toggle — a separate counter is required to prove the
   // context fan-out.
   const bystanderCounts = new Map<string, number>();
+  // Render-invocation counts of the ActionsProbe consumers, keyed by probe id
+  // ('actions-1'..'actions-5'). These probes stand in for a MIGRATED content
+  // component: they call `useDashboardActions()` (the mount-stable actions
+  // surface) instead of the legacy whole-value `useDashboard()`. Because the
+  // actions object identity is fixed for the provider's lifetime, a discrete
+  // widget op (bringToFront / drag-release) does NOT re-render them — that
+  // 0-delta, contrasted against the legacy bystander's >0 delta on the same
+  // scenarios, is the proof the migration eliminates the fan-out.
+  const actionsProbeCounts = new Map<string, number>();
   return {
     shellRenderCounts: counts,
     countShellRender: (widgetId: string) => {
@@ -114,6 +126,13 @@ const {
     bystanderRenderCounts: bystanderCounts,
     countBystanderRender: (probeId: string) => {
       bystanderCounts.set(probeId, (bystanderCounts.get(probeId) ?? 0) + 1);
+    },
+    actionsProbeRenderCounts: actionsProbeCounts,
+    countActionsProbeRender: (probeId: string) => {
+      actionsProbeCounts.set(
+        probeId,
+        (actionsProbeCounts.get(probeId) ?? 0) + 1
+      );
     },
     // 15 widgets across 8 distinct types — all on the standard (non-position-
     // aware) drag path, which is what every widget except the 3 catalyst types
@@ -408,6 +427,14 @@ interface ScenarioMetric {
   // visibility moves into its own context.
   bystanderRenders: number;
   bystanderRendersById: Record<string, number>;
+  // Actions-consumer fan-out: how many of the 5 ActionsProbe consumers (which
+  // read the mount-stable `useDashboardActions()` surface, modeling a MIGRATED
+  // content component) re-rendered during the scenario (sum), plus the per-probe
+  // breakdown. This is the migration CONTRAST metric — on bringToFront5 and
+  // drag.release it must be 0 (the actions object identity never changes), while
+  // the legacy `bystanderRenders` above stays > 0 on the same scenarios.
+  actionsProbeRenders: number;
+  actionsProbeRendersById: Record<string, number>;
 }
 
 const metrics: ScenarioMetric[] = [];
@@ -437,11 +464,25 @@ function bystanderRenderDeltas(
   return deltas;
 }
 
+/** Per-probe delta of actionsProbeRenderCounts since the given baseline snapshot. */
+function actionsProbeRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...actionsProbeRenderCounts.keys()].sort()) {
+    const delta =
+      (actionsProbeRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
 function createRecorder() {
   let commits = 0;
   let duration = 0;
   let shellBaseline: ReadonlyMap<string, number> = new Map();
   let bystanderBaseline: ReadonlyMap<string, number> = new Map();
+  let actionsProbeBaseline: ReadonlyMap<string, number> = new Map();
   const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
     commits += 1;
     duration += actualDuration;
@@ -453,10 +494,13 @@ function createRecorder() {
       duration = 0;
       shellBaseline = new Map(shellRenderCounts);
       bystanderBaseline = new Map(bystanderRenderCounts);
+      actionsProbeBaseline = new Map(actionsProbeRenderCounts);
     },
     record(scenario: string) {
       const shellRendersByWidget = shellRenderDeltas(shellBaseline);
       const bystanderRendersById = bystanderRenderDeltas(bystanderBaseline);
+      const actionsProbeRendersById =
+        actionsProbeRenderDeltas(actionsProbeBaseline);
       metrics.push({
         scenario,
         commits,
@@ -471,6 +515,11 @@ function createRecorder() {
           0
         ),
         bystanderRendersById,
+        actionsProbeRenders: Object.values(actionsProbeRendersById).reduce(
+          (sum, n) => sum + n,
+          0
+        ),
+        actionsProbeRendersById,
       });
     },
   };
@@ -615,6 +664,41 @@ const BYSTANDER_IDS = [
 ] as const;
 
 /**
+ * Migrated-consumer probe. Stands in for a content/settings component AFTER the
+ * useDashboard()→useDashboardActions() migration: it reads only the
+ * mount-stable actions surface (`useDashboardActions()`), exactly like the 9
+ * widgets migrated in this slice (Traffic, HotspotImage, NumberLine, MathTool,
+ * SyntaxFramer, CustomWidget, Embed, MathTools, StarterPack).
+ *
+ * With DashboardProvider mounted the actions object identity NEVER changes
+ * after mount (it delegates to a live-ref of the freshest closures), so a
+ * discrete widget op (bringToFront / drag-release) cannot re-render this probe
+ * — its scenario delta is 0. Contrasted against BystanderProbe (which reads the
+ * churning legacy value and re-renders on those same ops), this 0 is the direct
+ * proof the migration isolates content consumers from board-wide fan-out.
+ *
+ * Wrapped in React.memo with a stable `id` prop so the ONLY thing that could
+ * drive a re-render is the actions context changing identity — which it never
+ * does — isolating the metric to the surface under test.
+ */
+const ActionsProbe: React.FC<{ id: string }> = React.memo(({ id }) => {
+  const { updateWidget } = useDashboardActions();
+  countActionsProbeRender(id);
+  // Reference the read so the subscription is real and not optimized away.
+  void updateWidget;
+  return null;
+});
+ActionsProbe.displayName = 'ActionsProbe';
+
+const ACTIONS_PROBE_IDS = [
+  'actions-1',
+  'actions-2',
+  'actions-3',
+  'actions-4',
+  'actions-5',
+] as const;
+
+/**
  * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
  * BoardCanvas: context state and callbacks flow down as props, while
  * DraggableWindow/WidgetRenderer read the stable actions context and the
@@ -643,6 +727,9 @@ const BoardHarness: React.FC = () => {
     <>
       {BYSTANDER_IDS.map((id) => (
         <BystanderProbe key={id} id={id} />
+      ))}
+      {ACTIONS_PROBE_IDS.map((id) => (
+        <ActionsProbe key={id} id={id} />
       ))}
       <BoardCanvas
         dashboard={ctx.activeDashboard}
@@ -951,6 +1038,39 @@ describe('dashboard canvas performance baseline', () => {
     // isolated canvas store, not the tool-visibility context, so the
     // tool-visibility churn is invisible to them too.
     expect(shellDiff('toggleToolVisibility')).toEqual([]);
+
+    // ── Migration contrast-proof (the win this slice delivers) ────────────
+    // The 5 ActionsProbe consumers model a MIGRATED content component: they
+    // read the mount-stable `useDashboardActions()` surface instead of the
+    // churning legacy `useDashboard()` value. The contrast below is the proof
+    // that swapping that one hook eliminates the per-op fan-out.
+
+    // SANITY: the actions probes are actually mounted and counted — they each
+    // render at least once during mount15. Without this, a 0 delta on the hot
+    // scenarios could just mean the probe never mounted (a dead instrument).
+    expect(
+      Object.keys(metricFor('mount15').actionsProbeRendersById)
+    ).toHaveLength(5);
+
+    // bringToFront5: each of the 5 pointer-downs raises a widget →
+    // setDashboards → new activeDashboard identity → the big contextValue memo
+    // recreates → every legacy useDashboard() consumer re-renders. The legacy
+    // bystander probes therefore churn (5 probes × 5 raises = 25), while the
+    // migrated actions probes stay at 0 — their actions object identity is
+    // fixed for the provider's lifetime, so the raises are invisible to them.
+    const bringToFront = metricFor('bringToFront5');
+    expect(bringToFront.bystanderRenders).toBe(25);
+    expect(bringToFront.actionsProbeRenders).toBe(0);
+    expect(bringToFront.actionsProbeRendersById).toEqual({});
+
+    // drag.release: the pointer-up commits the moved widget → setDashboards →
+    // new activeDashboard identity → one contextValue recreation → the 5 legacy
+    // bystanders each re-render once (5), while the 5 migrated actions probes
+    // stay at 0. Same fan-out, silenced by the migration.
+    const dragRelease = metricFor('drag.release');
+    expect(dragRelease.bystanderRenders).toBe(5);
+    expect(dragRelease.actionsProbeRenders).toBe(0);
+    expect(dragRelease.actionsProbeRendersById).toEqual({});
   });
 });
 
@@ -980,6 +1100,14 @@ afterAll(() => {
           'own ToolVisibilityContext, so a toggle no longer churns the ' +
           'DashboardContext value the probes subscribe to), while addWidget ' +
           'still churns the probes (sanity that the instrument is live). ' +
+          'actionsProbeRenders/actionsProbeRendersById count how many of the 5 ' +
+          'ActionsProbe consumers (which read the mount-stable ' +
+          'useDashboardActions() surface, modeling a MIGRATED content ' +
+          'component) re-rendered per scenario — the migration contrast-proof: ' +
+          'on bringToFront5 and drag.release the actions probes read 0 while ' +
+          'the legacy bystander probes read 25 and 5 respectively, showing the ' +
+          'useDashboard()→useDashboardActions() swap isolates content consumers ' +
+          'from the per-op DashboardContext fan-out. ' +
           'actualDurationMs is machine-dependent and indicative only — ' +
           'compare medians of 3 runs.',
         skipped:

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-06-17T01:04:04.194Z",
+  "generatedAt": "2026-06-17T05:16:33.905Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
       "commits": 3,
-      "actualDurationMs": 483.293,
+      "actualDurationMs": 150.274,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -33,12 +33,20 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
+      },
+      "actionsProbeRenders": 5,
+      "actionsProbeRendersById": {
+        "actions-1": 1,
+        "actions-2": 1,
+        "actions-3": 1,
+        "actions-4": 1,
+        "actions-5": 1
       }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 21.447,
+      "actualDurationMs": 2.364,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -50,7 +58,9 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "drag.move30",
@@ -59,12 +69,14 @@
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
-      "bystanderRendersById": {}
+      "bystanderRendersById": {},
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "drag.release",
       "commits": 3,
-      "actualDurationMs": 8.299,
+      "actualDurationMs": 3.104,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -76,16 +88,20 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 2.299,
+      "actualDurationMs": 0.989,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
-      "bystanderRendersById": {}
+      "bystanderRendersById": {},
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "resize.move30",
@@ -94,12 +110,14 @@
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
-      "bystanderRendersById": {}
+      "bystanderRendersById": {},
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "resize.release",
       "commits": 3,
-      "actualDurationMs": 6.236,
+      "actualDurationMs": 3.267,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -111,12 +129,14 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 21.812,
+      "actualDurationMs": 10.493,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -132,12 +152,14 @@
         "bystander-3": 5,
         "bystander-4": 5,
         "bystander-5": 5
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "addWidget",
       "commits": 3,
-      "actualDurationMs": 13.46,
+      "actualDurationMs": 6.601,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -149,12 +171,14 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 2.305,
+      "actualDurationMs": 0.931,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -164,12 +188,14 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 2.922,
+      "actualDurationMs": 2.094,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -181,12 +207,14 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 4.434,
+      "actualDurationMs": 1.942,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -198,16 +226,20 @@
         "bystander-3": 1,
         "bystander-4": 1,
         "bystander-5": 1
-      }
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     },
     {
       "scenario": "toggleToolVisibility",
       "commits": 1,
-      "actualDurationMs": 1.32,
+      "actualDurationMs": 0.621,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
-      "bystanderRendersById": {}
+      "bystanderRendersById": {},
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {}
     }
   ]
 }


### PR DESCRIPTION
## What & why

Follow-up to the F9 review observation on #1996: a discrete widget op (`bringToFront`, drag-release) recreates the `DashboardContext` value, re-rendering all ~190 `useDashboard()` consumers — including content components that read only stable callbacks and have no reason to re-render.

This migrates **9 action-only content widgets** from the churning `useDashboard()` to the mount-stable `useDashboardActions()` (already provided by the canvas store). Each, wrapped in `WidgetRenderer`'s existing `memo`, now re-renders only when *its own* widget changes. **No new architecture** — reuses the existing actions context + memo boundary.

Migrated: TrafficLight, HotspotImage, NumberLine, MathToolInstance, SyntaxFramer, CustomWidget, Embed, MathTools, StarterPack. One action added to the surface: `addWidget` (already `useCallback`-stable, wired through the existing `liveActionsRef` → `stableActions` delegation).

## Proof

A `React.memo` `useDashboardActions()` probe vs the legacy `useDashboard()` probe, same scenarios in the perf harness:

| scenario | legacy probe | actions probe |
|---|---|---|
| `bringToFront5` | 25 | **0** |
| `drag.release` | 5 | **0** |
| `mount15` (sanity) | 5 | 5 |

The actions probe mounting at 5 but holding **0** on the churn ops proves genuine isolation, not a dead instrument. Falsifiable: reverting any widget to `useDashboard()` re-introduces its churn.

## Scope & safety

- Focused batch (9, within the approved 8–12). Strictly excluded the 13 `activeDashboard`-readers (separate follow-up).
- **No behavior change** — actions delegate to the same live closures; type-check is the exhaustive guard (a widget reading a non-action field won't compile).
- `type-check:all`, `eslint --max-warnings 0`, the perf harness, and the migrated widgets' tests all pass. Reviewed by three adversarial lenses (correctness/behavior, perf-contract, type/scope) — all **ship**, zero blocking findings.

## Stacking

Stacked on **F9 ([#1996](https://github.com/OPS-PIvers/SpartBoard/pull/1996))** — based on `f9-toolvis-context-split`. Merge #1996 first; GitHub will retarget this PR to `dev-paul` automatically.

## Natural next slice

Many more widgets (Clock, Dice, Scoreboard, Poll, Countdown, Checklist, Music, …) are blocked from migration *only* by reading `activeDashboard?.globalStyle`. A mount-stable `globalStyle` selector would unlock 10+ in one cheap move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)