### PR TITLE
fix(Modal): prevent scroll-lock flicker when parent re-renders with new onClose reference

### DIFF
--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import {
@@ -42,13 +42,29 @@ export const Modal: React.FC<ModalProps> = ({
   ariaLabel,
   ariaLabelledby,
 }) => {
+  // Store onClose in a ref so the effect never needs to list it as a dep.
+  // Callers almost always pass an inline arrow function (e.g.
+  // `onClose={() => setOpen(false)}`), which creates a new reference on every
+  // parent render. Having onClose in the deps array would fire the effect
+  // cleanup + re-run on every such render, momentarily dropping the
+  // openModalCount to 0, which releases the body scroll-lock even though the
+  // modal is still open. Using a ref (same pattern as SettingsPanel.tsx) keeps
+  // the Escape handler always up-to-date while leaving the effect stable.
+  const onCloseRef = useRef(onClose);
+  // Keep ref in sync with the latest onClose on every render.
+  // Intentionally NOT in useEffect deps — see comment below.
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync to avoid stale-closure without re-subscribing the effect (CLAUDE.md pattern)
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     if (!isOpen) return undefined;
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (captureEscape) e.stopImmediatePropagation();
-        onClose();
+        // Read from ref so we always call the current onClose even though
+        // onClose is not in the effect deps array.
+        onCloseRef.current();
       }
     };
 
@@ -73,7 +89,11 @@ export const Modal: React.FC<ModalProps> = ({
         captureEscape ? { capture: true } : undefined
       );
     };
-  }, [isOpen, onClose, captureEscape]);
+    // onClose is intentionally omitted from deps — it is read via onCloseRef so
+    // a new inline arrow from the parent never triggers a cleanup + re-run that
+    // would momentarily release the body scroll-lock. Only isOpen and
+    // captureEscape need to re-subscribe the listener.
+  }, [isOpen, captureEscape]);
 
   if (!isOpen) return null;
 

--- a/tests/components/common/Modal.test.tsx
+++ b/tests/components/common/Modal.test.tsx
@@ -1,5 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React, { useState } from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+} from '@testing-library/react';
 import { Modal } from '@/components/common/Modal';
 
 describe('Modal Component', () => {
@@ -12,6 +19,15 @@ describe('Modal Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Run RTL cleanup first so unmounting the Modal component decrements
+    // openModalCount. Then restore body overflow. This ordering ensures the
+    // singleton counter and scroll-lock are both back at baseline before the
+    // next test runs.
+    cleanup();
+    document.body.style.overflow = '';
   });
 
   it('renders correctly when isOpen is true', () => {
@@ -142,5 +158,94 @@ describe('Modal Component', () => {
     );
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-label', 'Test Modal');
+  });
+
+  // Regression: onClose in the useEffect deps array causes the effect to re-run
+  // on every parent render that creates a new inline onClose reference. Each
+  // re-run triggers decrementOpenModalCount() (cleanup) + incrementOpenModalCount()
+  // (setup), which briefly drops the count to 0 and sets body overflow to 'unset',
+  // breaking the scroll-lock while the modal is still open.
+  //
+  // Root cause: useEffect(() => { ... }, [isOpen, onClose, captureEscape]) —
+  // onClose in deps means every new function reference triggers cleanup + re-run.
+  //
+  // Fix: move onClose into a ref (same pattern as SettingsPanel.tsx) and remove
+  // it from the deps array. Only isOpen and captureEscape need to be deps.
+  //
+  // How we detect this in JSDOM: because act() runs effects synchronously,
+  // the intermediate count-0 state is invisible after act() completes. Instead
+  // we intercept every write to document.body.style.overflow and record the
+  // values. With the bug: each of 3 re-renders produces 'unset' + 'hidden'
+  // (cleanup releases lock, setup re-acquires it) → 6 entries total. With the
+  // fix: no intermediate writes → 0 entries.
+  it('does not re-run scroll-lock logic when parent re-renders with a new onClose reference', () => {
+    // Intercept document.body.style.overflow assignments.
+    const overflowWrites: string[] = [];
+    let currentOverflow = '';
+    Object.defineProperty(document.body.style, 'overflow', {
+      get: () => currentOverflow,
+      set: (v: string) => {
+        currentOverflow = v;
+        overflowWrites.push(v);
+      },
+      configurable: true,
+    });
+
+    // Parent component: new inline onClose reference on every render.
+    const ParentWithInlineOnClose = () => {
+      const [_counter, setCounter] = useState(0);
+      const onClose = () => setCounter(0); // new fn reference each render
+      return (
+        <div>
+          <button
+            data-testid="trigger-rerender"
+            onClick={() => setCounter((c) => c + 1)}
+          >
+            re-render
+          </button>
+          <Modal isOpen={true} onClose={onClose} title="Scroll Lock Test">
+            Content
+          </Modal>
+        </div>
+      );
+    };
+
+    const { unmount } = render(<ParentWithInlineOnClose />);
+    // After mount the effect should have set overflow once ('hidden').
+    expect(overflowWrites).toEqual(['hidden']);
+    // Clear so only re-render-caused writes are captured.
+    overflowWrites.length = 0;
+
+    // Trigger 3 parent re-renders, each producing a new onClose reference.
+    act(() => {
+      fireEvent.click(screen.getByTestId('trigger-rerender'));
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId('trigger-rerender'));
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId('trigger-rerender'));
+    });
+
+    // With the bug: each re-render fires cleanup (sets 'unset') then re-runs
+    // setup (sets 'hidden'). Three re-renders → ['unset','hidden', ...] (6).
+    // With the fix: no overflow changes during re-renders → [].
+    const midRenderWrites = overflowWrites.slice();
+
+    // Restore so afterEach cleanup doesn't use the intercepted property.
+    Object.defineProperty(document.body.style, 'overflow', {
+      get: () => currentOverflow,
+      set: (v: string) => {
+        currentOverflow = v;
+      },
+      configurable: true,
+    });
+
+    // Final cleanup.
+    unmount();
+
+    // KEY ASSERTION: No overflow mutations should happen between initial mount
+    // and final unmount. Any entry here means the effect re-ran on a re-render.
+    expect(midRenderWrites).toHaveLength(0);
   });
 });

--- a/tests/components/common/Modal.test.tsx
+++ b/tests/components/common/Modal.test.tsx
@@ -27,6 +27,11 @@ describe('Modal Component', () => {
     // singleton counter and scroll-lock are both back at baseline before the
     // next test runs.
     cleanup();
+    // Delete any shadowed instance property so JSDOM falls back to the native
+    // prototype getter/setter, then reset to baseline. This guarantees a test
+    // that intercepts overflow (see scroll-lock test below) cannot leak a dummy
+    // accessor into subsequent tests.
+    delete (document.body.style as { overflow?: string }).overflow;
     document.body.style.overflow = '';
   });
 
@@ -232,14 +237,11 @@ describe('Modal Component', () => {
     // With the fix: no overflow changes during re-renders → [].
     const midRenderWrites = overflowWrites.slice();
 
-    // Restore so afterEach cleanup doesn't use the intercepted property.
-    Object.defineProperty(document.body.style, 'overflow', {
-      get: () => currentOverflow,
-      set: (v: string) => {
-        currentOverflow = v;
-      },
-      configurable: true,
-    });
+    // Restore the native property by deleting the shadowed instance accessor.
+    // Re-defining a dummy getter/setter here would leave a closure-bound
+    // accessor in place that never updates the real DOM style, breaking any
+    // later test that reads/writes document.body.style.overflow.
+    delete (document.body.style as { overflow?: string }).overflow;
 
     // Final cleanup.
     unmount();


### PR DESCRIPTION
## Summary

- **Bug**: `Modal.tsx` listed `onClose` in its `useEffect` dependency array. Callers almost universally pass inline arrow functions (`onClose={() => setState(false)}`), which create a new reference on every parent re-render (Firestore update, state change, drag tick). Each new reference triggered effect cleanup → re-setup, which briefly dropped the scroll-lock `openModalCount` to 0 and wrote `document.body.style.overflow = 'unset'` — causing a visible scroll flicker under the modal backdrop. `useHasOpenModal()` subscribers (e.g. DraggableWindow floating toolbar) also briefly saw "no modal open."
- **Fix**: Move `onClose` into a render-body ref (`onCloseRef.current = onClose`), remove it from the `useEffect` dep array. Identical to the pattern already in `SettingsPanel.tsx`. The Escape handler calls `onCloseRef.current()` to always reach the current callback without re-subscribing.
- **Band-aid rejected**: Wrapping every `onClose` at every call site with `useCallback` would patch symptoms at dozens of sites rather than fixing the one broken invariant inside `Modal`.

## Verification

- **FAIL-before**: `document.body.style.overflow` writes: `['unset','hidden','unset','hidden','unset','hidden']` on 3 re-renders with new `onClose` references
- **PASS-after**: zero overflow writes mid-lifecycle (16/16 tests pass)

## Files changed

- `components/common/Modal.tsx` — `onCloseRef` pattern; `onClose` removed from deps
- `tests/components/common/Modal.test.tsx` — scroll-lock flicker regression test + `afterEach` cleanup

🤖 Nightly debugger run 21 · 2026-06-18

---
_Generated by [Claude Code](https://claude.ai/code/session_01EepnbGuv3hSbaCBoVgZKd1)_