### PR TITLE
fix(widgets): stale onBlur Escape-cancel guard — DrawingWidget InlineTitle + SmartNotebook PageEditor

### DIFF
--- a/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PageStrip } from './PageStrip';
+
+// Minimal DrawingPage fixture — only id, objects, and title are needed.
+const makePages = (title = 'Page 1') => [{ id: 'p1', objects: [], title }];
+
+const baseProps = {
+  currentPage: 0,
+  onSelectPage: vi.fn(),
+  onAddPage: vi.fn(),
+  onDeletePage: vi.fn(),
+};
+
+describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () => {
+  it('FAIL-BEFORE / PASS-AFTER: Escape + synchronous blur must NOT commit the edited text', async () => {
+    // Root cause: cancel() calls setIsEditing(false) which unmounts the
+    // focused <input>. React batches the state update; the browser fires a
+    // synchronous blur event on the still-mounted input BEFORE the new state
+    // commits. The onBlur=commit closure captures the pre-cancel draft and
+    // calls onCommit with the cancelled text.
+    // Fix: isCancellingRef set synchronously in cancel(); commit() checks it
+    // and short-circuits, clearing the flag.
+    const onRenamePage = vi.fn();
+    const pages = makePages('Page 1');
+
+    render(
+      <PageStrip pages={pages} onRenamePage={onRenamePage} {...baseProps} />
+    );
+
+    // Click the chip button to enter edit mode.
+    const renameBtn = screen.getByRole('button', { name: /rename "Page 1"/i });
+    fireEvent.click(renameBtn);
+
+    const input = screen.getByRole('textbox', { name: /page title/i });
+
+    // Type a name the user intends to discard.
+    fireEvent.change(input, { target: { value: 'Unwanted Name' } });
+
+    // Replicate the browser's synchronous blur-during-unmount sequence.
+    // Both events must be inside the SAME act() so React's flush is deferred
+    // until after both have fired (jsdom does not auto-fire blur on removal).
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    // The rename must NOT have been committed.
+    expect(onRenamePage).not.toHaveBeenCalled();
+  });
+
+  it('calls onRenamePage with edited text on plain blur (normal commit path)', async () => {
+    const onRenamePage = vi.fn();
+    render(
+      <PageStrip
+        pages={makePages()}
+        onRenamePage={onRenamePage}
+        {...baseProps}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /rename "Page 1"/i }));
+    const input = screen.getByRole('textbox', { name: /page title/i });
+    fireEvent.change(input, { target: { value: 'New Name' } });
+
+    await act(async () => {
+      fireEvent.blur(input);
+    });
+
+    expect(onRenamePage).toHaveBeenCalledWith(0, 'New Name');
+  });
+
+  it('calls onRenamePage with edited text on Enter (normal commit path)', async () => {
+    const onRenamePage = vi.fn();
+    render(
+      <PageStrip
+        pages={makePages()}
+        onRenamePage={onRenamePage}
+        {...baseProps}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /rename "Page 1"/i }));
+    const input = screen.getByRole('textbox', { name: /page title/i });
+    fireEvent.change(input, { target: { value: 'Enter Name' } });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    expect(onRenamePage).toHaveBeenCalledWith(0, 'Enter Name');
+  });
+});

--- a/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
@@ -14,7 +14,7 @@ const baseProps = {
 };
 
 describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () => {
-  it('FAIL-BEFORE / PASS-AFTER: Escape + synchronous blur must NOT commit the edited text', async () => {
+  it('FAIL-BEFORE / PASS-AFTER: Escape + synchronous blur must NOT commit the edited text', () => {
     // Root cause: cancel() calls setIsEditing(false) which unmounts the
     // focused <input>. React batches the state update; the browser fires a
     // synchronous blur event on the still-mounted input BEFORE the new state
@@ -41,7 +41,7 @@ describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () 
     // Replicate the browser's synchronous blur-during-unmount sequence.
     // Both events must be inside the SAME act() so React's flush is deferred
     // until after both have fired (jsdom does not auto-fire blur on removal).
-    await act(async () => {
+    act(() => {
       fireEvent.keyDown(input, { key: 'Escape' });
       fireEvent.blur(input);
     });
@@ -50,7 +50,7 @@ describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () 
     expect(onRenamePage).not.toHaveBeenCalled();
   });
 
-  it('calls onRenamePage with edited text on plain blur (normal commit path)', async () => {
+  it('calls onRenamePage with edited text on plain blur (normal commit path)', () => {
     const onRenamePage = vi.fn();
     render(
       <PageStrip
@@ -64,14 +64,14 @@ describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () 
     const input = screen.getByRole('textbox', { name: /page title/i });
     fireEvent.change(input, { target: { value: 'New Name' } });
 
-    await act(async () => {
+    act(() => {
       fireEvent.blur(input);
     });
 
     expect(onRenamePage).toHaveBeenCalledWith(0, 'New Name');
   });
 
-  it('calls onRenamePage with edited text on Enter (normal commit path)', async () => {
+  it('calls onRenamePage with edited text on Enter (normal commit path)', () => {
     const onRenamePage = vi.fn();
     render(
       <PageStrip
@@ -85,7 +85,7 @@ describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () 
     const input = screen.getByRole('textbox', { name: /page title/i });
     fireEvent.change(input, { target: { value: 'Enter Name' } });
 
-    await act(async () => {
+    act(() => {
       fireEvent.keyDown(input, { key: 'Enter' });
     });
 

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -373,7 +373,8 @@ const InlineTitle: React.FC<{
   // state commits. The blur's commit() closure sees the pre-cancel draft.
   // Setting this ref synchronously in cancel() lets commit() short-circuit.
   const isCancellingRef = useRef(false);
-  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md pattern)
+  // Intentional render-body ref sync (CLAUDE.md pattern): reset when a new
+  // edit session opens so a prior cancel flag doesn't leak across sessions.
   if (isEditing) isCancellingRef.current = false;
 
   // Sync local draft when the parent's `value` changes while we're NOT

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -367,6 +367,12 @@ const InlineTitle: React.FC<{
   const [isEditing, setIsEditing] = useState(autoFocusOnMount);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  // Guards against the stale-onBlur race: pressing Escape calls cancel(),
+  // which calls setIsEditing(false). React batches the update, so the browser
+  // fires a synchronous blur event on the still-mounted input before the new
+  // state commits. The blur's commit() closure sees the pre-cancel draft.
+  // Setting this ref synchronously in cancel() lets commit() short-circuit.
+  const isCancellingRef = useRef(false);
 
   // Sync local draft when the parent's `value` changes while we're NOT
   // editing (external rename, page switch). Uses the "adjusting state while
@@ -392,11 +398,16 @@ const InlineTitle: React.FC<{
   }, [isEditing]);
 
   const commit = () => {
+    if (isCancellingRef.current) {
+      isCancellingRef.current = false;
+      return;
+    }
     onCommit(draft);
     setIsEditing(false);
   };
 
   const cancel = () => {
+    isCancellingRef.current = true;
     setDraft(value);
     setIsEditing(false);
     onCancel?.();

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -375,6 +375,7 @@ const InlineTitle: React.FC<{
   const isCancellingRef = useRef(false);
   // Intentional render-body ref sync (CLAUDE.md pattern): reset when a new
   // edit session opens so a prior cancel flag doesn't leak across sessions.
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md pattern)
   if (isEditing) isCancellingRef.current = false;
 
   // Sync local draft when the parent's `value` changes while we're NOT

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -373,6 +373,8 @@ const InlineTitle: React.FC<{
   // state commits. The blur's commit() closure sees the pre-cancel draft.
   // Setting this ref synchronously in cancel() lets commit() short-circuit.
   const isCancellingRef = useRef(false);
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync (CLAUDE.md pattern)
+  if (isEditing) isCancellingRef.current = false;
 
   // Sync local draft when the parent's `value` changes while we're NOT
   // editing (external rename, page switch). Uses the "adjusting state while

--- a/components/widgets/SmartNotebook/components/PageEditor.test.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.test.tsx
@@ -101,12 +101,10 @@ describe('PageEditor — Escape-cancel must not commit stale text via onBlur', (
 
     // After React flushes, the textarea should be present.
     const textarea = container.querySelector('textarea');
-    if (!textarea) {
-      // If jsdom geometry stubs prevented the text-drop path from running
-      // (e.g. objectNearClient returned something unexpected), skip rather
-      // than fail — the pointerup test already covers the path.
-      return;
-    }
+    // Fail loudly rather than silently passing — a phantom green would give
+    // false confidence that the cancellingRef guard is being exercised.
+    expect(textarea).not.toBeNull();
+    if (!textarea) return; // TypeScript narrowing only; assertion above already fails
 
     // Count onChange calls so far (one expected: the text-object insert).
     const callsAfterInsert = onChange.mock.calls.length;

--- a/components/widgets/SmartNotebook/components/PageEditor.test.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { PageEditor } from './PageEditor';
 
 // jsdom does not implement SVGGraphicsElement.getBBox or DOMMatrix; stub them
@@ -51,6 +51,89 @@ const fire = (target: Element, type: string, props: PointerEventInit): void => {
 };
 
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+/**
+ * Regression test: Escape-cancel stale onBlur in the inline text editor.
+ *
+ * Bug summary
+ * -----------
+ * When the user pressed Escape to cancel a text edit, React queued
+ * `setEditing(null)` but the DOM blur event fired synchronously BEFORE
+ * that state update was committed.  The `onBlur={applyTextEdit}` handler
+ * ran with a stale closure where `editing` was still non-null, so it
+ * called `writeTextLines` + `emitChange` — saving the text the user
+ * intended to discard and firing `onChange` a second time.
+ *
+ * Fix: `cancellingRef.current = true` is set synchronously at the start
+ * of the Escape branch; `applyTextEdit` short-circuits when it sees that
+ * flag.  Identical pattern to RandomGroups.GroupDropZone (PR #1965).
+ */
+describe('PageEditor — Escape-cancel must not commit stale text via onBlur', () => {
+  it('does not call onChange when Escape cancels a modified text placeholder', async () => {
+    // Open a PageEditor in text-tool mode.
+    const onChange = vi.fn();
+    const { container } = render(
+      <PageEditor tool="text" svg={TEST_SVG} onChange={onChange} />
+    );
+    // Let the mount useEffect run (sets up the editable SVG DOM).
+    await tick();
+
+    // The editor container is the inner div with onPointerDown.
+    const editorDiv = container.querySelector(
+      '[data-no-drag="true"] div'
+    ) as HTMLElement;
+    expect(editorDiv).toBeTruthy();
+
+    // Fire a text-tool pointerdown on empty canvas → creates a placeholder
+    // text object and opens the inline textarea editor.
+    // The container uses React synthetic pointer events (onPointerDown) so
+    // fireEvent is the right vehicle here; native dispatchEvent bypasses
+    // React's SyntheticEvent system and would not reach the handler.
+    act(() => {
+      fireEvent.pointerDown(editorDiv, {
+        clientX: 400,
+        clientY: 300,
+        pointerId: 1,
+        buttons: 1,
+        isPrimary: true,
+      });
+    });
+
+    // After React flushes, the textarea should be present.
+    const textarea = container.querySelector('textarea');
+    if (!textarea) {
+      // If jsdom geometry stubs prevented the text-drop path from running
+      // (e.g. objectNearClient returned something unexpected), skip rather
+      // than fail — the pointerup test already covers the path.
+      return;
+    }
+
+    // Count onChange calls so far (one expected: the text-object insert).
+    const callsAfterInsert = onChange.mock.calls.length;
+
+    // Simulate the user typing — now editing.value !== editing.initialValue,
+    // which is the exact precondition that triggers the stale-closure bug:
+    // the Escape handler won't call emitChange (it only does so for
+    // unchanged placeholders), so only the stale onBlur path produces the
+    // spurious second onChange call.
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+
+    // Press Escape + blur in the same act() so React processes them in the
+    // same batch.  The sequence replicates the browser's synchronous
+    // focus-manager order:
+    //   1. keyDown schedules setEditing(null) → queued state update
+    //   2. blur fires (still inside the batch, before React commits)
+    //      → with the bug this calls applyTextEdit with stale editing
+    //      → with the fix it sees cancellingRef and exits early
+    act(() => {
+      fireEvent.keyDown(textarea, { key: 'Escape' });
+      fireEvent.blur(textarea);
+    });
+
+    // onChange must NOT have been called again after the insert.
+    expect(onChange.mock.calls.length).toBe(callsAfterInsert);
+  });
+});
 
 describe('PageEditor — pointerup robustness', () => {
   // Hold the original behind a wrapper so the lint rule against unbound

--- a/components/widgets/SmartNotebook/components/PageEditor.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.tsx
@@ -450,6 +450,7 @@ export const PageEditor: React.FC<PageEditorProps> = ({
   // a queued state update would not be committed in time.
   // Identical pattern to RandomGroups.GroupDropZone (PR #1965).
   const cancellingRef = useRef(false);
+  if (editing) cancellingRef.current = false;
 
   // PageEditor is purely write-only after mount: it reads the `svg` prop
   // exactly once (in the mount effect below) and never reacts to subsequent

--- a/components/widgets/SmartNotebook/components/PageEditor.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.tsx
@@ -442,6 +442,15 @@ export const PageEditor: React.FC<PageEditorProps> = ({
     isPlaceholder: boolean;
   } | null>(null);
 
+  // Synchronous cancel flag: set to true in the Escape keyDown handler
+  // BEFORE setEditing(null) so that the stale onBlur={applyTextEdit} closure
+  // can see it and bail out without persisting the discarded text.
+  // A ref is used (not state) because the write must be visible to the blur
+  // handler that fires in the same synchronous event-processing microtask —
+  // a queued state update would not be committed in time.
+  // Identical pattern to RandomGroups.GroupDropZone (PR #1965).
+  const cancellingRef = useRef(false);
+
   // PageEditor is purely write-only after mount: it reads the `svg` prop
   // exactly once (in the mount effect below) and never reacts to subsequent
   // prop changes. The host's autosave feedback (Storage URL bouncing back
@@ -1490,6 +1499,13 @@ export const PageEditor: React.FC<PageEditorProps> = ({
   };
 
   const applyTextEdit = () => {
+    // If the user pressed Escape just before this blur fired, bail out so
+    // the stale closure doesn't persist text the user intended to discard.
+    if (cancellingRef.current) {
+      cancellingRef.current = false;
+      setEditing(null);
+      return;
+    }
     const svgEl = svgRef.current;
     if (!svgEl || !editing) return;
     const obj = findObjectById(svgEl, editing.id);
@@ -2210,6 +2226,11 @@ export const PageEditor: React.FC<PageEditorProps> = ({
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               e.preventDefault();
+              // Signal applyTextEdit (via onBlur) to bail out. This ref write
+              // is synchronous and is therefore visible to the blur handler
+              // that fires in the same microtask before React commits the
+              // setEditing(null) state update below.
+              cancellingRef.current = true;
               if (
                 editing &&
                 editing.isPlaceholder &&


### PR DESCRIPTION
## Summary

Two instances of the stale `onBlur` / Escape-cancel race condition found and fixed in this run. Both are the same root cause: pressing Escape calls a state setter that unmounts the focused `<input>`/`<textarea>`, but the browser fires `blur` synchronously before React commits the state update — leaving the `onBlur` save handler seeing the pre-cancel draft and persisting text the user intended to discard.

### 1. `DrawingWidget/PageStrip.tsx` — `InlineTitle` rename

- Pressing Escape while renaming a page thumbnail fired `onRenamePage` with the typed (cancelled) text.
- Fix: `isCancellingRef = useRef(false)` set synchronously before `setIsEditing(false)`; `commit()` short-circuits when flag is set.
- Test: `PageStrip.InlineTitle.test.tsx` — wraps `keyDown(Escape)` + `blur` in single `act()`. Fails before; passes after.

### 2. `SmartNotebook/components/PageEditor.tsx` — text-edit `applyTextEdit`

- Pressing Escape during an inline text edit on a SmartNotebook page called `writeTextLines` + `emitChange` a second time (spurious save of cancelled text).
- Fix: same `cancellingRef` pattern; Escape handler sets flag before `setEditing(null)`; `applyTextEdit` bails when flag is set.
- Test: `PageEditor.test.tsx` — drops a placeholder, modifies it, fires Escape + blur in `act()`, asserts `onChange` called exactly once. Fails before (2 calls); passes after (1 call).

Both fixes are the 4th and 5th applications of the pattern documented in CLAUDE.md (`DraggableWindow` #1965, `RandomGroups` #1974, `FolderTree`/`FolderSidebar` #1975).

## Verification

| Component | FAIL-before | PASS-after |
|---|---|---|
| `InlineTitle` | `onRenamePage` called with cancelled text | not called ✓ |
| `PageEditor` | `onChange` called twice | called once ✓ |

## Files changed

- `components/widgets/DrawingWidget/PageStrip.tsx` — `isCancellingRef` guard in `InlineTitle`
- `components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx` — 3 new tests
- `components/widgets/SmartNotebook/components/PageEditor.tsx` — `cancellingRef` guard in `applyTextEdit`
- `components/widgets/SmartNotebook/components/PageEditor.test.tsx` — Escape-cancel regression test

🤖 Nightly debugger run 21 · 2026-06-18

---
_Generated by [Claude Code](https://claude.ai/code/session_01EepnbGuv3hSbaCBoVgZKd1)_