### PR TITLE
fix(plc): pre-release hardening (crash guards, digest pagination/bcc, transfer rules)

### DIFF
--- a/components/common/sessionViews/SegmentedTabs.tsx
+++ b/components/common/sessionViews/SegmentedTabs.tsx
@@ -73,8 +73,14 @@ export function SegmentedTabs<K extends string = string>({
       } else {
         nextIdx = (safeIdx - 1 + nodes.length) % nodes.length;
       }
+      // Guard: `nodes` (live DOM role="tab" query) can contain more elements
+      // than `tabs` (stray tabs, or `tabs` changing between render and keydown),
+      // so nextIdx may be out of range for `tabs` — bail rather than crash on
+      // `.key` of undefined.
+      const nextTab = tabs[nextIdx];
+      if (!nextTab) return;
       nodes[nextIdx].focus();
-      onChange(tabs[nextIdx].key);
+      onChange(nextTab.key);
     },
     [onChange, tabs]
   );

--- a/components/plc/comments/mentionUtils.ts
+++ b/components/plc/comments/mentionUtils.ts
@@ -37,7 +37,9 @@ export function filterMentionCandidates(
     .map((m) => ({
       uid: m.uid,
       displayName: m.displayName || m.email || m.uid,
-      email: m.email,
+      // Default to '' — a member with a missing/null email (incomplete profile)
+      // would otherwise crash the .split('@') / .toLowerCase() filters below.
+      email: m.email ?? '',
     }));
   if (q.length === 0) return pool.slice(0, 8);
   const starts: MentionCandidate[] = [];

--- a/firestore.rules
+++ b/firestore.rules
@@ -1876,11 +1876,20 @@ service cloud.firestore {
              request.resource.data.members[newLead].role == 'lead'
              && request.resource.data.members[oldLead].role != 'lead'
            );
+      // A transfer may change ONLY the two lead entries in the members map — a
+      // manager can't silently re-role other members in the same write (that
+      // must go through isChangingMemberRole, one entry at a time).
+      let membersDiffOk =
+        !mapPresent
+        || request.resource.data.members
+             .diff(resource.data.get('members', {}))
+             .affectedKeys().hasOnly([newLead, oldLead]);
       return isPlcMembershipManager(resource.data)
         && newLead != oldLead
         && (newLead in resource.data.memberUids)
         && (newLead in request.resource.data.memberUids)
         && mapLockstep
+        && membersDiffOk
         // The leaving/incoming lead both remain members — the set is identical.
         && request.resource.data.memberUids.toSet()
              .hasAll(resource.data.memberUids.toSet())
@@ -1989,6 +1998,13 @@ service cloud.firestore {
              request.resource.data.members[newLead].role == 'lead'
              && request.resource.data.members[oldLead].role != 'lead'
            );
+      // Recovery may change ONLY the two lead entries in the members map — an
+      // admin reassign can't silently re-role other members in the same write.
+      let membersDiffOk =
+        !mapPresent
+        || request.resource.data.members
+             .diff(resource.data.get('members', {}))
+             .affectedKeys().hasOnly([newLead, oldLead]);
       return isAdmin()
         && resource.data.get('orgId', null) is string
         && isOrgMember(resource.data.orgId)
@@ -1996,6 +2012,7 @@ service cloud.firestore {
         && (newLead in resource.data.memberUids)
         && (newLead in request.resource.data.memberUids)
         && mapLockstep
+        && membersDiffOk
         // The membership SET is unchanged — recovery reassigns, never adds/drops.
         && request.resource.data.memberUids.toSet()
              .hasAll(resource.data.memberUids.toSet())

--- a/functions/src/plcWeeklyDigest.test.ts
+++ b/functions/src/plcWeeklyDigest.test.ts
@@ -29,7 +29,12 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('firebase-admin', () => ({
   apps: [{ name: '[DEFAULT]' }],
   initializeApp: vi.fn(),
-  firestore: vi.fn(),
+  // The sweep paginates with admin.firestore.FieldPath.documentId(); expose it
+  // as the '__name__' sentinel so the stub ColRef.orderBy gets a stable value
+  // (the stub sorts any non-'createdAt' orderBy by doc id).
+  firestore: Object.assign(vi.fn(), {
+    FieldPath: { documentId: vi.fn(() => '__name__') },
+  }),
 }));
 
 // `./functionsInit` calls `setGlobalOptions` at import time.
@@ -287,7 +292,8 @@ function makeStubDb(seed: {
 
   interface ColRef {
     limit: (n: number) => ColRef;
-    orderBy: (field: string, dir: string) => ColRef;
+    orderBy: (field: unknown, dir?: string) => ColRef;
+    startAfter: (cursor: DocSnap) => ColRef;
     get: () => Promise<{ docs: DocSnap[]; size: number }>;
     doc: (id: string) => DocRef;
   }
@@ -319,11 +325,18 @@ function makeStubDb(seed: {
 
   const makeColRef = (
     backing: StubDoc[],
-    opts: { orderField?: string; desc?: boolean; lim?: number }
+    opts: {
+      orderField?: unknown;
+      desc?: boolean;
+      lim?: number;
+      afterId?: string;
+    }
   ): ColRef => ({
     limit: (n: number) => makeColRef(backing, { ...opts, lim: n }),
-    orderBy: (field: string, dir: string) =>
+    orderBy: (field: unknown, dir?: string) =>
       makeColRef(backing, { ...opts, orderField: field, desc: dir === 'desc' }),
+    startAfter: (cursor: DocSnap) =>
+      makeColRef(backing, { ...opts, afterId: cursor.id }),
     get: () => {
       let rows = [...backing];
       if (opts.orderField === 'createdAt') {
@@ -332,6 +345,13 @@ function makeStubDb(seed: {
           const bv = (b.data.createdAt as number) ?? 0;
           return opts.desc ? bv - av : av - bv;
         });
+      } else if (opts.orderField != null) {
+        // documentId() ordering — sort by doc id ascending (pagination cursor).
+        rows.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+      }
+      if (opts.afterId !== undefined) {
+        const i = rows.findIndex((d) => d.id === opts.afterId);
+        if (i >= 0) rows = rows.slice(i + 1);
       }
       if (opts.lim !== undefined) rows = rows.slice(0, opts.lim);
       return Promise.resolve({
@@ -467,12 +487,14 @@ describe('runPlcWeeklyDigest — switch ON', () => {
     expect(counts.mailQueued).toBe(1);
     expect(mail.size).toBe(1);
     const [[, doc]] = [...mail.entries()];
-    // ONE doc carrying ALL three recipients — not three docs.
-    expect(doc.to).toEqual([
+    // ONE doc carrying ALL three recipients in BCC (no per-member fan-out) —
+    // and no recipient exposed in `to` (this run has no configured `from`).
+    expect(doc.bcc).toEqual([
       'lead@school.org',
       'member@school.org',
       'third@school.org',
     ]);
+    expect(doc.to).toBeUndefined();
   });
 
   it('skips an opted-OUT PLC even with recent activity', async () => {

--- a/functions/src/plcWeeklyDigest.ts
+++ b/functions/src/plcWeeklyDigest.ts
@@ -47,8 +47,16 @@ import './functionsInit';
 /** Digest window — the trailing 7 days of activity. */
 export const DIGEST_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** Max PLCs visited per run — keeps one sweep from monopolising the slot. */
-export const MAX_PLCS_PER_RUN = 1000;
+/**
+ * Overall safety ceiling on PLCs visited per run — a runaway guard, NOT an
+ * expected limit. The sweep PAGINATES (PLC_PAGE_SIZE pages, startAfter cursor),
+ * so every PLC up to this ceiling is covered every run; set far above any
+ * realistic single-district tenant.
+ */
+export const MAX_PLCS_PER_RUN = 5000;
+
+/** Page size for the paginated PLC sweep (startAfter cursor on document id). */
+export const PLC_PAGE_SIZE = 300;
 
 /** Max activity events scanned per PLC per run (bounded read). */
 export const MAX_ACTIVITY_PER_PLC = 500;
@@ -65,7 +73,10 @@ export interface DigestEmailConfig {
 }
 
 export interface MailDoc {
-  to: string[];
+  /** Visible To — the sender (when a `from` is configured), never recipients. */
+  to?: string[];
+  /** Recipients go here so no teacher sees the others' addresses. */
+  bcc?: string[];
   from?: string;
   replyTo?: string;
   message: {
@@ -372,65 +383,81 @@ export async function runPlcWeeklyDigest(
     return counts;
   }
 
-  const plcsSnap = await db.collection('plcs').limit(MAX_PLCS_PER_RUN).get();
-  counts.plcsConsidered = plcsSnap.size;
-  // Coverage alarm: this is a single bounded page (no pagination). If a tenant
-  // ever grows past the cap, PLCs beyond it are silently skipped every run —
-  // warn so an operator knows to add startAfter pagination before that bites.
-  if (plcsSnap.size >= MAX_PLCS_PER_RUN) {
-    logger.warn(
-      'plcWeeklyDigest: hit MAX_PLCS_PER_RUN — some PLCs may be skipped; add pagination',
-      { cap: MAX_PLCS_PER_RUN }
-    );
+  // Paginated sweep (startAfter cursor on document id) so EVERY PLC is covered,
+  // not just the first page — bounded by MAX_PLCS_PER_RUN (runaway guard) and
+  // the function timeout. Fixes the prior single `limit()` page, which silently
+  // skipped any PLC past the cap every run.
+  let lastDoc: admin.firestore.QueryDocumentSnapshot | undefined;
+  while (counts.plcsConsidered < MAX_PLCS_PER_RUN) {
+    let pageQuery = db
+      .collection('plcs')
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(PLC_PAGE_SIZE);
+    if (lastDoc) pageQuery = pageQuery.startAfter(lastDoc);
+    const page = await pageQuery.get();
+    if (page.size === 0) break;
+
+    for (const plcDoc of page.docs) {
+      counts.plcsConsidered += 1;
+      const plc = plcDoc.data();
+      if (!isDigestOptIn(plc)) continue;
+      counts.optedIn += 1;
+
+      const events = await readWindowedActivity(plcDoc.ref, now);
+      if (events.length === 0) {
+        counts.skippedNoActivity += 1;
+        continue;
+      }
+
+      const recipients = collectRecipientEmails(plc);
+      if (recipients.length === 0) {
+        counts.skippedNoRecipients += 1;
+        continue;
+      }
+
+      const plcName = typeof plc.name === 'string' ? plc.name : 'your PLC';
+      const body = buildPlcDigestEmail({ plcName, events });
+
+      // ONE mail doc per PLC (NO per-member fan-out, §8). Recipients go in BCC
+      // so no teacher sees another's address; the visible To is the sender when
+      // a `from` is configured, else bcc-only (the firestore-send-email
+      // extension supplies the default from). Deterministic doc id keyed by
+      // PLC + run-week so a retried run overwrites rather than duplicates.
+      const weekStamp = Math.floor(now / DIGEST_WINDOW_MS);
+      const mailId = `plc-digest_${plcDoc.id}_${weekStamp}`;
+      const mailDoc: MailDoc = { bcc: recipients, message: body };
+      if (config.from) {
+        mailDoc.from = config.from;
+        mailDoc.to = [config.from];
+      }
+      if (config.replyTo) mailDoc.replyTo = config.replyTo;
+
+      try {
+        await db.collection('mail').doc(mailId).set(mailDoc);
+        counts.mailQueued += 1;
+        logger.info('plcWeeklyDigest: queued digest mail', {
+          plcId: plcDoc.id,
+          recipients: recipients.length,
+          events: events.length,
+        });
+      } catch (err) {
+        // Log and continue — a thrown handler would retry the whole weekly run.
+        logger.error('plcWeeklyDigest: failed to queue digest mail', {
+          plcId: plcDoc.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    if (page.size < PLC_PAGE_SIZE) break;
+    lastDoc = page.docs[page.docs.length - 1];
   }
 
-  for (const plcDoc of plcsSnap.docs) {
-    const plc = plcDoc.data();
-    if (!isDigestOptIn(plc)) continue;
-    counts.optedIn += 1;
-
-    const events = await readWindowedActivity(plcDoc.ref, now);
-    if (events.length === 0) {
-      counts.skippedNoActivity += 1;
-      continue;
-    }
-
-    const recipients = collectRecipientEmails(plc);
-    if (recipients.length === 0) {
-      counts.skippedNoRecipients += 1;
-      continue;
-    }
-
-    const plcName = typeof plc.name === 'string' ? plc.name : 'your PLC';
-    const body = buildPlcDigestEmail({ plcName, events });
-
-    // ONE mail doc per PLC (NO per-member fan-out, §8). Deterministic doc id
-    // keyed by PLC + run-week so a retried run overwrites rather than
-    // duplicates. The `to: [...]` list carries every recipient.
-    const weekStamp = Math.floor(now / DIGEST_WINDOW_MS);
-    const mailId = `plc-digest_${plcDoc.id}_${weekStamp}`;
-    const mailDoc: MailDoc = {
-      to: recipients,
-      message: body,
-    };
-    if (config.from) mailDoc.from = config.from;
-    if (config.replyTo) mailDoc.replyTo = config.replyTo;
-
-    try {
-      await db.collection('mail').doc(mailId).set(mailDoc);
-      counts.mailQueued += 1;
-      logger.info('plcWeeklyDigest: queued digest mail', {
-        plcId: plcDoc.id,
-        recipients: recipients.length,
-        events: events.length,
-      });
-    } catch (err) {
-      // Log and continue — a thrown handler would retry the whole weekly run.
-      logger.error('plcWeeklyDigest: failed to queue digest mail', {
-        plcId: plcDoc.id,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  if (counts.plcsConsidered >= MAX_PLCS_PER_RUN) {
+    logger.warn(
+      'plcWeeklyDigest: hit MAX_PLCS_PER_RUN safety ceiling — raise it or shard the sweep',
+      { cap: MAX_PLCS_PER_RUN }
+    );
   }
 
   return counts;

--- a/tests/rules/plcMembership.test.ts
+++ b/tests/rules/plcMembership.test.ts
@@ -217,6 +217,29 @@ describe('plcs/{plcId} update — transferLead', () => {
       })
     );
   });
+
+  it('rejects a transfer that also re-roles a THIRD member in the same write (members-diff guard)', async () => {
+    // A valid transfer touches ONLY the two lead entries. Smuggling a third
+    // member's role change (OTHER member -> viewer) into the same write must be
+    // denied — role changes go through isChangingMemberRole, one at a time.
+    await assertFails(
+      updateDoc(doc(asLead(), `plcs/${PLC_ID}`), {
+        leadUid: MEMBER_UID,
+        members: {
+          [LEAD_UID]: member(LEAD_UID, LEAD_EMAIL, 'member'),
+          [MEMBER_UID]: member(MEMBER_UID, MEMBER_EMAIL, 'lead'),
+          [OTHER_UID]: member(OTHER_UID, OTHER_EMAIL, 'viewer'),
+        },
+        memberUids: [LEAD_UID, MEMBER_UID, OTHER_UID],
+        memberEmails: {
+          [LEAD_UID]: LEAD_EMAIL,
+          [MEMBER_UID]: MEMBER_EMAIL,
+          [OTHER_UID]: OTHER_EMAIL,
+        },
+        updatedAt: 2,
+      })
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Pre-release hardening (clears the remaining review findings before `dev-paul → main`)

Small, focused follow-ups so the release PR (#2027) goes out clean. All verified locally: `type-check:all`, `lint` (root + functions), `format`, root tests **5667/5667**, functions tests **658/658**.

- **`mentionUtils` crash (Gemini HIGH):** default a member's email to `''` so a missing/null email can't crash the `@mention` `.split('@')`/`.toLowerCase()` filters.
- **`SegmentedTabs` out-of-bounds (Gemini HIGH):** keyboard nav now guards `tabs[nextIdx]` — bails if the live `role="tab"` node set outruns `tabs` rather than crashing on `.key`.
- **`plcWeeklyDigest` pagination:** the PLC sweep now paginates (`startAfter` on document id) so every PLC is covered, not just the first page.
- **`plcWeeklyDigest` privacy:** recipients go in **BCC** (one mail doc, no roster leak); visible `To` is the configured sender. Stub + tests updated.
- **`firestore.rules` transfer/admin-recovery:** `isTransferringPlcLead` / `isAdminManagingPlc` now constrain the members-map diff to exactly the two lead entries (can't smuggle a third member's role change into a transfer). Rules test added.

Rules tests run emulator-only (CI `test:rules`); everything else verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
