### PR TITLE
fix(plc): guard TodosBody inline-edit onBlur against stale Escape-cancel write

### DIFF
--- a/components/plc/bodies/TodosBody.test.tsx
+++ b/components/plc/bodies/TodosBody.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TodosBody } from './TodosBody';
+import type { Plc, PlcTodo } from '@/types';
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+const mockUpdateText = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/hooks/usePlcTodos', () => ({
+  usePlcTodos: () => ({
+    todos: TODOS,
+    loading: false,
+    createTodo: vi.fn().mockResolvedValue(undefined),
+    toggleDone: vi.fn().mockResolvedValue(undefined),
+    updateText: mockUpdateText,
+    deleteTodo: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({
+    showConfirm: vi.fn().mockResolvedValue(false),
+    showAlert: vi.fn(),
+    showPrompt: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const TODOS: PlcTodo[] = [
+  {
+    id: 'todo-1',
+    text: 'Original text',
+    done: false,
+    createdBy: 'uid-1',
+    createdAt: 0,
+  },
+];
+
+const MOCK_PLC: Plc = {
+  id: 'plc-1',
+  name: 'Test PLC',
+  leadUid: 'uid-1',
+  memberUids: ['uid-1'],
+  memberEmails: { 'uid-1': 'teacher@test.com' },
+} as Plc;
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('TodosBody — Escape-cancel must not persist text via stale onBlur', () => {
+  beforeEach(() => {
+    mockUpdateText.mockClear();
+  });
+
+  /**
+   * Regression: pressing Escape to cancel an inline edit was persisting the
+   * typed text to Firestore.
+   *
+   * Root cause: the Escape onKeyDown handler called setEditingId(null), which
+   * React batched. During the commit, the browser fires blur synchronously on
+   * the unmounting input with the OLD onBlur closure (still closing over the
+   * typed editingText). That stale onBlur called handleSubmitEdit, which wrote
+   * to Firestore — even though the user pressed Escape.
+   *
+   * Fix: isCancellingEditRef.current = true is set synchronously before
+   * setEditingId(null). The onBlur reads the ref and short-circuits.
+   *
+   * jsdom does not fire blur during DOM unmount the same way real browsers do,
+   * so we replicate the browser sequence by firing blur manually BEFORE React
+   * commits (inside the same act() as the keyDown).
+   *
+   * Note: TodosBody renders a draft text input ("Add a to-do for the PLC…")
+   * above the todo list. The inline edit input is identified by its initial
+   * value (the todo's text), not by querySelector order.
+   */
+  it('does NOT call updateText when Escape cancels an in-progress edit', async () => {
+    const user = userEvent.setup();
+    render(<TodosBody plc={MOCK_PLC} />);
+
+    // Click the todo text button to open the inline editor.
+    const editButton = screen.getByRole('button', { name: 'Original text' });
+    await user.click(editButton);
+
+    // The inline edit input appears with the todo's current text as its value.
+    // (Note: the component also renders a separate draft input at the top —
+    // getByDisplayValue is the reliable way to target the edit input.)
+    const input = screen.getByDisplayValue('Original text');
+
+    // Type a different value so editingText !== todo.text.
+    // handleSubmitEdit only calls updateText when the trimmed value differs,
+    // so a genuinely different value makes isCancellingEditRef the sole guard
+    // against the write (not just the early-return equality check).
+    await user.clear(input);
+    await user.type(input, 'Cancelled edit');
+
+    // Simulate the browser's Escape-then-blur sequence.
+    //   1. keyDown Escape → isCancellingEditRef.current = true → setEditingId(null) queued
+    //   2. blur fires synchronously (before React commits the state update)
+    //      • Bug: isCancellingEditRef not set → handleSubmitEdit called → updateText('todo-1', 'Cancelled edit')
+    //      • Fix: isCancellingEditRef.current === true → onBlur bails out
+    const activeInput = screen.getByDisplayValue('Cancelled edit');
+    act(() => {
+      fireEvent.keyDown(activeInput, { key: 'Escape', bubbles: true });
+      fireEvent.blur(activeInput);
+    });
+
+    // Drain the microtask queue so any async updateText calls settle.
+    await tick();
+
+    // updateText must NOT have been called.
+    expect(mockUpdateText).not.toHaveBeenCalled();
+  });
+
+  it('DOES call updateText when blur commits an edit with different text (no cancel)', async () => {
+    // Sanity check: a normal blur (without Escape) should still persist the edit.
+    // isCancellingEditRef starts false for every new editing session, so the
+    // onBlur handler should reach handleSubmitEdit.
+    const user = userEvent.setup();
+    render(<TodosBody plc={MOCK_PLC} />);
+
+    const editButton = screen.getByRole('button', { name: 'Original text' });
+    await user.click(editButton);
+
+    const input = screen.getByDisplayValue('Original text');
+    await user.clear(input);
+    await user.type(input, 'Updated text');
+
+    // Blur without any Escape → isCancellingEditRef.current is false → save.
+    const activeInput = screen.getByDisplayValue('Updated text');
+    act(() => {
+      fireEvent.blur(activeInput);
+    });
+
+    await tick();
+    expect(mockUpdateText).toHaveBeenCalledWith('todo-1', 'Updated text');
+  });
+});

--- a/components/plc/bodies/TodosBody.test.tsx
+++ b/components/plc/bodies/TodosBody.test.tsx
@@ -54,7 +54,9 @@ const MOCK_PLC: Plc = {
   leadUid: 'uid-1',
   memberUids: ['uid-1'],
   memberEmails: { 'uid-1': 'teacher@test.com' },
-} as Plc;
+  createdAt: 0,
+  updatedAt: 0,
+};
 
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 

--- a/components/plc/bodies/TodosBody.tsx
+++ b/components/plc/bodies/TodosBody.tsx
@@ -31,6 +31,14 @@ export const TodosBody: React.FC<TodosBodyProps> = ({ plc }) => {
   // handler bail out instead of committing the cancelled edit to Firestore.
   // Same pattern as DraggableWindow's isCancellingTitleRef (Bug #1965).
   const isCancellingEditRef = useRef(false);
+  // Reset the flag in the render body whenever an edit is active so it can
+  // never leak from one editing session into the next (CLAUDE.md: render-body
+  // ref assignment; suppressed because react-hooks/refs fires on conditional
+  // render-body mutations).
+  if (editingId !== null) {
+    // eslint-disable-next-line react-hooks/refs
+    isCancellingEditRef.current = false;
+  }
 
   const incomplete = todos.filter((t) => !t.done);
   const complete = todos.filter((t) => t.done);
@@ -144,7 +152,6 @@ export const TodosBody: React.FC<TodosBodyProps> = ({ plc }) => {
           <button
             type="button"
             onClick={() => {
-              isCancellingEditRef.current = false;
               setEditingId(todo.id);
               setEditingText(todo.text);
             }}

--- a/components/plc/bodies/TodosBody.tsx
+++ b/components/plc/bodies/TodosBody.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ListChecks, Loader2, Plus, Trash2 } from 'lucide-react';
 import { Plc, PlcTodo } from '@/types';
@@ -24,6 +24,13 @@ export const TodosBody: React.FC<TodosBodyProps> = ({ plc }) => {
   const [draft, setDraft] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingText, setEditingText] = useState('');
+  // Guards against the stale-onBlur race: pressing Escape calls
+  // setEditingId(null) which unmounts the focused input. The browser then
+  // fires a synchronous blur carrying the stale onBlur closure (still holding
+  // the typed text). Setting this ref before unmounting lets the onBlur
+  // handler bail out instead of committing the cancelled edit to Firestore.
+  // Same pattern as DraggableWindow's isCancellingTitleRef (Bug #1965).
+  const isCancellingEditRef = useRef(false);
 
   const incomplete = todos.filter((t) => !t.done);
   const complete = todos.filter((t) => t.done);
@@ -107,12 +114,26 @@ export const TodosBody: React.FC<TodosBodyProps> = ({ plc }) => {
             type="text"
             value={editingText}
             onChange={(e) => setEditingText(e.target.value)}
-            onBlur={() => void handleSubmitEdit(todo)}
+            onBlur={(e) => {
+              // Bail out if the input is no longer connected (e.g. Enter
+              // committed the edit and React already unmounted it).
+              if (!e.currentTarget?.isConnected) return;
+              if (isCancellingEditRef.current) {
+                isCancellingEditRef.current = false;
+                return;
+              }
+              void handleSubmitEdit(todo);
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault();
                 void handleSubmitEdit(todo);
               } else if (e.key === 'Escape') {
+                // Set the cancellation flag BEFORE calling setEditingId(null)
+                // — the state update unmounts the input, which synchronously
+                // fires blur with the stale onBlur closure (still holding the
+                // typed text). The flag is read in onBlur to skip the write.
+                isCancellingEditRef.current = true;
                 setEditingId(null);
               }
             }}
@@ -123,6 +144,7 @@ export const TodosBody: React.FC<TodosBodyProps> = ({ plc }) => {
           <button
             type="button"
             onClick={() => {
+              isCancellingEditRef.current = false;
               setEditingId(todo.id);
               setEditingText(todo.text);
             }}


### PR DESCRIPTION
## Summary

- `components/plc/bodies/TodosBody.tsx` inline-edit `onBlur` had the same stale Escape-cancel race as `DraggableWindow` (#1965), `RandomGroups` (#1974), and `FolderTree` (#1975).
- Pressing Escape called `setEditingId(null)` which unmounted the focused `<input>`; the browser fired synchronous `blur` during unmount, and the stale `onBlur` closure saw the typed (cancelled) text and persisted it to Firestore.
- Fixed with `isCancellingEditRef = useRef(false)` set synchronously in the Escape branch before `setEditingId(null)`; `onBlur` reads the ref and short-circuits.
- Also added `isConnected` guard to prevent double-commit on Enter (handles detached-node edge case).
- Pattern matches `DraggableWindow.isCancellingTitleRef` (#1965), `GroupDropZone.cancelledRef` (#1974), `FolderTree.isCancellingRef` (#1975).

**Regression test** (`TodosBody.test.tsx`):
- Uses `userEvent.setup()` + `user.type()` for realistic typing (so `editingText` state is genuinely committed before blur fires).
- Uses `screen.getByDisplayValue` to target the inline edit input specifically — the component also renders a separate draft input at the top.
- Escape test: `act(() => { fireEvent.keyDown(Escape); fireEvent.blur() })` inside one `act()` replicates the browser's synchronous blur-on-unmount sequence (jsdom doesn't fire blur during DOM removal like real browsers do). `updateText` must NOT be called.
- Positive test: blur without Escape → `updateText` called with the new text.

## Test plan

- [x] Regression test: `act(() => { keyDown(Escape); blur; })` → `updateText` NOT called with cancelled text (fails before fix, passes after)
- [x] Positive test: blur without Escape → `updateText` called with typed text
- [x] `pnpm run validate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code) (nightly debugger run #21, 2026-06-19)
https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM

---
_Generated by [Claude Code](https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM)_