### PR TITLE
fix(widgets/expectations): use shared Toggle in Settings panel

### DIFF
--- a/components/widgets/ExpectationsWidget/Settings.tsx
+++ b/components/widgets/ExpectationsWidget/Settings.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
-import { WidgetData, ExpectationsConfig } from '@/types';
+import { WidgetData, ExpectationsConfig, SoundConfig } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
 
 export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
@@ -28,14 +28,14 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
           (w) =>
             w.type === 'expectations' &&
             w.id !== widget.id &&
-            (w.config as import('@/types').ExpectationsConfig).syncSoundWidget
+            (w.config as ExpectationsConfig).syncSoundWidget
         )
         .forEach((w) => {
           updateWidget(w.id, {
             config: {
               ...w.config,
               syncSoundWidget: false,
-            } as import('@/types').ExpectationsConfig,
+            } as ExpectationsConfig,
           });
         });
     }
@@ -50,7 +50,7 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
         config: {
           ...w.config,
           syncExpectations: isActive,
-        } as import('@/types').SoundConfig,
+        } as SoundConfig,
       });
     });
   };

--- a/components/widgets/ExpectationsWidget/Settings.tsx
+++ b/components/widgets/ExpectationsWidget/Settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, ExpectationsConfig } from '@/types';
+import { Toggle } from '@/components/common/Toggle';
 
 export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
@@ -8,65 +9,63 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
   const { updateWidget, activeDashboard } = useDashboard();
   const config = widget.config as ExpectationsConfig;
 
+  const handleSyncToggle = (isActive: boolean) => {
+    updateWidget(widget.id, {
+      config: {
+        ...config,
+        syncSoundWidget: isActive,
+      },
+    });
+
+    if (!activeDashboard) {
+      return;
+    }
+
+    // If activating sync, ensure no other Expectations widget is also syncing.
+    if (isActive) {
+      activeDashboard.widgets
+        .filter(
+          (w) =>
+            w.type === 'expectations' &&
+            w.id !== widget.id &&
+            (w.config as import('@/types').ExpectationsConfig).syncSoundWidget
+        )
+        .forEach((w) => {
+          updateWidget(w.id, {
+            config: {
+              ...w.config,
+              syncSoundWidget: false,
+            } as import('@/types').ExpectationsConfig,
+          });
+        });
+    }
+
+    // Update all sound widgets. With the logic above, `isActive` is the correct
+    // state for `syncExpectations` on all sound widgets.
+    const soundWidgets = activeDashboard.widgets.filter(
+      (w) => w.type === 'sound'
+    );
+    soundWidgets.forEach((w) => {
+      updateWidget(w.id, {
+        config: {
+          ...w.config,
+          syncExpectations: isActive,
+        } as import('@/types').SoundConfig,
+      });
+    });
+  };
+
   return (
     <div className="space-y-6">
       <div>
         <label className="text-xxs text-slate-400 uppercase tracking-widest mb-3 block flex items-center gap-2">
           Nexus Connections
         </label>
-        <button
-          onClick={() => {
-            const isActive = !config.syncSoundWidget;
-
-            updateWidget(widget.id, {
-              config: {
-                ...config,
-                syncSoundWidget: isActive,
-              },
-            });
-
-            if (!activeDashboard) {
-              return;
-            }
-
-            // If activating sync, ensure no other Expectations widget is also syncing.
-            if (isActive) {
-              activeDashboard.widgets
-                .filter(
-                  (w) =>
-                    w.type === 'expectations' &&
-                    w.id !== widget.id &&
-                    (w.config as import('@/types').ExpectationsConfig)
-                      .syncSoundWidget
-                )
-                .forEach((w) => {
-                  updateWidget(w.id, {
-                    config: {
-                      ...w.config,
-                      syncSoundWidget: false,
-                    } as import('@/types').ExpectationsConfig,
-                  });
-                });
-            }
-
-            // Update all sound widgets. With the logic above, `isActive` is the correct
-            // state for `syncExpectations` on all sound widgets.
-            const soundWidgets = activeDashboard.widgets.filter(
-              (w) => w.type === 'sound'
-            );
-            soundWidgets.forEach((w) => {
-              updateWidget(w.id, {
-                config: {
-                  ...w.config,
-                  syncExpectations: isActive,
-                } as import('@/types').SoundConfig,
-              });
-            });
-          }}
+        <div
           className={`w-full p-4 rounded-xl border-2 flex items-center justify-between transition-all ${
             config.syncSoundWidget
               ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
-              : 'border-slate-100 bg-white text-slate-500 hover:border-slate-200'
+              : 'border-slate-100 bg-white text-slate-500'
           }`}
         >
           <div className="flex flex-col items-start gap-1">
@@ -78,18 +77,15 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
               Voice Level expectation.
             </span>
           </div>
-          <div
-            className={`w-10 h-6 rounded-full p-1 transition-colors duration-300 ${
-              config.syncSoundWidget ? 'bg-indigo-500' : 'bg-slate-200'
-            }`}
-          >
-            <div
-              className={`w-4 h-4 rounded-full bg-white shadow-sm transition-transform duration-300 ${
-                config.syncSoundWidget ? 'translate-x-4' : 'translate-x-0'
-              }`}
-            />
-          </div>
-        </button>
+          <Toggle
+            checked={config.syncSoundWidget ?? false}
+            onChange={handleSyncToggle}
+            label="Auto-Adjust Sound Meter"
+            size="sm"
+            activeColor="bg-indigo-500"
+            showLabels={false}
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/widgets/ExpectationsWidget/Settings.tsx
+++ b/components/widgets/ExpectationsWidget/Settings.tsx
@@ -28,7 +28,7 @@ export const ExpectationsSettings: React.FC<{ widget: WidgetData }> = ({
           (w) =>
             w.type === 'expectations' &&
             w.id !== widget.id &&
-            (w.config as ExpectationsConfig).syncSoundWidget
+            (w.config as ExpectationsConfig)?.syncSoundWidget
         )
         .forEach((w) => {
           updateWidget(w.id, {


### PR DESCRIPTION
## Summary

Resolves the **MEDIUM** ui-unification journal item: `ExpectationsWidget/Settings.tsx` implements a custom toggle instead of the shared `Toggle` component.

The "Auto-Adjust Sound Meter" control in the Expectations widget settings panel was a full-card `<button>` whose right edge hand-rolled a pill toggle (a `w-10 h-6` track div with an inner translating knob). That bespoke markup carried its own colors, sizing, and transition logic that would drift from the shared `components/common/Toggle.tsx` (already used by ~15 other settings panels), and the whole-card `<button>` was not exposed as an accessible switch.

## Changes

- Replace the inline knob/track markup with `<Toggle checked={...} onChange={handleSyncToggle} label="Auto-Adjust Sound Meter" size="sm" activeColor="bg-indigo-500" showLabels={false} />`.
- Extract the cross-widget sync side effects (deduping other syncing Expectations widgets, propagating `syncExpectations` to all sound widgets) into a named `handleSyncToggle(isActive)` handler — **behavior unchanged**.
- Convert the outer card from a `<button>` to a `<div>` (keeping the indigo active border/background) so `Toggle` provides the accessible `role="switch"` + `aria-checked` semantics.

## Verification

- `pnpm run type-check` — clean
- `pnpm exec eslint components/widgets/ExpectationsWidget/Settings.tsx --max-warnings 0` — clean
- `pnpm exec prettier --check` — clean
- `pnpm exec vitest run` ExpectationsWidget tests — 8/8 pass

The four additional binary-toggle button-pairs (ClockWidget / TimeTool / MaterialsWidget / NextUp) remain tracked as a separate LOW journal item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X3wDCQbzFd9uFH8apGszir

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3wDCQbzFd9uFH8apGszir)_