### PR TITLE
fix(lti): preserve stored contextTitle in linkLtiCourseV1 against null-clobber on privacy-stripped relaunches

### DIFF
--- a/functions/src/lti/courseLinkEndpoints.test.ts
+++ b/functions/src/lti/courseLinkEndpoints.test.ts
@@ -160,6 +160,17 @@ const seenSession = () => {
     }),
   };
 };
+/** Simulates a privacy-stripped relaunch where the LMS omits the context title. */
+const seenSessionNullTitle = () => {
+  sessionDoc = { exists: true, data: () => ({ teacherUid: 'teacher-1' }) };
+  contextDoc = {
+    exists: true,
+    data: () => ({
+      contextTitle: null,
+      contextMembershipsUrl: 'https://lms/ctx/members',
+    }),
+  };
+};
 
 beforeEach(() => {
   sessionDoc = { exists: false, data: () => undefined };
@@ -257,6 +268,34 @@ describe('linkLtiCourseV1', () => {
     expect(courseLinks.get('ctx-1')).toMatchObject({
       teacherUid: 'teacher-1',
       classlinkClassId: 'cl-new',
+    });
+  });
+
+  it('preserves a stored contextTitle when a privacy-stripped relaunch yields null (#null-clobber)', async () => {
+    // Regression: a Schoology deployment with privacy configuration may omit the
+    // context title on relaunches. nrpsStore.ts stores null for the title in the
+    // NEW session's membership doc (there's no prior doc for that session to
+    // fall back on). linkLtiCourseV1 was writing `contextTitle: null` directly
+    // to lti_course_links, silently clearing the section name captured from an
+    // earlier launch — the same clobber pattern fixed in nrpsStore.ts and
+    // launchEndpoints.ts. The fix: prefer the stored title over null, matching
+    // the pattern `contextTitle ?? storedTitle`.
+    seenSessionNullTitle(); // session membership doc has contextTitle: null
+    courseLinks.set('ctx-1', {
+      teacherUid: 'teacher-1',
+      classlinkClassId: 'cl-old',
+      contextTitle: 'Algebra 1 · P1', // previously captured valid title
+      createdAt: 1,
+    });
+    await callLink({
+      auth: TEACHER,
+      data: { ...base, classlinkClassId: 'cl-new' },
+    });
+    // The stored title must survive the relink — it must NOT be overwritten with null.
+    expect(courseLinks.get('ctx-1')).toMatchObject({
+      teacherUid: 'teacher-1',
+      classlinkClassId: 'cl-new',
+      contextTitle: 'Algebra 1 · P1',
     });
   });
 });

--- a/functions/src/lti/courseLinkEndpoints.ts
+++ b/functions/src/lti/courseLinkEndpoints.ts
@@ -251,7 +251,7 @@ export const linkLtiCourseV1 = onCall(
       // linking UI — the same preservation pattern applied in nrpsStore.ts
       // (contextTitle) and launchEndpoints.ts (contextId).
       const storedTitle =
-        typeof priorData?.contextTitle === 'string'
+        priorData && typeof priorData.contextTitle === 'string'
           ? priorData.contextTitle
           : null;
       const finalContextTitle = contextTitle ?? storedTitle;

--- a/functions/src/lti/courseLinkEndpoints.ts
+++ b/functions/src/lti/courseLinkEndpoints.ts
@@ -225,10 +225,15 @@ export const linkLtiCourseV1 = onCall(
     await db.runTransaction(async (tx) => {
       const ref = db.collection(LTI_COURSE_LINKS_COLLECTION).doc(contextId);
       const existing = await tx.get(ref);
-      if (existing.exists) {
-        const prior = existing.data() as { teacherUid?: unknown };
+      const priorData = existing.exists
+        ? (existing.data() as {
+            teacherUid?: unknown;
+            contextTitle?: unknown;
+          })
+        : null;
+      if (priorData) {
         const priorTeacher =
-          typeof prior?.teacherUid === 'string' ? prior.teacherUid : '';
+          typeof priorData.teacherUid === 'string' ? priorData.teacherUid : '';
         if (priorTeacher && priorTeacher !== callerUid) {
           throw new HttpsError(
             'already-exists',
@@ -236,12 +241,26 @@ export const linkLtiCourseV1 = onCall(
           );
         }
       }
+      // Preserve a previously-captured contextTitle: some Schoology deployments
+      // omit the context title on relaunches (privacy config). The session
+      // membership doc written by nrpsStore.ts may then store null for the
+      // title (a new session has no prior record to fall back on), so
+      // contextTitle arriving here can be null even though a valid title was
+      // captured from an earlier launch and already written to this doc.
+      // Overwriting with null would clear the section name shown in the
+      // linking UI — the same preservation pattern applied in nrpsStore.ts
+      // (contextTitle) and launchEndpoints.ts (contextId).
+      const storedTitle =
+        typeof priorData?.contextTitle === 'string'
+          ? priorData.contextTitle
+          : null;
+      const finalContextTitle = contextTitle ?? storedTitle;
       const payload: Record<string, unknown> = {
         teacherUid: callerUid,
         contextId,
         classlinkClassId,
         classlinkOrgId,
-        contextTitle,
+        contextTitle: finalContextTitle,
         rosterId,
         updatedAt: Date.now(),
       };


### PR DESCRIPTION
## Summary

- **Bug**: `linkLtiCourseV1` wrote `contextTitle: null` into `lti_course_links/{contextId}` when a privacy-configured Schoology deployment omitted the context title on a relaunch. The previous merge-write silently cleared the section name captured from an earlier launch.
- **Impact**: Course-link records lose their `contextTitle` after any privacy-stripped relaunch. The linking UI shows a blank section name for affected courses.
- **Root cause**: Same null-clobber pattern previously fixed in `nrpsStore.ts` (#1903) and `launchEndpoints.ts` (#1958). The function read the existing doc to check `teacherUid` ownership but discarded `contextTitle`, then wrote the new (null) value unconditionally.
- **Fix**: Read `storedTitle` from the existing `lti_course_links` doc inside the transaction; apply `contextTitle ?? storedTitle` before writing the payload. Adds a regression test (`seenSessionNullTitle`) that fails on original code and passes after.

## Verification

- **FAIL-BEFORE**: `courseLinks.get('ctx-1').contextTitle` → `null` (was overwritten); test expects `'Algebra 1 · P1'`
- **PASS-AFTER**: `contextTitle` preserved as `'Algebra 1 · P1'` ✓ (17/17 tests pass)

## Files changed

- `functions/src/lti/courseLinkEndpoints.ts` — read stored title, apply `??` guard
- `functions/src/lti/courseLinkEndpoints.test.ts` — `seenSessionNullTitle` fixture + regression test case

🤖 Nightly debugger run 21 · 2026-06-18

---
_Generated by [Claude Code](https://claude.ai/code/session_01EepnbGuv3hSbaCBoVgZKd1)_