### PR TITLE
perf(widgets): add useGlobalStyle() selector, migrate 13 widgets off useDashboard()

### DIFF
--- a/components/layout/dock/DockLabel.tsx
+++ b/components/layout/dock/DockLabel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
-import { DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
 /**
  * Custom Label Component for consistent readability
@@ -13,8 +12,7 @@ export const DockLabel = ({
   children: React.ReactNode;
   className?: string;
 }) => {
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
 
   return (
     <span

--- a/components/widgets/Calendar/Widget.test.tsx
+++ b/components/widgets/Calendar/Widget.test.tsx
@@ -3,7 +3,13 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CalendarWidget } from './Widget';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
 import type { CalendarConfig, WidgetData } from '@/types';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 
 vi.mock('../WidgetLayout', () => ({
   WidgetLayout: ({ content }: { content: React.ReactNode }) => (
@@ -11,16 +17,7 @@ vi.mock('../WidgetLayout', () => ({
   ),
 }));
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: () => ({
-    activeDashboard: {
-      globalStyle: { fontFamily: 'sans' },
-      widgets: [],
-    },
-    addWidget: vi.fn(),
-    updateWidget: vi.fn(),
-  }),
-}));
+vi.mock('@/context/dashboardCanvasStore');
 
 vi.mock('@/hooks/useFeaturePermissions', () => ({
   useFeaturePermissions: () => ({
@@ -59,6 +56,14 @@ const buildWidget = (config: Partial<CalendarConfig>): WidgetData =>
 
 describe('CalendarWidget', () => {
   beforeEach(() => {
+    vi.mocked(useGlobalStyle).mockReturnValue({
+      ...DEFAULT_GLOBAL_STYLE,
+      fontFamily: 'sans',
+    });
+    vi.mocked(useDashboardActions).mockReturnValue({
+      addWidget: vi.fn(),
+      updateWidget: vi.fn(),
+    } as unknown as DashboardActions);
     vi.useFakeTimers();
   });
 

--- a/components/widgets/Calendar/Widget.tsx
+++ b/components/widgets/Calendar/Widget.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
 import {
   WidgetData,
   CalendarConfig,
   CalendarGlobalConfig,
   CalendarEvent,
-  DEFAULT_GLOBAL_STYLE,
 } from '@/types';
 import { Calendar as CalendarIcon, Ban, Timer } from 'lucide-react';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -38,11 +40,11 @@ const parseTimeSeconds = (t: string | undefined): number => {
 export const CalendarWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { activeDashboard, addWidget } = useDashboard();
+  const { addWidget } = useDashboardActions();
   const buildingId = useWidgetBuildingId(widget);
   const { subscribeToPermission } = useFeaturePermissions();
   const { calendarService, isConnected } = useGoogleCalendar();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const config = widget.config as CalendarConfig;
   const localEvents = useMemo(() => config.events ?? [], [config.events]);
   const isBuildingSyncEnabled = config.isBuildingSyncEnabled ?? true;

--- a/components/widgets/ClockWidget/Widget.test.tsx
+++ b/components/widgets/ClockWidget/Widget.test.tsx
@@ -1,16 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, cleanup } from '@testing-library/react';
-import { useDashboard } from '@/context/useDashboard';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { WidgetData, ClockConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { ClockWidget } from './Widget';
 
-vi.mock('@/context/useDashboard');
-
-const mockDashboardContext = {
-  activeDashboard: {
-    globalStyle: DEFAULT_GLOBAL_STYLE,
-  },
-};
+vi.mock('@/context/dashboardCanvasStore');
 
 // Helper to render widget
 const renderWidget = (widget: WidgetData) => {
@@ -20,9 +14,7 @@ const renderWidget = (widget: WidgetData) => {
 describe('ClockWidget', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
-      mockDashboardContext
-    );
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
   });
 
   afterEach(() => {

--- a/components/widgets/ClockWidget/Widget.tsx
+++ b/components/widgets/ClockWidget/Widget.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, ClockConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
+import { WidgetData, ClockConfig } from '@/types';
 import { STANDARD_COLORS } from '@/config/colors';
 
 import { WidgetLayout } from '../WidgetLayout';
 
 export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { i18n } = useTranslation();
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {

--- a/components/widgets/Countdown/Widget.test.tsx
+++ b/components/widgets/Countdown/Widget.test.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CountdownWidget } from './Widget';
-import { CountdownConfig, WidgetData } from '@/types';
+import { CountdownConfig, WidgetData, DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
 vi.mock('../WidgetLayout', () => ({
   WidgetLayout: ({ content }: { content: React.ReactNode }) => (
@@ -11,12 +12,7 @@ vi.mock('../WidgetLayout', () => ({
   ),
 }));
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: () => ({
-    activeDashboard: { globalStyle: { fontFamily: 'sans' } },
-    updateWidget: vi.fn(),
-  }),
-}));
+vi.mock('@/context/dashboardCanvasStore');
 
 const buildWidget = (config: Partial<CountdownConfig>): WidgetData =>
   ({
@@ -41,6 +37,10 @@ const buildWidget = (config: Partial<CountdownConfig>): WidgetData =>
 
 describe('CountdownWidget', () => {
   beforeEach(() => {
+    vi.mocked(useGlobalStyle).mockReturnValue({
+      ...DEFAULT_GLOBAL_STYLE,
+      fontFamily: 'sans',
+    });
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-03T09:00:00.000Z'));
   });

--- a/components/widgets/Countdown/Widget.tsx
+++ b/components/widgets/Countdown/Widget.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { WidgetData, CountdownConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
+import { WidgetData, CountdownConfig } from '@/types';
 import { WidgetLayout } from '../WidgetLayout';
 import { getFontClass, hexToRgba } from '@/utils/styles';
-import { useDashboard } from '@/context/useDashboard';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
 interface CountdownDay {
   date: Date;
@@ -26,8 +26,7 @@ const isWeekendDate = (value: Date): boolean => {
 export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const config = widget.config as CountdownConfig;
 
   const {

--- a/components/widgets/DiceWidget/Widget.test.tsx
+++ b/components/widgets/DiceWidget/Widget.test.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import { DiceWidget } from './Widget';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { WidgetData } from '@/types';
+import { WidgetData, DEFAULT_GLOBAL_STYLE } from '@/types';
 
 // Mock audio utilities to prevent context errors during tests
 vi.mock('./utils/audio', () => ({
@@ -14,20 +18,18 @@ vi.mock('./utils/audio', () => ({
   playRollSound: vi.fn(),
 }));
 
-// Mock the dashboard context provider
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
+// Mock the mount-stable dashboard store surfaces the widget consumes.
+vi.mock('@/context/dashboardCanvasStore');
 
 describe('DiceWidget', () => {
   const mockUpdateWidget = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      activeDashboard: { globalStyle: { fontFamily: 'sans' } },
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
+    vi.mocked(useDashboardActions).mockReturnValue({
       updateWidget: mockUpdateWidget,
-    });
+    } as unknown as DashboardActions);
     // Mock random so dice rolls are deterministic in tests (always roll 1)
     vi.spyOn(Math, 'random').mockReturnValue(0.1);
   });

--- a/components/widgets/DiceWidget/Widget.tsx
+++ b/components/widgets/DiceWidget/Widget.tsx
@@ -1,14 +1,17 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, DiceConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
+import { WidgetData, DiceConfig } from '@/types';
 import { RefreshCw } from 'lucide-react';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { DiceFace } from './components/DiceFace';
 import { getDiceAudioCtx, playRollSound } from './utils/audio';
 
 export const DiceWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { activeDashboard, updateWidget } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as DiceConfig;
   const diceCount = config.count ?? 1;
   const { diceColor = '#ffffff', dotColor = '#1e293b' } = config;

--- a/components/widgets/NeedDoPutThen/Widget.tsx
+++ b/components/widgets/NeedDoPutThen/Widget.tsx
@@ -9,13 +9,11 @@ import {
   ListTodo,
   Package,
 } from 'lucide-react';
+import { WidgetData, NeedDoPutThenConfig, NeedDoPutThenTile } from '@/types';
 import {
-  WidgetData,
-  NeedDoPutThenConfig,
-  NeedDoPutThenTile,
-  DEFAULT_GLOBAL_STYLE,
-} from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { getFontClass, hexToRgba } from '@/utils/styles';
@@ -562,7 +560,8 @@ const Drawer: React.FC<DrawerProps> = ({
 export const NeedDoPutThenWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { activeDashboard, updateWidget } = useDashboard();
+  const globalStyle = useGlobalStyle();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as NeedDoPutThenConfig;
 
   const {
@@ -609,8 +608,7 @@ export const NeedDoPutThenWidget: React.FC<{ widget: WidgetData }> = ({
     setPortalTarget((prev) => (prev === target ? prev : target));
   }, []);
 
-  const globalFont =
-    activeDashboard?.globalStyle?.fontFamily ?? DEFAULT_GLOBAL_STYLE.fontFamily;
+  const globalFont = globalStyle.fontFamily;
   const fontClass = getFontClass(config.fontFamily ?? 'global', globalFont);
   const sizeMultiplier = resolveTextPresetMultiplier(config.textSizePreset);
 

--- a/components/widgets/PollWidget/PollWidget.test.tsx
+++ b/components/widgets/PollWidget/PollWidget.test.tsx
@@ -1,15 +1,23 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { PollWidget, PollSettings } from '.';
 import { useDashboard } from '@/context/useDashboard';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
 import { vi, describe, it, expect, Mock, beforeEach, afterEach } from 'vitest';
-import { WidgetData } from '@/types';
+import { WidgetData, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { GeneratedPoll } from '@/utils/ai';
 
-// Mock useDashboard
+// Mock useDashboard (PollSettings still consumes the legacy context).
 vi.mock('@/context/useDashboard', () => ({
   useDashboard: vi.fn(),
 }));
+
+// Mock the mount-stable store surfaces (PollWidget consumes these).
+vi.mock('@/context/dashboardCanvasStore');
 
 // Mock useAuth
 vi.mock('@/context/useAuth', () => ({
@@ -68,10 +76,13 @@ describe('PollWidget', () => {
     // wipe nothing functional (clearAllMocks keeps implementations) but reads
     // as a footgun. Order it conventionally so the stubs are the final word.
     vi.clearAllMocks();
-    (useDashboard as Mock).mockReturnValue({
-      updateWidget: mockUpdateWidget,
-      activeDashboard: { globalStyle: { fontFamily: 'sans' } },
+    vi.mocked(useGlobalStyle).mockReturnValue({
+      ...DEFAULT_GLOBAL_STYLE,
+      fontFamily: 'sans',
     });
+    vi.mocked(useDashboardActions).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+    } as unknown as DashboardActions);
     (useAuth as Mock).mockReturnValue({
       user: { uid: 'teacher-1' },
       canAccessFeature: vi.fn(() => true),

--- a/components/widgets/PollWidget/Widget.tsx
+++ b/components/widgets/PollWidget/Widget.tsx
@@ -7,14 +7,12 @@ import {
   increment,
 } from 'firebase/firestore';
 import { db } from '@/config/firebase';
-import { useDashboard } from '@/context/useDashboard';
-import { useAuth } from '@/context/useAuth';
 import {
-  WidgetData,
-  PollConfig,
-  PollVoteDoc,
-  DEFAULT_GLOBAL_STYLE,
-} from '@/types';
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
+import { useAuth } from '@/context/useAuth';
+import { WidgetData, PollConfig, PollVoteDoc } from '@/types';
 import { RotateCcw, Radio } from 'lucide-react';
 
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
@@ -26,9 +24,9 @@ import {
 } from '@/components/poll/pollSession';
 
 export const PollWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const { updateWidget, activeDashboard } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const { showConfirm } = useDialog();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const config = widget.config as PollConfig & { _announcementId?: string };
   const { question = 'Vote Now!', _announcementId } = config;
   const options = useMemo(

--- a/components/widgets/RevealGrid/Widget.tsx
+++ b/components/widgets/RevealGrid/Widget.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { useDashboard } from '@/context/useDashboard';
 import {
-  WidgetData,
-  RevealGridConfig,
-  DEFAULT_GLOBAL_STYLE,
-  MemoryCard,
-} from '@/types';
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
+import { WidgetData, RevealGridConfig, MemoryCard } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { Toggle } from '@/components/common/Toggle';
 import { getFontClass } from '@/utils/styles';
@@ -14,9 +12,9 @@ import { shuffleArray } from '@/utils/randomHelpers';
 export const RevealGridWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, activeDashboard } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const config = widget.config as RevealGridConfig;
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const [isShowAnswersMode, setIsShowAnswersMode] = useState(false);
 
   // Fallback to defaults if needed

--- a/components/widgets/Scoreboard/Widget.test.tsx
+++ b/components/widgets/Scoreboard/Widget.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ScoreboardWidget } from './Widget';
 import { ScoreboardSettings } from './Settings';
 import { useDashboard } from '@/context/useDashboard';
+import {
+  useGlobalStyle,
+  useDashboardActions,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 import * as ScoreboardItemModule from './components/ScoreboardItem';
 import {
@@ -11,9 +16,13 @@ import {
   RandomConfig,
   WidgetType,
   ScoreboardTeam,
+  DEFAULT_GLOBAL_STYLE,
 } from '@/types';
 
+// ScoreboardSettings still consumes the legacy context; ScoreboardWidget reads
+// the mount-stable store surfaces.
 vi.mock('@/context/useDashboard');
+vi.mock('@/context/dashboardCanvasStore');
 
 // Mock ScoreboardItem to spy on renders
 vi.mock('./components/ScoreboardItem', async (importOriginal) => {
@@ -63,6 +72,10 @@ describe('ScoreboardWidget', () => {
     (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockDashboardContext
     );
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
+    vi.mocked(useDashboardActions).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+    } as unknown as DashboardActions);
   });
 
   it('migrates legacy config on mount', () => {

--- a/components/widgets/Scoreboard/Widget.tsx
+++ b/components/widgets/Scoreboard/Widget.tsx
@@ -1,11 +1,9 @@
 import React, { useEffect, useRef, useCallback, useMemo } from 'react';
-import { useDashboard } from '@/context/useDashboard';
 import {
-  WidgetData,
-  ScoreboardConfig,
-  ScoreboardTeam,
-  DEFAULT_GLOBAL_STYLE,
-} from '@/types';
+  useGlobalStyle,
+  useDashboardActions,
+} from '@/context/dashboardCanvasStore';
+import { WidgetData, ScoreboardConfig, ScoreboardTeam } from '@/types';
 import { Trophy } from 'lucide-react';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { ScoreboardItem } from './components/ScoreboardItem';
@@ -20,8 +18,8 @@ const DEFAULT_TEAMS: ScoreboardTeam[] = [
 export const ScoreboardWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const { updateWidget } = useDashboardActions();
+  const globalStyle = useGlobalStyle();
   const config = widget.config as ScoreboardConfig;
 
   // Auto-migration: If no teams array, convert legacy A/B to teams

--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -2,11 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useDashboard } from '@/context/useDashboard';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { WidgetData, TimeToolConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { TimeToolWidget } from './TimeToolWidget';
 import { DashboardContextValue } from '@/context/DashboardContextValue';
 
+// useTimeTool still reads the legacy context (updateWidget + activeDashboard);
+// TimeToolWidget itself now reads globalStyle from the mount-stable store.
 vi.mock('@/context/useDashboard');
+vi.mock('@/context/dashboardCanvasStore');
 vi.mock('@/utils/timeToolAudio', () => ({
   playTimerAlert: vi.fn(),
   resumeAudio: vi.fn().mockResolvedValue(undefined),
@@ -40,6 +44,7 @@ describe('TimeToolWidget', () => {
     (useDashboard as Mock).mockReturnValue(
       mockDashboardContext as unknown as DashboardContextValue
     );
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
   });
 
   afterEach(() => {

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { WidgetData, DEFAULT_GLOBAL_STYLE, TimeToolConfig } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import { WidgetData, TimeToolConfig } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { useTimeTool } from './useTimeTool';
 import { useHoldAccelerate } from './useHoldAccelerate';
 import {
@@ -333,8 +333,7 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
   const { t } = useTranslation();
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const {
     displayTime,
     isRunning,

--- a/components/widgets/random/RandomFlash.tsx
+++ b/components/widgets/random/RandomFlash.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
-import { DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
 /**
  * Placeholder text shown when no winner has been picked yet. Exported so the
@@ -20,8 +19,7 @@ export const RandomFlash: React.FC<RandomFlashProps> = ({
   isSpinning,
   fontSize,
 }) => {
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
 
   const fontStyle = typeof fontSize === 'number' ? `${fontSize}px` : fontSize;
 

--- a/components/widgets/random/RandomSlots.test.tsx
+++ b/components/widgets/random/RandomSlots.test.tsx
@@ -1,18 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RandomSlots } from './RandomSlots';
-import { useDashboard } from '@/context/useDashboard';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { DEFAULT_GLOBAL_STYLE } from '@/types';
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
+vi.mock('@/context/dashboardCanvasStore');
 
 describe('RandomSlots Component', () => {
   beforeEach(() => {
-    (useDashboard as Mock).mockReturnValue({
-      activeDashboard: { globalStyle: DEFAULT_GLOBAL_STYLE },
-    });
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
   });
 
   it('renders correctly with default props', () => {

--- a/components/widgets/random/RandomSlots.tsx
+++ b/components/widgets/random/RandomSlots.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
-import { DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
 interface RandomSlotsProps {
   displayResult: string | string[] | string[][] | null;
@@ -13,8 +12,7 @@ export const RandomSlots: React.FC<RandomSlotsProps> = ({
   fontSize,
   slotHeight,
 }) => {
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
 
   const fontStyle = typeof fontSize === 'number' ? `${fontSize}px` : fontSize;
 

--- a/components/widgets/random/RandomWheel.test.tsx
+++ b/components/widgets/random/RandomWheel.test.tsx
@@ -1,18 +1,14 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RandomWheel } from './RandomWheel';
-import { useDashboard } from '@/context/useDashboard';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { DEFAULT_GLOBAL_STYLE } from '@/types';
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
+vi.mock('@/context/dashboardCanvasStore');
 
 describe('RandomWheel Component', () => {
   beforeEach(() => {
-    (useDashboard as Mock).mockReturnValue({
-      activeDashboard: { globalStyle: DEFAULT_GLOBAL_STYLE },
-    });
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
   });
 
   it('renders correctly', () => {

--- a/components/widgets/random/RandomWheel.tsx
+++ b/components/widgets/random/RandomWheel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { useDashboard } from '@/context/useDashboard';
-import { DEFAULT_GLOBAL_STYLE } from '@/types';
+import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 import { PASTEL_PALETTE } from '@/config/colors';
 
 const WHEEL_COLORS = PASTEL_PALETTE;
@@ -22,8 +21,7 @@ export const RandomWheel: React.FC<RandomWheelProps> = ({
   isSpinning,
   resultFontSize,
 }) => {
-  const { activeDashboard } = useDashboard();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const radius = 145;
   const centerX = 150;
   const centerY = 150;

--- a/context/dashboardCanvasStore.ts
+++ b/context/dashboardCanvasStore.ts
@@ -48,7 +48,8 @@ import {
   useRef,
   useSyncExternalStore,
 } from 'react';
-import type { Dashboard } from '@/types';
+import type { Dashboard, GlobalStyle } from '@/types';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
 import {
   DashboardContext,
   type DashboardContextValue,
@@ -241,6 +242,26 @@ export function useDashboardCanvasSelector<T>(
   if (!legacy)
     throw new Error('useDashboard must be used within DashboardProvider');
   return selector(sliceFromLegacy(legacy));
+}
+
+/**
+ * Selector hook for the active board's `globalStyle`. Reads it off the canvas
+ * hot slice (`activeDashboard.globalStyle`) so consumers re-render ONLY when
+ * the style object identity changes — NOT on unrelated widget ops. A discrete
+ * op (updateWidget/bringToFront) spreads a new board object + widgets array but
+ * never touches `globalStyle`, so the nested reference survives and the
+ * selector's `Object.is` cache bails the re-render; only `setGlobalStyle`
+ * allocates a new style object.
+ *
+ * The `?? DEFAULT_GLOBAL_STYLE` fallback MUST reference the module-level
+ * singleton (a stable identity), never an inline object literal — a fresh
+ * object each call would defeat the `Object.is` dedupe and trip
+ * `useSyncExternalStore`'s render-loop guard (see `useDashboardCanvasSelector`).
+ */
+export function useGlobalStyle(): GlobalStyle {
+  return useDashboardCanvasSelector(
+    (s) => s.activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE
+  );
 }
 
 /**

--- a/tests/CalendarWidget.test.tsx
+++ b/tests/CalendarWidget.test.tsx
@@ -1,13 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { CalendarWidget } from '@/components/widgets/Calendar/Widget';
 import { expect, test, vi, describe, beforeEach, afterEach } from 'vitest';
-import { WidgetData } from '@/types';
+import { WidgetData, DEFAULT_GLOBAL_STYLE } from '@/types';
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: () => ({
+// CalendarWidget reads addWidget from the mount-stable useDashboardActions()
+// surface and the active board style from useGlobalStyle() — both from the
+// canvas store, not the legacy useDashboard() context.
+vi.mock('@/context/dashboardCanvasStore', () => ({
+  useDashboardActions: () => ({
     addWidget: vi.fn(),
-    activeDashboard: { globalStyle: { fontFamily: 'sans' } },
   }),
+  useGlobalStyle: () => DEFAULT_GLOBAL_STYLE,
 }));
 
 vi.mock('@/hooks/useFeaturePermissions', () => ({

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -73,7 +73,10 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { DashboardProvider } from '@/context/DashboardContext';
 import { useDashboard } from '@/context/useDashboard';
-import { useDashboardActions } from '@/context/dashboardCanvasStore';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+} from '@/context/dashboardCanvasStore';
 import { useToolVisibility } from '@/context/useToolVisibility';
 import { BoardCanvas } from '@/components/layout/BoardCanvas';
 import type {
@@ -94,6 +97,8 @@ const {
   countBystanderRender,
   actionsProbeRenderCounts,
   countActionsProbeRender,
+  globalStyleProbeRenderCounts,
+  countGlobalStyleProbeRender,
 } = vi.hoisted(() => {
   // Render-invocation counts of the DraggableWindow shell, keyed by widget
   // id. Widgets added mid-test get random UUIDs, so those are normalized to
@@ -117,6 +122,16 @@ const {
   // 0-delta, contrasted against the legacy bystander's >0 delta on the same
   // scenarios, is the proof the migration eliminates the fan-out.
   const actionsProbeCounts = new Map<string, number>();
+  // Render-invocation counts of the GlobalStyleProbe consumers, keyed by probe
+  // id ('gs-1'..'gs-5'). These probes call `useGlobalStyle()` — a selector over
+  // the canvas store that returns `activeDashboard.globalStyle`. Because a
+  // discrete widget op (bringToFront / drag-release) spreads a new board +
+  // widgets array but never touches the nested `globalStyle` object, the
+  // selector's `Object.is` cache bails and these probes do NOT re-render. Only a
+  // genuine `setGlobalStyle` allocates a new style identity and fires them. That
+  // 0-delta on widget ops, contrasted against a 5-delta on a real style change,
+  // proves the selector isolates style consumers from the per-op fan-out.
+  const globalStyleProbeCounts = new Map<string, number>();
   return {
     shellRenderCounts: counts,
     countShellRender: (widgetId: string) => {
@@ -132,6 +147,13 @@ const {
       actionsProbeCounts.set(
         probeId,
         (actionsProbeCounts.get(probeId) ?? 0) + 1
+      );
+    },
+    globalStyleProbeRenderCounts: globalStyleProbeCounts,
+    countGlobalStyleProbeRender: (probeId: string) => {
+      globalStyleProbeCounts.set(
+        probeId,
+        (globalStyleProbeCounts.get(probeId) ?? 0) + 1
       );
     },
     // 15 widgets across 8 distinct types — all on the standard (non-position-
@@ -435,6 +457,15 @@ interface ScenarioMetric {
   // the legacy `bystanderRenders` above stays > 0 on the same scenarios.
   actionsProbeRenders: number;
   actionsProbeRendersById: Record<string, number>;
+  // GlobalStyle-consumer fan-out: how many of the 5 GlobalStyleProbe consumers
+  // (which call `useGlobalStyle()`, a selector over the canvas store's
+  // `activeDashboard.globalStyle`) re-rendered during the scenario (sum), plus
+  // the per-probe breakdown. This is the selector-isolation proof — on
+  // bringToFront5 and drag.release it must be 0 (those ops never touch the
+  // nested globalStyle object, so the selector's Object.is cache bails), while a
+  // real setGlobalStyle change re-renders all 5.
+  globalStyleProbeRenders: number;
+  globalStyleProbeRendersById: Record<string, number>;
 }
 
 const metrics: ScenarioMetric[] = [];
@@ -477,12 +508,26 @@ function actionsProbeRenderDeltas(
   return deltas;
 }
 
+/** Per-probe delta of globalStyleProbeRenderCounts since the given baseline snapshot. */
+function globalStyleProbeRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...globalStyleProbeRenderCounts.keys()].sort()) {
+    const delta =
+      (globalStyleProbeRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
 function createRecorder() {
   let commits = 0;
   let duration = 0;
   let shellBaseline: ReadonlyMap<string, number> = new Map();
   let bystanderBaseline: ReadonlyMap<string, number> = new Map();
   let actionsProbeBaseline: ReadonlyMap<string, number> = new Map();
+  let globalStyleProbeBaseline: ReadonlyMap<string, number> = new Map();
   const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
     commits += 1;
     duration += actualDuration;
@@ -495,12 +540,16 @@ function createRecorder() {
       shellBaseline = new Map(shellRenderCounts);
       bystanderBaseline = new Map(bystanderRenderCounts);
       actionsProbeBaseline = new Map(actionsProbeRenderCounts);
+      globalStyleProbeBaseline = new Map(globalStyleProbeRenderCounts);
     },
     record(scenario: string) {
       const shellRendersByWidget = shellRenderDeltas(shellBaseline);
       const bystanderRendersById = bystanderRenderDeltas(bystanderBaseline);
       const actionsProbeRendersById =
         actionsProbeRenderDeltas(actionsProbeBaseline);
+      const globalStyleProbeRendersById = globalStyleProbeRenderDeltas(
+        globalStyleProbeBaseline
+      );
       metrics.push({
         scenario,
         commits,
@@ -520,6 +569,10 @@ function createRecorder() {
           0
         ),
         actionsProbeRendersById,
+        globalStyleProbeRenders: Object.values(
+          globalStyleProbeRendersById
+        ).reduce((sum, n) => sum + n, 0),
+        globalStyleProbeRendersById,
       });
     },
   };
@@ -699,6 +752,37 @@ const ACTIONS_PROBE_IDS = [
 ] as const;
 
 /**
+ * GlobalStyle-consumer probe. Stands in for a content/settings component that
+ * reads only the active board's `globalStyle` via the mount-stable
+ * `useGlobalStyle()` selector (context/dashboardCanvasStore.ts) — e.g. a widget
+ * face that honors the dashboard's font family / window transparency.
+ *
+ * The selector subscribes to the canvas store but projects only
+ * `activeDashboard.globalStyle`. A discrete widget op (bringToFront /
+ * drag-release) spreads a new board object + widgets array yet leaves the nested
+ * `globalStyle` reference untouched, so the selector's `Object.is` cache bails
+ * and this probe does NOT re-render — its scenario delta is 0. Only a genuine
+ * `setGlobalStyle` allocates a new style identity and fires all 5. Contrasted
+ * against the legacy BystanderProbe (which re-renders on those same widget ops),
+ * this 0 is the direct proof the selector isolates style consumers from the
+ * board-wide fan-out.
+ *
+ * Wrapped in React.memo with a stable `id` prop so the ONLY thing that can drive
+ * a re-render is the projected `globalStyle` slice changing identity —
+ * isolating the metric to the selector under test.
+ */
+const GlobalStyleProbe: React.FC<{ id: string }> = React.memo(({ id }) => {
+  const globalStyle = useGlobalStyle();
+  countGlobalStyleProbeRender(id);
+  // Reference the read so the subscription is real and not optimized away.
+  void globalStyle;
+  return null;
+});
+GlobalStyleProbe.displayName = 'GlobalStyleProbe';
+
+const GLOBALSTYLE_PROBE_IDS = ['gs-1', 'gs-2', 'gs-3', 'gs-4', 'gs-5'] as const;
+
+/**
  * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
  * BoardCanvas: context state and callbacks flow down as props, while
  * DraggableWindow/WidgetRenderer read the stable actions context and the
@@ -730,6 +814,9 @@ const BoardHarness: React.FC = () => {
       ))}
       {ACTIONS_PROBE_IDS.map((id) => (
         <ActionsProbe key={id} id={id} />
+      ))}
+      {GLOBALSTYLE_PROBE_IDS.map((id) => (
+        <GlobalStyleProbe key={id} id={id} />
       ))}
       <BoardCanvas
         dashboard={ctx.activeDashboard}
@@ -969,9 +1056,29 @@ describe('dashboard canvas performance baseline', () => {
       !visibleBefore
     );
 
+    // (8) setGlobalStyle — positive control for the GlobalStyleProbe. Change the
+    // active board's font family through the real context action. The seed
+    // widgets carry no globalStyle, so this writes
+    // {...DEFAULT_GLOBAL_STYLE, fontFamily:'handwritten'} → a brand-new style
+    // object identity → every useGlobalStyle() selector consumer re-renders.
+    // This proves the probe is wired to the real mechanism (so the 0-deltas on
+    // bringToFront5/drag.release below are genuine isolation, not a dead probe),
+    // while the action-only ActionsProbe consumers stay put (the actions surface
+    // never changes identity).
+    rec.start();
+    act(() => {
+      getCtx().setGlobalStyle({ fontFamily: 'handwritten' });
+    });
+    await settle();
+    rec.record('setGlobalStyle');
+    // Behavioral validity: the style change actually landed on the active board.
+    expect(getCtx().activeDashboard?.globalStyle?.fontFamily).toBe(
+      'handwritten'
+    );
+
     // The harness only asserts that metrics were produced — no duration
     // thresholds (CI machines vary; this must never be flaky).
-    expect(metrics).toHaveLength(13);
+    expect(metrics).toHaveLength(14);
     for (const m of metrics) {
       expect(m.commits).toBeGreaterThanOrEqual(0);
       expect(m.actualDurationMs).toBeGreaterThanOrEqual(0);
@@ -1016,10 +1123,13 @@ describe('dashboard canvas performance baseline', () => {
       return m;
     };
 
-    // SANITY: the probe is wired correctly — a real DashboardContext change
-    // (addWidget mutates dashboards/activeDashboard → contextValue identity)
-    // makes the bystander probes re-render. If THIS were 0, the probe isn't
-    // subscribed to the churning context and every other reading is worthless.
+    // SANITY: the BYSTANDER probe specifically is wired correctly — a real
+    // DashboardContext change (addWidget mutates dashboards/activeDashboard →
+    // contextValue identity) re-renders the legacy `useDashboard()` consumers.
+    // Post-migration only the bystander probes churn on addWidget; the
+    // actions/globalStyle probes do NOT (they read mount-stable surfaces). If
+    // this bystander delta were 0, the probe isn't subscribed to the churning
+    // context and every other bystander reading is worthless.
     const sanityAddWidgetProbeDelta = metricFor('addWidget').bystanderRenders;
     expect(sanityAddWidgetProbeDelta).toBeGreaterThan(0);
 
@@ -1071,6 +1181,39 @@ describe('dashboard canvas performance baseline', () => {
     expect(dragRelease.bystanderRenders).toBe(5);
     expect(dragRelease.actionsProbeRenders).toBe(0);
     expect(dragRelease.actionsProbeRendersById).toEqual({});
+
+    // ── Selector-isolation proof (the win this slice delivers) ────────────
+    // The 5 GlobalStyleProbe consumers read the active board's `globalStyle`
+    // via the mount-stable `useGlobalStyle()` selector. A discrete widget op
+    // spreads a new board + widgets array but never touches the nested
+    // `globalStyle` object, so the selector's Object.is cache bails and these
+    // probes do NOT re-render on those ops — while a real setGlobalStyle change
+    // fires all 5. The contrast is the proof the selector isolates style
+    // consumers from the per-op fan-out.
+
+    // SANITY: the globalStyle probes are actually mounted and counted — they
+    // each render at least once during mount15. Without this, a 0 delta on the
+    // hot scenarios could just mean the probe never mounted (a dead instrument).
+    expect(
+      Object.keys(metricFor('mount15').globalStyleProbeRendersById)
+    ).toHaveLength(5);
+
+    // bringToFront5 / drag.release: each raise/commit spreads a new board +
+    // widgets array but leaves the nested `globalStyle` reference untouched, so
+    // the useGlobalStyle() selector's Object.is cache bails — the 5 globalStyle
+    // probes never re-render. (Contrast: the legacy bystanders churn 25 and 5
+    // on these same ops above.)
+    expect(metricFor('bringToFront5').globalStyleProbeRenders).toBe(0);
+    expect(metricFor('drag.release').globalStyleProbeRenders).toBe(0);
+
+    // POSITIVE CONTROL: a real setGlobalStyle change allocates a new style
+    // object identity → all 5 globalStyle probes re-render, while the
+    // action-only ActionsProbe consumers stay at 0 (the actions surface never
+    // changes identity). This is the live-instrument check that makes the two
+    // 0-deltas above genuine isolation rather than a dead probe.
+    const setStyle = metricFor('setGlobalStyle');
+    expect(setStyle.globalStyleProbeRenders).toBe(5);
+    expect(setStyle.actionsProbeRenders).toBe(0);
   });
 });
 
@@ -1108,6 +1251,14 @@ afterAll(() => {
           'the legacy bystander probes read 25 and 5 respectively, showing the ' +
           'useDashboard()→useDashboardActions() swap isolates content consumers ' +
           'from the per-op DashboardContext fan-out. ' +
+          'globalStyleProbeRenders/globalStyleProbeRendersById count how many of ' +
+          'the 5 GlobalStyleProbe consumers (which read the active board ' +
+          'globalStyle via the mount-stable useGlobalStyle() selector) ' +
+          're-rendered per scenario — the selector-isolation proof: on ' +
+          'bringToFront5 and drag.release they read 0 (those ops never touch the ' +
+          'nested globalStyle object, so the selector Object.is cache bails), ' +
+          'while the setGlobalStyle scenario reads 5 (a real style change ' +
+          'allocates a new style identity) with the actions probes still at 0. ' +
           'actualDurationMs is machine-dependent and indicative only — ' +
           'compare medians of 3 runs.',
         skipped:

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-06-17T05:16:33.905Z",
+  "generatedAt": "2026-06-18T03:35:11.195Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. globalStyleProbeRenders/globalStyleProbeRendersById count how many of the 5 GlobalStyleProbe consumers (which read the active board globalStyle via the mount-stable useGlobalStyle() selector) re-rendered per scenario — the selector-isolation proof: on bringToFront5 and drag.release they read 0 (those ops never touch the nested globalStyle object, so the selector Object.is cache bails), while the setGlobalStyle scenario reads 5 (a real style change allocates a new style identity) with the actions probes still at 0. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
       "commits": 3,
-      "actualDurationMs": 150.274,
+      "actualDurationMs": 228.535,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -41,12 +41,20 @@
         "actions-3": 1,
         "actions-4": 1,
         "actions-5": 1
+      },
+      "globalStyleProbeRenders": 5,
+      "globalStyleProbeRendersById": {
+        "gs-1": 1,
+        "gs-2": 1,
+        "gs-3": 1,
+        "gs-4": 1,
+        "gs-5": 1
       }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 2.364,
+      "actualDurationMs": 4.135,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -60,7 +68,9 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "drag.move30",
@@ -71,12 +81,14 @@
       "bystanderRenders": 0,
       "bystanderRendersById": {},
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "drag.release",
       "commits": 3,
-      "actualDurationMs": 3.104,
+      "actualDurationMs": 5.423,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -90,18 +102,22 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 0.989,
+      "actualDurationMs": 1.326,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
       "bystanderRendersById": {},
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "resize.move30",
@@ -112,12 +128,14 @@
       "bystanderRenders": 0,
       "bystanderRendersById": {},
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "resize.release",
       "commits": 3,
-      "actualDurationMs": 3.267,
+      "actualDurationMs": 5.852,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -131,12 +149,14 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 10.493,
+      "actualDurationMs": 16.248,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -154,12 +174,14 @@
         "bystander-5": 5
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "addWidget",
       "commits": 3,
-      "actualDurationMs": 6.601,
+      "actualDurationMs": 8.492,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -173,12 +195,14 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 0.931,
+      "actualDurationMs": 1.184,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -190,12 +214,14 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 2.094,
+      "actualDurationMs": 3.592,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -209,12 +235,14 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 1.942,
+      "actualDurationMs": 3.307,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -228,18 +256,63 @@
         "bystander-5": 1
       },
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
     },
     {
       "scenario": "toggleToolVisibility",
       "commits": 1,
-      "actualDurationMs": 0.621,
+      "actualDurationMs": 0.857,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
       "bystanderRendersById": {},
       "actionsProbeRenders": 0,
-      "actionsProbeRendersById": {}
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {}
+    },
+    {
+      "scenario": "setGlobalStyle",
+      "commits": 2,
+      "actualDurationMs": 29.007,
+      "totalShellRenders": 15,
+      "shellRendersByWidget": {
+        "w-1": 1,
+        "w-10": 1,
+        "w-11": 1,
+        "w-12": 1,
+        "w-13": 1,
+        "w-14": 1,
+        "w-15": 1,
+        "w-2": 1,
+        "w-3": 1,
+        "w-4": 1,
+        "w-5": 1,
+        "w-6": 1,
+        "w-7": 1,
+        "w-8": 1,
+        "w-9": 1
+      },
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 5,
+      "globalStyleProbeRendersById": {
+        "gs-1": 1,
+        "gs-2": 1,
+        "gs-3": 1,
+        "gs-4": 1,
+        "gs-5": 1
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Third slice of the `DashboardContext` churn-reduction effort (after F9 [#1996](https://github.com/OPS-PIvers/SpartBoard/pull/1996) — tool-visibility split — and content-actions [#2004](https://github.com/OPS-PIvers/SpartBoard/pull/2004) — 9 action-only widgets).

A discrete widget op (`bringToFront` / drag-release / `moveWidgetLayer`) recreates the whole `DashboardContext` value, so every `useDashboard()` consumer re-renders. After #2004, **13 more widgets were blocked** from the `useDashboardActions()` migration for one reason only: they also read `activeDashboard?.globalStyle`.

This PR adds a **mount-stable `useGlobalStyle()` selector** and migrates those 13 widgets off `useDashboard()`.

## What changed

- **`context/dashboardCanvasStore.ts`** — new `useGlobalStyle()`: a thin wrapper over the existing `useDashboardCanvasSelector`, returning `s.activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE`. Reading `globalStyle` no longer subscribes to the churning context. `updateWidget`/`bringToFront` spread a new board + widgets array but **never touch the nested `globalStyle` object**, so the selector's `Object.is` cache bails on unrelated ops; only `setGlobalStyle` allocates a new style identity. The `?? DEFAULT_GLOBAL_STYLE` fallback uses the module-level singleton (stable identity) — required so the `useSyncExternalStore` dedupe holds. No new provider and no new bare-host guard: the selector's built-in legacy fallback already covers Subs/Student hosts.
- **13 widgets migrated** to `useGlobalStyle()` + `useDashboardActions()`: Clock, Countdown, Dice, Calendar, Poll, Scoreboard, RevealGrid, TimeTool, NeedDoPutThen, random Wheel/Slots/Flash, and the Dock label. Each, inside `WidgetRenderer`'s existing `memo()`, now re-renders only when its own widget changes.
- **8 colocated tests** updated to mock the stable surfaces (retaining the legacy `useDashboard` mock where an unmigrated Settings panel or hook still consumes it — Poll, Scoreboard, TimeTool).
- **Perf harness** (`tests/perf/dashboardPerf.test.tsx`) — new `GlobalStyleProbe` (5×, `React.memo`, calls `useGlobalStyle()`).

## Proof (perf harness)

| scenario | globalStyle probe | legacy bystander probe |
|---|---|---|
| `bringToFront5` | **0** | 25 |
| `drag.release` | **0** | 5 |
| `setGlobalStyle` (positive control) | **5** | 5 |

- **Isolation:** 0 re-renders on `bringToFront5`/`drag.release`.
- **Positive control:** a real `setGlobalStyle` re-renders all 5 globalStyle probes while the action probes stay at **0** — so the test can't pass trivially. Includes a behavioral `fontFamily` validity assertion.
- **Falsifiability:** pointing the probe back at `useDashboard()` makes the isolation assertions fail (observed 25 instead of 0).

## Out of scope (next lever)

12 widgets still read other dashboard state (`rosters`/`activeRosterId`/`isActiveBoardReadOnly`/`selectedWidgetId`/`setBackground`/`activeDashboard.widgets`/pending-share-setters). Three of them (GraphicOrganizer, ConceptWeb, TextWidget) block only on `isActiveBoardReadOnly`/`selectedWidgetId`, which already live on the canvas store — a later slice could finish them with `useDashboardCanvasSelector`.

## Verification

- `pnpm run type-check` — clean
- `pnpm run lint` / `prettier --check` on all changed files — clean
- 22 test files / 240 tests pass (migrated widget suites + perf harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)