### PR TITLE
fix(test): add missing vi.mock() stubs in mirrorPlcIndex.test.ts to recover 5 silently-dropped tests

### DIFF
--- a/functions/src/mirrorPlcIndex.test.ts
+++ b/functions/src/mirrorPlcIndex.test.ts
@@ -1,4 +1,50 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// mirrorPlcIndex.ts has four module-level side effects that must be mocked
+// before the import so Vitest's transform can resolve them:
+//
+//   1. `import { onDocumentWritten } from 'firebase-functions/v2/firestore'`
+//      — not installed in the test node_modules; must be intercepted.
+//   2. `import * as logger from 'firebase-functions/logger'`
+//      — likewise absent; replace with no-op stubs.
+//   3. `import * as admin from 'firebase-admin'`
+//      — guard `admin.apps.length` so the initializeApp() in functionsInit
+//        no-ops instead of attempting a real connection.
+//   4. `import './functionsInit'`
+//      — functionsInit calls `setGlobalOptions` (firebase-functions/v2) and
+//        `admin.initializeApp()`. Both are mocked via (1) and (3) above, but
+//        the `setGlobalOptions` import also needs a firebase-functions/v2 stub.
+//
+// This mirrors the approach used by `aggregatePlcAssessment.test.ts` and
+// `detachPlcSyncLinkage.test.ts`, which test sibling modules with the same
+// module-level bootstrap pattern.
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  firestore: Object.assign(vi.fn(), {
+    FieldValue: { serverTimestamp: () => ({ __serverTimestamp: true }) },
+  }),
+}));
+
+// `functionsInit` calls `setGlobalOptions` at import time.
+vi.mock('firebase-functions/v2', () => ({
+  setGlobalOptions: vi.fn(),
+}));
+
+// The trigger factory — returns the handler directly so the module can be
+// imported without registering a real Firestore trigger.
+vi.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: vi.fn((_opts: unknown, handler: unknown) => handler),
+}));
+
+vi.mock('firebase-functions/logger', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+}));
+
 import { buildPlcIndexMirror } from './mirrorPlcIndex';
 
 describe('buildPlcIndexMirror — slim, PII-free discovery mirror', () => {


### PR DESCRIPTION
## Bug

`functions/src/mirrorPlcIndex.test.ts` was missing all four required `vi.mock()` declarations.

`mirrorPlcIndex.ts` has four module-level side-effecting imports at load time:
- `firebase-functions/v2/firestore` (for `onDocumentWritten`)
- `firebase-functions/logger`
- `firebase-admin`
- `./functionsInit` (calls `setGlobalOptions` from `firebase-functions/v2`)

Without `vi.mock()` hoisting stubs, Vitest crashed with `ERR_MODULE_NOT_FOUND` before any test case could execute — **silently dropping all 5 tests** from the suite. The test file showed no failures because it never ran; the 5 cases were simply omitted from the count.

The sibling test files for modules with the same import pattern (`aggregatePlcAssessment.test.ts`, `detachPlcSyncLinkage.test.ts`) already use the correct hoisting approach. `mirrorPlcIndex.test.ts` was the only outlier.

## Fix

Added four `vi.mock()` calls to `functions/src/mirrorPlcIndex.test.ts` before the `buildPlcIndexMirror` import, mirroring the established pattern. The five test cases themselves are unchanged.

## Test coverage

The 5 existing test cases are the regression test — they were previously unreachable (crash at import) and now all pass (5/5).

## Checklist

- [x] 5 tests were unreachable before fix, all 5 pass after
- [x] `pnpm -C functions run validate` passes on branch
- [x] Fix mirrors established pattern in sibling test files

🤖 Nightly debugger run 2026-06-22 — Build & Tooling area

Claude-Session: https://claude.ai/code/session_018zoYwTbiihDhoNUH7Xd4he

---
_Generated by [Claude Code](https://claude.ai/code/session_018zoYwTbiihDhoNUH7Xd4he)_