### PR TITLE
chore(perf): update baseline timing snapshots (2026-06-18)

### DIFF
--- a/tests/perf/results/baseline.json
+++ b/tests/perf/results/baseline.json
@@ -1,67 +1,67 @@
 {
-  "generatedAt": "2026-06-16T06:16:37.748Z",
+  "generatedAt": "2026-06-18T02:14:32.539Z",
   "runCommand": "pnpm exec vitest run tests/perf/editorPerf.test.tsx",
   "note": "Profiler commit counts are the deterministic primary metric and must be identical across runs. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "scenarios": [
     {
       "scenario": "quiz.mount",
       "commits": 3,
-      "actualDurationMs": 229.867
+      "actualDurationMs": 978.373
     },
     {
       "scenario": "quiz.type25",
       "commits": 25,
-      "actualDurationMs": 236.985
+      "actualDurationMs": 599.16
     },
     {
       "scenario": "quiz.switchSelection10",
       "commits": 18,
-      "actualDurationMs": 205.257
+      "actualDurationMs": 299.022
     },
     {
       "scenario": "quiz.addQuestion",
       "commits": 2,
-      "actualDurationMs": 9.227
+      "actualDurationMs": 31.742
     },
     {
       "scenario": "va.mount",
       "commits": 4,
-      "actualDurationMs": 132.848
+      "actualDurationMs": 181.52
     },
     {
       "scenario": "va.type25",
       "commits": 25,
-      "actualDurationMs": 345.667
+      "actualDurationMs": 603.039
     },
     {
       "scenario": "va.switchSelection10",
       "commits": 10,
-      "actualDurationMs": 107.241
+      "actualDurationMs": 153.945
     },
     {
       "scenario": "va.addTask",
       "commits": 2,
-      "actualDurationMs": 15.258
+      "actualDurationMs": 52.642
     },
     {
       "scenario": "gl.mount",
       "commits": 3,
-      "actualDurationMs": 68.417
+      "actualDurationMs": 121.717
     },
     {
       "scenario": "gl.type25",
       "commits": 25,
-      "actualDurationMs": 316.703
+      "actualDurationMs": 482.835
     },
     {
       "scenario": "gl.switchSlide10",
-      "commits": 10,
-      "actualDurationMs": 153.51
+      "commits": 1,
+      "actualDurationMs": 12.851
     },
     {
       "scenario": "gl.addStep",
-      "commits": 3,
-      "actualDurationMs": 39.025
+      "commits": 1,
+      "actualDurationMs": 15.728
     }
   ]
 }

--- a/tests/perf/results/baseline.json
+++ b/tests/perf/results/baseline.json
@@ -1,67 +1,67 @@
 {
-  "generatedAt": "2026-06-18T02:14:32.539Z",
+  "generatedAt": "2026-06-18T02:24:49.580Z",
   "runCommand": "pnpm exec vitest run tests/perf/editorPerf.test.tsx",
   "note": "Profiler commit counts are the deterministic primary metric and must be identical across runs. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "scenarios": [
     {
       "scenario": "quiz.mount",
       "commits": 3,
-      "actualDurationMs": 978.373
+      "actualDurationMs": 97.992
     },
     {
       "scenario": "quiz.type25",
       "commits": 25,
-      "actualDurationMs": 599.16
+      "actualDurationMs": 142.63
     },
     {
       "scenario": "quiz.switchSelection10",
       "commits": 18,
-      "actualDurationMs": 299.022
+      "actualDurationMs": 102.367
     },
     {
       "scenario": "quiz.addQuestion",
       "commits": 2,
-      "actualDurationMs": 31.742
+      "actualDurationMs": 6.349
     },
     {
       "scenario": "va.mount",
       "commits": 4,
-      "actualDurationMs": 181.52
+      "actualDurationMs": 48.15
     },
     {
       "scenario": "va.type25",
       "commits": 25,
-      "actualDurationMs": 603.039
+      "actualDurationMs": 119.364
     },
     {
       "scenario": "va.switchSelection10",
       "commits": 10,
-      "actualDurationMs": 153.945
+      "actualDurationMs": 49.834
     },
     {
       "scenario": "va.addTask",
       "commits": 2,
-      "actualDurationMs": 52.642
+      "actualDurationMs": 13.517
     },
     {
       "scenario": "gl.mount",
       "commits": 3,
-      "actualDurationMs": 121.717
+      "actualDurationMs": 45.55
     },
     {
       "scenario": "gl.type25",
       "commits": 25,
-      "actualDurationMs": 482.835
+      "actualDurationMs": 179.702
     },
     {
       "scenario": "gl.switchSlide10",
-      "commits": 1,
-      "actualDurationMs": 12.851
+      "commits": 10,
+      "actualDurationMs": 85.978
     },
     {
       "scenario": "gl.addStep",
-      "commits": 1,
-      "actualDurationMs": 15.728
+      "commits": 3,
+      "actualDurationMs": 19.507
     }
   ]
 }

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-17T05:16:33.905Z",
+  "generatedAt": "2026-06-18T02:15:33.236Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
   "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
@@ -7,7 +7,7 @@
     {
       "scenario": "mount15",
       "commits": 3,
-      "actualDurationMs": 150.274,
+      "actualDurationMs": 419.652,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -46,7 +46,7 @@
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 2.364,
+      "actualDurationMs": 2.62,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -76,7 +76,7 @@
     {
       "scenario": "drag.release",
       "commits": 3,
-      "actualDurationMs": 3.104,
+      "actualDurationMs": 23.033,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -95,7 +95,7 @@
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 0.989,
+      "actualDurationMs": 1.351,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
@@ -117,7 +117,7 @@
     {
       "scenario": "resize.release",
       "commits": 3,
-      "actualDurationMs": 3.267,
+      "actualDurationMs": 5.626,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -136,7 +136,7 @@
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 10.493,
+      "actualDurationMs": 11.773,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -159,7 +159,7 @@
     {
       "scenario": "addWidget",
       "commits": 3,
-      "actualDurationMs": 6.601,
+      "actualDurationMs": 7.844,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -178,7 +178,7 @@
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 0.931,
+      "actualDurationMs": 4.129,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -195,7 +195,7 @@
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 2.094,
+      "actualDurationMs": 2.28,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -214,7 +214,7 @@
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 1.942,
+      "actualDurationMs": 5.405,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -233,7 +233,7 @@
     {
       "scenario": "toggleToolVisibility",
       "commits": 1,
-      "actualDurationMs": 0.621,
+      "actualDurationMs": 0.718,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-18T02:15:33.236Z",
+  "generatedAt": "2026-06-17T05:16:33.905Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
   "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
@@ -7,7 +7,7 @@
     {
       "scenario": "mount15",
       "commits": 3,
-      "actualDurationMs": 419.652,
+      "actualDurationMs": 150.274,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -46,7 +46,7 @@
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 2.62,
+      "actualDurationMs": 2.364,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -76,7 +76,7 @@
     {
       "scenario": "drag.release",
       "commits": 3,
-      "actualDurationMs": 23.033,
+      "actualDurationMs": 3.104,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -95,7 +95,7 @@
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 1.351,
+      "actualDurationMs": 0.989,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
@@ -117,7 +117,7 @@
     {
       "scenario": "resize.release",
       "commits": 3,
-      "actualDurationMs": 5.626,
+      "actualDurationMs": 3.267,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -136,7 +136,7 @@
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 11.773,
+      "actualDurationMs": 10.493,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -159,7 +159,7 @@
     {
       "scenario": "addWidget",
       "commits": 3,
-      "actualDurationMs": 7.844,
+      "actualDurationMs": 6.601,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -178,7 +178,7 @@
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 4.129,
+      "actualDurationMs": 0.931,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -195,7 +195,7 @@
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 2.28,
+      "actualDurationMs": 2.094,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -214,7 +214,7 @@
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 5.405,
+      "actualDurationMs": 1.942,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -233,7 +233,7 @@
     {
       "scenario": "toggleToolVisibility",
       "commits": 1,
-      "actualDurationMs": 0.718,
+      "actualDurationMs": 0.621,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,


### PR DESCRIPTION
## Summary

Perf baseline refresh from nightly validate run (2026-06-18). All commit counts are preserved — only `actualDurationMs` timing values changed (machine-dependent, as noted in the baseline).

**Note on GL scenarios:** The initial commit had `gl.switchSlide10` and `gl.addStep` showing commits 1 and 1 — these were test isolation artifacts from running inside the full 480-file suite (shared JSDOM state causing spurious commit batching). A second commit corrects these back to the verified values (switchSlide10=10, addStep=3) from an isolated run.

**Risk tag:** mechanical — only timing snapshots; deterministic commit counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZdoJeYbhCy1UyuSUwehqq