### PR TITLE
fix(widgets): remove stale-ref useEffect in PageEditor and RandomSettings

### DIFF
--- a/components/widgets/SmartNotebook/components/PageEditor.test.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { act, fireEvent, render } from '@testing-library/react';
+import { flushSync } from 'react-dom';
 import { PageEditor } from './PageEditor';
 
 // jsdom does not implement SVGGraphicsElement.getBBox or DOMMatrix; stub them
@@ -194,5 +195,125 @@ describe('PageEditor — pointerup robustness', () => {
     });
 
     expect(onChange).toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression test: onChange ref must be current immediately after a
+ * synchronous re-render (flushSync), not deferred to the next passive-effect
+ * flush.
+ *
+ * Bug (fixed)
+ * -----------
+ * The original code used `useEffect(() => { onChangeRef.current = onChange; })`
+ * (no dep array — fires after every render). Between the render commit and the
+ * passive-effect flush there is a window where `onChangeRef.current` still
+ * holds the PREVIOUS render's callback. In production this window is open for
+ * at least one browser paint frame (~16 ms). Any synchronous call into the
+ * editor during that window — e.g. a native window keydown handler invoking
+ * `undo()` → `onChangeRef.current?.(prev)` — would silently call the stale
+ * callback and miss the current one.
+ *
+ * Fix: assign refs in the render body so the ref is always current by the time
+ * any handler fires. CLAUDE.md: "Assign refs directly in the render body —
+ * no effect needed."
+ *
+ * Test strategy
+ * -------------
+ * 1. Render with onChange=fnA, make a drag edit (populates the undo stack and
+ *    calls fnA once via emitChange).
+ * 2. `flushSync(rerender with onChange=fnB)` — commits synchronously, but
+ *    passive effects are NOT flushed (flushSync only runs layout effects).
+ * 3. Dispatch a native `window` keydown Ctrl+Z — the capture-phase listener
+ *    registered in the previous useEffect is still active. It calls `undo()`
+ *    which calls `onChangeRef.current?.(prev)` synchronously.
+ *    • Old code: `onChangeRef.current === fnA` (stale; effect hasn't fired) → FAIL
+ *    • New code: `onChangeRef.current === fnB` (render-body update ran) → PASS
+ *
+ * Why this works in the test environment
+ * ----------------------------------------
+ * `flushSync` commits the React tree (runs synchronous render + layout
+ * effects) but deliberately does NOT drain the passive-effect queue.
+ * `window.dispatchEvent` fires synchronously — no act(), no timer, nothing
+ * that could accidentally flush effects before the assertion.
+ */
+describe('PageEditor — onChange ref is current immediately after flushSync re-render', () => {
+  it('Ctrl+Z calls the NEW onChange after a flushSync prop swap, not the pre-swap one', async () => {
+    const fnA = vi.fn();
+    const fnB = vi.fn();
+
+    // Render in default select-mode so no textarea opens (editing stays null,
+    // which is required for the keydown handler to reach the undo branch).
+    const { container, rerender } = render(
+      <PageEditor svg={TEST_SVG} onChange={fnA} />
+    );
+    // Let the mount useEffect run (sets up the editable SVG DOM and records
+    // initialSvgRef — required for emitChange to push onto the undo stack).
+    await tick();
+
+    const rect = container.querySelector('[data-edit-id]');
+    if (!rect)
+      throw new Error(
+        'PageEditor did not assign edit ids to foreground objects'
+      );
+
+    // Drag the rect past DRAG_THRESHOLD_PX so the pointerup handler calls
+    // emitChange() → onChangeRef.current(serialized). This:
+    //   (a) calls fnA once, and
+    //   (b) pushes the pre-drag SVG baseline onto pastSvgStackRef
+    //       (required for undo() to have something to pop).
+    fire(rect, 'pointerdown', {
+      clientX: 200,
+      clientY: 200,
+      pointerId: 1,
+      buttons: 1,
+      isPrimary: true,
+    });
+    fire(rect, 'pointermove', {
+      clientX: 260,
+      clientY: 220,
+      pointerId: 1,
+      buttons: 1,
+      isPrimary: true,
+    });
+    fire(rect, 'pointerup', {
+      clientX: 260,
+      clientY: 220,
+      pointerId: 1,
+      buttons: 0,
+      isPrimary: true,
+    });
+
+    // fnA must have been called (confirms emitChange ran and undo stack is set).
+    expect(fnA).toHaveBeenCalled();
+    fnA.mockClear();
+    fnB.mockClear();
+
+    // Swap to fnB via flushSync: commits the React tree (layout effects run)
+    // but does NOT flush passive effects. With the old useEffect-based ref
+    // sync, `onChangeRef.current` still equals fnA at this point.
+    // With the render-body fix it already equals fnB.
+    flushSync(() => {
+      rerender(<PageEditor svg={TEST_SVG} onChange={fnB} />);
+    });
+
+    // Dispatch a native capture-phase keydown on window.
+    // • This bypasses React's synthetic event system and act() entirely.
+    // • The listener registered during the previous useEffect is still active.
+    // • It is synchronous: no scheduler, no microtask, no effect flush.
+    // • The listener calls undo() → onChangeRef.current?.(prev).
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'z',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    // Old code (useEffect ref sync): passive effect hasn't run → fnA called → FAIL
+    // New code (render-body ref sync): ref updated during flushSync → fnB called → PASS
+    expect(fnB).toHaveBeenCalled();
+    expect(fnA).not.toHaveBeenCalled();
   });
 });

--- a/components/widgets/SmartNotebook/components/PageEditor.tsx
+++ b/components/widgets/SmartNotebook/components/PageEditor.tsx
@@ -405,10 +405,10 @@ export const PageEditor: React.FC<PageEditorProps> = ({
 
   const onSelRef = useRef(onSelectionChange);
   const onChangeRef = useRef(onChange);
-  useEffect(() => {
-    onSelRef.current = onSelectionChange;
-    onChangeRef.current = onChange;
-  });
+  // Assign in the render body so handlers always read the latest callbacks.
+  // CLAUDE.md: "Assign refs directly in the render body — no effect needed."
+  onSelRef.current = onSelectionChange;
+  onChangeRef.current = onChange;
 
   // Mirror controlled tool props into refs so the pointer handlers always see
   // the latest value at fire time. Assigning in render body is the project's

--- a/components/widgets/Stations/components/accentText.ts
+++ b/components/widgets/Stations/components/accentText.ts
@@ -102,9 +102,13 @@ export function getAccessibleAccentText(accent: string): string {
     return toHex(rgb);
   }
 
-  const [h, s] = rgbToHsl(...rgb);
-  // Step lightness down until contrast clears the bar (or we hit black).
-  let l = 0.5;
+  const [h, s, origL] = rgbToHsl(...rgb);
+  // Step lightness down from the original value until contrast clears the
+  // 4.5:1 bar (or we hit black). Starting from the original lightness rather
+  // than a hard-coded 0.5 preserves the lightest accessible variant of the
+  // color — starting from 0.5 would overshoot for colors whose accessible
+  // range lies above l=0.5 (blue-violets, purples, desaturated reds).
+  let l = origL;
   for (let i = 0; i < 50; i++) {
     const candidate = hslToRgb(h, s, l);
     if (contrastVsWhite(candidate) >= TARGET_CONTRAST) {

--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -201,18 +201,12 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   const firstNamesTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastNamesTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Keep refs current so debounced callbacks always read the latest values
-  const configRef = useRef(config);
+  // Mirror updateWidget into a ref so the debounced setTimeout callbacks
+  // always read the current function even if the context value changes
+  // mid-debounce. CLAUDE.md: assign in the render body, no useEffect needed.
   const updateWidgetRef = useRef(updateWidget);
-
-  // Note: These need to be updated in useEffect or event handlers to avoid react-hooks/refs errors
-  useEffect(() => {
-    configRef.current = config;
-  }, [config]);
-
-  useEffect(() => {
-    updateWidgetRef.current = updateWidget;
-  }, [updateWidget]);
+  // eslint-disable-next-line react-hooks/refs
+  updateWidgetRef.current = updateWidget;
 
   // Sync local inputs when the external value changes (e.g. roster import)
   if (firstNames !== prevFirstNames) {

--- a/tests/components/widgets/Stations/accentText.test.ts
+++ b/tests/components/widgets/Stations/accentText.test.ts
@@ -47,4 +47,44 @@ describe('getAccessibleAccentText', () => {
     expect(getAccessibleAccentText('not-a-color')).toBe('not-a-color');
     expect(getAccessibleAccentText('')).toBe('');
   });
+
+  /**
+   * Regression test: getAccessibleAccentText must start stepping from the
+   * ORIGINAL lightness, not a hard-coded 0.5.
+   *
+   * Bug (fixed)
+   * -----------
+   * The original code destructured only [h, s] from rgbToHsl, discarding
+   * the lightness, then initialised `let l = 0.5` before the stepping loop.
+   * For colors whose accessible lightness lies ABOVE 0.5 — blue-violets,
+   * purples, desaturated reds — the loop would miss the lightest passing
+   * value and return a needlessly dark result.
+   *
+   * Concrete case: #6675ff (blue-violet, l≈0.70, contrast 3.77 vs white).
+   *   • Buggy code starts at l=0.5 → first passing value is l=0.50 (#0019ff,
+   *     contrast 8.1) — far darker than the accessible threshold requires.
+   *   • Fixed code starts at l=0.70 → first passing value is l=0.66 (#5263ff,
+   *     contrast 4.58) — the lightest accessible version of that color.
+   *
+   * The test proves the fix by asserting that the returned color is not darker
+   * than l=0.50 when a lighter accessible version exists above that threshold.
+   * This assertion FAILS on the buggy code and PASSES after the fix.
+   */
+  it('returns the lightest accessible variant, not an unnecessarily dark one', () => {
+    // #6675ff: blue-violet whose HSL lightness is ~0.70. It fails contrast
+    // (3.77:1 vs white), but the first accessible value while stepping DOWN
+    // from l=0.70 is at l≈0.66 (#5263ff, contrast 4.58:1). The buggy code
+    // started from l=0.50 and returned l=0.50 (#0019ff, contrast 8.11:1)
+    // — over-darkened by roughly 4 stops of lightness.
+    const result = getAccessibleAccentText('#6675ff');
+
+    // The result must still pass WCAG AA contrast.
+    expect(contrastVsWhite(result)).toBeGreaterThanOrEqual(4.5);
+
+    // The result's contrast must NOT be drastically higher than the minimum
+    // threshold: a contrast ≥ 6.0 here means the code over-darkened the color
+    // (the buggy code returned contrast ≈ 8.1). 5.5 gives headroom for
+    // floating-point differences while ruling out the over-darkened result.
+    expect(contrastVsWhite(result)).toBeLessThan(5.5);
+  });
 });


### PR DESCRIPTION
## Summary

Three bugs fixed, two tests added.

**`SmartNotebook/components/PageEditor.tsx`**
- `onSelRef` and `onChangeRef` were updated inside a bare `useEffect` (no dep array). Between render-commit and passive-effect flush, both refs still held the previous render's callbacks. Any synchronous call into the editor during that window (e.g. the native `window` keydown handler firing `undo()` → `onChangeRef.current?.(prev)`) would invoke the stale callback — silently calling the wrong `onChange` for at least one browser paint frame (~16ms).
- Fixed: render-body assignment `onSelRef.current = onSelectionChange; onChangeRef.current = onChange;` (the `react-hooks/refs` rule does NOT fire for these specific assignments in this file).

**`components/widgets/random/RandomSettings.tsx`**
- `updateWidgetRef` had the identical pattern. Debounced `setTimeout` callbacks inside the settings form read `updateWidgetRef.current` — after prop identity change in a debounce window, they would call the stale function.
- Fixed: render-body assignment with `// eslint-disable-next-line react-hooks/refs` suppression (the rule does fire here).

**`components/widgets/Stations/components/accentText.ts`** (`getAccessibleAccentText`)
- The lightness-stepping loop started from a hard-coded `l = 0.5` instead of the color's original lightness. For colors whose accessible lightness lies above 0.5 — blue-violets, purples, desaturated reds — the loop would miss the lightest passing value and return a needlessly dark result.
- Concrete: `#6675ff` (l≈0.70, contrast 3.77:1 vs white) — buggy code started at l=0.5 and returned `#0019ff` (contrast 8.1:1); fixed code starts at l=0.70 and returns `#5263ff` (contrast 4.58:1) — the lightest accessible variant.
- Fixed: `let l = origL;` (destructure the third component of `rgbToHsl`).

**Regression tests**:
- `PageEditor.test.tsx`: `flushSync(rerender with onChange=fnB)` commits a prop swap without draining passive effects; native `window` keydown Ctrl+Z fires synchronously; asserts `fnB` called, `fnA` not called. FAIL before fix, PASS after.
- `accentText.test.ts`: asserts the returned color's contrast is ≥4.5:1 but <5.5:1 for `#6675ff`, ruling out the over-darkened result from the buggy code.

## Test plan

- [x] `PageEditor` Ctrl+Z regression test: `fnB` called, `fnA` not called (fails before, passes after)
- [x] `accentText` lightness regression test: contrast ≥4.5 and <5.5 for `#6675ff` (fails before, passes after)
- [x] `pnpm run validate` green

🤖 Generated with [Claude Code](https://claude.com/claude-code) (nightly debugger run #21, 2026-06-19)
https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM

---
_Generated by [Claude Code](https://claude.ai/code/session_011rCFKGFyrZAJTtYoYwAVjM)_