### PR TITLE
perf(widgets): add canvas-store selection/read-only selectors, migrate 8 widgets

### DIFF
--- a/components/widgets/ActivityWall/Widget.test.tsx
+++ b/components/widgets/ActivityWall/Widget.test.tsx
@@ -64,11 +64,23 @@ const {
 
 let snapshotDocs: Record<string, unknown>[] = [];
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: () => ({
+vi.mock('@/context/dashboardCanvasStore', () => ({
+  useDashboardActions: () => ({
     addWidget: mockAddWidget,
     addToast: mockAddToast,
     updateWidget: mockUpdateWidget,
+  }),
+  // Tests don't set up a read-only board, so the widget renders in its
+  // default editable state (matching the prior mock, which omitted the flag).
+  useIsActiveBoardReadOnly: () => false,
+}));
+
+// ActivityWallShareModal (a child still on the legacy useDashboard() value)
+// reads `addToast` when the live view mounts the share UI, so keep the legacy
+// mock for that unmigrated component.
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    addToast: mockAddToast,
   }),
 }));
 

--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -26,7 +26,10 @@ import {
   ActivityWallSubmission,
   ClassLinkClass,
 } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useIsActiveBoardReadOnly,
+} from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
 import { classLinkService } from '@/utils/classlinkService';
 import {
@@ -281,8 +284,8 @@ const formatClassLinkClassLabel = (cls: ClassLinkClass): string => {
 export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, addWidget, addToast, isActiveBoardReadOnly } =
-    useDashboard();
+  const { updateWidget, addWidget, addToast } = useDashboardActions();
+  const isActiveBoardReadOnly = useIsActiveBoardReadOnly();
   const {
     user,
     googleAccessToken,

--- a/components/widgets/ConceptWeb/Widget.tsx
+++ b/components/widgets/ConceptWeb/Widget.tsx
@@ -1,5 +1,9 @@
 import React, { useRef, useState, useMemo } from 'react';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsActiveBoardReadOnly,
+} from '@/context/dashboardCanvasStore';
 import {
   WidgetComponentProps,
   ConceptWebConfig,
@@ -13,8 +17,9 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
   widget,
   isStudentView,
 }) => {
-  const { updateWidget, bringToFront, activeDashboard, isActiveBoardReadOnly } =
-    useDashboard();
+  const { updateWidget, bringToFront } = useDashboardActions();
+  const isActiveBoardReadOnly = useIsActiveBoardReadOnly();
+  const globalStyle = useGlobalStyle();
   // Treat substitute / view-only boards the same as the student view —
   // both modes want the diagram visible but uneditable. Promote a single
   // `isReadOnly` flag so the existing student-view guards extend cleanly.
@@ -368,14 +373,9 @@ export const ConceptWebWidget: React.FC<WidgetComponentProps> = ({
     return displayNodes.find((n) => n.id === drawingFromId);
   }, [drawingFromId, displayNodes]);
 
-  const globalStyle = activeDashboard?.globalStyle;
   const fontClassName = useMemo(
-    () =>
-      getFontClass(
-        config.fontFamily ?? 'global',
-        globalStyle?.fontFamily ?? 'sans'
-      ),
-    [config.fontFamily, globalStyle?.fontFamily]
+    () => getFontClass(config.fontFamily ?? 'global', globalStyle.fontFamily),
+    [config.fontFamily, globalStyle.fontFamily]
   );
 
   return (

--- a/components/widgets/GraphicOrganizer/Widget.test.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.test.tsx
@@ -1,14 +1,21 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { GraphicOrganizerWidget } from './Widget';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsActiveBoardReadOnly,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
-import { WidgetData, GraphicOrganizerConfig } from '@/types';
+import {
+  WidgetData,
+  GraphicOrganizerConfig,
+  DEFAULT_GLOBAL_STYLE,
+} from '@/types';
 
-// Mock the Dashboard context
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
+// Mock the canvas store surfaces the widget now consumes
+vi.mock('@/context/dashboardCanvasStore');
 
 vi.mock('@/context/useAuth', () => ({
   useAuth: vi.fn(),
@@ -25,10 +32,11 @@ describe('GraphicOrganizerWidget', () => {
   const mockUpdateWidget = vi.fn();
 
   beforeEach(() => {
-    vi.mocked(useDashboard).mockReturnValue({
+    vi.mocked(useDashboardActions).mockReturnValue({
       updateWidget: mockUpdateWidget,
-      activeDashboard: { globalStyle: { fontFamily: 'sans' } },
-    } as unknown as ReturnType<typeof useDashboard>);
+    } as unknown as DashboardActions);
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
+    vi.mocked(useIsActiveBoardReadOnly).mockReturnValue(false);
     vi.mocked(useAuth).mockReturnValue({
       user: { buildingId: 'test-building' } as unknown,
       selectedBuildings: ['test-building'],

--- a/components/widgets/GraphicOrganizer/Widget.tsx
+++ b/components/widgets/GraphicOrganizer/Widget.tsx
@@ -5,7 +5,11 @@ import {
   GraphicOrganizerTemplate,
 } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsActiveBoardReadOnly,
+} from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
 import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { getFontClass, hexToRgba } from '@/utils/styles';
@@ -23,7 +27,7 @@ const EditableNode: React.FC<{
   const onUpdateRef = useRef(onUpdate);
   // Disable contentEditable for substitute / view-only boards so subs can
   // see the teacher's diagram but cannot retype or delete cell text.
-  const { isActiveBoardReadOnly } = useDashboard();
+  const isActiveBoardReadOnly = useIsActiveBoardReadOnly();
 
   useEffect(() => {
     onUpdateRef.current = onUpdate;
@@ -86,7 +90,8 @@ const EditableNode: React.FC<{
 export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, activeDashboard } = useDashboard();
+  const { updateWidget } = useDashboardActions();
+  const globalStyle = useGlobalStyle();
   const { featurePermissions } = useAuth();
   const buildingId = useWidgetBuildingId(widget) ?? 'global';
   const config = widget.config as GraphicOrganizerConfig;
@@ -110,7 +115,6 @@ export const GraphicOrganizerWidget: React.FC<{ widget: WidgetData }> = ({
     ? selectedTemplate.layout
     : config.templateType;
 
-  const globalStyle = activeDashboard?.globalStyle ?? { fontFamily: 'sans' };
   const templateFontFamily = selectedTemplate?.fontFamily;
   const currentFontFamily = config.fontFamily ?? templateFontFamily ?? 'global';
   const fontClass = getFontClass(currentFontFamily, globalStyle.fontFamily);

--- a/components/widgets/MaterialsWidget/index.tsx
+++ b/components/widgets/MaterialsWidget/index.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import {
   MaterialsConfig,
-  DEFAULT_GLOBAL_STYLE,
   WidgetComponentProps,
   MaterialsGlobalConfig,
 } from '@/types';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsWidgetSelected,
+} from '@/context/dashboardCanvasStore';
 import { Package } from 'lucide-react';
 import { getMaterialMap } from './constants';
 import { MaterialsSettings } from './Settings';
@@ -17,11 +20,11 @@ export { MaterialsSettings };
 import { WidgetLayout } from '../WidgetLayout';
 
 export const MaterialsWidget: React.FC<WidgetComponentProps> = ({ widget }) => {
-  const { updateWidget, activeDashboard, selectedWidgetId } = useDashboard();
+  const { updateWidget } = useDashboardActions();
   const { featurePermissions } = useAuth();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
+  const globalStyle = useGlobalStyle();
   const config = widget.config as MaterialsConfig;
-  const isFocused = selectedWidgetId === widget.id;
+  const isFocused = useIsWidgetSelected(widget.id);
   const permission = featurePermissions.find(
     (item) => item.widgetType === 'materials'
   );

--- a/components/widgets/SoundboardWidget/Widget.test.tsx
+++ b/components/widgets/SoundboardWidget/Widget.test.tsx
@@ -2,16 +2,18 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { SoundboardWidget } from './Widget';
 import { useAuth } from '@/context/useAuth';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useIsWidgetSelected,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 import { WidgetData } from '@/types';
 
 vi.mock('@/context/useAuth', () => ({
   useAuth: vi.fn(),
 }));
 
-vi.mock('@/context/useDashboard', () => ({
-  useDashboard: vi.fn(),
-}));
+vi.mock('@/context/dashboardCanvasStore');
 
 const mockPlay = vi
   .fn<() => Promise<void>>()
@@ -80,10 +82,10 @@ describe('SoundboardWidget', () => {
       ],
     } as unknown as ReturnType<typeof useAuth>);
 
-    vi.mocked(useDashboard).mockReturnValue({
-      selectedWidgetId: null,
+    vi.mocked(useDashboardActions).mockReturnValue({
       updateWidget: vi.fn(),
-    } as unknown as ReturnType<typeof useDashboard>);
+    } as unknown as DashboardActions);
+    vi.mocked(useIsWidgetSelected).mockReturnValue(false);
   });
 
   afterAll(() => {
@@ -267,10 +269,7 @@ describe('SoundboardWidget', () => {
   });
 
   it('shows selection bar when focused', () => {
-    vi.mocked(useDashboard).mockReturnValue({
-      selectedWidgetId: 'soundboard-1',
-      updateWidget: vi.fn(),
-    } as unknown as ReturnType<typeof useDashboard>);
+    vi.mocked(useIsWidgetSelected).mockReturnValue(true);
 
     render(<SoundboardWidget widget={defaultWidget} />);
 

--- a/components/widgets/SoundboardWidget/Widget.tsx
+++ b/components/widgets/SoundboardWidget/Widget.tsx
@@ -6,7 +6,10 @@ import {
   SoundboardSound,
 } from '@/types';
 import { useAuth } from '@/context/useAuth';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useIsWidgetSelected,
+} from '@/context/dashboardCanvasStore';
 import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -210,8 +213,8 @@ export const SoundboardWidget: React.FC<{ widget: WidgetData }> = ({
   const { selectedSoundIds = [], activeSoundIds } = config;
 
   const { featurePermissions, googleAccessToken } = useAuth();
-  const { updateWidget, selectedWidgetId } = useDashboard();
-  const isFocused = selectedWidgetId === widget.id;
+  const { updateWidget } = useDashboardActions();
+  const isFocused = useIsWidgetSelected(widget.id);
   const buildingId = useWidgetBuildingId(widget) ?? null;
 
   const globalConfig = useMemo(() => {

--- a/components/widgets/TextWidget/Widget.test.tsx
+++ b/components/widgets/TextWidget/Widget.test.tsx
@@ -2,25 +2,31 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TextWidget, TextSettings } from './index';
-import { WidgetData, TextConfig } from '@/types';
+import { WidgetData, TextConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsActiveBoardReadOnly,
+  useIsWidgetSelected,
+  type DashboardActions,
+} from '@/context/dashboardCanvasStore';
 
-// Mock useDashboard
+// Mock the dashboard surfaces both TextWidget (canvas store) and TextSettings
+// (legacy useDashboard) consume.
 const mockUpdateWidget = vi.fn();
 const mockSetSelectedWidgetId = vi.fn();
+// TextSettings (back-face panel) still reads `updateWidget` off the legacy
+// useDashboard() value, so its mock is preserved for that describe block.
 const mockDashboardContext = {
   updateWidget: mockUpdateWidget,
-  selectedWidgetId: null,
-  setSelectedWidgetId: mockSetSelectedWidgetId,
-  activeDashboard: {
-    globalStyle: { fontFamily: 'sans' },
-  },
 };
 
 // Mock useDialog
 const mockShowPrompt = vi.fn();
 
 vi.mock('@/context/useDashboard');
+vi.mock('@/context/dashboardCanvasStore');
 vi.mock('@/context/useDialog', () => ({
   useDialog: () => ({
     showPrompt: mockShowPrompt,
@@ -36,9 +42,13 @@ describe('TextWidget', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
-      mockDashboardContext
-    );
+    vi.mocked(useDashboardActions).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+      setSelectedWidgetId: mockSetSelectedWidgetId,
+    } as unknown as DashboardActions);
+    vi.mocked(useGlobalStyle).mockReturnValue(DEFAULT_GLOBAL_STYLE);
+    vi.mocked(useIsActiveBoardReadOnly).mockReturnValue(false);
+    vi.mocked(useIsWidgetSelected).mockReturnValue(false);
     // Mock document.execCommand
     execCommandMock = vi.fn(
       (_commandId: string, _showUI?: boolean, _value?: string) => true
@@ -70,10 +80,7 @@ describe('TextWidget', () => {
   });
 
   it('shows toolbar when selected', async () => {
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      ...mockDashboardContext,
-      selectedWidgetId: 'test-widget',
-    });
+    vi.mocked(useIsWidgetSelected).mockReturnValue(true);
     render(<TextWidget widget={mockWidget} />);
     // Toolbar renders via portal and depends on RAF-based position tracking.
     // In jsdom getBoundingClientRect returns zeros, so we wait for the RAF to fire.
@@ -83,10 +90,7 @@ describe('TextWidget', () => {
   });
 
   it('updates vertical alignment from the toolbar', async () => {
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      ...mockDashboardContext,
-      selectedWidgetId: 'test-widget',
-    });
+    vi.mocked(useIsWidgetSelected).mockReturnValue(true);
 
     render(<TextWidget widget={mockWidget} />);
 
@@ -105,10 +109,7 @@ describe('TextWidget', () => {
   });
 
   it('hides toolbar when not selected', () => {
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      ...mockDashboardContext,
-      selectedWidgetId: 'other-widget',
-    });
+    vi.mocked(useIsWidgetSelected).mockReturnValue(false);
     render(<TextWidget widget={mockWidget} />);
     expect(screen.queryByTitle('Bold')).not.toBeInTheDocument();
   });
@@ -127,10 +128,7 @@ describe('TextWidget', () => {
     // toolbar's portal wrapper. This test guards that regression by
     // mounting an ancestor pointerdown handler around TextWidget and
     // verifying it does NOT fire when a toolbar button is pressed.
-    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      ...mockDashboardContext,
-      selectedWidgetId: 'test-widget',
-    });
+    vi.mocked(useIsWidgetSelected).mockReturnValue(true);
 
     const ancestorPointerDown = vi.fn();
     render(

--- a/components/widgets/TextWidget/Widget.tsx
+++ b/components/widgets/TextWidget/Widget.tsx
@@ -1,7 +1,12 @@
 import React, { useRef, useEffect, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, TextConfig, DEFAULT_GLOBAL_STYLE } from '@/types';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsActiveBoardReadOnly,
+  useIsWidgetSelected,
+} from '@/context/dashboardCanvasStore';
+import { WidgetData, TextConfig } from '@/types';
 import { STICKY_NOTE_COLORS } from '@/config/colors';
 import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
 import { sanitizeHtml } from '@/utils/security';
@@ -28,15 +33,11 @@ const TOOLBAR_GAP = 8;
 const TOOLBAR_FLIP_THRESHOLD = 50;
 
 export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
-  const {
-    updateWidget,
-    activeDashboard,
-    selectedWidgetId,
-    setSelectedWidgetId,
-    isActiveBoardReadOnly,
-  } = useDashboard();
+  const { updateWidget, setSelectedWidgetId } = useDashboardActions();
+  const isSelected = useIsWidgetSelected(widget.id);
+  const isActiveBoardReadOnly = useIsActiveBoardReadOnly();
+  const globalStyle = useGlobalStyle();
   const { showPrompt } = useDialog();
-  const globalStyle = activeDashboard?.globalStyle ?? DEFAULT_GLOBAL_STYLE;
   const config = widget.config as TextConfig;
   const {
     content = '',
@@ -53,7 +54,6 @@ export const TextWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   );
 
   const fontClass = getFontClass(fontFamily, globalStyle.fontFamily);
-  const isSelected = selectedWidgetId === widget.id;
 
   const editorRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/components/widgets/Webcam/Widget.tsx
+++ b/components/widgets/Webcam/Widget.tsx
@@ -15,7 +15,7 @@ import {
 import { WidgetData, WebcamConfig } from '@/types';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { useAuth } from '@/context/useAuth';
-import { useDashboard } from '@/context/useDashboard';
+import { useDashboardActions } from '@/context/dashboardCanvasStore';
 import { useDialog } from '@/context/useDialog';
 import { extractTextWithGemini } from '@/utils/ai';
 import Tesseract from 'tesseract.js';
@@ -27,7 +27,7 @@ export const WebcamWidget: React.FC<{
   isActive?: boolean;
 }> = ({ widget: _widget, isActive = true }) => {
   const { canAccessFeature } = useAuth();
-  const { addWidget, addToast, updateWidget } = useDashboard();
+  const { addWidget, addToast, updateWidget } = useDashboardActions();
   const { showAlert, showConfirm } = useDialog();
   const ocrMode: 'standard' | 'gemini' = canAccessFeature('gemini-functions')
     ? 'gemini'

--- a/components/widgets/WorkSymbols/Widget.tsx
+++ b/components/widgets/WorkSymbols/Widget.tsx
@@ -1,13 +1,16 @@
 import React, { useCallback, useMemo } from 'react';
 import { Image as ImageIcon } from 'lucide-react';
-import { useDashboard } from '@/context/useDashboard';
+import {
+  useDashboardActions,
+  useGlobalStyle,
+  useIsWidgetSelected,
+} from '@/context/dashboardCanvasStore';
 import { useAuth } from '@/context/useAuth';
 import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
 import {
   WidgetData,
   WorkSymbolsConfig,
   WorkSymbolsGlobalConfig,
-  DEFAULT_GLOBAL_STYLE,
 } from '@/types';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -17,12 +20,13 @@ import { resolveTextPresetMultiplier } from '@/config/widgetAppearance';
 export const WorkSymbolsWidget: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget, activeDashboard, selectedWidgetId } = useDashboard();
+  const { updateWidget } = useDashboardActions();
+  const globalStyle = useGlobalStyle();
   const { featurePermissions } = useAuth();
   const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as WorkSymbolsConfig;
   const { selectedSymbolId = null } = config;
-  const isFocused = selectedWidgetId === widget.id;
+  const isFocused = useIsWidgetSelected(widget.id);
 
   // Resolve global config
   const globalConfig = useMemo(() => {
@@ -47,8 +51,7 @@ export const WorkSymbolsWidget: React.FC<{ widget: WidgetData }> = ({
   );
 
   // Font resolution
-  const globalFont =
-    activeDashboard?.globalStyle?.fontFamily ?? DEFAULT_GLOBAL_STYLE.fontFamily;
+  const globalFont = globalStyle.fontFamily;
   const fontClass = getFontClass(config.fontFamily ?? 'global', globalFont);
   const sizeMultiplier = resolveTextPresetMultiplier(config.textSizePreset);
   const titlePosition = config.titlePosition ?? 'bottom';

--- a/context/dashboardCanvasStore.ts
+++ b/context/dashboardCanvasStore.ts
@@ -265,6 +265,31 @@ export function useGlobalStyle(): GlobalStyle {
 }
 
 /**
+ * Selector hook for the active board's read-only flag. Returns a boolean, so
+ * the `Object.is` snapshot cache bails on any commit that doesn't flip
+ * read-only — a discrete widget op (updateWidget/bringToFront) never touches
+ * the `linkedShareRole`/`linkedShareEnded` this is derived from, so consumers
+ * never re-render on unrelated ops. Prefer this over reading
+ * `isActiveBoardReadOnly` off the legacy `useDashboard()` value, which pierces
+ * `memo()` on every provider commit.
+ */
+export function useIsActiveBoardReadOnly(): boolean {
+  return useDashboardCanvasSelector((s) => s.isActiveBoardReadOnly);
+}
+
+/**
+ * Per-instance selector for "is THIS widget the selected one". Returns the
+ * boolean `selectedWidgetId === id`, NOT the raw `selectedWidgetId` — so a
+ * given widget re-renders only when ITS OWN selected-ness flips, and selecting
+ * a DIFFERENT widget leaves it untouched (the `Object.is` cache returns the
+ * same `false`). Reading the raw `selectedWidgetId` instead would re-render
+ * every consumer on any selection change. `id` is the widget's id.
+ */
+export function useIsWidgetSelected(id: string): boolean {
+  return useDashboardCanvasSelector((s) => s.selectedWidgetId === id);
+}
+
+/**
  * Returns a STABLE function for event-handler-time reads of the canvas hot
  * slice (e.g. pointer-down group-sibling capture) without subscribing the
  * component to any of it.

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -1536,6 +1536,14 @@ describe('dashboard canvas performance baseline', () => {
     expect(metricFor('bringToFront5').readOnlyProbeRenders).toBe(0);
     expect(metricFor('drag.release').readOnlyProbeRenders).toBe(0);
 
+    // ORTHOGONALITY: a selection change (selectOther/selectSelf) flips
+    // selectedWidgetId but never touches read-only-ness, so the read-only probes
+    // stay at 0 — making explicit that the two new selectors subscribe to
+    // independent slice fields (the converse of loadReadOnlyBoard, which fires the
+    // ReadOnlyProbe while leaving the w-8-bound SelectionProbe untouched).
+    expect(metricFor('selectOther').readOnlyProbeRenders).toBe(0);
+    expect(metricFor('selectSelf').readOnlyProbeRenders).toBe(0);
+
     // POSITIVE CONTROL: activating a genuinely read-only board flips
     // isActiveBoardReadOnly false→true → all 5 read-only probes re-render, while
     // the action-only ActionsProbe consumers stay at 0 (the actions surface never

--- a/tests/perf/dashboardPerf.test.tsx
+++ b/tests/perf/dashboardPerf.test.tsx
@@ -76,6 +76,8 @@ import { useDashboard } from '@/context/useDashboard';
 import {
   useDashboardActions,
   useGlobalStyle,
+  useIsActiveBoardReadOnly,
+  useIsWidgetSelected,
 } from '@/context/dashboardCanvasStore';
 import { useToolVisibility } from '@/context/useToolVisibility';
 import { BoardCanvas } from '@/components/layout/BoardCanvas';
@@ -99,6 +101,10 @@ const {
   countActionsProbeRender,
   globalStyleProbeRenderCounts,
   countGlobalStyleProbeRender,
+  selectionProbeRenderCounts,
+  countSelectionProbeRender,
+  readOnlyProbeRenderCounts,
+  countReadOnlyProbeRender,
 } = vi.hoisted(() => {
   // Render-invocation counts of the DraggableWindow shell, keyed by widget
   // id. Widgets added mid-test get random UUIDs, so those are normalized to
@@ -132,6 +138,28 @@ const {
   // 0-delta on widget ops, contrasted against a 5-delta on a real style change,
   // proves the selector isolates style consumers from the per-op fan-out.
   const globalStyleProbeCounts = new Map<string, number>();
+  // Render-invocation counts of the SelectionProbe consumers, keyed by probe id
+  // ('sel-1'..'sel-5'). Each probe calls `useIsWidgetSelected(widgetId)` — a
+  // PER-INSTANCE selector over the canvas store that projects the boolean
+  // `selectedWidgetId === widgetId`. All 5 are bound to a FIXED widget id (w-8)
+  // that no scenario touches, so selecting a DIFFERENT widget leaves the
+  // projected boolean at `false` and the selector's `Object.is` cache bails —
+  // the probes do NOT re-render (0 delta). Only selecting w-8 itself flips the
+  // boolean to `true` and fires all 5. That 0-on-other / 5-on-self contrast is
+  // the proof the per-instance selector isolates each widget's selection
+  // subscription from unrelated selection changes — and the broader proof that
+  // a discrete widget op (bringToFront / drag-release) never touches selection.
+  const selectionProbeCounts = new Map<string, number>();
+  // Render-invocation counts of the ReadOnlyProbe consumers, keyed by probe id
+  // ('ro-1'..'ro-5'). Each probe calls `useIsActiveBoardReadOnly()` — a selector
+  // over the canvas store that returns the active board's read-only boolean
+  // (derived from `linkedShareRole === 'viewer' && !linkedShareEnded`). A
+  // discrete widget op (bringToFront / drag-release) spreads a new board +
+  // widgets array but never touches the `linkedShareRole`/`linkedShareEnded` the
+  // flag is derived from, so the boolean is unchanged and the selector's
+  // `Object.is` cache bails — the probes do NOT re-render (0 delta). Activating a
+  // genuinely read-only board flips the boolean to `true` and fires all 5.
+  const readOnlyProbeCounts = new Map<string, number>();
   return {
     shellRenderCounts: counts,
     countShellRender: (widgetId: string) => {
@@ -154,6 +182,20 @@ const {
       globalStyleProbeCounts.set(
         probeId,
         (globalStyleProbeCounts.get(probeId) ?? 0) + 1
+      );
+    },
+    selectionProbeRenderCounts: selectionProbeCounts,
+    countSelectionProbeRender: (probeId: string) => {
+      selectionProbeCounts.set(
+        probeId,
+        (selectionProbeCounts.get(probeId) ?? 0) + 1
+      );
+    },
+    readOnlyProbeRenderCounts: readOnlyProbeCounts,
+    countReadOnlyProbeRender: (probeId: string) => {
+      readOnlyProbeCounts.set(
+        probeId,
+        (readOnlyProbeCounts.get(probeId) ?? 0) + 1
       );
     },
     // 15 widgets across 8 distinct types — all on the standard (non-position-
@@ -466,6 +508,25 @@ interface ScenarioMetric {
   // real setGlobalStyle change re-renders all 5.
   globalStyleProbeRenders: number;
   globalStyleProbeRendersById: Record<string, number>;
+  // Selection-consumer fan-out: how many of the 5 SelectionProbe consumers
+  // (each calling `useIsWidgetSelected('w-8')`, a PER-INSTANCE selector over the
+  // canvas store's `selectedWidgetId === id`) re-rendered during the scenario
+  // (sum), plus the per-probe breakdown. This is the per-instance isolation
+  // proof — on selectOther (a DIFFERENT widget is selected) it must be 0 (the
+  // w-8 boolean stays false → Object.is cache bails), and on bringToFront5 /
+  // drag.release it must be 0 (those ops never touch selection), while
+  // selectSelf (w-8 itself is selected) re-renders all 5.
+  selectionProbeRenders: number;
+  selectionProbeRendersById: Record<string, number>;
+  // ReadOnly-consumer fan-out: how many of the 5 ReadOnlyProbe consumers (each
+  // calling `useIsActiveBoardReadOnly()`, a selector over the canvas store's
+  // read-only boolean) re-rendered during the scenario (sum), plus the per-probe
+  // breakdown. This is the read-only isolation proof — on bringToFront5 /
+  // drag.release it must be 0 (those ops never touch the linkedShareRole the flag
+  // is derived from), while activating a genuinely read-only board re-renders
+  // all 5.
+  readOnlyProbeRenders: number;
+  readOnlyProbeRendersById: Record<string, number>;
 }
 
 const metrics: ScenarioMetric[] = [];
@@ -521,6 +582,32 @@ function globalStyleProbeRenderDeltas(
   return deltas;
 }
 
+/** Per-probe delta of selectionProbeRenderCounts since the given baseline snapshot. */
+function selectionProbeRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...selectionProbeRenderCounts.keys()].sort()) {
+    const delta =
+      (selectionProbeRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
+/** Per-probe delta of readOnlyProbeRenderCounts since the given baseline snapshot. */
+function readOnlyProbeRenderDeltas(
+  baseline: ReadonlyMap<string, number>
+): Record<string, number> {
+  const deltas: Record<string, number> = {};
+  for (const key of [...readOnlyProbeRenderCounts.keys()].sort()) {
+    const delta =
+      (readOnlyProbeRenderCounts.get(key) ?? 0) - (baseline.get(key) ?? 0);
+    if (delta > 0) deltas[key] = delta;
+  }
+  return deltas;
+}
+
 function createRecorder() {
   let commits = 0;
   let duration = 0;
@@ -528,6 +615,8 @@ function createRecorder() {
   let bystanderBaseline: ReadonlyMap<string, number> = new Map();
   let actionsProbeBaseline: ReadonlyMap<string, number> = new Map();
   let globalStyleProbeBaseline: ReadonlyMap<string, number> = new Map();
+  let selectionProbeBaseline: ReadonlyMap<string, number> = new Map();
+  let readOnlyProbeBaseline: ReadonlyMap<string, number> = new Map();
   const onRender: ProfilerOnRenderCallback = (_id, _phase, actualDuration) => {
     commits += 1;
     duration += actualDuration;
@@ -541,6 +630,8 @@ function createRecorder() {
       bystanderBaseline = new Map(bystanderRenderCounts);
       actionsProbeBaseline = new Map(actionsProbeRenderCounts);
       globalStyleProbeBaseline = new Map(globalStyleProbeRenderCounts);
+      selectionProbeBaseline = new Map(selectionProbeRenderCounts);
+      readOnlyProbeBaseline = new Map(readOnlyProbeRenderCounts);
     },
     record(scenario: string) {
       const shellRendersByWidget = shellRenderDeltas(shellBaseline);
@@ -549,6 +640,12 @@ function createRecorder() {
         actionsProbeRenderDeltas(actionsProbeBaseline);
       const globalStyleProbeRendersById = globalStyleProbeRenderDeltas(
         globalStyleProbeBaseline
+      );
+      const selectionProbeRendersById = selectionProbeRenderDeltas(
+        selectionProbeBaseline
+      );
+      const readOnlyProbeRendersById = readOnlyProbeRenderDeltas(
+        readOnlyProbeBaseline
       );
       metrics.push({
         scenario,
@@ -573,6 +670,16 @@ function createRecorder() {
           globalStyleProbeRendersById
         ).reduce((sum, n) => sum + n, 0),
         globalStyleProbeRendersById,
+        selectionProbeRenders: Object.values(selectionProbeRendersById).reduce(
+          (sum, n) => sum + n,
+          0
+        ),
+        selectionProbeRendersById,
+        readOnlyProbeRenders: Object.values(readOnlyProbeRendersById).reduce(
+          (sum, n) => sum + n,
+          0
+        ),
+        readOnlyProbeRendersById,
       });
     },
   };
@@ -783,6 +890,88 @@ GlobalStyleProbe.displayName = 'GlobalStyleProbe';
 const GLOBALSTYLE_PROBE_IDS = ['gs-1', 'gs-2', 'gs-3', 'gs-4', 'gs-5'] as const;
 
 /**
+ * Per-instance selection probe. Stands in for a widget shell/content component
+ * that subscribes ONLY to "am I the selected widget?" via the mount-stable
+ * `useIsWidgetSelected(widgetId)` selector (context/dashboardCanvasStore.ts) —
+ * the per-instance projection `selectedWidgetId === widgetId`.
+ *
+ * All 5 instances are bound to a FIXED widget id (`w-8`) that NO scenario
+ * touches: drag moves w-5, resize moves w-7, bringToFront5 raises w-1..w-6, and
+ * the add/remove/minimize scenarios target other ids — so w-8's selected-ness
+ * never flips through any of those ops. Because the selector projects a boolean
+ * and `Object.is(false, false)` holds, selecting a DIFFERENT widget (selectOther)
+ * leaves these probes untouched (0 delta) — true per-instance isolation, NOT the
+ * board-wide re-render a raw `selectedWidgetId` read would cause. Only selecting
+ * w-8 itself (selectSelf) flips the projected boolean and fires all 5.
+ *
+ * Wrapped in React.memo with stable `id`/`widgetId` props so the ONLY thing that
+ * can drive a re-render is the projected boolean changing identity — isolating
+ * the metric to the per-instance selector under test.
+ */
+const SelectionProbe: React.FC<{ id: string; widgetId: string }> = React.memo(
+  ({ id, widgetId }) => {
+    const isSelected = useIsWidgetSelected(widgetId);
+    countSelectionProbeRender(id);
+    // Reference the read so the subscription is real and not optimized away.
+    void isSelected;
+    return null;
+  }
+);
+SelectionProbe.displayName = 'SelectionProbe';
+
+const SELECTION_PROBE_IDS = [
+  'sel-1',
+  'sel-2',
+  'sel-3',
+  'sel-4',
+  'sel-5',
+] as const;
+
+// The widget all SelectionProbes are bound to. Chosen because NO scenario
+// touches it: drag→w-5, resize→w-7, bringToFront5→w-1..w-4,w-6, add/remove→a
+// fresh uuid, minimize/restore→w-3. So w-8's selected-ness only flips when a
+// scenario explicitly selects it (selectSelf), never as a side effect.
+const SELECTION_PROBE_WIDGET_ID = 'w-8';
+
+/**
+ * Read-only-board probe. Stands in for a widget shell/toolbar component that
+ * subscribes ONLY to "is the active board read-only?" via the mount-stable
+ * `useIsActiveBoardReadOnly()` selector (context/dashboardCanvasStore.ts) — the
+ * boolean derived from the active board's `linkedShareRole === 'viewer' &&
+ * !linkedShareEnded` (DashboardContext.tsx).
+ *
+ * A discrete widget op (bringToFront / drag-release) spreads a new board +
+ * widgets array but never touches `linkedShareRole`/`linkedShareEnded`, so the
+ * derived boolean is unchanged and the selector's `Object.is` cache bails — these
+ * probes do NOT re-render on those ops (0 delta). Activating a genuinely
+ * read-only board (`loadReadOnlyBoard`, a viewer-role snapshot pushed + made
+ * active) flips the boolean to `true` and fires all 5.
+ *
+ * Note on the positive control: the SELECTOR MECHANISM these probes ride
+ * (`useDashboardCanvasSelector` over a boolean projection) is identical to the
+ * mechanism the SelectionProbe and GlobalStyleProbe positive controls already
+ * exercise — a real state change to the projected slice re-renders exactly the
+ * subscribed consumers and nothing else. Here we ALSO prove the read-only path
+ * end-to-end with a dedicated `loadReadOnlyBoard` positive control (a viewer
+ * board is pushed cleanly through the harness snapshot path), so the two
+ * 0-deltas above are demonstrably genuine isolation rather than a dead probe.
+ *
+ * Wrapped in React.memo with a stable `id` prop so the ONLY thing that can drive
+ * a re-render is the projected boolean changing identity — isolating the metric
+ * to the selector under test.
+ */
+const ReadOnlyProbe: React.FC<{ id: string }> = React.memo(({ id }) => {
+  const isReadOnly = useIsActiveBoardReadOnly();
+  countReadOnlyProbeRender(id);
+  // Reference the read so the subscription is real and not optimized away.
+  void isReadOnly;
+  return null;
+});
+ReadOnlyProbe.displayName = 'ReadOnlyProbe';
+
+const RO_PROBE_IDS = ['ro-1', 'ro-2', 'ro-3', 'ro-4', 'ro-5'] as const;
+
+/**
  * Mirrors the production wiring in DashboardView → MountedBoardsLayer →
  * BoardCanvas: context state and callbacks flow down as props, while
  * DraggableWindow/WidgetRenderer read the stable actions context and the
@@ -817,6 +1006,12 @@ const BoardHarness: React.FC = () => {
       ))}
       {GLOBALSTYLE_PROBE_IDS.map((id) => (
         <GlobalStyleProbe key={id} id={id} />
+      ))}
+      {SELECTION_PROBE_IDS.map((id) => (
+        <SelectionProbe key={id} id={id} widgetId={SELECTION_PROBE_WIDGET_ID} />
+      ))}
+      {RO_PROBE_IDS.map((id) => (
+        <ReadOnlyProbe key={id} id={id} />
       ))}
       <BoardCanvas
         dashboard={ctx.activeDashboard}
@@ -1076,9 +1271,78 @@ describe('dashboard canvas performance baseline', () => {
       'handwritten'
     );
 
+    // (9) selectOther — per-instance ISOLATION for the SelectionProbe. Select a
+    // DIFFERENT widget (w-9) than the one the 5 probes are bound to (w-8). Each
+    // probe reads `useIsWidgetSelected('w-8')`, which projects the boolean
+    // `selectedWidgetId === 'w-8'`. Selecting w-9 leaves that boolean at `false`,
+    // so the selector's Object.is cache bails and NONE of the probes re-render —
+    // proof the per-instance selector isolates each widget's selection
+    // subscription from unrelated selection changes (a raw `selectedWidgetId`
+    // read would re-render every consumer here).
+    rec.start();
+    act(() => {
+      getCtx().setSelectedWidgetId('w-9');
+    });
+    await settle();
+    rec.record('selectOther');
+    // Behavioral validity: the selection actually moved to w-9 (so the store
+    // genuinely changed — this is not a no-op masquerading as isolation).
+    expect(getCtx().selectedWidgetId).toBe('w-9');
+
+    // (10) selectSelf — positive control for the SelectionProbe. Select w-8
+    // itself, the id all 5 probes are bound to. The projected boolean flips
+    // false→true, allocating a new snapshot for each probe, so all 5 re-render.
+    // This live-instrument check makes the selectOther / bringToFront5 /
+    // drag.release 0-deltas genuine isolation rather than a dead probe.
+    rec.start();
+    act(() => {
+      getCtx().setSelectedWidgetId('w-8');
+    });
+    await settle();
+    rec.record('selectSelf');
+    // Behavioral validity: w-8 is now the selected widget.
+    expect(getCtx().selectedWidgetId).toBe('w-8');
+
+    // (11) loadReadOnlyBoard — positive control for the ReadOnlyProbe. Push a
+    // fresh snapshot that ADDS a viewer-role board (linkedShareRole:'viewer',
+    // linkedShareEnded falsy) alongside the existing board, then activate it via
+    // the real loadDashboard action. The provider derives
+    // isActiveBoardReadOnly = activeBoard.linkedShareRole === 'viewer' &&
+    // !linkedShareEnded (DashboardContext.tsx ~4277) and publishes it to the
+    // canvas store, so the active board flipping read-only changes the boolean
+    // false→true → all 5 useIsActiveBoardReadOnly() probes re-render. This is a
+    // clean push: a brand-new board id is accepted wholesale by the snapshot
+    // handler (no surgical-merge for non-active boards). We deliberately set NO
+    // `linkedShareId` — it isn't part of the read-only derivation, and including
+    // it would arm the live-share subscribe effect (which calls
+    // subscribeToSharedBoard, outside this harness's useFirestore mock surface).
+    // The role alone is sufficient to flip the derived flag.
+    const readOnlyBoard: Dashboard = {
+      ...buildDashboard(buildWidgets()),
+      id: 'perf-dash-ro',
+      name: 'Perf Read-Only Board',
+      linkedShareRole: 'viewer',
+      linkedShareEnded: false,
+    };
+    rec.start();
+    await pushSnapshot([
+      buildDashboard(getCtx().activeDashboard?.widgets ?? []),
+      readOnlyBoard,
+    ]);
+    act(() => {
+      getCtx().loadDashboard('perf-dash-ro');
+    });
+    await settle();
+    rec.record('loadReadOnlyBoard');
+    // Behavioral validity: the active board is now the viewer board AND the
+    // derived read-only flag is true (so the 5 RO-probe renders are a real
+    // read-only transition, not noise).
+    expect(getCtx().activeDashboard?.id).toBe('perf-dash-ro');
+    expect(getCtx().isActiveBoardReadOnly).toBe(true);
+
     // The harness only asserts that metrics were produced — no duration
     // thresholds (CI machines vary; this must never be flaky).
-    expect(metrics).toHaveLength(14);
+    expect(metrics).toHaveLength(17);
     for (const m of metrics) {
       expect(m.commits).toBeGreaterThanOrEqual(0);
       expect(m.actualDurationMs).toBeGreaterThanOrEqual(0);
@@ -1214,6 +1478,72 @@ describe('dashboard canvas performance baseline', () => {
     const setStyle = metricFor('setGlobalStyle');
     expect(setStyle.globalStyleProbeRenders).toBe(5);
     expect(setStyle.actionsProbeRenders).toBe(0);
+
+    // ── Per-instance selection-isolation proof (the win this slice delivers) ─
+    // The 5 SelectionProbe consumers each read `useIsWidgetSelected('w-8')` — a
+    // per-instance selector projecting `selectedWidgetId === 'w-8'`. Because no
+    // scenario touches w-8's selected-ness, selecting any OTHER widget leaves the
+    // projected boolean false and the selector's Object.is cache bails; only
+    // selecting w-8 itself flips it and fires all 5.
+
+    // SANITY: the selection probes are actually mounted and counted — they each
+    // render at least once during mount15. Without this, a 0 delta on the
+    // isolation scenarios could just mean the probe never mounted (a dead
+    // instrument), so the per-instance claim would be vacuous.
+    expect(
+      Object.keys(metricFor('mount15').selectionProbeRendersById)
+    ).toHaveLength(5);
+
+    // selectOther: selecting a DIFFERENT widget (w-9) than the bound id (w-8)
+    // leaves `selectedWidgetId === 'w-8'` at false → the per-instance selector's
+    // Object.is cache bails → 0 of the 5 w-8 probes re-render. This is the
+    // headline per-instance isolation result: a raw `selectedWidgetId` read would
+    // re-render every consumer here.
+    expect(metricFor('selectOther').selectionProbeRenders).toBe(0);
+
+    // selectSelf: positive control — selecting w-8 itself flips the projected
+    // boolean false→true, so all 5 bound probes re-render. This live-instrument
+    // check proves the selectOther / bringToFront5 / drag.release 0-deltas are
+    // genuine isolation, not a dead probe.
+    expect(metricFor('selectSelf').selectionProbeRenders).toBe(5);
+
+    // ISOLATION: a discrete widget op never touches selection of the bound w-8 —
+    // bringToFront5 raises w-1..w-6 (and selects each in turn, but never w-8) and
+    // drag.release commits w-5 — so the w-8 probes stay at 0 on both. (If
+    // SelectionProbe read the RAW `selectedWidgetId` off the churning legacy
+    // value instead, both of these would be > 0 — that's the falsifiability
+    // pivot documented in the test header.)
+    expect(metricFor('bringToFront5').selectionProbeRenders).toBe(0);
+    expect(metricFor('drag.release').selectionProbeRenders).toBe(0);
+
+    // ── Read-only-board isolation proof (the win this slice delivers) ────────
+    // The 5 ReadOnlyProbe consumers each read `useIsActiveBoardReadOnly()` — a
+    // selector over the active board's read-only boolean. A discrete widget op
+    // never touches the `linkedShareRole`/`linkedShareEnded` the flag is derived
+    // from, so the boolean is unchanged and the selector's Object.is cache bails.
+
+    // SANITY: the read-only probes are actually mounted and counted — they each
+    // render at least once during mount15. Without this, a 0 delta on the
+    // isolation scenarios could just mean the probe never mounted (a dead
+    // instrument).
+    expect(
+      Object.keys(metricFor('mount15').readOnlyProbeRendersById)
+    ).toHaveLength(5);
+
+    // ISOLATION: bringToFront5 / drag.release spread a new board + widgets array
+    // but never touch read-only-ness, so the derived boolean is unchanged and the
+    // 5 read-only probes stay at 0 on both.
+    expect(metricFor('bringToFront5').readOnlyProbeRenders).toBe(0);
+    expect(metricFor('drag.release').readOnlyProbeRenders).toBe(0);
+
+    // POSITIVE CONTROL: activating a genuinely read-only board flips
+    // isActiveBoardReadOnly false→true → all 5 read-only probes re-render, while
+    // the action-only ActionsProbe consumers stay at 0 (the actions surface never
+    // changes identity). This live-instrument check makes the two 0-deltas above
+    // genuine isolation rather than a dead probe.
+    const loadReadOnly = metricFor('loadReadOnlyBoard');
+    expect(loadReadOnly.readOnlyProbeRenders).toBe(5);
+    expect(loadReadOnly.actionsProbeRenders).toBe(0);
   });
 });
 
@@ -1259,6 +1589,20 @@ afterAll(() => {
           'nested globalStyle object, so the selector Object.is cache bails), ' +
           'while the setGlobalStyle scenario reads 5 (a real style change ' +
           'allocates a new style identity) with the actions probes still at 0. ' +
+          'selectionProbeRenders/selectionProbeRendersById count how many of the ' +
+          '5 SelectionProbe consumers (each reading useIsWidgetSelected("w-8"), a ' +
+          'PER-INSTANCE selector projecting selectedWidgetId === id) re-rendered ' +
+          'per scenario — the per-instance isolation proof: on selectOther (a ' +
+          'DIFFERENT widget is selected), bringToFront5, and drag.release they ' +
+          'read 0 (the w-8 boolean stays false, so the selector Object.is cache ' +
+          'bails), while selectSelf (w-8 itself is selected) reads 5. ' +
+          'readOnlyProbeRenders/readOnlyProbeRendersById count how many of the 5 ' +
+          'ReadOnlyProbe consumers (each reading useIsActiveBoardReadOnly(), a ' +
+          'selector over the active board read-only boolean) re-rendered per ' +
+          'scenario — the read-only isolation proof: on bringToFront5 and ' +
+          'drag.release they read 0 (those ops never touch the linkedShareRole the ' +
+          'flag is derived from), while loadReadOnlyBoard (a viewer-role board is ' +
+          'pushed and activated) reads 5 with the actions probes still at 0. ' +
           'actualDurationMs is machine-dependent and indicative only — ' +
           'compare medians of 3 runs.',
         skipped:

--- a/tests/perf/results/dashboard-baseline.json
+++ b/tests/perf/results/dashboard-baseline.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-06-18T03:35:11.195Z",
+  "generatedAt": "2026-06-18T04:36:46.173Z",
   "runCommand": "pnpm exec vitest run tests/perf/dashboardPerf.test.tsx",
-  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. globalStyleProbeRenders/globalStyleProbeRendersById count how many of the 5 GlobalStyleProbe consumers (which read the active board globalStyle via the mount-stable useGlobalStyle() selector) re-rendered per scenario — the selector-isolation proof: on bringToFront5 and drag.release they read 0 (those ops never touch the nested globalStyle object, so the selector Object.is cache bails), while the setGlobalStyle scenario reads 5 (a real style change allocates a new style identity) with the actions probes still at 0. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
+  "note": "Profiler commit counts and per-shell render counts are the deterministic primary metrics and must be identical across runs. totalShellRenders sums DraggableWindow render invocations across all widgets per scenario; shellRendersByWidget shows which shells rendered (widgets added mid-test are keyed \"added-widget\"). bystanderRenders/bystanderRendersById count how many of the 5 legacy-DashboardContext consumer probes re-rendered per scenario — this is the F9 context-split ruler: post-split the toggleToolVisibility scenario reads 0 (tool visibility lives on its own ToolVisibilityContext, so a toggle no longer churns the DashboardContext value the probes subscribe to), while addWidget still churns the probes (sanity that the instrument is live). actionsProbeRenders/actionsProbeRendersById count how many of the 5 ActionsProbe consumers (which read the mount-stable useDashboardActions() surface, modeling a MIGRATED content component) re-rendered per scenario — the migration contrast-proof: on bringToFront5 and drag.release the actions probes read 0 while the legacy bystander probes read 25 and 5 respectively, showing the useDashboard()→useDashboardActions() swap isolates content consumers from the per-op DashboardContext fan-out. globalStyleProbeRenders/globalStyleProbeRendersById count how many of the 5 GlobalStyleProbe consumers (which read the active board globalStyle via the mount-stable useGlobalStyle() selector) re-rendered per scenario — the selector-isolation proof: on bringToFront5 and drag.release they read 0 (those ops never touch the nested globalStyle object, so the selector Object.is cache bails), while the setGlobalStyle scenario reads 5 (a real style change allocates a new style identity) with the actions probes still at 0. selectionProbeRenders/selectionProbeRendersById count how many of the 5 SelectionProbe consumers (each reading useIsWidgetSelected(\"w-8\"), a PER-INSTANCE selector projecting selectedWidgetId === id) re-rendered per scenario — the per-instance isolation proof: on selectOther (a DIFFERENT widget is selected), bringToFront5, and drag.release they read 0 (the w-8 boolean stays false, so the selector Object.is cache bails), while selectSelf (w-8 itself is selected) reads 5. readOnlyProbeRenders/readOnlyProbeRendersById count how many of the 5 ReadOnlyProbe consumers (each reading useIsActiveBoardReadOnly(), a selector over the active board read-only boolean) re-rendered per scenario — the read-only isolation proof: on bringToFront5 and drag.release they read 0 (those ops never touch the linkedShareRole the flag is derived from), while loadReadOnlyBoard (a viewer-role board is pushed and activated) reads 5 with the actions probes still at 0. actualDurationMs is machine-dependent and indicative only — compare medians of 3 runs.",
   "skipped": "Snap-overlay edge snapping and the snap-layout menu need real viewport geometry, so they are not exercised in jsdom; the drag path deliberately stays away from screen edges.",
   "scenarios": [
     {
       "scenario": "mount15",
       "commits": 3,
-      "actualDurationMs": 228.535,
+      "actualDurationMs": 187.505,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -49,12 +49,28 @@
         "gs-3": 1,
         "gs-4": 1,
         "gs-5": 1
+      },
+      "selectionProbeRenders": 5,
+      "selectionProbeRendersById": {
+        "sel-1": 1,
+        "sel-2": 1,
+        "sel-3": 1,
+        "sel-4": 1,
+        "sel-5": 1
+      },
+      "readOnlyProbeRenders": 5,
+      "readOnlyProbeRendersById": {
+        "ro-1": 1,
+        "ro-2": 1,
+        "ro-3": 1,
+        "ro-4": 1,
+        "ro-5": 1
       }
     },
     {
       "scenario": "drag.press",
       "commits": 2,
-      "actualDurationMs": 4.135,
+      "actualDurationMs": 2.785,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -70,7 +86,11 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "drag.move30",
@@ -83,12 +103,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "drag.release",
       "commits": 3,
-      "actualDurationMs": 5.423,
+      "actualDurationMs": 3.553,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-5": 1
@@ -104,12 +128,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "resize.press",
       "commits": 1,
-      "actualDurationMs": 1.326,
+      "actualDurationMs": 1.098,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
@@ -117,7 +145,11 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "resize.move30",
@@ -130,12 +162,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "resize.release",
       "commits": 3,
-      "actualDurationMs": 5.852,
+      "actualDurationMs": 5.47,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-7": 1
@@ -151,12 +187,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "bringToFront5",
       "commits": 10,
-      "actualDurationMs": 16.248,
+      "actualDurationMs": 20.577,
       "totalShellRenders": 5,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -176,12 +216,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "addWidget",
       "commits": 3,
-      "actualDurationMs": 8.492,
+      "actualDurationMs": 9.575,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "added-widget": 1
@@ -197,12 +241,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "removeWidget",
       "commits": 2,
-      "actualDurationMs": 1.184,
+      "actualDurationMs": 1.519,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 5,
@@ -216,12 +264,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "minimize",
       "commits": 2,
-      "actualDurationMs": 3.592,
+      "actualDurationMs": 2.47,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -237,12 +289,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "restore",
       "commits": 2,
-      "actualDurationMs": 3.307,
+      "actualDurationMs": 2.46,
       "totalShellRenders": 1,
       "shellRendersByWidget": {
         "w-3": 1
@@ -258,12 +314,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "toggleToolVisibility",
       "commits": 1,
-      "actualDurationMs": 0.857,
+      "actualDurationMs": 1.904,
       "totalShellRenders": 0,
       "shellRendersByWidget": {},
       "bystanderRenders": 0,
@@ -271,12 +331,16 @@
       "actionsProbeRenders": 0,
       "actionsProbeRendersById": {},
       "globalStyleProbeRenders": 0,
-      "globalStyleProbeRendersById": {}
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
     },
     {
       "scenario": "setGlobalStyle",
       "commits": 2,
-      "actualDurationMs": 29.007,
+      "actualDurationMs": 20.571,
       "totalShellRenders": 15,
       "shellRendersByWidget": {
         "w-1": 1,
@@ -312,6 +376,113 @@
         "gs-3": 1,
         "gs-4": 1,
         "gs-5": 1
+      },
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
+    },
+    {
+      "scenario": "selectOther",
+      "commits": 3,
+      "actualDurationMs": 20.251,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {},
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
+    },
+    {
+      "scenario": "selectSelf",
+      "commits": 3,
+      "actualDurationMs": 17.136,
+      "totalShellRenders": 0,
+      "shellRendersByWidget": {},
+      "bystanderRenders": 5,
+      "bystanderRendersById": {
+        "bystander-1": 1,
+        "bystander-2": 1,
+        "bystander-3": 1,
+        "bystander-4": 1,
+        "bystander-5": 1
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 0,
+      "globalStyleProbeRendersById": {},
+      "selectionProbeRenders": 5,
+      "selectionProbeRendersById": {
+        "sel-1": 1,
+        "sel-2": 1,
+        "sel-3": 1,
+        "sel-4": 1,
+        "sel-5": 1
+      },
+      "readOnlyProbeRenders": 0,
+      "readOnlyProbeRendersById": {}
+    },
+    {
+      "scenario": "loadReadOnlyBoard",
+      "commits": 5,
+      "actualDurationMs": 50.106,
+      "totalShellRenders": 30,
+      "shellRendersByWidget": {
+        "w-1": 2,
+        "w-10": 2,
+        "w-11": 2,
+        "w-12": 2,
+        "w-13": 2,
+        "w-14": 2,
+        "w-15": 2,
+        "w-2": 2,
+        "w-3": 2,
+        "w-4": 2,
+        "w-5": 2,
+        "w-6": 2,
+        "w-7": 2,
+        "w-8": 2,
+        "w-9": 2
+      },
+      "bystanderRenders": 15,
+      "bystanderRendersById": {
+        "bystander-1": 3,
+        "bystander-2": 3,
+        "bystander-3": 3,
+        "bystander-4": 3,
+        "bystander-5": 3
+      },
+      "actionsProbeRenders": 0,
+      "actionsProbeRendersById": {},
+      "globalStyleProbeRenders": 5,
+      "globalStyleProbeRendersById": {
+        "gs-1": 1,
+        "gs-2": 1,
+        "gs-3": 1,
+        "gs-4": 1,
+        "gs-5": 1
+      },
+      "selectionProbeRenders": 0,
+      "selectionProbeRendersById": {},
+      "readOnlyProbeRenders": 5,
+      "readOnlyProbeRendersById": {
+        "ro-1": 1,
+        "ro-2": 1,
+        "ro-3": 1,
+        "ro-4": 1,
+        "ro-5": 1
       }
     }
   ]


### PR DESCRIPTION
## Summary

Fourth slice of the `DashboardContext` churn-reduction effort (after F9 [#1996](https://github.com/OPS-PIvers/SpartBoard/pull/1996), content-actions [#2004](https://github.com/OPS-PIvers/SpartBoard/pull/2004), globalStyle [#2008](https://github.com/OPS-PIvers/SpartBoard/pull/2008)).

Widgets that read `selectedWidgetId` or `isActiveBoardReadOnly` off the legacy `useDashboard()` value re-render on **every** unrelated dashboard op, because that context value re-creates on each commit. Both fields are already canvas-store slice fields, so this PR exposes them as mount-stable selectors and migrates the widgets that were blocked *only* on them.

## What changed

- **`context/dashboardCanvasStore.ts`** — two named boolean convenience hooks (mirroring the `useGlobalStyle` precedent):
  - `useIsActiveBoardReadOnly()` = `useDashboardCanvasSelector(s => s.isActiveBoardReadOnly)`
  - `useIsWidgetSelected(id)` = `useDashboardCanvasSelector(s => s.selectedWidgetId === id)`

  `useIsWidgetSelected` returns the **predicate**, not the raw `selectedWidgetId` — so a widget re-renders only when *its own* selected-ness flips; selecting a different widget bails via the `Object.is` snapshot cache. Both return primitives (required for the dedupe). No new provider/context; the selector's built-in legacy fallback already covers bare hosts (Subs/Student/tests).
- **8 widgets migrated** off `useDashboard()`: ConceptWeb, GraphicOrganizer (parent + its `EditableNode` sub-component), TextWidget, WorkSymbols, MaterialsWidget, SoundboardWidget, Webcam (pure actions), ActivityWall (actions + read-only).
- **4 colocated tests** updated to mock the stable surfaces (keeping the legacy `useDashboard` mock where an unmigrated child — `TextSettings`, ActivityWall's `ShareModal` — still consumes it).
- **Perf harness** — new `SelectionProbe` and `ReadOnlyProbe` families.

## Proof (perf harness, 17 scenarios)

**SelectionProbe** (5×, bound to an untouched widget `w-8`):

| scenario | selection probe |
|---|---|
| `bringToFront5` | **0** |
| `drag.release` | **0** |
| `selectOther` (select a *different* widget) | **0** |
| `selectSelf` (select `w-8`) | **5** |

→ true per-instance isolation: only the widget that actually becomes selected re-renders.

**ReadOnlyProbe** (5×):

| scenario | read-only probe |
|---|---|
| `bringToFront5` / `drag.release` | **0** |
| `loadReadOnlyBoard` (push a viewer board) | **5** |

**Falsifiability:** pointing `SelectionProbe` at the raw legacy `selectedWidgetId` makes `selectOther=5`, `bringToFront5=25`, `drag.release=5` — the isolation assertions fail. Both probe families have real positive controls so the 0-deltas can't pass trivially.

## Out of scope (next levers)

Remaining blocked widgets need surfaces this slice doesn't add: `activeDashboard.widgets`/`.background`/`.id` (cross-widget & background sync — Schedule, SoundWidget, NextUp, QR, Music, Drawing, …) and roster reads (`rosters`/`activeRosterId` — Checklist, LunchCount, Stations, SeatingChart, …). A `widgets`-selector surface and a roster surface would be the next two slices; Weather additionally needs `setBackground` added to the actions surface.

## Verification

- `pnpm run type-check` — clean
- `pnpm run lint` / `prettier --check` on all changed files — clean
- Full unit suite green (the one editor-perf timeout in the run was a load-induced flake — passes 3/3 in isolation, unrelated to this change)
- Dashboard perf harness — all 17 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)