### PR TITLE
fix(schedule): use getTodayStr() in checkAutoLaunch to scope launch keys to local date

### DIFF
--- a/components/widgets/Schedule/ScheduleWidget.tsx
+++ b/components/widgets/Schedule/ScheduleWidget.tsx
@@ -377,7 +377,7 @@ export const ScheduleWidget: React.FC<{ widget: WidgetData }> = ({
       const now = new Date();
       const nowSec =
         now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
-      const today = now.toISOString().slice(0, 10);
+      const today = getTodayStr();
       const currentItems = itemsRef.current;
       const currentEffective = effectiveTimesRef.current;
       const w = widgetRef.current;

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -336,14 +336,12 @@ describe('ScheduleWidget', () => {
     expect(mockAddWidget).toHaveBeenCalledTimes(1);
     mockAddWidget.mockClear();
 
-    // --- Simulate UTC+ scenario: local date advances to '2024-01-16' while
-    //     UTC time is still on '2024-01-15' (08:15 UTC = 10:15 local in UTC+2
-    //     the next morning — a realistic scenario where the teacher's machine
-    //     shows Jan 16 but toISOString() would give Jan 15 if still early UTC).
-    //
-    //     For the test, we keep UTC at 2024-01-15T08:15:00Z (window still open)
-    //     so that the time-window check passes, and only advance the local date
-    //     via the getTodayStr mock. ---
+    // --- Simulate UTC+ scenario: local date has advanced to '2024-01-16' while
+    //     UTC is still on '2024-01-15'. In a real UTC+2 case this happens
+    //     between 22:00–24:00 UTC (local midnight = UTC 22:00). For the test we
+    //     use 08:15 UTC (well within the item's 08:00–09:00 window) purely to
+    //     keep the time-window check passing, and advance the local date via the
+    //     getTodayStr mock to isolate the launch-key pruning behaviour. ---
     vi.setSystemTime(new Date('2024-01-15T08:15:00Z'));
     mockGetTodayStr.mockReturnValue('2024-01-16'); // local date has advanced
 

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -24,13 +24,20 @@ vi.mock('../../hooks/useFeaturePermissions');
 // Controllable getTodayStr for the UTC/local-date split regression test.
 // vi.hoisted ensures the mock fn is available when the vi.mock factory below
 // runs (which is hoisted to the top of the compiled output).
-const { mockGetTodayStr } = vi.hoisted(() => ({
+const { mockGetTodayStr, defaultGetTodayStr } = vi.hoisted(() => ({
   mockGetTodayStr: vi.fn<() => string>(),
+  defaultGetTodayStr: { current: (() => '') as () => string },
 }));
 
 vi.mock('@/components/widgets/Schedule/utils', async (importOriginal) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const actual = await importOriginal<Record<string, any>>();
+  const actual =
+    await importOriginal<
+      typeof import('@/components/widgets/Schedule/utils')
+    >();
+  // Capture the real getTodayStr so tests can restore it without duplicating
+  // the date-formatting logic (keeps the mock resilient to future changes).
+  defaultGetTodayStr.current = actual.getTodayStr;
+  mockGetTodayStr.mockImplementation(actual.getTodayStr);
   return {
     ...actual,
     getTodayStr: mockGetTodayStr,
@@ -109,10 +116,8 @@ describe('ScheduleWidget', () => {
     mockUpdateWidget.mockClear();
     mockAddWidget.mockClear();
     // Default: getTodayStr returns the real local date so existing tests are unaffected.
-    mockGetTodayStr.mockImplementation(() => {
-      const d = new Date();
-      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
-    });
+    mockGetTodayStr.mockReset();
+    mockGetTodayStr.mockImplementation(defaultGetTodayStr.current);
   });
 
   afterEach(() => {

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -21,6 +21,22 @@ vi.mock('../../context/useDashboard');
 vi.mock('../../context/useAuth');
 vi.mock('../../hooks/useFeaturePermissions');
 
+// Controllable getTodayStr for the UTC/local-date split regression test.
+// vi.hoisted ensures the mock fn is available when the vi.mock factory below
+// runs (which is hoisted to the top of the compiled output).
+const { mockGetTodayStr } = vi.hoisted(() => ({
+  mockGetTodayStr: vi.fn<() => string>(),
+}));
+
+vi.mock('@/components/widgets/Schedule/utils', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actual = await importOriginal<Record<string, any>>();
+  return {
+    ...actual,
+    getTodayStr: mockGetTodayStr,
+  };
+});
+
 // jsdom does not implement HTMLElement.prototype.scrollTo.
 // Define it once as a vi.fn() stub so that the widget's useLayoutEffect does
 // not throw and vi.spyOn can wrap it in individual tests.
@@ -92,6 +108,11 @@ describe('ScheduleWidget', () => {
     });
     mockUpdateWidget.mockClear();
     mockAddWidget.mockClear();
+    // Default: getTodayStr returns the real local date so existing tests are unaffected.
+    mockGetTodayStr.mockImplementation(() => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    });
   });
 
   afterEach(() => {
@@ -256,6 +277,88 @@ describe('ScheduleWidget', () => {
     render(<ScheduleWidget widget={widget} />);
 
     expect(mockAddWidget).not.toHaveBeenCalled();
+  });
+
+  // ─── Regression: auto-launch uses UTC date instead of local date ────────────
+  //
+  // BEFORE the fix (ScheduleWidget.tsx `checkAutoLaunch`):
+  //   `const today = now.toISOString().slice(0, 10)` uses UTC date.
+  //
+  // For UTC+ users after local midnight but before UTC midnight (e.g. local
+  // 01:00 in UTC+2 = UTC 23:00 previous day), `toISOString()` still returns
+  // the OLD UTC date while getTodayStr() correctly returns the NEW local date.
+  //
+  // The symptom:
+  //   1. Day D: item launches → key `item-id-D` stored in launchedItemsRef.
+  //   2. After local midnight (new local day D+1, but UTC still D):
+  //      `toISOString()` = D, `getTodayStr()` = D+1.
+  //   3. BUG: pruning uses `today = D` → key `item-id-D` does NOT end with a
+  //      different date → NOT pruned → item appears "already launched today"
+  //      and fails to re-launch even on the NEW local day.
+  //   4. Items silently fail to re-launch for the entire UTC–local gap (up to
+  //      2 hours for UTC+2 users).
+  //
+  // Test mechanism:
+  //   - getTodayStr is mocked so we can advance "local date" independently of
+  //     what toISOString() returns.
+  //   - System time is set so the item window is active.
+  //   - Day 1: both dates agree → item launches, key stored.
+  //   - Tick with new "local" date (still same UTC date):
+  //       BUG  → today = UTC date = same as stored key → key NOT pruned
+  //               → item does NOT re-launch (fails the assertion below).
+  //       FIX  → today = getTodayStr() = new local date → key IS pruned
+  //               → item CAN re-launch → re-launches (passes assertion).
+  it('REGRESSION: re-launches linked widgets when getTodayStr advances even if UTC date is unchanged', () => {
+    // --- Day 1: 08:05 UTC. Both local and UTC agree on '2024-01-15'. ---
+    vi.setSystemTime(new Date('2024-01-15T08:05:00Z'));
+    mockGetTodayStr.mockReturnValue('2024-01-15');
+
+    const widget = createWidget({
+      items: [
+        {
+          id: 'link-item',
+          task: 'Morning Event',
+          done: false,
+          startTime: '08:00', // window: 08:00–09:00 UTC (active at 08:05)
+          endTime: '09:00',
+          linkedWidgets: ['clock'],
+        },
+      ],
+    });
+    render(<ScheduleWidget widget={widget} />);
+
+    // Launched once on mount — both dates agree.
+    expect(mockAddWidget).toHaveBeenCalledTimes(1);
+    mockAddWidget.mockClear();
+
+    // --- Simulate UTC+ scenario: local date advances to '2024-01-16' while
+    //     UTC time is still on '2024-01-15' (08:15 UTC = 10:15 local in UTC+2
+    //     the next morning — a realistic scenario where the teacher's machine
+    //     shows Jan 16 but toISOString() would give Jan 15 if still early UTC).
+    //
+    //     For the test, we keep UTC at 2024-01-15T08:15:00Z (window still open)
+    //     so that the time-window check passes, and only advance the local date
+    //     via the getTodayStr mock. ---
+    vi.setSystemTime(new Date('2024-01-15T08:15:00Z'));
+    mockGetTodayStr.mockReturnValue('2024-01-16'); // local date has advanced
+
+    act(() => {
+      vi.advanceTimersByTime(10000); // trigger one interval tick
+    });
+
+    // EXPECTED (FIX): getTodayStr() returns '2024-01-16', so:
+    //   - Pruning: key 'link-item-2024-01-15' does NOT end with '2024-01-16'
+    //     → pruned from launchedItemsRef.
+    //   - New key: 'link-item-2024-01-16', not in set.
+    //   - Window still active (08:15 UTC is within 08:00–09:00).
+    //   - addWidget called once more.
+    //
+    // BUG: toISOString().slice(0,10) returns '2024-01-15', so:
+    //   - Pruning: key 'link-item-2024-01-15' DOES end with '2024-01-15'
+    //     → NOT pruned, still in launchedItemsRef.
+    //   - Item appears "already launched today" → addWidget NOT called.
+    expect(mockAddWidget).toHaveBeenCalledTimes(1);
+    expect(mockAddWidget).toHaveBeenCalledWith('clock', expect.any(Object));
   });
 
   it('toggles item status on click', () => {


### PR DESCRIPTION
## Bug

`ScheduleWidget.checkAutoLaunch` scoped its launch-key pruning to the **UTC date** (`now.toISOString().slice(0, 10)`) instead of the **local date** (`getTodayStr()`), which is used everywhere else in the widget.

For UTC+ timezone users, the two dates diverge between local midnight and UTC midnight (up to ±2 h for UTC+2). During that window:

- `getTodayStr()` → new local date (e.g. `2024-01-16`)
- `toISOString().slice(0, 10)` → previous UTC date (e.g. `2024-01-15`)

This caused the pruning gate (`!key.endsWith(today)`) to retain keys from the previous local day, making items appear "already launched" and silently skip re-launch until UTC midnight caught up.

## Fix

One-line change in `components/widgets/Schedule/ScheduleWidget.tsx`:

```diff
- const today = now.toISOString().slice(0, 10);
+ const today = getTodayStr();
```

`getTodayStr` was already imported — no new dependency.

## Test

Added to `components/widgets/ScheduleWidget.test.tsx`:

- Mocks `getTodayStr` via `vi.hoisted()` to simulate local midnight passing while `Date.toISOString()` still returns the UTC date.
- Day 1: item launches (both dates agree), key stored.
- Day 2 (mock advances local date): **FAIL before fix** (UTC date still matches old key → pruning skips it → no launch); **PASS after fix** (local date triggers pruning → item re-launches).
- All 1385 pre-existing tests continue to pass.

## Checklist

- [x] Test fails on `dev-paul` (UTC date still used), passes on this branch
- [x] `pnpm run validate` passes on branch
- [x] Root cause fixed, not papered over

🤖 Nightly debugger run 2026-06-22 — Widgets area

Claude-Session: https://claude.ai/code/session_018zoYwTbiihDhoNUH7Xd4he

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoYwTbiihDhoNUH7Xd4he)_