### PR TITLE
fix(quizMaxPoints): dedup Set guard prevents LMS scoreMaximum inflation from Drive-sync races

### DIFF
--- a/tests/utils/quizMaxPoints.test.ts
+++ b/tests/utils/quizMaxPoints.test.ts
@@ -7,8 +7,10 @@ import type { QuizQuestion } from '@/types';
  * AND scaled onto at grade-push, so the two surfaces can't drift. These pin the
  * defaulting contract any future edit must preserve.
  */
+let _qCounter = 0;
+/** Make a minimal QuizQuestion with a unique id so dedup tests are not trivially broken. */
 const q = (points?: number): QuizQuestion =>
-  ({ id: 'x', points }) as unknown as QuizQuestion;
+  ({ id: `q-${++_qCounter}`, points }) as unknown as QuizQuestion;
 
 describe('quizMaxPoints', () => {
   it('sums per-question points', () => {
@@ -25,5 +27,37 @@ describe('quizMaxPoints', () => {
 
   it('falls back to 100 when the summed points are 0', () => {
     expect(quizMaxPoints([q(0), q(0)])).toBe(100);
+  });
+
+  it('deduplicates questions by id — Drive-sync duplicate guard', () => {
+    // Drive-sync duplication or arrayUnion races can write the same question id
+    // twice into `quiz.questions`. Without a dedup guard, the denominator
+    // inflates (e.g. 10 + 10 = 20) while the push path's `buildQuizClassroomGradeEntries`
+    // (which already deduplicates via its own seenIds Set) stays correct at 10.
+    // The attach-time `scoreMaximum` is then 20 while the maximum a student can
+    // ever earn is 10 — they can never achieve a perfect LMS grade.
+    const dupQuestion: QuizQuestion = {
+      id: 'q-dup',
+      type: 'MC',
+      points: 10,
+    } as unknown as QuizQuestion;
+    // Two entries with the SAME id simulate the Drive-sync duplicate.
+    expect(quizMaxPoints([dupQuestion, dupQuestion])).toBe(10);
+  });
+
+  it('deduplicates mixed unique and duplicate questions', () => {
+    // Ensure dedup only collapses the duplicate, not the distinct question.
+    const dup: QuizQuestion = {
+      id: 'dup',
+      type: 'MC',
+      points: 5,
+    } as unknown as QuizQuestion;
+    const unique: QuizQuestion = {
+      id: 'unique',
+      type: 'MC',
+      points: 3,
+    } as unknown as QuizQuestion;
+    // [dup, dup, unique] → only dup(5) + unique(3) = 8
+    expect(quizMaxPoints([dup, dup, unique])).toBe(8);
   });
 });

--- a/utils/quizMaxPoints.ts
+++ b/utils/quizMaxPoints.ts
@@ -11,7 +11,25 @@ import type { QuizQuestion } from '@/types';
  * attached as N points could be pushed against a different denominator and post
  * the wrong fraction. Sharing one helper makes that drift impossible (it
  * previously lived as an inline `reduce(...) || 100` copied per surface).
+ *
+ * Deduplicates by question id — Drive-sync or arrayUnion races can write the
+ * same question id twice. Without the guard the denominator is inflated (e.g.
+ * 4 instead of 2) while `buildQuizClassroomGradeEntries` (which already
+ * deduplicates via its own `seenIds` Set) stays correct, producing a line item
+ * `scoreMaximum` that is larger than the actual point total a student can ever
+ * earn. A student who answers every question correctly then pushes a grade of
+ * `(earned / currentTotal) * inflatedMaxPoints`, which rounds to LESS than
+ * `inflatedMaxPoints` in the gradebook — they can never achieve a perfect
+ * score. Mirrors the identical fence in `videoActivityMaxPoints` (#2000) and
+ * `buildContributionDoc` (#1777).
  */
 export function quizMaxPoints(questions: QuizQuestion[]): number {
-  return questions.reduce((sum, q) => sum + (q.points ?? 1), 0) || 100;
+  const seen = new Set<string>();
+  let total = 0;
+  for (const q of questions) {
+    if (seen.has(q.id)) continue;
+    seen.add(q.id);
+    total += q.points ?? 1;
+  }
+  return total || 100;
 }


### PR DESCRIPTION
## Summary

- **Bug**: `quizMaxPoints()` summed points with a plain `reduce` — no dedup by question ID. Drive-sync or `arrayUnion` races can write the same question ID twice into `quiz.questions`. The denominator frozen into the LMS line item (`scoreMaximum`) at quiz-attach time was then inflated (e.g. 2×10 = 20 instead of 10).
- **Impact**: The push path's `buildQuizClassroomGradeEntries` already deduplicates via its own `seenIds` Set, so earned points are computed correctly at 10 — but `scoreMaximum` is 20. A student who answers every question correctly earns 10/20 = 50% in the gradebook. They can **never** achieve a perfect LMS grade.
- **Fix**: Added `Set<string>` dedup fence — iterates questions, skips duplicates by ID. Also updated the `q()` test helper to generate unique IDs per call (the previous `id: 'x'` masked the bug for all pre-existing tests). Mirrors the identical fence in `videoActivityMaxPoints` (#2000) and `buildContributionDoc` (#1777).

## Verification

- **FAIL-BEFORE**: `quizMaxPoints([dup, dup])` with `points: 10` → returns `20` ≠ expected `10`
- **PASS-AFTER**: returns `10` ✓ (6/6 tests pass)

## Files changed

- `utils/quizMaxPoints.ts` — add dedup fence
- `tests/utils/quizMaxPoints.test.ts` — unique-ID helper + 2 new dedup test cases

🤖 Nightly debugger run 21 · 2026-06-18

---
_Generated by [Claude Code](https://claude.ai/code/session_01EepnbGuv3hSbaCBoVgZKd1)_