### PR TITLE
fix(functions): enforce accessLevel restriction in generateVideoActivity

### DIFF
--- a/functions/src/aiGeneration.ts
+++ b/functions/src/aiGeneration.ts
@@ -221,7 +221,15 @@ export const generateWithAI = onCall(
     // Check if user is an admin (cached for 5 minutes per warm instance).
     const isAdmin = await getCachedAdminStatus(db, email.toLowerCase());
 
-    // 1. Determine specific feature ID if applicable
+    // 1. Determine specific feature ID if applicable.
+    //
+    // Only include genTypes that are ALSO keys in the promptMap below.
+    // `video-activity` and `guided-learning` are handled by dedicated Cloud
+    // Functions (`generateVideoActivity` / `generateGuidedLearning`) that own
+    // their own usage-counter writes. Including them here was dead code that
+    // silently inflated their per-feature usage counters for any request that
+    // reached this branch with those types — the counters were incremented
+    // before the promptMap lookup threw "Invalid generation type".
     let specificFeatureId: string | null = null;
     const genType = String(data?.type || '')
       .toLowerCase()
@@ -229,10 +237,7 @@ export const generateWithAI = onCall(
     if (genType === 'mini-app') specificFeatureId = 'embed-mini-app';
     if (genType === 'poll') specificFeatureId = 'smart-poll';
     if (genType === 'quiz') specificFeatureId = 'quiz';
-    if (genType === 'video-activity')
-      specificFeatureId = 'video-activity-audio-transcription';
     if (genType === 'ocr') specificFeatureId = 'ocr';
-    if (genType === 'guided-learning') specificFeatureId = 'guided-learning';
     if (genType === 'blooms-ai') specificFeatureId = 'blooms-ai';
     if (genType === 'video-activity-recommend')
       specificFeatureId = 'video-activity-recommend';
@@ -1381,29 +1386,55 @@ export const generateVideoActivity = onCall(
     const isAdmin = adminDoc.exists;
 
     if (!isAdmin) {
+      // --- Check Global Gemini Permission (enabled + accessLevel) ---
+      const globalPermDoc = await db
+        .collection('global_permissions')
+        .doc('gemini-functions')
+        .get();
+      const globalPerm = globalPermDoc.data() as GlobalPermission | undefined;
+
+      if (globalPerm && !globalPerm.enabled) {
+        throw new HttpsError(
+          'permission-denied',
+          'Gemini functions are currently disabled by an administrator.'
+        );
+      }
+
+      if (globalPerm) {
+        const { accessLevel, betaUsers = [] } = globalPerm;
+        if (accessLevel === 'admin') {
+          throw new HttpsError(
+            'permission-denied',
+            'Gemini functions are currently restricted to administrators.'
+          );
+        }
+        if (
+          accessLevel === 'beta' &&
+          !betaUsers.includes(email.toLowerCase())
+        ) {
+          throw new HttpsError(
+            'permission-denied',
+            'You do not have access to Gemini beta functions.'
+          );
+        }
+      }
+
       // --- Check Overall Gemini Limit ---
       const today = new Date().toISOString().split('T')[0];
       const overallUsageRef = db.collection('ai_usage').doc(`${uid}_${today}`);
 
       try {
         await db.runTransaction(async (transaction) => {
-          const globalPermDoc = await transaction.get(
+          const globalPermDoc2 = await transaction.get(
             db.collection('global_permissions').doc('gemini-functions')
           );
-          const globalPerm = globalPermDoc.data() as
+          const globalPerm2 = globalPermDoc2.data() as
             | GlobalPermission
             | undefined;
 
-          if (globalPerm && !globalPerm.enabled) {
-            throw new HttpsError(
-              'permission-denied',
-              'Gemini functions are currently disabled by an administrator.'
-            );
-          }
-
           const overallLimitEnabled =
-            globalPerm?.config?.dailyLimitEnabled !== false;
-          const overallLimit = globalPerm?.config?.dailyLimit ?? 20;
+            globalPerm2?.config?.dailyLimitEnabled !== false;
+          const overallLimit = globalPerm2?.config?.dailyLimit ?? 20;
 
           const overallUsageDoc = await transaction.get(overallUsageRef);
           const currentOverallUsage =

--- a/functions/src/aiGeneration.ts
+++ b/functions/src/aiGeneration.ts
@@ -1391,7 +1391,9 @@ export const generateVideoActivity = onCall(
         .collection('global_permissions')
         .doc('gemini-functions')
         .get();
-      const accessPerm = accessPermDoc.data() as GlobalPermission | undefined;
+      const accessPerm = accessPermDoc.exists
+        ? (accessPermDoc.data() as GlobalPermission)
+        : undefined;
 
       if (accessPerm && !accessPerm.enabled) {
         throw new HttpsError(

--- a/functions/src/aiGeneration.ts
+++ b/functions/src/aiGeneration.ts
@@ -1387,21 +1387,21 @@ export const generateVideoActivity = onCall(
 
     if (!isAdmin) {
       // --- Check Global Gemini Permission (enabled + accessLevel) ---
-      const globalPermDoc = await db
+      const accessPermDoc = await db
         .collection('global_permissions')
         .doc('gemini-functions')
         .get();
-      const globalPerm = globalPermDoc.data() as GlobalPermission | undefined;
+      const accessPerm = accessPermDoc.data() as GlobalPermission | undefined;
 
-      if (globalPerm && !globalPerm.enabled) {
+      if (accessPerm && !accessPerm.enabled) {
         throw new HttpsError(
           'permission-denied',
           'Gemini functions are currently disabled by an administrator.'
         );
       }
 
-      if (globalPerm) {
-        const { accessLevel, betaUsers = [] } = globalPerm;
+      if (accessPerm) {
+        const { accessLevel, betaUsers = [] } = accessPerm;
         if (accessLevel === 'admin') {
           throw new HttpsError(
             'permission-denied',
@@ -1425,16 +1425,16 @@ export const generateVideoActivity = onCall(
 
       try {
         await db.runTransaction(async (transaction) => {
-          const globalPermDoc2 = await transaction.get(
+          const globalPermDoc = await transaction.get(
             db.collection('global_permissions').doc('gemini-functions')
           );
-          const globalPerm2 = globalPermDoc2.data() as
+          const globalPerm = globalPermDoc.data() as
             | GlobalPermission
             | undefined;
 
           const overallLimitEnabled =
-            globalPerm2?.config?.dailyLimitEnabled !== false;
-          const overallLimit = globalPerm2?.config?.dailyLimit ?? 20;
+            globalPerm?.config?.dailyLimitEnabled !== false;
+          const overallLimit = globalPerm?.config?.dailyLimit ?? 20;
 
           const overallUsageDoc = await transaction.get(overallUsageRef);
           const currentOverallUsage =

--- a/functions/src/aiGeneration.ts
+++ b/functions/src/aiGeneration.ts
@@ -1427,16 +1427,9 @@ export const generateVideoActivity = onCall(
 
       try {
         await db.runTransaction(async (transaction) => {
-          const globalPermDoc = await transaction.get(
-            db.collection('global_permissions').doc('gemini-functions')
-          );
-          const globalPerm = globalPermDoc.data() as
-            | GlobalPermission
-            | undefined;
-
           const overallLimitEnabled =
-            globalPerm?.config?.dailyLimitEnabled !== false;
-          const overallLimit = globalPerm?.config?.dailyLimit ?? 20;
+            accessPerm?.config?.dailyLimitEnabled !== false;
+          const overallLimit = accessPerm?.config?.dailyLimit ?? 20;
 
           const overallUsageDoc = await transaction.get(overallUsageRef);
           const currentOverallUsage =

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -381,6 +381,7 @@ import {
   adminAnalytics,
   getPseudonymsForAssignmentV1,
   archiveActivityWallPhoto,
+  generateVideoActivity,
   __getCachedAdminStatus,
   __getGeminiModelConfig,
   __resetGenerateWithAICaches,
@@ -2814,5 +2815,129 @@ describe('getGeminiModelConfig usedFallback flag', () => {
     /* eslint-enable @typescript-eslint/no-unsafe-argument */
 
     expect(result.usedFallback).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateVideoActivity — accessLevel enforcement (regression test)
+// ---------------------------------------------------------------------------
+// Bug: before the fix, generateVideoActivity only checked `enabled: false`
+// from the `global_permissions/gemini-functions` doc. It did NOT check the
+// `accessLevel` field, so a non-admin teacher could bypass an admin-only or
+// beta restriction by calling generateVideoActivity instead of generateWithAI.
+//
+// Fix: read globalPerm outside the usage-counter transaction and throw
+// `permission-denied` when accessLevel === 'admin' (and the caller is not an
+// admin) or when accessLevel === 'beta' and the caller is not in betaUsers.
+// ---------------------------------------------------------------------------
+describe('generateVideoActivity — accessLevel enforcement', () => {
+  // Minimal valid YouTube URL and type counts so input validation passes
+  // before we reach the permission check under test.
+  const VALID_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+  const VALID_DATA = { url: VALID_URL, questionCount: 3 };
+  const NON_ADMIN_AUTH = {
+    uid: 'uid-teacher-1',
+    token: { email: 'teacher@school.org' },
+  };
+
+  const handler = generateVideoActivity as unknown as (
+    data: unknown,
+    context: unknown
+  ) => Promise<unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFirestoreState.admins = new Set<string>();
+    __resetGenerateWithAICaches();
+    // Default: gemini-functions doc does not exist → no restrictions.
+    geminiConfigDocGet.mockResolvedValue({
+      exists: false,
+      data: () => undefined as Record<string, unknown> | undefined,
+    });
+  });
+
+  it('throws permission-denied for non-admin when accessLevel is "admin"', async () => {
+    // Arrange: global permission restricts Gemini to admins only.
+    geminiConfigDocGet.mockResolvedValue({
+      exists: true,
+      data: () =>
+        ({
+          enabled: true,
+          accessLevel: 'admin',
+          betaUsers: [],
+        }) as Record<string, unknown>,
+    });
+
+    // Act / Assert: non-admin teacher must be rejected.
+    await expect(handler(VALID_DATA, { auth: NON_ADMIN_AUTH })).rejects.toThrow(
+      'Gemini functions are currently restricted to administrators.'
+    );
+  });
+
+  it('throws permission-denied for non-beta user when accessLevel is "beta"', async () => {
+    // Arrange: global permission restricts Gemini to beta users.
+    geminiConfigDocGet.mockResolvedValue({
+      exists: true,
+      data: () =>
+        ({
+          enabled: true,
+          accessLevel: 'beta',
+          betaUsers: ['beta@school.org'],
+        }) as Record<string, unknown>,
+    });
+
+    // teacher@school.org is NOT in betaUsers → must be rejected.
+    await expect(handler(VALID_DATA, { auth: NON_ADMIN_AUTH })).rejects.toThrow(
+      'You do not have access to Gemini beta functions.'
+    );
+  });
+
+  it('does not throw for a beta user when accessLevel is "beta"', async () => {
+    // Arrange: caller is in betaUsers — should pass the accessLevel gate.
+    // runTransaction mock won't call its callback, so the function will
+    // resolve (no Gemini API call needed — the function throws from the
+    // try/catch wrapper when the transaction is a no-op). We just need to
+    // confirm it does NOT throw a permission-denied error.
+    geminiConfigDocGet.mockResolvedValue({
+      exists: true,
+      data: () =>
+        ({
+          enabled: true,
+          accessLevel: 'beta',
+          betaUsers: ['teacher@school.org'],
+        }) as Record<string, unknown>,
+    });
+
+    // The function will reach runTransaction (which is a no-op mock) and
+    // then proceed; it will eventually fail because GEMINI_API_KEY is a
+    // mock secret and the AI client is not configured, but it must NOT
+    // throw the permission-denied error from the accessLevel check.
+    const result = handler(VALID_DATA, { auth: NON_ADMIN_AUTH });
+    await expect(result).rejects.not.toThrow(
+      'You do not have access to Gemini beta functions.'
+    );
+    await expect(result).rejects.not.toThrow(
+      'Gemini functions are currently restricted to administrators.'
+    );
+  });
+
+  it('does not throw accessLevel errors for an admin regardless of accessLevel setting', async () => {
+    // Arrange: caller is an admin; even with accessLevel === 'admin' the
+    // admin check short-circuits and skips the permission gate entirely.
+    mockFirestoreState.admins.add('teacher@school.org');
+    geminiConfigDocGet.mockResolvedValue({
+      exists: true,
+      data: () =>
+        ({
+          enabled: true,
+          accessLevel: 'admin',
+          betaUsers: [],
+        }) as Record<string, unknown>,
+    });
+
+    const result = handler(VALID_DATA, { auth: NON_ADMIN_AUTH });
+    await expect(result).rejects.not.toThrow(
+      'Gemini functions are currently restricted to administrators.'
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `functions/src/aiGeneration.ts` `generateVideoActivity` only checked `!globalPerm.enabled` inside the Firestore rate-limit transaction, but **never checked `accessLevel`** (`admin` / `beta` restriction).
- A non-admin user with a beta-restricted Gemini permission could bypass the restriction entirely by calling `generateVideoActivity` directly instead of routing through `generateWithAI` (which enforced `accessLevel` correctly at lines 287–303).
- Fixed: reads `global_permissions/gemini-functions` immediately after the `isAdmin` check (outside the transaction); enforces `enabled`, `accessLevel === 'admin'`, and `accessLevel === 'beta'` + `betaUsers` allowlist — mirrors the outside-transaction pattern used in `transcribeVideoWithGemini` (not inside the transaction like `generateWithAI`; both approaches are correct for admin-managed config that changes rarely).
- Removed `video-activity` and `guided-learning` entries from `generateWithAI`'s `specificFeatureId` map — those types have no `promptMap` entry so the function always threw before returning, but the usage counter was already incremented; dead code and a counter-inflation bug.
- 4 regression tests added: admin-restricted rejects non-admin, beta-restricted rejects non-beta, beta-restricted allows beta user, admin caller bypasses restriction.
- All 537 functions tests pass.

## Test plan

- [ ] Non-admin call with `accessLevel: 'admin'` → `permission-denied` (fails before, passes after)
- [ ] Beta-restricted call without email in `betaUsers` → `permission-denied` (fails before, passes after)
- [ ] `pnpm run validate` green (functions suite included)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (nightly debugger run #21, 2026-06-19)
https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM

---
_Generated by [Claude Code](https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM)_