### PR TITLE
feat(external-access): gate org-only surfaces + isolate data for self-serve external users

### DIFF
--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -643,7 +643,7 @@ const PollResponsesPanel: React.FC<{
 };
 
 export const AnnouncementsManager: React.FC = () => {
-  const { user } = useAuth();
+  const { user, orgId } = useAuth();
   const { addToast } = useDashboard();
   const BUILDINGS = useAdminBuildings();
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
@@ -863,6 +863,17 @@ export const AnnouncementsManager: React.FC = () => {
         createdAt: existing?.createdAt ?? now,
         updatedAt: now,
         createdBy: user?.email ?? 'admin',
+        // Multi-tenant isolation: stamp the creating admin's org on new docs
+        // (Orono admins resolve to 'orono'). On edit, self-heal toward tenancy:
+        // preserve an existing orgId, else fall back to the editing admin's
+        // current org so a pre-isolation legacy doc gets stamped on its first
+        // edit by a resolved-org admin (rather than staying globally readable
+        // until the backfill runs). `orgId` may be null (no-org admin, or org
+        // not yet resolved) — written as undefined (omitted) so the
+        // legacy/global visibility path still applies, never an explicit null.
+        orgId: existing
+          ? (existing.orgId ?? orgId ?? undefined)
+          : (orgId ?? undefined),
       };
 
       if (editingId) {

--- a/components/admin/DrawingConfigurationPanel.test.tsx
+++ b/components/admin/DrawingConfigurationPanel.test.tsx
@@ -3,11 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DrawingConfigurationPanel } from './DrawingConfigurationPanel';
 import { DrawingGlobalConfig } from '@/types';
 
-// Mock BUILDINGS
-vi.mock('@/config/buildings', () => ({
-  BUILDINGS: [
-    { id: 'b1', name: 'Building 1' },
-    { id: 'b2', name: 'Building 2' },
+// The panel reads its building list from `useAdminBuildings()`, which returns
+// `[]` for a no-org/provider-less render. An admin always has an org in real
+// usage, so mock the hook to supply the building list the panel renders.
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [
+    { id: 'b1', name: 'Building 1', gradeLevels: [], gradeLabel: '' },
+    { id: 'b2', name: 'Building 2', gradeLevels: [], gradeLabel: '' },
   ],
 }));
 

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -544,6 +544,14 @@ export const GlobalPermissionsManager: React.FC = () => {
         betaUsers: [],
         enabled: defaults.defaultEnabled,
         buildings: [],
+        // Seed the synthetic permission's `minTier` from the in-code default so
+        // the admin editor shows the effective tier floor that `canAccessFeature`
+        // already enforces on the missing-doc path (e.g. google-classroom /
+        // ai-file-context default to 'org'). Omit the field when there's no
+        // default so the "Any tier" option stays selected for pre-tier features.
+        ...(defaults.defaultMinTier
+          ? { minTier: defaults.defaultMinTier }
+          : {}),
         config: GEMINI_FEATURES.includes(featureId)
           ? { dailyLimit: defaultLimit, dailyLimitEnabled: true }
           : {},

--- a/components/admin/ScheduleConfigurationPanel.test.tsx
+++ b/components/admin/ScheduleConfigurationPanel.test.tsx
@@ -4,11 +4,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ScheduleConfigurationPanel } from './ScheduleConfigurationPanel';
 import { ScheduleGlobalConfig } from '@/types';
 
-// Mock BUILDINGS
-vi.mock('@/config/buildings', () => ({
-  BUILDINGS: [
-    { id: 'b1', name: 'Building 1' },
-    { id: 'b2', name: 'Building 2' },
+// The panel reads its building list from `useAdminBuildings()`, which returns
+// `[]` for a no-org/provider-less render. An admin always has an org in real
+// usage, so mock the hook to supply the building list the panel renders.
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [
+    { id: 'b1', name: 'Building 1', gradeLevels: [], gradeLabel: '' },
+    { id: 'b2', name: 'Building 2', gradeLevels: [], gradeLabel: '' },
   ],
 }));
 

--- a/components/admin/SoundboardConfigurationPanel.test.tsx
+++ b/components/admin/SoundboardConfigurationPanel.test.tsx
@@ -9,6 +9,15 @@ vi.mock('@/context/useAuth', () => ({
   useAuth: vi.fn().mockReturnValue({ googleAccessToken: 'test-token' }),
 }));
 
+// The panel reads its building list from `useAdminBuildings()`, which returns
+// `[]` for a no-org/provider-less render. An admin always has an org in real
+// usage, so mock the hook to return the real seed buildings — the second test
+// iterates `BUILDINGS` directly and expects each one toggled on.
+vi.mock('@/hooks/useAdminBuildings', async () => {
+  const { BUILDINGS } = await import('@/config/buildings');
+  return { useAdminBuildings: () => BUILDINGS };
+});
+
 vi.mock('@/utils/soundboardAudioUrl', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@/utils/soundboardAudioUrl')>();

--- a/components/announcements/AnnouncementOverlay.tsx
+++ b/components/announcements/AnnouncementOverlay.tsx
@@ -353,7 +353,7 @@ const AnnouncementWindow: React.FC<{
  * as floating windows above the dashboard.
  */
 export const AnnouncementOverlay: React.FC = () => {
-  const { user, selectedBuildings } = useAuth();
+  const { user, selectedBuildings, userTier, orgId } = useAuth();
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [dismissed, setDismissed] = useState<Set<string>>(() => {
     // Pre-populate from localStorage on mount
@@ -365,13 +365,37 @@ export const AnnouncementOverlay: React.FC = () => {
   // date-window transitions (start/end across midnight) trigger correctly.
   const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
-  // Subscribe to the announcements collection (only active announcements)
+  // Subscribe to the announcements collection (only active announcements).
+  //
+  // Multi-tenant leak-closer: announcements are a single global collection
+  // with no per-tenant query scope, so a no-org ("free") teacher would
+  // otherwise stream every operator-org announcement. We therefore NEVER open
+  // the listener for free-tier users. `userTier` is the already-exposed
+  // distribution tier ('internal' | 'org' | 'free'); Orono and every other
+  // org/internal user resolve to a non-free tier and are unaffected. The
+  // loading/unresolved state is treated as NOT subscribed (the gate only opens
+  // once the tier is positively known to be non-free), which fails closed.
   useEffect(() => {
     // We only subscribe if we have a user object.
     // isAuthBypass allows the UI to render, but Firestore still needs an auth token
     // unless the rules are set to allow public read (which they are not).
     if (!user) return;
+    // Free-tier (no-org) users must NEVER open the global announcements
+    // listener. We simply don't subscribe — a free user's effect never streams
+    // anything, so `announcements` stays empty. (We do NOT call
+    // setAnnouncements([]) here: a synchronous setState in an effect trips
+    // react-hooks/set-state-in-effect, and the render-time guard below already
+    // renders nothing for free users even if their tier flips mid-session.)
+    if (userTier === 'free') return;
 
+    // MULTI-TENANT TODO (before onboarding a SECOND org with active
+    // announcements): this query is org-unscoped. The tightened /announcements
+    // read rule denies foreign-org docs per-doc, and Firestore rejects an
+    // entire listener query if any matched doc is unreadable. Before a 2nd org
+    // goes live: (1) run scripts/migrateAnnouncements.js to stamp legacy docs
+    // orgId='orono', then (2) scope this query with where('orgId','==', orgId)
+    // (mirroring hooks/usePlcBuildingDirectory.ts). Safe today: only
+    // Orono/legacy docs exist.
     const unsub = onSnapshot(
       query(collection(db, 'announcements'), where('isActive', '==', true)),
       (snap) => {
@@ -386,7 +410,7 @@ export const AnnouncementOverlay: React.FC = () => {
       }
     );
     return unsub;
-  }, [user]);
+  }, [user, userTier]);
 
   // Periodic clock update for scheduled activation/dismissal checks
   useEffect(() => {
@@ -413,6 +437,18 @@ export const AnnouncementOverlay: React.FC = () => {
   const visible = useMemo(
     () =>
       announcements.filter((a) => {
+        // Tenant isolation (defense-in-depth alongside the listener gate and the
+        // Firestore read rule): hide an announcement that belongs to a DIFFERENT
+        // resolved org. Legacy/global docs (no orgId) are always visible. We only
+        // apply the exclusion once this user's `orgId` has positively resolved to
+        // a non-null value — while it's still null (membership snapshot not yet
+        // delivered), an internal/org user (e.g. Orono, who derives a non-free
+        // tier from their email domain BEFORE orgId resolves) must NOT have their
+        // own org's announcements hidden. Hiding during that window would flicker
+        // Orono's announcements off then on post-backfill — a regression vs.
+        // today. Once orgId resolves, any foreign-org doc is filtered out.
+        if (orgId != null && a.orgId != null && a.orgId !== orgId) return false;
+
         // Must pass scheduled/manual activation check + auto-deactivate window
         if (!isWithinActiveWindow(a, nowMs)) return false;
 
@@ -450,8 +486,14 @@ export const AnnouncementOverlay: React.FC = () => {
 
         return true;
       }),
-    [announcements, dismissed, selectedBuildings, nowMs, user?.email]
+    [announcements, dismissed, selectedBuildings, nowMs, user?.email, orgId]
   );
+
+  // Render-time tenant gate (double-guards the listener gate above): a free-tier
+  // (no-org) user must never see any announcement, even if their tier flipped to
+  // 'free' mid-session after a prior non-free subscription had already streamed
+  // docs. This makes the in-effect setState([]) unnecessary.
+  if (userTier === 'free') return null;
 
   if (visible.length === 0) return null;
 

--- a/components/common/WidgetBuildingToggle.test.tsx
+++ b/components/common/WidgetBuildingToggle.test.tsx
@@ -21,10 +21,19 @@ const makeWidget = (overrides: Partial<WidgetData> = {}): WidgetData =>
 
 const mockUpdateWidget = vi.fn();
 
-/** Minimal AuthContext value with only the fields the toggle reads. */
+/**
+ * Minimal AuthContext value with only the fields the toggle reads.
+ *
+ * `orgId` is set to a non-null org so `useAdminBuildings` returns the seed
+ * BUILDINGS list (the org-set-but-buildings-not-yet-loaded window). External
+ * (no-org) users get an empty building list now — see useAdminBuildings — so
+ * this fixture must represent an org member for the grade-label labels under
+ * test to resolve.
+ */
 const makeAuth = (selectedBuildings: string[]): AuthContextType =>
   ({
     selectedBuildings,
+    orgId: 'orono',
   }) as unknown as AuthContextType;
 
 const renderToggle = (

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -100,7 +100,7 @@ export const Sidebar: React.FC = () => {
   const [activeSection, setActiveSection] = useState<MenuSection>('main');
   const [isFullscreen, setIsFullscreen] = useState(false);
 
-  const { user, signOut, isAdmin, appSettings } = useAuth();
+  const { user, signOut, isAdmin, appSettings, isExternalUser } = useAuth();
   const {
     dashboards,
     activeDashboard,
@@ -123,8 +123,16 @@ export const Sidebar: React.FC = () => {
   // The PLC dashboard is now a first-class route (`/plc/:id/:section`, Decision
   // 0.3) rendered by `PlcRouteHost`, which mounts its OWN `usePlcs` listener —
   // so the sidebar only needs the list while the drawer itself is open.
-  const plcsHook = usePlcs({ enabled: isOpen });
-  const plcInvitationsHook = usePlcInvitations({ enabled: isOpen });
+  //
+  // Skip the PLC listeners entirely for external (no-org/free-tier) users: PLCs
+  // are an org-only surface that's hidden for them below, so attaching the
+  // three Firestore `onSnapshot` subscriptions (1 from usePlcs, 2 from
+  // usePlcInvitations) would be pure waste. Gating on `!isExternalUser` (which
+  // is false while membership resolves) means org members keep their listeners
+  // unchanged.
+  const plcsEnabled = isOpen && !isExternalUser;
+  const plcsHook = usePlcs({ enabled: plcsEnabled });
+  const plcInvitationsHook = usePlcInvitations({ enabled: plcsEnabled });
 
   const { isConnected: isDriveConnected } = useGoogleDrive();
 
@@ -468,44 +476,54 @@ export const Sidebar: React.FC = () => {
                     </span>
                     <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
                   </button>
-                  <button
-                    onClick={() => setActiveSection('classes')}
-                    className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
-                  >
-                    <div className="w-8 h-8 rounded-lg bg-brand-blue-lighter group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
-                      <Users className="w-4 h-4 text-brand-blue-light group-hover:text-brand-blue-primary transition-colors" />
-                    </div>
-                    <span className="flex-grow text-[13px]">
-                      {t('sidebar.nav.classes', {
-                        defaultValue: 'My Classes',
-                      })}
-                    </span>
-                    <span className="text-xxs bg-brand-blue-lighter text-brand-blue-primary px-2 py-0.5 rounded-full font-bold">
-                      {rosters.length}
-                    </span>
-                    <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
-                  </button>
-                  <PlcsMenuButton
-                    onClick={() => setActiveSection('plcs')}
-                    plcCount={plcsHook.plcs.length}
-                    pendingInviteCount={
-                      plcInvitationsHook.pendingInvites.length
-                    }
-                  />
-                  <button
-                    onClick={() => setActiveSection('buildings')}
-                    className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
-                  >
-                    <div className="w-8 h-8 rounded-lg bg-teal-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
-                      <Building2 className="w-4 h-4 text-teal-400 group-hover:text-brand-blue-primary transition-colors" />
-                    </div>
-                    <span className="flex-grow text-[13px]">
-                      {t('sidebar.nav.buildings', {
-                        defaultValue: 'My Building(s)',
-                      })}
-                    </span>
-                    <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
-                  </button>
+                  {/* Org-only surfaces: My Classes (incl. ClassLink import),
+                      My PLCs, and My Building(s). Hidden for external (no-org/
+                      free-tier) users — buildings/PLCs/ClassLink are all org
+                      concepts. `isExternalUser` is false while membership
+                      resolves, so org/internal members never see these flicker
+                      off during load. */}
+                  {!isExternalUser && (
+                    <>
+                      <button
+                        onClick={() => setActiveSection('classes')}
+                        className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
+                      >
+                        <div className="w-8 h-8 rounded-lg bg-brand-blue-lighter group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
+                          <Users className="w-4 h-4 text-brand-blue-light group-hover:text-brand-blue-primary transition-colors" />
+                        </div>
+                        <span className="flex-grow text-[13px]">
+                          {t('sidebar.nav.classes', {
+                            defaultValue: 'My Classes',
+                          })}
+                        </span>
+                        <span className="text-xxs bg-brand-blue-lighter text-brand-blue-primary px-2 py-0.5 rounded-full font-bold">
+                          {rosters.length}
+                        </span>
+                        <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
+                      </button>
+                      <PlcsMenuButton
+                        onClick={() => setActiveSection('plcs')}
+                        plcCount={plcsHook.plcs.length}
+                        pendingInviteCount={
+                          plcInvitationsHook.pendingInvites.length
+                        }
+                      />
+                      <button
+                        onClick={() => setActiveSection('buildings')}
+                        className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
+                      >
+                        <div className="w-8 h-8 rounded-lg bg-teal-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
+                          <Building2 className="w-4 h-4 text-teal-400 group-hover:text-brand-blue-primary transition-colors" />
+                        </div>
+                        <span className="flex-grow text-[13px]">
+                          {t('sidebar.nav.buildings', {
+                            defaultValue: 'My Building(s)',
+                          })}
+                        </span>
+                        <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
+                      </button>
+                    </>
+                  )}
                 </div>
 
                 <div className="mx-5 my-2.5 border-t border-slate-100" />
@@ -567,84 +585,114 @@ export const Sidebar: React.FC = () => {
                   </span>
                 </div>
                 <div className="flex flex-col px-2.5">
-                  <button
-                    onClick={() => setActiveSection('google-drive')}
-                    className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
-                  >
-                    <div className="w-8 h-8 rounded-lg bg-blue-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
-                      <GoogleDriveIcon className="w-4 h-4" />
-                    </div>
-                    <span className="flex-grow text-[13px]">
-                      {t('sidebar.nav.googleDrive', {
-                        defaultValue: 'Google Drive',
-                      })}
-                    </span>
-                    <div
-                      className={`w-2 h-2 rounded-full flex-shrink-0 ${isDriveConnected ? 'bg-emerald-500' : 'bg-amber-400'}`}
-                    />
-                    <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
-                  </button>
-                  <button
-                    onClick={() => setShowWhatsNew(true)}
-                    className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
-                  >
-                    <div className="relative w-8 h-8 rounded-lg bg-emerald-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
-                      <Sparkles className="w-4 h-4 text-emerald-500 group-hover:text-brand-blue-primary transition-colors" />
+                  {/* Google Drive backup/sync is a Google-API feature excluded
+                      from the free tier (docs/wide-distro-plan.md Phase 3:
+                      "excludes all Google-API features"). Hide the entry for
+                      external (no-org/free-tier) users so they never connect
+                      Drive — keeping their boards Firestore-only and the Sheets
+                      export inert. `isExternalUser` is false while membership
+                      resolves, so org/internal members are unaffected. */}
+                  {!isExternalUser && (
+                    <button
+                      onClick={() => setActiveSection('google-drive')}
+                      className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
+                    >
+                      <div className="w-8 h-8 rounded-lg bg-blue-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
+                        <GoogleDriveIcon className="w-4 h-4" />
+                      </div>
+                      <span className="flex-grow text-[13px]">
+                        {t('sidebar.nav.googleDrive', {
+                          defaultValue: 'Google Drive',
+                        })}
+                      </span>
+                      <div
+                        className={`w-2 h-2 rounded-full flex-shrink-0 ${isDriveConnected ? 'bg-emerald-500' : 'bg-amber-400'}`}
+                      />
+                      <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
+                    </button>
+                  )}
+                  {/* "What's New" / announcements: org-only surface, hidden for
+                      external (no-org/free-tier) users along with the other org
+                      menu items. `isExternalUser` is false during the
+                      membership-loading window, so org members never see it
+                      flicker off. */}
+                  {!isExternalUser && (
+                    <button
+                      onClick={() => setShowWhatsNew(true)}
+                      className="group flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium text-slate-700 hover:bg-brand-blue-lighter/40 transition-colors text-left"
+                    >
+                      <div className="relative w-8 h-8 rounded-lg bg-emerald-50 group-hover:bg-brand-blue-lighter flex items-center justify-center transition-colors flex-shrink-0">
+                        <Sparkles className="w-4 h-4 text-emerald-500 group-hover:text-brand-blue-primary transition-colors" />
+                        {hasUnreadWhatsNew && (
+                          <span
+                            className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-brand-red-primary border-2 border-white"
+                            aria-hidden="true"
+                          />
+                        )}
+                      </div>
+                      <span className="flex-grow text-[13px]">
+                        {t('sidebar.nav.whatsNew', {
+                          defaultValue: "What's New",
+                        })}
+                      </span>
                       {hasUnreadWhatsNew && (
-                        <span
-                          className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-brand-red-primary border-2 border-white"
-                          aria-hidden="true"
-                        />
+                        <>
+                          <span className="sr-only">
+                            {t('sidebar.nav.whatsNewSrAnnouncement', {
+                              defaultValue: 'New release notes available',
+                            })}
+                          </span>
+                          <span
+                            className="text-xxs font-bold text-brand-red-primary group-hover:text-brand-red-dark uppercase tracking-wide transition-colors"
+                            aria-hidden="true"
+                          >
+                            {t('sidebar.nav.whatsNewBadge', {
+                              defaultValue: 'New',
+                            })}
+                          </span>
+                        </>
                       )}
-                    </div>
-                    <span className="flex-grow text-[13px]">
-                      {t('sidebar.nav.whatsNew', {
-                        defaultValue: "What's New",
-                      })}
-                    </span>
-                    {hasUnreadWhatsNew && (
-                      <>
-                        <span className="sr-only">
-                          {t('sidebar.nav.whatsNewSrAnnouncement', {
-                            defaultValue: 'New release notes available',
-                          })}
-                        </span>
-                        <span
-                          className="text-xxs font-bold text-brand-red-primary group-hover:text-brand-red-dark uppercase tracking-wide transition-colors"
-                          aria-hidden="true"
-                        >
-                          {t('sidebar.nav.whatsNewBadge', {
-                            defaultValue: 'New',
-                          })}
-                        </span>
-                      </>
-                    )}
-                    <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
-                  </button>
+                      <ChevronRight className="w-4 h-4 text-slate-300 group-hover:text-brand-blue-primary transition-colors" />
+                    </button>
+                  )}
                 </div>
               </nav>
 
-              {/* CLASSES SECTION */}
-              <SidebarClasses isVisible={activeSection === 'classes'} />
+              {/* Org-only section panels (Classes / PLCs / Buildings). Not
+                  rendered for external (no-org/free-tier) users — their menu
+                  buttons are hidden above, so the panels are unreachable, but
+                  skipping them entirely is defense-in-depth (and avoids passing
+                  the disabled PLC hook's empty data into SidebarPlcs).
+                  `isExternalUser` is false while membership resolves. */}
+              {!isExternalUser && (
+                <>
+                  {/* CLASSES SECTION */}
+                  <SidebarClasses isVisible={activeSection === 'classes'} />
 
-              {/* PLCS SECTION */}
-              <SidebarPlcs
-                isVisible={activeSection === 'plcs'}
-                plcs={plcsHook.plcs}
-                plcsLoading={plcsHook.loading}
-                createPlc={plcsHook.createPlc}
-                leavePlc={plcsHook.leavePlc}
-                deletePlc={plcsHook.deletePlc}
-                pendingInvites={plcInvitationsHook.pendingInvites}
-                onOpenDashboard={(plcId) => {
-                  // Navigate to the first-class PLC route (Decision 0.3) instead
-                  // of opening an overlay. Close the drawer + reset the section
-                  // so returning to the board lands on the main menu.
-                  setIsOpen(false);
-                  setActiveSection('main');
-                  spaNavigate(buildPlcPath(plcId));
-                }}
-              />
+                  {/* PLCS SECTION */}
+                  <SidebarPlcs
+                    isVisible={activeSection === 'plcs'}
+                    plcs={plcsHook.plcs}
+                    plcsLoading={plcsHook.loading}
+                    createPlc={plcsHook.createPlc}
+                    leavePlc={plcsHook.leavePlc}
+                    deletePlc={plcsHook.deletePlc}
+                    pendingInvites={plcInvitationsHook.pendingInvites}
+                    onOpenDashboard={(plcId) => {
+                      // Navigate to the first-class PLC route (Decision 0.3)
+                      // instead of opening an overlay. Close the drawer + reset
+                      // the section so returning to the board lands on the main
+                      // menu.
+                      setIsOpen(false);
+                      setActiveSection('main');
+                      spaNavigate(buildPlcPath(plcId));
+                    }}
+                  />
+
+                  {/* MY BUILDING(S) SECTION */}
+                  <SidebarBuildings isVisible={activeSection === 'buildings'} />
+                </>
+              )}
 
               {/* STYLE / LANGUAGE / PREFERENCES — now consolidated into the
                   SettingsModal (opened from the "Settings" entry above). */}
@@ -653,9 +701,6 @@ export const Sidebar: React.FC = () => {
               <SidebarGoogleDrive
                 isVisible={activeSection === 'google-drive'}
               />
-
-              {/* MY BUILDING(S) SECTION */}
-              <SidebarBuildings isVisible={activeSection === 'buildings'} />
             </div>
 
             {/* Footer */}

--- a/components/legal/PrivacyPolicyPage.tsx
+++ b/components/legal/PrivacyPolicyPage.tsx
@@ -9,21 +9,76 @@
  *   - the exact Google Workspace for Education / DPA references
  *   - the effective date (set to publish date below)
  * Google's OAuth consent + Marketplace listing require this URL to be public.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * DRAFT — EXTERNAL ELIGIBILITY (work item W10, wide-distro plan Phase 4 §1)
+ * ───────────────────────────────────────────────────────────────────────────
+ * The eligibility / availability language below has been DRAFTED to reflect
+ * open, self-serve external availability (any educator with a Google account
+ * may create a free-tier account) ahead of flipping the GCP OAuth consent
+ * screen to External. It is NOT finalized.
+ *
+ * OPEN QUESTION (district counsel must resolve before publish): the OPERATOR
+ * MODEL — who legally operates SpartBoard for non-Orono users, and the
+ * corresponding DPA / FERPA "school official" framing per consuming district.
+ * Do NOT assert a final legal position on the operator model here until counsel
+ * signs off. See docs/external-availability-legal-review.md and
+ * docs/wide-distro-plan.md (Open Questions → "Operator model").
+ *
+ * The Google API Services User Data Policy / Limited Use disclosure (in the
+ * "Google services and third parties" section) is INTENTIONALLY left intact and
+ * must remain — it is required for OAuth verification regardless of audience.
+ *
+ * Search for `DRAFT_EXTERNAL_ELIGIBILITY` to find every spot touched by W10.
+ * ───────────────────────────────────────────────────────────────────────────
  */
 import React from 'react';
 import { LegalPageLayout, LegalH2, LegalP, LegalList } from './LegalPageLayout';
 
 const PRIVACY_CONTACT = 'spartboard@orono.k12.mn.us';
 
+/**
+ * DRAFT_EXTERNAL_ELIGIBILITY — pending district counsel sign-off on operator model.
+ *
+ * Visible, unmissable in-page banner so any reviewer (or accidental publish)
+ * sees that the eligibility language is not final. REMOVE this banner — and the
+ * inline DRAFT note in the intro — once counsel has signed off on the operator
+ * model and the copy is finalized.
+ */
+const DraftEligibilityBanner: React.FC = () => (
+  <div
+    role="note"
+    className="mb-8 rounded-md border-2 border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+  >
+    <strong className="font-semibold">
+      DRAFT — pending district counsel sign-off on operator model.
+    </strong>{' '}
+    The eligibility and availability language on this page has been drafted for
+    open external availability but is not yet final. The legal operator model
+    for non-Orono users is under review.
+  </div>
+);
+
 export const PrivacyPolicyPage: React.FC = () => (
   <LegalPageLayout title="Privacy Policy" lastUpdated="May 29, 2026">
+    {/* DRAFT_EXTERNAL_ELIGIBILITY — remove banner once operator model is finalized (W10). */}
+    <DraftEligibilityBanner />
+
+    {/*
+      DRAFT_EXTERNAL_ELIGIBILITY (W10): intro rewritten from "provided only to
+      members of the District's domain" to open self-serve external availability.
+      The operator framing ("operated by Orono Public Schools") is the OPEN
+      operator-model question — counsel must confirm or revise before publish.
+    */}
     <LegalP>
-      SpartBoard is a classroom-management tool operated by Orono Public Schools
-      (&ldquo;the District,&rdquo; &ldquo;we,&rdquo; &ldquo;us&rdquo;) for use
-      by the District&rsquo;s staff and students. This policy explains what
-      information SpartBoard collects, how it is used, and the choices available
-      to you. SpartBoard is provided only to members of the District&rsquo;s
-      Google Workspace for Education domain.
+      SpartBoard is a classroom-management tool that any educator with a Google
+      account may use to create a free account. SpartBoard is operated by Orono
+      Public Schools (&ldquo;the District,&rdquo; &ldquo;we,&rdquo;
+      &ldquo;us&rdquo;), which also makes it available to its own staff and
+      students. This policy explains what information SpartBoard collects, how
+      it is used, and the choices available to you. The data practices described
+      below apply to all users; some sections note where additional protections
+      apply specifically to Orono Public Schools staff and students.
     </LegalP>
 
     <LegalH2>Information we collect</LegalH2>
@@ -110,15 +165,25 @@ export const PrivacyPolicyPage: React.FC = () => (
     </LegalP>
 
     <LegalH2>Student data, FERPA, and children&rsquo;s privacy</LegalH2>
+    {/*
+      DRAFT_EXTERNAL_ELIGIBILITY (W10): this section is currently written ONLY
+      for Orono Public Schools students and is left substantively unchanged
+      because it is accurate for the District. How FERPA "education records",
+      the "school official" framing, and COPPA consent apply to students of an
+      EXTERNAL educator's classroom depends entirely on the unresolved operator
+      model. Do NOT broaden this language to external students until district
+      counsel resolves the operator model. See
+      docs/external-availability-legal-review.md.
+    */}
     <LegalP>
-      Student information in SpartBoard constitutes &ldquo;education
-      records&rdquo; under the Family Educational Rights and Privacy Act (FERPA)
-      and remains under the control of Orono Public Schools. The District
-      operates SpartBoard as part of its educational program. For students under
-      13, the school provides consent for the use of this educational tool
-      consistent with the Children&rsquo;s Online Privacy Protection Act
-      (COPPA). Student data is used only for educational purposes within the
-      District and is never sold or used for advertising.
+      For students of Orono Public Schools, student information in SpartBoard
+      constitutes &ldquo;education records&rdquo; under the Family Educational
+      Rights and Privacy Act (FERPA) and remains under the control of Orono
+      Public Schools. The District operates SpartBoard as part of its
+      educational program. For students under 13, the school provides consent
+      for the use of this educational tool consistent with the Children&rsquo;s
+      Online Privacy Protection Act (COPPA). Student data is used only for
+      educational purposes and is never sold or used for advertising.
     </LegalP>
 
     <LegalH2>Data retention and security</LegalH2>

--- a/components/legal/TermsOfServicePage.tsx
+++ b/components/legal/TermsOfServicePage.tsx
@@ -6,14 +6,63 @@
  *   - governing law / venue (drafted as Minnesota)
  *   - the liability / disclaimer posture for a public-school-operated tool
  *   - the effective date (set to publish date below)
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * DRAFT — EXTERNAL ELIGIBILITY (work item W10, wide-distro plan Phase 4 §1)
+ * ───────────────────────────────────────────────────────────────────────────
+ * The eligibility / availability language below has been DRAFTED to reflect
+ * open, self-serve external availability (any educator with a Google account
+ * may create a free-tier account) ahead of flipping the GCP OAuth consent
+ * screen to External. It is NOT finalized.
+ *
+ * OPEN QUESTION (district counsel must resolve before publish): the OPERATOR
+ * MODEL — who legally operates SpartBoard for non-Orono users, and the
+ * corresponding DPA / FERPA "school official" framing per consuming district.
+ * Do NOT assert a final legal position on the operator model here until counsel
+ * signs off. See docs/external-availability-legal-review.md and
+ * docs/wide-distro-plan.md (Open Questions → "Operator model").
+ *
+ * Search for `DRAFT_EXTERNAL_ELIGIBILITY` to find every spot touched by W10.
+ * ───────────────────────────────────────────────────────────────────────────
  */
 import React from 'react';
 import { LegalPageLayout, LegalH2, LegalP, LegalList } from './LegalPageLayout';
 
 const TERMS_CONTACT = 'spartboard@orono.k12.mn.us';
 
+/**
+ * DRAFT_EXTERNAL_ELIGIBILITY — pending district counsel sign-off on operator model.
+ *
+ * Visible, unmissable in-page banner so any reviewer (or accidental publish)
+ * sees that the eligibility language is not final. REMOVE this banner — and the
+ * inline DRAFT notes in the intro + "Eligibility and accounts" section — once
+ * counsel has signed off on the operator model and the copy is finalized.
+ */
+const DraftEligibilityBanner: React.FC = () => (
+  <div
+    role="note"
+    className="mb-8 rounded-md border-2 border-amber-400 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+  >
+    <strong className="font-semibold">
+      DRAFT — pending district counsel sign-off on operator model.
+    </strong>{' '}
+    The eligibility and availability language on this page has been drafted for
+    open external availability but is not yet final. The legal operator model
+    for non-Orono users is under review.
+  </div>
+);
+
 export const TermsOfServicePage: React.FC = () => (
   <LegalPageLayout title="Terms of Service" lastUpdated="May 29, 2026">
+    {/* DRAFT_EXTERNAL_ELIGIBILITY — remove banner once operator model is finalized (W10). */}
+    <DraftEligibilityBanner />
+
+    {/*
+      DRAFT_EXTERNAL_ELIGIBILITY (W10): intro broadened to cover any user, not
+      only the District. The operator framing ("operated by Orono Public
+      Schools") is the OPEN operator-model question — counsel must confirm or
+      revise before publish.
+    */}
     <LegalP>
       These Terms of Service (&ldquo;Terms&rdquo;) govern your use of
       SpartBoard, a classroom-management tool operated by Orono Public Schools
@@ -22,12 +71,23 @@ export const TermsOfServicePage: React.FC = () => (
     </LegalP>
 
     <LegalH2>Eligibility and accounts</LegalH2>
+    {/*
+      DRAFT_EXTERNAL_ELIGIBILITY (W10): rewritten from "provided to staff and
+      students of Orono Public Schools who sign in with a District-issued Google
+      account" to open self-serve external availability. Pending counsel sign-off
+      on the operator model.
+    */}
     <LegalP>
-      SpartBoard is provided to staff and students of Orono Public Schools who
-      sign in with a District-issued Google account. You are responsible for
+      SpartBoard is available to educators who sign in with a Google account.
+      Any educator with a Google account may create a free account to use the
+      features available to that account type; additional features are available
+      to Orono Public Schools staff and students and to organizations that have
+      arranged broader access with the District. You are responsible for
       activity that occurs under your account and for keeping your credentials
-      secure. Use of SpartBoard is also subject to the District&rsquo;s
-      acceptable-use and technology policies.
+      secure. If you use SpartBoard through a school or district, your use is
+      also subject to that institution&rsquo;s acceptable-use and technology
+      policies; Orono Public Schools staff and students remain subject to the
+      District&rsquo;s policies.
     </LegalP>
 
     <LegalH2>Acceptable use</LegalH2>

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -137,7 +137,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
     activeRosterId,
     addToast,
   } = useDashboard();
-  const { canAccessFeature, selectedBuildings } = useAuth();
+  const { canAccessFeature, selectedBuildings, hasOrg } = useAuth();
   const { plcs } = usePlcs();
   const adminBuildings = useAdminBuildings();
   const [mode, setMode] = useState<ShareMode>('synced');
@@ -152,9 +152,17 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
 
   // Substitute-mode config state (Phase A — UI only).
   const teacherBuildings = useMemo(() => {
-    const list = adminBuildings.length > 0 ? adminBuildings : BUILDINGS;
+    // Fall back to the hardcoded BUILDINGS seed ONLY for org members during the
+    // org-set-but-loading window. For external (no-org/free-tier) users
+    // `useAdminBuildings()` deliberately returns [] (it no longer leaks the
+    // Orono seed), so we must NOT re-introduce the seed here — `hasOrg` keeps
+    // the substitute-mode building picker from listing another district's real
+    // school names. Org members (incl. Orono) keep the seed placeholder while
+    // their Firestore buildings hydrate, so their behavior is unchanged.
+    const list =
+      adminBuildings.length > 0 ? adminBuildings : hasOrg ? BUILDINGS : [];
     return list.map((b) => ({ id: canonicalBuildingId(b.id), name: b.name }));
-  }, [adminBuildings]);
+  }, [adminBuildings, hasOrg]);
   const defaultBuildingId = useMemo(() => {
     const first = selectedBuildings?.[0];
     if (

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -23,6 +23,10 @@ const mockAuth: AuthContextType = {
   canAccessWidget: () => true, // Allow everything in student view
   canAccessFeature: () => true,
   userTier: 'free',
+  // Students are never org members and never external (the real isExternalUser
+  // predicate excludes student roles outright).
+  hasOrg: false,
+  isExternalUser: false,
   // Student view doesn't render assignment-creation UI; the default keeps
   // any consumers that read this returning the safe pre-feature default.
   getAssignmentMode: () => 'submissions',

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -409,6 +409,8 @@ describe('EmbedWidget', () => {
         canAccessWidget: vi.fn(() => true),
         canAccessFeature: vi.fn(() => false),
         userTier: 'free' as const,
+        hasOrg: false,
+        isExternalUser: false,
         getAssignmentMode: vi.fn(() => 'submissions' as const),
         canSeeShareTracking: vi.fn(() => false),
         signInWithGoogle: vi.fn(),

--- a/components/widgets/QuizWidget/components/QuizResults.tsx
+++ b/components/widgets/QuizWidget/components/QuizResults.tsx
@@ -259,7 +259,8 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
 }) => {
   const { activeDashboard, updateWidget, addWidget, addToast, rosters } =
     useDashboard();
-  const { googleAccessToken, user, orgId, canAccessFeature } = useAuth();
+  const { googleAccessToken, user, orgId, canAccessFeature, isExternalUser } =
+    useAuth();
   const { showConfirm } = useDialog();
   const { plcs, clearPlcSharedSheetUrl, setPlcSharedSheetUrl } = usePlcs();
   const [exporting, setExporting] = useState(false);
@@ -1257,7 +1258,13 @@ export const QuizResults: React.FC<QuizResultsProps> = ({
   // when attached, else Schoology — and the overflow never carries a push
   // that's already visible.
   const overflowItems: OverflowMenuItem[] = [];
-  if (!exportUrl) {
+  // Google Sheets export is a Google-API feature excluded from the free tier
+  // (docs/wide-distro-plan.md Phase 3). External (no-org/free-tier) users can't
+  // connect Drive (the Drive entry is hidden for them), so they have no token
+  // and the export would only surface a "sign in again" error — hide the
+  // affordance cleanly instead. `isExternalUser` is false while membership
+  // resolves, so org/internal members keep the button.
+  if (!exportUrl && !isExternalUser) {
     overflowItems.push({
       label: 'Export to Sheets',
       icon: Download,

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -85,6 +85,8 @@ const mockAuthContext = (
   buildingIds: [],
   orgBuildings: [],
   orgBuildingsLoaded: true,
+  hasOrg: false,
+  isExternalUser: false,
   favoriteBackgrounds: [],
   recentBackgrounds: [],
   toggleFavoriteBackground: async () => {

--- a/components/widgets/VideoActivityWidget/components/Results.tsx
+++ b/components/widgets/VideoActivityWidget/components/Results.tsx
@@ -92,7 +92,8 @@ export const Results: React.FC<ResultsProps> = ({
   onBack,
   plc: _plc,
 }) => {
-  const { googleAccessToken, user, orgId, canAccessFeature } = useAuth();
+  const { googleAccessToken, user, orgId, canAccessFeature, isExternalUser } =
+    useAuth();
   const { showConfirm } = useDialog();
   const { addToast } = useDashboard();
   // Use the multi-class variant — `session.classId` is a transitional
@@ -440,7 +441,12 @@ export const Results: React.FC<ResultsProps> = ({
   //   • Open Sheet — shown when `exportUrl` is truthy; opens the sheet in a
   //                  new tab (was an outlined <a target="_blank"> link).
   const overflowItems: OverflowMenuItem[] = [];
-  if (!exportUrl) {
+  // Google Sheets export is a Google-API feature excluded from the free tier
+  // (docs/wide-distro-plan.md Phase 3). External (no-org/free-tier) users have
+  // no Drive token (the Drive connect entry is hidden for them), so the export
+  // would only error — hide it cleanly. `isExternalUser` is false while
+  // membership resolves, so org/internal members keep the button.
+  if (!exportUrl && !isExternalUser) {
     overflowItems.push({
       label: 'Export',
       icon: Download,

--- a/config/featureDefaults.ts
+++ b/config/featureDefaults.ts
@@ -24,7 +24,7 @@
  *   permission object.
  */
 
-import type { AccessLevel, GlobalFeature } from '@/types';
+import type { AccessLevel, GlobalFeature, UserTier, WidgetType } from '@/types';
 
 export interface FeatureDefault {
   /** Access level used by the admin UI when no permission doc exists yet. */
@@ -43,6 +43,24 @@ export interface FeatureDefault {
    * the code is not the same as shipping the OAuth setup.
    */
   missingDocPublic: boolean;
+  /**
+   * Default minimum tier applied by `canAccessFeature(...)` when NO permission
+   * doc exists (docs/wide-distro-plan.md Phase 3). This is the in-code default
+   * for the wide-distribution Google-API gate: an external/free-tier user is
+   * denied while org + internal pass, without needing a hand-authored admin
+   * doc. Undefined ⇒ no tier floor (the historical baseline; every feature
+   * written before the tier model behaves exactly as before).
+   *
+   * Note: this default ONLY applies to the missing-doc path. Once an admin
+   * persists a `global_permissions/{featureId}` doc, that doc's own `minTier`
+   * field (which may be unset) is authoritative — the admin can loosen or
+   * tighten it, and an explicitly-unset `minTier` on a real doc means "no
+   * floor", matching the pre-tier back-compat contract.
+   *
+   * Admins always bypass tier checks (same as accessLevel), so this never
+   * affects an admin's own access.
+   */
+  defaultMinTier?: UserTier;
 }
 
 /**
@@ -116,10 +134,16 @@ export const FEATURE_DEFAULTS: Record<GlobalFeature, FeatureDefault> = {
     defaultEnabled: true,
     missingDocPublic: true,
   },
+  // Google-API-backed (attaches Google Drive files as AI context). Default
+  // tier floor of `org` denies external/free-tier users — they have only the
+  // basic OAuth scopes and no Drive integration — while org + internal pass
+  // (docs/wide-distro-plan.md Phase 3: free tier "excludes all Google-API
+  // features"). The `useFeaturePermission`-gated affordances hide cleanly.
   'ai-file-context': {
     defaultAccessLevel: 'public',
     defaultEnabled: true,
     missingDocPublic: true,
+    defaultMinTier: 'org',
   },
   'org-admin-writes': {
     defaultAccessLevel: 'public',
@@ -141,13 +165,20 @@ export const FEATURE_DEFAULTS: Record<GlobalFeature, FeatureDefault> = {
     defaultEnabled: false,
     missingDocPublic: false,
   },
-  // Default-public matches the historical missing-doc convention; the
-  // intended restriction is an admin-created doc with `minTier:
-  // 'internal'` (docs/wide-distro-plan.md Phase 3), not a default-off.
+  // Google-API-backed (assign quizzes/video activities to Google Classroom +
+  // push grades). Default-public keeps the historical missing-doc convention
+  // for the accessLevel, but a default tier floor of `org` denies
+  // external/free-tier users (basic scopes only) while org + internal pass
+  // (docs/wide-distro-plan.md Phase 3: free tier "excludes all Google-API
+  // features"). An admin can still tighten to `internal` via a persisted doc;
+  // that doc's own `minTier` then takes over. The `canAccessFeature
+  // ('google-classroom')`-gated affordances (VideoActivity assign + results,
+  // quiz Classroom push) hide cleanly.
   'google-classroom': {
     defaultAccessLevel: 'public',
     defaultEnabled: true,
     missingDocPublic: true,
+    defaultMinTier: 'org',
   },
   // Default-public preserves today's behavior: every teacher keeps the
   // no-sign-in (anonymous) join link until an admin creates a restricting
@@ -158,4 +189,29 @@ export const FEATURE_DEFAULTS: Record<GlobalFeature, FeatureDefault> = {
     defaultEnabled: true,
     missingDocPublic: true,
   },
+};
+
+/**
+ * In-code default minimum tier per widget, applied by `canAccessWidget(...)`
+ * when NO `feature_permissions/{widgetType}` doc exists yet
+ * (docs/wide-distro-plan.md Phase 3).
+ *
+ * Mirrors `FeatureDefault.defaultMinTier` but for the widget gate: a
+ * Google-API-backed widget defaults to `'org'` so external/free-tier users
+ * (basic OAuth scopes, no Google integration) are denied while org + internal
+ * pass — without an admin needing to hand-author a permission doc. The Dock /
+ * widget library already hide widgets where `canAccessWidget` is false, so the
+ * affordance disappears cleanly rather than erroring.
+ *
+ * Only widgets that actually need a tier floor are listed; an absent entry
+ * means "no floor" (the historical public-by-default behavior for widgets with
+ * no permission doc). Once an admin persists a `feature_permissions/{widgetType}`
+ * doc, that doc's own `minTier` is authoritative and this default no longer
+ * applies (matching the doc-wins precedence of the feature path).
+ *
+ *   - `calendar` (label "Events") renders Google Calendar events via
+ *     `useGoogleCalendar` — a Google-API surface, so org-and-up only.
+ */
+export const WIDGET_DEFAULT_MIN_TIER: Partial<Record<WidgetType, UserTier>> = {
+  calendar: 'org',
 };

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -64,7 +64,10 @@ import {
   revokeBackendRefreshToken,
 } from '@/utils/googleOAuthRefresh';
 import { logError } from '@/utils/logError';
-import { FEATURE_DEFAULTS } from '@/config/featureDefaults';
+import {
+  FEATURE_DEFAULTS,
+  WIDGET_DEFAULT_MIN_TIER,
+} from '@/config/featureDefaults';
 import { stripTransientKeys } from '@/utils/widgetConfigPersistence';
 import { parseAssignmentModesConfig } from '@/utils/assignmentModesConfig';
 import {
@@ -1995,6 +1998,40 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     [user, orgId]
   );
 
+  // Does this user belong to an org? `orgId` is null until the membership
+  // snapshot resolves AND for genuine no-org (free-tier) users, so a bare
+  // `orgId !== null` is NOT a safe "external" signal on its own (it's false
+  // during the loading window for Orono members too). `hasOrg` is the simple
+  // positive form; `isExternalUser` below adds the resolution + student guards.
+  const hasOrg = orgId !== null;
+
+  // True ONLY for a fully-resolved, no-org, FREE-tier, non-student user — i.e.
+  // the free/external tier that the wide-distribution rollout gates org surfaces
+  // away from (docs/wide-distro-plan.md Phase 3). Four conditions, all required,
+  // so org/internal members (and the in-flight loading window) never flicker
+  // their org surfaces away:
+  //   1. `membershipResolved` — the org-membership effect has settled. While
+  //      it's still resolving this is false, so an Orono member's "My PLCs" /
+  //      "My Building(s)" never blink off during load. Bypass mode seeds
+  //      `membershipResolved = true` with a non-null `orgId`, so bypass is
+  //      never external either.
+  //   2. `orgId === null` — no org membership doc resolved for this user.
+  //   3. `userTier === 'free'` — the decisive guard. `userTier` derives from
+  //      the email DOMAIN (orono.k12.mn.us → 'internal') INDEPENDENT of orgId,
+  //      so a brand-new / not-yet-backfilled Orono teacher who has no
+  //      `members/{email}` doc yet (orgId === null) is still 'internal' and is
+  //      NEVER classified external. Only genuine non-org, non-internal users
+  //      derive 'free'. This is what makes the gate zero-change for Orono even
+  //      before org member docs exist.
+  //   4. `!isStudentRole` — SSO students have no email/member doc and could
+  //      otherwise derive 'free' with orgId null; they are not "external
+  //      teachers" and must not be treated as such by the org-surface gates.
+  const isExternalUser =
+    membershipResolved &&
+    orgId === null &&
+    userTier === 'free' &&
+    !isStudentRole;
+
   // Check if user can access a specific widget
   // Wrapped in useCallback to prevent unnecessary re-renders since this function
   // is passed through context and used in component dependencies
@@ -2011,8 +2048,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
       // Default behavior: If no permission record exists, allow public access
       // This means new widgets are accessible to all authenticated users until
-      // an admin explicitly configures permissions
-      if (!permission) return true;
+      // an admin explicitly configures permissions.
+      //
+      // Exception: an in-code default tier floor for Google-API-backed widgets
+      // (docs/wide-distro-plan.md Phase 3). `WIDGET_DEFAULT_MIN_TIER[calendar]
+      // = 'org'` denies external/free-tier users the Calendar (Events) widget
+      // while org + internal pass — without an admin needing to author a
+      // permission doc. Admins bypass the floor (consistent with the
+      // accessLevel bypass below). Widgets with no entry have no floor, so the
+      // historical public-by-default behavior is unchanged. `meetsMinTier`
+      // treats an undefined floor as "allow".
+      if (!permission) {
+        if (isAdmin) return true;
+        return meetsMinTier(userTier, WIDGET_DEFAULT_MIN_TIER[widgetType]);
+      }
 
       // If the feature is disabled, no one can access it (including admins)
       if (!permission.enabled) return false;
@@ -2141,11 +2190,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
       // depend on external config (OAuth, API keys) the code can't
       // verify on its own.
       if (!permission) {
-        return FEATURE_DEFAULTS[featureId].missingDocPublic;
+        const def = FEATURE_DEFAULTS[featureId];
+        if (!def.missingDocPublic) return false;
+        // Admins bypass the tier floor (same as the accessLevel bypass in
+        // resolvePermissionAccess). For everyone else, apply the in-code
+        // default tier floor (docs/wide-distro-plan.md Phase 3): a
+        // Google-API-backed feature with `defaultMinTier: 'org'` denies
+        // external/free-tier users while org + internal pass. An undefined
+        // `defaultMinTier` imposes no floor, so pre-tier features are
+        // unchanged. `meetsMinTier` treats an undefined floor as "allow".
+        if (isAdmin) return true;
+        return meetsMinTier(userTier, def.defaultMinTier);
       }
       return resolvePermissionAccess(permission, user.email);
     },
-    [user, globalPermissions, resolvePermissionAccess]
+    [user, globalPermissions, resolvePermissionAccess, isAdmin, userTier]
   );
 
   const getAssignmentMode = useCallback(
@@ -2268,6 +2327,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         canAccessWidget,
         canAccessFeature,
         userTier,
+        hasOrg,
+        isExternalUser,
         getAssignmentMode,
         canSeeShareTracking,
         signInWithGoogle,

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -46,6 +46,24 @@ export interface AuthContextType {
    */
   userTier: UserTier;
   /**
+   * True when the user belongs to an organization (`orgId !== null`). This is
+   * `false` both for genuine no-org users AND during the membership-loading
+   * window, so prefer `isExternalUser` (which adds the resolution + student
+   * guards) when deciding whether to HIDE org-only surfaces — using `!hasOrg`
+   * alone would flicker org surfaces off for org members while membership
+   * resolves.
+   */
+  hasOrg: boolean;
+  /**
+   * True ONLY for a fully-resolved, no-org, non-student (free/external-tier)
+   * user (docs/wide-distro-plan.md Phase 3). Gates org-only surfaces (My
+   * PLCs / My Building(s) / My Classes + ClassLink / announcements) away from
+   * external users. NEVER true while org membership is still resolving, so
+   * org/internal members (incl. Orono) never see their org surfaces flicker
+   * off during load. Auth-bypass and SSO students are never external.
+   */
+  isExternalUser: boolean;
+  /**
    * The org-wide assignment mode for a student-facing widget. Reads from the
    * `assignment-modes` GlobalFeaturePermission doc; defaults to `'submissions'`
    * when no record exists or the widget key is missing from `config`.

--- a/docs/external-availability-journal.md
+++ b/docs/external-availability-journal.md
@@ -1,0 +1,133 @@
+# External Availability — Work Journal
+
+**Goal:** Make the SpartBoard Firebase web app fully available to **open self-serve external (non-org) users**, behind appropriate gates, with **zero change for existing Orono org users**.
+
+**Started:** 2026-06-22 (overnight autonomous run)
+**Owner:** Paul Ivers · **Driver:** Claude Code (orchestrating via Workflow + subagents)
+**Branch:** `dev-paul`
+
+> This journal is updated as each phase/task completes so you can check in on progress. Newest status at the top of each section.
+
+---
+
+## Locked Decisions (approved by Paul, 2026-06-22)
+
+| #   | Decision                            | Choice                                                                                                                                                                           |
+| --- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Access scope** for external users | Full teacher app, **org-only surfaces gated** (admin, buildings, PLC, announcements, ClassLink, building-scoped permissions hidden)                                              |
+| 2   | **Entry model**                     | **Open self-serve** — any Google account whose domain isn't mapped to an org auto-gets the external (no-org) experience                                                          |
+| 3   | **AI features** (Gemini)            | **Enabled but per-user rate-limited** (extend `ai_usage` tracking)                                                                                                               |
+| 4   | **OAuth / Google**                  | Move consent screen to **External/Production + prep Google verification** for sensitive scopes (Drive, Calendar, Sheets); gate sensitive-scope features gracefully if unverified |
+
+**Hard constraint:** existing Orono org users must notice **zero** difference.
+
+---
+
+## Plan of Record (phases)
+
+0. **Audit** _(in progress)_ — read-only fan-out across 8 dimensions → consolidated blockers + work items + roadmap.
+1. **Plan** — turn the audit into an ordered, dependency-aware implementation plan (waves).
+2. **Implement** — code + Firestore rules changes per work item, isolated so org behavior is untouched.
+3. **Verify** — type-check, lint, format, unit tests, rules tests, build; adversarial review for regressions & data leaks.
+4. **OAuth/GCP** — configure consent screen → External, prep verification submission, document anything requiring Google's review.
+5. **Sign-off** — final journal summary + remaining-work / handoff for anything blocked on Google review.
+
+---
+
+## Status Log
+
+### 2026-06-22 — Phase 0: Audit kicked off
+
+- Confirmed the four locked decisions above with Paul.
+- Launched read-only audit workflow (`external-availability-audit`): 8 parallel dimensions —
+  auth/sign-in gating · GCP/OAuth config · Firestore rules · org/building coupling · existing external-user work · AI quota · student/anon routes · data isolation — feeding a synthesis pass.
+- Journal created. Next update will land the consolidated audit findings + the concrete work-item roadmap.
+
+---
+
+### 2026-06-22 — Phase 0: Audit COMPLETE
+
+Ran an 8-dimension read-only audit (auth/sign-in · GCP/OAuth · Firestore rules · org/building coupling · existing work · AI quota · student routes · data isolation) + synthesis.
+
+**Headline finding — this is NOT greenfield.** A coherent "wide-distribution" effort already shipped to `main` across 5 phases (plan of record: [docs/wide-distro-plan.md](wide-distro-plan.md)):
+
+- Public `LandingPage` + pilot/rollout-request form (`/request` → `rollout_requests` + email).
+- **Dynamic org resolution** — `resolveOrgForUser` callable maps a verified email domain → org; a non-Orono domain cleanly resolves to `orgId=null` / **free tier** with no crash/spinner/loop. Org-less `NewUserSetup` already skips the building step.
+- **Three-tier model** `internal | org | free` (`utils/userTier.ts`) with `meetsMinTier` ANDed into `canAccessWidget` / `canAccessFeature`, plus admin `MinTier` UI. **Sign-in is already open in code** (no `hd` gate, no blocking function).
+- Firestore rules already isolate the multi-tenant data layer (org/members/buildings/PLC/invitations/rosters are owner- or member-scoped; a no-org outsider is denied every org read).
+
+**So the remaining work is targeted gating + isolation + the launch switch — not architecture.**
+
+#### Blockers found
+
+1. **(CRITICAL, non-code) OAuth consent screen is `Internal`** — prod project `spartboard` (759666600376) sits directly under the `orono.k12.mn.us` Workspace org, so Google rejects every external account (`org_internal`) _before app code runs_. The launch switch is a Cloud Console flip to **External/Production**. Flipping changes nothing for Orono accounts/scopes/client.
+2. **(CRITICAL, code) `/announcements` is a global cross-org collection** — no `orgId` field, auth-only read, overlay mounts for every teacher. An external user would stream (and broadcast announcements would _render_) all of Orono's announcements. The one true data leak.
+3. **(HIGH, code) Org-only surfaces not hidden for free tier** — Sidebar renders My Building(s), My Classes (+ClassLink import), My PLCs unconditionally; `useAdminBuildings` leaks the **hardcoded Orono building seed list** (real school names) to no-org users; orgless PLC creation is possible; Google-API features aren't denied by default (tier model is plumbing, no default policy).
+4. **(HIGH, code) AI rate-limit is flat per-user (20/day), not tier-aware** — no separate external cap (Decision 3).
+
+#### Decisions I made reconciling the audit against the locked decisions + plan-of-record
+
+- **Deny Google-API features for free tier (W5): IN SCOPE.** Confirmed as an _agreed product decision_ in wide-distro-plan.md (free tier "excludes all Google-API features… hide cleanly, not error"). Implement via `minTier` defaults on the Google-API features/widgets (Drive/Sheets/Calendar/Classroom) — uses the existing `meetsMinTier` gate, no-op for org/internal users. (NOT over-gating; personal vs org distinction is moot — it's the established tiering.)
+- **Do NOT move sensitive login scopes off login (audit's W8): DROPPED.** Paul chose "Go External + **prep verification**" over "minimize scopes," and keeping login scopes as-is fully protects Orono's Sheets/Calendar (zero-change). → I prep the Google sensitive-scope **verification** package instead. (Path A, which Paul selected.)
+- **Announcements (W6): no risky overnight prod migration.** Stamp `orgId` on new announcements at write time; gate the overlay listener so no-org users never subscribe (closes the practical leak immediately); tighten the rule tolerant of legacy docs; ship a `migrateAnnouncements` backfill script to be **run by Paul** (or together) before the prod launch — not executed unattended tonight.
+- **AI cap (W7):** additive lower external/free daily cap (new config key), keyed on no-org callers; org users keep the existing limit untouched.
+- **Launch boundary:** I will land + validate all code on `feat/external-availability-rollout` → squash into `dev-paul` (preview deploy; all changes are no-ops for Orono). I will **not** merge to `main` (prod) or flip the consent screen overnight — the flip is coupled to the legal/operator-model sign-off (needs district counsel) and is the single most outward-facing action. Everything is teed up + documented for Paul's morning go/no-go.
+
+#### Work items (this push)
+
+| ID  | Item                                                                                                                         | Status |
+| --- | ---------------------------------------------------------------------------------------------------------------------------- | ------ |
+| W1  | `isExternalUser`/`hasOrg` from AuthContext + hide org-only Sidebar surfaces (Buildings, Classes/ClassLink, PLCs, What's New) | ✅     |
+| W2  | Block orgless PLC creation for free tier (`usePlcs.createPlc` guard + entry hide)                                            | ✅     |
+| W3  | Stop the Orono building seed-list leak (`useAdminBuildings` returns `[]` when `orgId===null`)                                | ✅     |
+| W4  | Hide ClassLink import for no-org users (`useClassLinkEnabled`)                                                               | ✅     |
+| W5  | Default-deny Google-API features for free tier via `minTier` defaults + clean affordance hiding                              | ✅     |
+| W6  | `/announcements` org-isolation (write-stamp + listener gate + rule + backfill script)                                        | ✅     |
+| W7  | Additive external/free-tier AI daily cap (functions)                                                                         | ✅     |
+| W9  | No-org persona Firestore-rules test suite                                                                                    | ✅     |
+| W10 | Draft `/privacy` + `/terms` external-eligibility copy (flagged for counsel — not finalized)                                  | ✅     |
+| —   | OAuth verification prep package + Console runbook (no flip)                                                                  | ✅     |
+
+**Deferred / documented (not blocking external launch):** `feature_permissions` exposes `betaUsers` emails + district config world-readable (pre-existing; careful data-model fix later); global catalogs (routines/templates/backgrounds) show Orono-authored content to externals (shared-by-design); student SSO stays org-gated by the _student's_ domain (intended); keep `CLASSROOM_ASSIGN_ENABLED` **off** until the restricted Classroom scope is Marketplace-declared (an undeclared restricted scope would reproduce an org-wide outage hitting Orono too); single shared prod project = no staging buffer for the flip.
+
+---
+
+### 2026-06-22 — Phases 1–3 COMPLETE (code done, validated, landed on `dev-paul`)
+
+All ten work items implemented on `feat/external-availability-rollout` via parallel subagents (each self-reviewed), then a full validation pass + two adversarial reviews.
+
+**Validation — all green (local):**
+
+- `type-check:all` ✅ · `lint` (--max-warnings 0) ✅ · `format:check` ✅
+- `test:all` ✅ — **root 5,747 tests / 518 files + functions 693 tests / 37 files** pass
+- `build` (vite prod + SSR legal prerender) ✅
+- `test:rules` — _not runnable locally_ (no emulator, [[spartboard-test-gotchas]]); the new no-org persona suite (W9) is statically validated and will run in CI/emulator.
+
+**Adversarial review outcome:** `zeroChangeViolations: []`, `leakStillOpen: false`. Two substantive issues were caught and FIXED before landing:
+
+1. **W7 was unimplemented** (the AI-cap agent died on an API overload) — `externalDailyLimit` was dead config. Now fully wired in `functions/src/aiGeneration.ts` at all three Gemini entry points (lookup hoisted outside the txn, bounded LRU cache, **fail-safe toward the org path**, admins exempt) + 22 new functions tests.
+2. **`isExternalUser` zero-change risk** — it keyed on `orgId` alone, so a not-yet-backfilled Orono teacher with no `members/{email}` doc (orgId null, but tier `internal` from domain) would have been misclassified external and lost their org surfaces. **Fixed:** the predicate now also requires `userTier === 'free'` (Orono always derives `internal` from its domain regardless of member-doc state), with a dedicated regression test.
+
+**Why landing on `dev-paul` is safe for Orono now:** every gate keys on `isExternalUser`/`userTier`/`orgId` (all of which resolve non-external for Orono) and treats the loading window as not-external; the `firestore.rules` change is **dormant** (no prod announcement has an `orgId` yet → all stay legacy-readable, identical to today); the W7 functions change is fail-safe toward the org path; and external users **cannot sign in at all** until the consent screen flips. The dev-deploy CI deploys `functions`+`firestore`+`storage` to the prod project (routine for `dev-*` branches) + a 30-day preview hosting channel.
+
+---
+
+## 🔑 Launch gates — Paul's go/no-go before flipping to External
+
+Code is done and safe-to-land, but the **actual external launch** (flipping the OAuth consent screen) is intentionally left to you and is gated on these, in order:
+
+1. **District counsel / operator-model sign-off** → then finalize the `/privacy` + `/terms` DRAFT copy (W10) and re-run the legal prerender. See [external-availability-legal-review.md](external-availability-legal-review.md).
+2. **OAuth verification** — follow [external-availability-oauth-runbook.md](external-availability-oauth-runbook.md): Search Console domain ownership → submit Google sensitive-scope verification (drive.file / spreadsheets / calendar.readonly) → flip Audience to External + Publish.
+3. **`CLASSROOM_ASSIGN_ENABLED` decision** — it is currently `true` in `config/constants.ts`. Set it **false** (and deploy) for launch unless the restricted `classroom.coursework.students` scope is confirmed Marketplace-declared + the OAuth client Trusted under External (an undeclared restricted scope reproduces an **org-wide** Account-Restricted outage that hits Orono too).
+4. **Announcements backfill sequence (do all three together, before admitting any external user):**
+   1. Re-run `scripts/backfill-org-members.js` so **every** Orono user has a `members/{email}` doc (otherwise a member-doc-less Orono user's announcement listener is rejected once docs are org-stamped — see review Finding 1b).
+   2. Scope the `AnnouncementOverlay` listener query with `where('orgId','==', orgId)` (see the `MULTI-TENANT TODO` comment in the file) — required before a **second** org has active announcements, and a prerequisite for the backfill.
+   3. Run `node scripts/migrateAnnouncements.js --dry-run`, then for real, to stamp legacy docs `orgId='orono'`.
+5. **Promote `dev-paul → main`** per the merge flow ([[spartboard-merge-flow]]: **regular merge commit, never squash**) when ready to ship the frontend to prod hosting.
+
+## Open Questions / Risks
+
+- **Operator model (for district counsel, not code):** who operates SpartBoard for non-Orono users (DPA / FERPA "school official" framing)? Gates W10 and the External publish. _Paul._
+- **AI free-tier daily cap value** — defaulted external/free to **5/day** (`DEFAULT_EXTERNAL_DAILY_LIMIT`), vs the org default of 20; tune via the `externalDailyLimit` config key in `global_permissions`.
+- **`SupportPage.tsx`** still carries Orono-only framing (out of W10's `/privacy`+`/terms` scope) — broaden it before the flip.
+- **Deferred isolation follow-ups** (not blocking launch): `feature_permissions` exposes `betaUsers` emails + district config world-readable; `/announcements/{id}/pollVotes` subcollection is still `auth != null` (kept open for anonymous public-poll voting); global catalogs show Orono-authored content to externals (shared-by-design).

--- a/docs/external-availability-legal-review.md
+++ b/docs/external-availability-legal-review.md
@@ -1,0 +1,162 @@
+# External-Availability Legal Review — DRAFT eligibility copy (W10)
+
+_Created: 2026-06-22. Owner: Paul Ivers (spartboard@orono.k12.mn.us)._
+_Status: **DRAFT — pending district counsel sign-off on the operator model.**_
+
+This is the review packet for the DRAFTED eligibility/availability changes to
+the public legal pages (`/privacy`, `/terms`) that work item **W10** introduced
+ahead of the wide-distribution External flip. See
+[`docs/wide-distro-plan.md`](./wide-distro-plan.md) lines 23–26 and 139–141, and
+its "Open questions → Operator model" section.
+
+> **Do not publish these changes yet.** The eligibility language is drafted but
+> the legal **operator model** (who operates SpartBoard for non-Orono users; the
+> DPA / FERPA "school official" framing per consuming district) is an OPEN
+> question that must be resolved by the District's data-privacy officer /
+> counsel first. Nothing here asserts a final legal position on that model.
+
+## Why this exists
+
+The public legal pages are prerendered to static HTML at build time
+(`scripts/prerender-legal.tsx` → `dist/{privacy,terms,support}/index.html`) so
+Google's OAuth verification crawlers and human reviewers see real content. The
+prior copy said SpartBoard is "provided only to members of the District's
+domain" / "provided to staff and students of Orono Public Schools." Before the
+GCP OAuth consent screen flips from Internal to External (wide-distro Phase 4),
+that District-members-only language must change to reflect open self-serve
+external availability: **any educator with a Google account may create a
+free-tier account.**
+
+## Source of truth (where the copy lives)
+
+The prerender consumes React components — edit these, never the generated HTML:
+
+- `components/legal/PrivacyPolicyPage.tsx` → `/privacy`
+- `components/legal/TermsOfServicePage.tsx` → `/terms`
+- `components/legal/LegalPageLayout.tsx` (shared shell — **not** changed by W10)
+- `scripts/prerender-legal.tsx` (build-time prerender — **not** changed by W10)
+
+`SupportPage.tsx` was **not** touched (no eligibility language there).
+
+All W10 edits are tagged with the searchable marker `DRAFT_EXTERNAL_ELIGIBILITY`
+and a visible in-page amber "DRAFT — pending district counsel sign-off on
+operator model" banner at the top of each page.
+
+## Exactly what changed
+
+### `components/legal/PrivacyPolicyPage.tsx`
+
+1. **File header comment** — added a `DRAFT — EXTERNAL ELIGIBILITY` block
+   explaining the W10 intent, the open operator-model question, and that the
+   Google Limited Use disclosure must stay intact.
+2. **`DraftEligibilityBanner` component** — new in-page amber banner
+   (`role="note"`) rendered at the top of the page so the DRAFT status is
+   unmissable to any reviewer or in case of accidental publish.
+3. **Intro paragraph** — rewritten from "SpartBoard is provided only to members
+   of the District's Google Workspace for Education domain" to: any educator
+   with a Google account may create a free account; Orono operates it and also
+   makes it available to its own staff and students; data practices apply to all
+   users, with some sections noting added protections for Orono staff/students.
+   The "operated by Orono Public Schools" framing is left in place **as the open
+   operator-model question** for counsel to confirm or revise.
+4. **"Student data, FERPA, and children's privacy" section** — left
+   substantively as Orono-only (it is accurate for the District) but **scoped**
+   with a lead-in ("For students of Orono Public Schools, …") and removed the
+   stray "within the District" qualifier on the use limitation so it reads
+   correctly for all students. A `DRAFT_EXTERNAL_ELIGIBILITY` comment flags that
+   FERPA/COPPA framing for an external educator's students depends on the
+   unresolved operator model and must NOT be broadened until counsel decides.
+
+**Intentionally NOT changed in PrivacyPolicyPage:** the entire "Google services
+and third parties" section, including the **Google API Services User Data Policy
+/ Limited Use disclosure** (required for OAuth verification regardless of
+audience); the contact address (`spartboard@orono.k12.mn.us`); data
+retention/security, access/correction/deletion, and changes sections; the
+`Last updated` date.
+
+### `components/legal/TermsOfServicePage.tsx`
+
+1. **File header comment** — same `DRAFT — EXTERNAL ELIGIBILITY` block.
+2. **`DraftEligibilityBanner` component** — same in-page amber DRAFT banner.
+3. **Intro paragraph** — left operative wording intact but flagged with a
+   `DRAFT_EXTERNAL_ELIGIBILITY` comment noting the "operated by Orono Public
+   Schools" framing is the open operator-model question.
+4. **"Eligibility and accounts" section** — rewritten from "provided to staff
+   and students of Orono Public Schools who sign in with a District-issued
+   Google account" to: available to educators who sign in with a Google account;
+   any educator may create a free account for that account type's features;
+   additional features for Orono staff/students and for organizations that have
+   arranged broader access; institution acceptable-use policies apply where used
+   through a school/district; Orono users remain subject to District policy.
+
+**Intentionally NOT changed in TermsOfServicePage:** acceptable use, content and
+ownership, third-party services, service availability, limitation of liability,
+termination, governing law (Minnesota), and changes sections; the contact
+address; the `Last updated` date.
+
+## The OPEN operator-model question (must resolve before publish)
+
+From `docs/wide-distro-plan.md` (Open questions): **who operates SpartBoard for
+non-Orono users?** Each consuming district will want its own DPA; the FERPA
+"school official" framing works district-by-district. The DRAFT copy
+deliberately:
+
+- keeps "operated by Orono Public Schools" as the placeholder operator framing
+  (counsel may decide Orono is the operator/processor, that an external educator
+  is the controller for their own classroom, or that a different entity
+  operates the external/free tier);
+- does **not** extend the FERPA/COPPA "education records" + school-consent
+  framing to external students;
+- does **not** describe any DPA mechanism for external districts.
+
+Counsel + the District data-privacy officer must sign off on the operator model
+and confirm/replace the bracketed framing before these pages go live.
+
+## Steps to finalize and re-prerender
+
+1. **Resolve the operator model with district counsel** and capture the decision
+   (controller/processor roles for the free/external tier; per-district DPA
+   mechanism; how FERPA/COPPA apply to external students).
+2. **Update the copy** in `PrivacyPolicyPage.tsx` and `TermsOfServicePage.tsx`
+   to reflect counsel's decision. Find every spot with the searchable marker
+   `DRAFT_EXTERNAL_ELIGIBILITY`.
+3. **Remove the DRAFT scaffolding:** delete the `DraftEligibilityBanner`
+   component and its render in each page, the `DRAFT — EXTERNAL ELIGIBILITY`
+   header blocks, and the inline `DRAFT_EXTERNAL_ELIGIBILITY` comments.
+4. **Verify the Google Limited Use disclosure is still intact** in the Privacy
+   "Google services and third parties" section (required for OAuth verification).
+5. **Bump the `lastUpdated` date** on both pages to the publish date.
+6. **Re-prerender:** run the production build so the static HTML regenerates from
+   the updated components (`vite build` → `vite build --ssr scripts/prerender-legal.tsx`
+   → `node dist-ssr/prerender-legal.js`; this is the `build` script in
+   `package.json`). Confirm `dist/privacy/index.html` and `dist/terms/index.html`
+   contain the finalized copy and no longer contain the DRAFT banner text.
+7. **Deploy** and confirm `/privacy` and `/terms` serve the finalized content to
+   signed-out visitors (these are anonymous, no-provider routes).
+
+## Follow-up: `/support` also still says "Orono only" (out of W10 scope)
+
+`components/legal/SupportPage.tsx` was **deliberately NOT edited** — W10 and the
+wide-distro plan (Phase 4 §1) name only `/privacy` and `/terms`. But a reviewer
+should know `/support` still contains Orono-only availability framing that will
+also need revisiting before the External flip:
+
+- _"We're here for Orono Public Schools staff and students."_ (intro)
+- _"SpartBoard accounts are tied to your Orono Public Schools Google account.
+  For password resets, account access, or device questions, contact your
+  school's technology support."_ ("Account and access")
+
+This is support-routing copy rather than a legal eligibility statement, so it is
+lower-risk to leave temporarily, but it should be broadened (and a self-serve /
+free-tier support path described) when the eligibility copy is finalized. Track
+as a small follow-up, not part of W10.
+
+## Scope / safety notes
+
+- These are **signed-out public-content** pages on anonymous, no-provider routes.
+  They are static React with no auth/tier branching, so the edits have **zero
+  effect on Orono app behavior** for internal/org users.
+- The prerender was **not** re-run as part of W10 (per task constraints); the
+  deployed static HTML still shows the old copy until step 6 above is performed.
+- No contact info, no governing-law/venue, and no unrelated sections were
+  changed.

--- a/docs/external-availability-oauth-runbook.md
+++ b/docs/external-availability-oauth-runbook.md
@@ -1,0 +1,408 @@
+# External Availability — Google OAuth "External" Launch Runbook
+
+**Audience:** Paul Ivers (operator + Workspace admin for `orono.k12.mn.us`).
+**Status:** Documentation only. **Nothing in this file has been executed.** No
+GCP/Firebase config was changed, no `gcloud`/`firebase` mutating command was
+run, and the consent screen was **not** flipped. This is the ordered,
+copy-pasteable plan for you to run by hand when you give the go.
+
+**Chosen path:** **Path A — "Go External + PREP VERIFICATION."** Keep the
+sensitive login scopes (`spreadsheets`, `calendar.readonly`) on the login
+consent flow and complete Google's one-time, free sensitive-scope
+verification. Do **not** minimize scopes (Path B is explicitly not taken).
+
+**Why this exists:** The prod project `spartboard` (project number
+**759666600376**) sits directly under the `orono.k12.mn.us` Workspace
+organization, and its OAuth consent screen is currently **Internal**. That is
+the single switch that rejects every non-Orono Google account today
+(`org_internal` / `Error 403: org_internal`) _before any app code runs_. All
+the code-side gating (tier model, org isolation, free-tier feature hiding) is
+already shipped and is a no-op for Orono users — see
+[external-availability-journal.md](external-availability-journal.md) and
+[wide-distro-plan.md](wide-distro-plan.md) Phase 4. This runbook covers only
+the Google Console side.
+
+---
+
+## 0. The hard constraint (read first)
+
+**Existing Orono org / internal users must notice ZERO change.** Everything in
+this runbook is engineered so that flipping the audience to External:
+
+- does **not** change Orono accounts' sign-in, scopes, granted permissions,
+  the OAuth client ID, or any token they already hold;
+- does **not** re-prompt Orono users beyond the normal `prompt: 'consent'`
+  re-consent they already get;
+- only changes whether **non-Orono** accounts are _admitted at all_.
+
+Internal users authenticate against the same client and the same scope list
+(`config/firebase.ts` → `GOOGLE_OAUTH_SCOPES`). Switching the audience to
+External widens _who may consent_; it does not alter _what Orono consents to_.
+
+### Facts this runbook is built on (verified against the repo, 2026-06-22)
+
+- **Prod project:** `spartboard`, number **759666600376**, parent = Workspace
+  org `orono.k12.mn.us` (org id **63276922281**, customer `C027lkte3`). Internal
+  is only selectable because the project is org-owned; External is therefore a
+  reversible toggle on the same project.
+- **Login scopes** (`config/firebase.ts`, `GOOGLE_OAUTH_SCOPES`):
+  | Scope | Tier | Verification impact when External |
+  |---|---|---|
+  | `https://www.googleapis.com/auth/drive.file` | **unrestricted** | none — no review even when External |
+  | `https://www.googleapis.com/auth/spreadsheets` | **sensitive** | one-time free verification |
+  | `https://www.googleapis.com/auth/calendar.readonly` | **sensitive** | one-time free verification |
+  Plus the standard `openid` / `userinfo.email` / `userinfo.profile`, which are
+  not sensitive.
+- **Restricted Classroom scope is separate from login.** The restricted
+  `classroom.coursework.students` scope lives only in
+  `components/classroomAddon/gisOAuth.ts` (on-demand GIS popups), never in the
+  login flow. See §6 for the critical caveat — its in-app gate
+  (`CLASSROOM_ASSIGN_ENABLED`) is currently `true` in the tree, which is a
+  decision point you must resolve before flipping External.
+- **Single shared prod project — no staging buffer.** There is no separate
+  staging GCP project for the consent screen; the flip happens on the live
+  project Orono uses every day. Flip in a low-traffic window.
+- **UI-only steps below cannot be scripted.** `iap.googleapis.com` and
+  `apikeys.googleapis.com` are disabled on this project, so the Cloud Console
+  UI is the only way to read/change the audience and publishing status — do not
+  expect a `gcloud` equivalent for the audience flip.
+- **Legal pages are live and prerendered:** `/privacy`, `/terms`, `/support`
+  (`components/legal/*`, prerendered via `scripts/prerender-legal.tsx`). Contact
+  on all of them: `spartboard@orono.k12.mn.us`. The Limited Use disclosure is
+  already in `components/legal/PrivacyPolicyPage.tsx`.
+
+---
+
+## 1. Read current Audience / User type + Publishing status (no changes)
+
+Goal: confirm where you're starting from before touching anything.
+
+1. Open the Cloud Console for the prod project:
+   `https://console.cloud.google.com/auth/overview?project=spartboard`
+   (If the project picker shows a different project, switch to **spartboard**
+   / number **759666600376**.)
+2. In the left nav under **Google Auth Platform**, open **Audience**
+   (`https://console.cloud.google.com/auth/audience?project=spartboard`).
+3. Read and record (screenshot for the journal):
+   - **User type** — expect **Internal** today.
+   - **Publishing status** — for an Internal app this is effectively "In
+     production" with no user cap and no verification concept (Internal apps
+     are exempt). After the flip to External it becomes meaningful (see §5).
+4. Open **Branding** / **Overview**
+   (`https://console.cloud.google.com/auth/branding?project=spartboard`) and
+   record: **App name**, **User support email**, **App logo** (present or not),
+   **Authorized domains**, **Developer contact email**.
+5. Open **Data Access** (the scopes page,
+   `https://console.cloud.google.com/auth/scopes?project=spartboard`) and
+   record the currently declared scopes. Confirm the three login scopes above
+   are present and that **no restricted scope is on the _login_ set**
+   (`classroom.coursework.*` should appear only via the Classroom add-on /
+   Marketplace declaration, not the login consent set — see §6).
+
+> These are read-only steps. The `iap.googleapis.com` / `apikeys.googleapis.com`
+> APIs are disabled, so there is no API read for the audience setting — the
+> Console pages above are the source of truth.
+
+---
+
+## 2. Search Console domain ownership (verification prerequisite)
+
+Google's sensitive-scope verification requires every **authorized domain** on
+the consent screen to be a verified property you own, in the **same Google
+account** doing the verification submission (`spartboard@orono.k12.mn.us` or
+`paul.ivers@orono.k12.mn.us` — use whichever account will own the OAuth
+verification; keep it consistent throughout).
+
+1. Go to Google Search Console: `https://search.google.com/search-console`.
+2. Add a **URL-prefix** property (not Domain property) for:
+   `https://spartboard.web.app/`
+   - **Why URL-prefix, not Domain:** `web.app` is on the **Public Suffix List**,
+     so `spartboard.web.app` behaves as a registrable domain you control at the
+     prefix level, but you do **not** control DNS for the parent `web.app` zone.
+     The **Domain** property method requires a DNS TXT record on the registrable
+     domain, which you cannot add for `web.app`. The **URL-prefix** method
+     verifies the single origin via an HTML file or `<meta>` tag you can serve
+     from the app — that's the supported route for `*.web.app`.
+3. Choose the **HTML file** or **HTML tag** verification method. For a Firebase
+   Hosting site, the HTML-file method is simplest:
+   - Download the `googleXXXXXXXXXXXX.html` token file Search Console gives you.
+   - Place it in the Firebase Hosting public root so it serves at
+     `https://spartboard.web.app/googleXXXXXXXXXXXX.html` (200, raw file). Then
+     a normal `firebase deploy --only hosting` from `main`. **This is the one
+     deploy this runbook may require; it changes only a static token file and
+     is safe for Orono.** Confirm the file returns 200 in a browser before
+     clicking Verify.
+   - Click **Verify** in Search Console.
+4. Record the verified property. The same verified account must be used in §3.
+
+> Long-term cleaner answer (optional, not required for launch): verify a custom
+> domain such as `spartboard.orono.k12.mn.us` (a real Domain property with DNS
+> TXT you control) and use it as the authorized domain. Out of scope for this
+> launch; `spartboard.web.app` via URL-prefix is sufficient.
+
+---
+
+## 3. Sensitive-scope verification submission checklist
+
+This is the one-time, **free** Google review for the two sensitive login
+scopes. (`drive.file` is unrestricted and needs no justification, but list it
+so the reviewer sees the complete picture.) Prepare everything below _before_
+submitting so the review isn't bounced for missing assets.
+
+### 3.1 Branding / consent-screen assets (Console → Branding)
+
+- [ ] **App name:** `SpartBoard` (matches `config/constants.ts` `APP_NAME`).
+- [ ] **App logo:** upload the SpartBoard logo (square PNG, ≤ 1 MB, no rounded
+      corners added by you — Google crops). A logo upload **triggers
+      brand-verification** and is required for External anyway.
+- [ ] **User support email:** `spartboard@orono.k12.mn.us`.
+- [ ] **Developer contact email:** `spartboard@orono.k12.mn.us`.
+- [ ] **Application home page:** `https://spartboard.web.app/`.
+- [ ] **Privacy policy URL:** `https://spartboard.web.app/privacy`.
+- [ ] **Terms of service URL:** `https://spartboard.web.app/terms`.
+- [ ] **Authorized domains:** `web.app` (the registrable authorized domain that
+      covers `spartboard.web.app`; this is the domain that must match the §2
+      Search Console verification ownership).
+
+### 3.2 Scope-by-scope justification (ready-to-paste)
+
+Paste each justification into the matching scope's "How will the scopes be
+used?" box. Each ties to a specific in-app feature with a real code path.
+
+**`https://www.googleapis.com/auth/drive.file` — UNRESTRICTED (no review, listed for completeness)**
+
+> SpartBoard saves and opens teacher-created classroom content (quizzes,
+> guided-learning sets, rosters, and exported results spreadsheets) in the
+> teacher's own Google Drive. We use `drive.file`, which grants access only to
+> files the user explicitly creates or opens through the Google Picker — never
+> broad Drive access. Per-file access is wired through the Google Picker
+> (`PickerBuilder.setAppId`) in `hooks/useGooglePicker.ts`, and file
+> create/read happens in `utils/quizDriveService.ts`. No other Drive files are
+> accessed.
+
+**`https://www.googleapis.com/auth/spreadsheets` — SENSITIVE (verification required)**
+
+> SpartBoard writes student quiz and activity results into a Google Sheet in
+> the teacher's own Drive so teachers can review and grade work in a familiar
+> spreadsheet, and exports PLC meeting notes to Sheets. The Sheets API is used
+> only to create and update these teacher-owned result/export spreadsheets that
+> the teacher initiates from within SpartBoard (see `utils/quizDriveService.ts`
+> and `utils/plcMeetingExport.ts`). We do not read or modify any other
+> spreadsheets in the user's Drive.
+
+**`https://www.googleapis.com/auth/calendar.readonly` — SENSITIVE (verification required)**
+
+> SpartBoard's optional Calendar widget displays the teacher's upcoming Google
+> Calendar events on their classroom dashboard so they can see their schedule
+> at a glance during a lesson. Access is read-only and used solely to list and
+> display the signed-in teacher's own events (`utils/googleCalendarService.ts`).
+> We never create, modify, or delete calendar data, and we do not access other
+> users' calendars.
+
+### 3.3 Demo video (script / storyboard)
+
+Google requires an unlisted YouTube video, recorded against the **production**
+OAuth client, that (a) shows the OAuth consent screen with the exact scopes,
+and (b) demonstrates each sensitive scope's feature end to end. Keep it 1–3
+minutes. Storyboard:
+
+1. **Title card / URL (5s):** Show the browser address bar at
+   `https://spartboard.web.app` so the reviewer sees the production origin and
+   the verified app name.
+2. **Sign-in + consent (15s):** Click Sign in with Google. **Pause on the
+   consent screen** long enough to read it; the screen must clearly list
+   `spreadsheets` and `calendar.readonly` (and `drive.file`). This frame is the
+   single most-checked part of the review — the on-screen scopes must match the
+   submitted scopes exactly.
+3. **`drive.file` (15s):** Create or open a quiz that saves to Drive; show the
+   Google Picker opening and a file being created/picked. Narrate: "Files are
+   created in the teacher's own Drive via the Picker — per-file access only."
+4. **`spreadsheets` (20s):** Run/finish a short activity, then export results
+   to Google Sheets; show the result Sheet opening in the teacher's Drive.
+   Narrate: "Results are written to a teacher-owned Sheet."
+5. **`calendar.readonly` (20s):** Add the Calendar widget to the dashboard; show
+   it listing the teacher's own upcoming events. Narrate: "Read-only display of
+   the signed-in teacher's calendar."
+6. **Close (5s):** Return to the dashboard; optionally show the Privacy Policy
+   link in the footer (`/privacy`) to reinforce the Limited Use disclosure.
+
+Record signed in as a normal teacher account (not an admin) so the flow matches
+what an external user sees. Upload to YouTube as **Unlisted** and paste the link
+into the submission.
+
+### 3.4 Limited Use disclosure
+
+- [ ] Confirm the live Privacy Policy contains the **Google API Services User
+      Data Policy / Limited Use** language. It already does — see
+      `components/legal/PrivacyPolicyPage.tsx` (the paragraph that links to the
+      "Google API Services User Data Policy … including the Limited Use
+      requirements"). Provide the reviewer the direct link:
+      `https://spartboard.web.app/privacy`.
+- [ ] Make sure the policy text is reachable as crawlable HTML (it is —
+      prerendered by `scripts/prerender-legal.tsx`), so Google's reviewer (and
+      crawler) sees the disclosure without booting the SPA.
+
+> **Submission note:** Submitting for verification is **not** the same as
+> publishing to Production, and it does not by itself change Orono's sign-in.
+> You can prepare and even submit the verification while the app is still
+> Internal _only if_ the audience is External (Internal apps have no
+> verification flow). In practice the order is: switch to External + Testing
+> (or directly Production) → submit verification → operate under the
+> unverified-app behavior in §5 until Google approves.
+
+---
+
+## 4. The flip: Audience → External → Publish to Production
+
+**Do this in a low-traffic window** (evening / weekend — no live classes), and
+have §7 rollback ready.
+
+1. Console → **Google Auth Platform → Audience**
+   (`https://console.cloud.google.com/auth/audience?project=spartboard`).
+2. Change **User type** from **Internal** to **External**.
+3. Set publishing status to **Publish to Production** (vs. leaving it in
+   **Testing**). See §5 for what each state means for the unverified period.
+4. Confirm the scope list is unchanged (the three login scopes + the standard
+   OpenID scopes) — the flip must not add scopes.
+
+### What the flip DOES change
+
+- Non-Orono Google accounts can now reach the consent screen and sign in
+  (today they're rejected with `org_internal`). The app's already-shipped tier
+  logic then routes them to the free/no-org experience.
+
+### What the flip does NOT change (Orono guarantee)
+
+- The OAuth **client ID** is identical — Orono users' existing grants and
+  tokens keep working; no forced re-auth beyond the normal `prompt: 'consent'`.
+- The **scope list** is identical — Orono consents to exactly what it does now.
+- Orono's data isolation is unchanged — org/building/PLC/announcement
+  collections remain owner/member-scoped (handled in code + `firestore.rules`).
+- **Nothing about the Classroom add-on flow** changes from the audience flip
+  itself — but see §6, which is a _separate_ gate you must verify first.
+
+---
+
+## 5. Unverified-app behavior until Google approves
+
+Between publishing to Production and Google's sensitive-scope approval, the app
+is an **unverified External app**. Plan for both user-facing effects:
+
+- **Unverified-app interstitial.** New external users hitting the sensitive
+  scopes see Google's "Google hasn't verified this app" warning. They can still
+  proceed via **Advanced → Go to SpartBoard (unsafe)**, but it is alarming for
+  non-technical teachers. This warning disappears once verification is approved.
+  - **Orono users are unaffected:** their accounts already granted these scopes
+    under the Internal screen, so they do not see the interstitial.
+- **100-user cap (Testing mode only).** If you leave the app in **Testing**
+  rather than Production, only listed **test users** (max 100) may sign in, and
+  refresh tokens expire in 7 days. **For an actual external launch, publish to
+  Production**, which removes the 100-user cap; the unverified _interstitial_
+  remains until approval, but there is no hard user cap in Production.
+  - Decision: if you want a small, controlled external pilot first, keep it in
+    **Testing** and add the pilot teachers as test users (≤100). For open
+    self-serve launch, go to **Production** and accept the interstitial until
+    verification lands.
+
+---
+
+## 6. DO-NOT list (each item maps to a real outage/leak risk)
+
+- **NEVER add a restricted scope to the _login_ consent set.** The login scopes
+  stay exactly `drive.file` + `spreadsheets` + `calendar.readonly`
+  (+ OpenID). Adding a restricted scope (e.g. `drive.readonly`, or a Classroom
+  restricted scope) to login triggers an annual CASA security assessment and,
+  if undeclared, reproduces the org-wide "Account Restricted" sign-in outage —
+  which would hit **Orono**, not just externals.
+
+- **Classroom restricted scope — verify the gate before flipping External.**
+  ⚠️ The in-app gate `CLASSROOM_ASSIGN_ENABLED` in `config/constants.ts` is
+  currently **`true`** in the working tree (enabled 2026-06-05 when the
+  restricted `classroom.coursework.students` scope was declared on the Workspace
+  Marketplace listing **under the Internal consent screen**), with
+  `CLASSROOM_ASSIGN_ADMIN_ONLY = true` limiting it to admins. The original plan
+  assumed this flag ships **off**. Before flipping the audience to External you
+  must consciously resolve this, because the restricted Classroom scope is
+  requested (on-demand, incremental consent) by
+  `requestClassroomAssignToken` / `requestClassroomFinalGradeToken`
+  (`components/classroomAddon/gisOAuth.ts`):
+  - **The safe default for the External flip is to set
+    `CLASSROOM_ASSIGN_ENABLED = false`** (and ship/deploy that) until you have
+    re-confirmed that the restricted scope is still declared on the Marketplace
+    listing **and** that the OAuth client is still **Trusted** in Admin → API
+    Controls _after_ the audience changes to External. An undeclared or
+    untrusted restricted scope under External is exactly the org-wide outage
+    that hits Orono.
+  - Do **not** leave the restricted Classroom assign path reachable by external
+    users at all: it is an Orono-internal, Marketplace-declared,
+    admin-installed flow. Even with the flag on for Orono admins, external/free
+    users must never reach it (it is also tier/org-gated in code, but the
+    belt-and-suspenders answer for launch is the flag off).
+  - **Bottom line for this runbook's scope:** treat "keep the restricted
+    Classroom assign flow OFF for the External launch" as a hard requirement.
+    The cleanest way is `CLASSROOM_ASSIGN_ENABLED = false`. If you decide to
+    keep it on for Orono admins, you own re-verifying the Marketplace
+    declaration + Trusted client status under External _before_ the flip.
+
+- **Single shared prod project = no staging buffer.** There is no separate
+  staging GCP project for the consent screen. The flip is on the live project
+  Orono uses daily. **Flip only in a low-traffic window**, with §7 rollback at
+  hand, and watch sign-ins immediately after.
+
+- **Do not change App Visibility on the Marketplace SDK.** It is set to
+  **Private** and is **irreversible** to Public without a brand-new Cloud
+  project (per `docs/classroom-addon-gcp-state.md`). The External _audience_
+  flip is unrelated to Marketplace App Visibility — leave Visibility alone.
+
+---
+
+## 7. Rollback
+
+If external sign-ins cause any problem (unexpected data exposure, support load
+from the interstitial, a Classroom-scope error, anything anomalous):
+
+1. Console → **Google Auth Platform → Audience**
+   (`https://console.cloud.google.com/auth/audience?project=spartboard`).
+2. Switch **User type** back to **Internal**.
+   - This immediately re-rejects all non-Orono accounts (`org_internal`) at the
+     consent screen.
+   - **Orono is unaffected by the rollback** for the same reason it was
+     unaffected by the flip: same client, same scopes, existing grants intact.
+3. Internal apps have no verification/user-cap concepts, so the unverified
+   interstitial and any cap disappear immediately for Orono.
+4. The Search Console property (§2) and any prepared verification assets (§3)
+   can stay in place — they cost nothing and are reusable when you re-attempt
+   External later.
+
+> **Caveat:** Reverting the _audience_ to Internal does **not** un-declare any
+> scope or change the Marketplace listing. If you had toggled
+> `CLASSROOM_ASSIGN_ENABLED` or touched Marketplace/Trusted-client settings as
+> part of §6, those are separate changes with their own revert steps — track
+> them independently of the audience flip.
+
+---
+
+## Pre-flip go/no-go checklist
+
+- [ ] §1 current Internal state recorded (screenshots).
+- [ ] §2 `spartboard.web.app` verified in Search Console (URL-prefix) under the
+      account that will own verification.
+- [ ] §3 branding assets, scope justifications, demo video, Limited Use link
+      all prepared.
+- [ ] §6 Classroom decision made: `CLASSROOM_ASSIGN_ENABLED` set to `false` for
+      launch **or** Marketplace declaration + Trusted client re-confirmed under
+      External.
+- [ ] Operator-model / legal eligibility language sign-off (district counsel) —
+      gates the `/privacy` + `/terms` external-eligibility copy (W10); this is a
+      **non-OAuth** prerequisite tracked in the journal, but it gates the
+      Production publish decision.
+- [ ] Low-traffic window chosen; §7 rollback understood.
+- [ ] Post-flip: watch sign-ins for 24h; confirm an Orono account signs in with
+      **no** change and a non-Orono test account reaches the free tier.
+
+---
+
+_Cross-references: [external-availability-journal.md](external-availability-journal.md)
+(work-item context + locked decisions), [wide-distro-plan.md](wide-distro-plan.md)
+Phase 4 (the launch switch), [classroom-addon-gcp-state.md](classroom-addon-gcp-state.md)
+(Marketplace / consent-screen history, App Visibility irreversibility)._

--- a/firestore.rules
+++ b/firestore.rules
@@ -3821,9 +3821,24 @@ service cloud.firestore {
       );
     }
 
-    // Announcements - all authenticated users can read, only admins can create/update/delete
+    // Announcements - admins write; reads are tenant-scoped.
+    //
+    // Multi-tenant isolation (defense-in-depth with the client listener gate):
+    //   - Legacy docs (no `orgId`) stay readable by ANY authenticated user.
+    //     This preserves the pre-isolation behavior so existing Orono
+    //     announcements (which predate the field, until the backfill stamps
+    //     'orono') keep showing for everyone, exactly as today.
+    //   - A doc WITH an `orgId` is readable only by a member of that org
+    //     (via `isOrgMember`) — or any admin, since the admin manager UI
+    //     subscribes to the full collection to manage every announcement.
+    // The write rule is unchanged: only admins create/update/delete.
     match /announcements/{announcementId} {
-      allow read: if request.auth != null;
+      allow read: if request.auth != null
+        && (
+          !('orgId' in resource.data)
+          || isOrgMember(resource.data.orgId)
+          || isAdmin()
+        );
       allow write: if isAdmin();
 
       // Poll votes subcollection — authenticated users can read live tallies and cast votes

--- a/functions/src/aiGeneration.ts
+++ b/functions/src/aiGeneration.ts
@@ -5,9 +5,14 @@ import { GoogleGenAI, Content, Type, Schema } from '@google/genai';
 import { sanitizePrompt } from './sanitize';
 import { parseGeminiJson } from './parseGeminiJson';
 import { BoundedLruMap } from './utils/boundedLruMap';
-import { ALLOWED_ORIGINS } from './classlinkShared';
+import { ALLOWED_ORIGINS, resolveOrgIdForDomain } from './classlinkShared';
+import { resolveDomainCandidates } from './resolveOrgForUser';
 import { GEMINI_API_KEY } from './secrets';
-import { GlobalPermission, normalizeModelName } from './shared';
+import {
+  GlobalPermission,
+  GlobalPermConfig,
+  normalizeModelName,
+} from './shared';
 
 interface AIData {
   type:
@@ -81,6 +86,153 @@ const ADMIN_STATUS_CACHE_MAX = 500;
 const cachedAdminStatus = new BoundedLruMap<string, AdminStatusCacheEntry>(
   ADMIN_STATUS_CACHE_MAX
 );
+
+// --- External (no-org / free-tier) daily AI cap -----------------------------
+//
+// W7: external availability rollout. Callers whose VERIFIED email domain does
+// not resolve to any organization (e.g. personal gmail.com accounts using the
+// public/free tier) get a separate, LOWER daily cap than org/internal users.
+// Org/internal users continue to read `config.dailyLimit ?? DEFAULT_DAILY_LIMIT`
+// exactly as before — see `isExternalCaller` + `pickOverallLimit`.
+
+/**
+ * Default overall daily cap applied to ORG/INTERNAL callers when an admin has
+ * not configured `dailyLimit`. This is the pre-existing inlined `?? 20`
+ * fallback, lifted to a named constant so the external-vs-org split is legible.
+ * Its VALUE is unchanged (20), so org users see identical behavior.
+ */
+const DEFAULT_DAILY_LIMIT = 20;
+
+/**
+ * Default overall daily cap applied to EXTERNAL (no-org / free-tier) callers
+ * when an admin has not configured `externalDailyLimit`. Deliberately well
+ * below {@link DEFAULT_DAILY_LIMIT} to bound free-tier AI spend.
+ */
+const DEFAULT_EXTERNAL_DAILY_LIMIT = 5;
+
+// Module-level domain→orgId resolution cache. The collectionGroup query in
+// `resolveOrgIdForDomain` is identical for every caller on a given domain and
+// rarely changes, so caching it per warm Cloud Functions instance keeps the
+// external/internal classification off the hot path (no extra Firestore read
+// per AI call once warm). Keyed by the lowercased '@domain' string. Bounded so
+// a long-lived instance that sees many unique domains can't grow unboundedly.
+// 5-minute TTL bounds how long a newly-verified domain (org promotion) lags.
+const ORG_RESOLUTION_CACHE_MAX = 500;
+const ORG_RESOLUTION_TTL_MS = READ_CACHE_TTL_MS;
+
+interface OrgResolutionCacheEntry {
+  orgId: string | null;
+  cachedAt: number;
+}
+const cachedOrgResolution = new BoundedLruMap<string, OrgResolutionCacheEntry>(
+  ORG_RESOLUTION_CACHE_MAX
+);
+
+/**
+ * Resolves the caller's org from their VERIFIED token (the `hd` hosted-domain
+ * claim first, else the email-domain suffix — same precedence as
+ * `resolveOrgForUser`), returning the orgId or `null` when no verified domain
+ * is registered to any org. Results are cached per-domain (module-level Map).
+ *
+ * Pure-ish: the only side effect is the cached Firestore collectionGroup read.
+ * `token` is the verified `request.auth.token`; never trust client-supplied
+ * data here.
+ */
+async function resolveOrgIdForToken(
+  db: admin.firestore.Firestore,
+  token: { email?: string; hd?: string }
+): Promise<string | null> {
+  const candidates = resolveDomainCandidates(token.hd, token.email);
+  if (candidates.length === 0) return null;
+  const now = Date.now();
+  for (const domain of candidates) {
+    const cached = cachedOrgResolution.get(domain);
+    if (cached && now - cached.cachedAt < ORG_RESOLUTION_TTL_MS) {
+      if (cached.orgId) return cached.orgId;
+      continue; // cached miss for this domain — try the next candidate
+    }
+    const orgId = await resolveOrgIdForDomain(db, domain);
+    cachedOrgResolution.set(domain, { orgId, cachedAt: now });
+    if (orgId) return orgId;
+  }
+  return null;
+}
+
+/**
+ * Classifies a caller as EXTERNAL (no org) or INTERNAL (org) from their
+ * VERIFIED token, for the purpose of picking the overall daily AI cap. Run
+ * this OUTSIDE any Firestore transaction — `resolveOrgIdForToken` issues a
+ * collectionGroup read that must not be entangled with a transaction's
+ * read/write set (and must not re-run on transaction retries).
+ *
+ * FAIL-SAFE TOWARD THE ORG PATH: returns `true` (external → lower cap) ONLY
+ * when we can affirmatively determine the caller has no org. A missing
+ * email/domain, or a lookup that throws, returns `false` (treat as org →
+ * normal cap). Misclassifying an org user as external (throttling them to the
+ * free-tier cap) is the worse failure, so undefined/error states err toward
+ * the normal limit. The trade-off — a transient lookup error lets a genuine
+ * external user briefly keep the org cap — is acceptable.
+ *
+ * Admins never reach this — the admin-exempt branch at each call site short-
+ * circuits before any limit is computed, exactly as before.
+ */
+async function isExternalCaller(
+  db: admin.firestore.Firestore,
+  token: { email?: string; hd?: string } | undefined
+): Promise<boolean> {
+  // No usable token/email → cannot prove "external"; treat as org.
+  if (!token || !token.email) return false;
+  try {
+    const orgId = await resolveOrgIdForToken(db, token);
+    return orgId === null; // null org = affirmatively external
+  } catch (error) {
+    console.warn(
+      'Org resolution failed during AI quota check; treating caller as org.',
+      error
+    );
+    return false;
+  }
+}
+
+/**
+ * Picks the effective OVERALL daily AI cap from the global config given a
+ * caller's external/internal classification (from {@link isExternalCaller}):
+ *
+ *  - INTERNAL (`isExternal === false`) → `config.dailyLimit ?? DEFAULT_DAILY_LIMIT`
+ *    — the UNCHANGED legacy path. Org/internal users see identical behavior.
+ *  - EXTERNAL (`isExternal === true`)  →
+ *    `config.externalDailyLimit ?? DEFAULT_EXTERNAL_DAILY_LIMIT`.
+ *
+ * Pure + synchronous so it is safe to call inside a Firestore transaction body
+ * (no foreign reads). The `dailyLimitEnabled` flag is checked separately by the
+ * caller and governs BOTH caps (when disabled, neither caps anyone).
+ */
+function pickOverallLimit(
+  config: GlobalPermConfig | undefined,
+  isExternal: boolean
+): number {
+  if (isExternal) {
+    return config?.externalDailyLimit ?? DEFAULT_EXTERNAL_DAILY_LIMIT;
+  }
+  return config?.dailyLimit ?? DEFAULT_DAILY_LIMIT;
+}
+
+/**
+ * Test-only: reset the module-scope org-resolution cache so tests can observe
+ * a cold-start classification sequence.
+ */
+export function __resetOrgResolutionCache(): void {
+  cachedOrgResolution.clear();
+}
+
+// Test-only re-exports of the W7 quota helpers.
+export {
+  isExternalCaller as __isExternalCaller,
+  pickOverallLimit as __pickOverallLimit,
+  resolveOrgIdForToken as __resolveOrgIdForToken,
+  DEFAULT_EXTERNAL_DAILY_LIMIT as __DEFAULT_EXTERNAL_DAILY_LIMIT,
+  DEFAULT_DAILY_LIMIT as __DEFAULT_DAILY_LIMIT,
+};
 
 /**
  * Test-only: reset the module-scope read caches so tests can observe a
@@ -221,6 +373,14 @@ export const generateWithAI = onCall(
     // Check if user is an admin (cached for 5 minutes per warm instance).
     const isAdmin = await getCachedAdminStatus(db, email.toLowerCase());
 
+    // W7: classify the caller as external (no org) for the daily-cap branch.
+    // Resolved BEFORE the transaction (collectionGroup read must not be inside
+    // it) and only for non-admins (admins are exempt, so the lookup is wasted
+    // for them). Cached per-domain; fail-safe toward "org" — see helper docs.
+    const isExternal = isAdmin
+      ? false
+      : await isExternalCaller(db, request.auth.token);
+
     // 1. Determine specific feature ID if applicable.
     //
     // Only include genTypes that are ALSO keys in the promptMap below.
@@ -310,7 +470,9 @@ export const generateWithAI = onCall(
 
           const overallLimitEnabled =
             globalPerm?.config?.dailyLimitEnabled !== false;
-          const overallLimit = globalPerm?.config?.dailyLimit ?? 20;
+          // W7: external (no-org) callers get the lower external cap; org/
+          // internal callers keep `config.dailyLimit ?? 20` (unchanged).
+          const overallLimit = pickOverallLimit(globalPerm?.config, isExternal);
 
           if (overallLimitEnabled && currentOverallUsage >= overallLimit) {
             throw new HttpsError(
@@ -1425,11 +1587,17 @@ export const generateVideoActivity = onCall(
       const today = new Date().toISOString().split('T')[0];
       const overallUsageRef = db.collection('ai_usage').doc(`${uid}_${today}`);
 
+      // W7: classify external (no-org) vs org caller BEFORE the transaction
+      // (collectionGroup read must not run inside it). Fail-safe toward org.
+      const isExternal = await isExternalCaller(db, request.auth.token);
+
       try {
         await db.runTransaction(async (transaction) => {
           const overallLimitEnabled =
             accessPerm?.config?.dailyLimitEnabled !== false;
-          const overallLimit = accessPerm?.config?.dailyLimit ?? 20;
+          // W7: external callers get the lower external cap; org/internal
+          // callers keep `config.dailyLimit ?? 20` (unchanged).
+          const overallLimit = pickOverallLimit(accessPerm?.config, isExternal);
 
           const overallUsageDoc = await transaction.get(overallUsageRef);
           const currentOverallUsage =
@@ -1666,6 +1834,10 @@ export const transcribeVideoWithGemini = onCall(
         .collection('ai_usage')
         .doc(`${uid}_video-activity-audio-transcription_${today}`);
 
+      // W7: classify external (no-org) vs org caller BEFORE the transaction
+      // (collectionGroup read must not run inside it). Fail-safe toward org.
+      const isExternal = await isExternalCaller(db, request.auth.token);
+
       try {
         await db.runTransaction(async (transaction) => {
           // 1. Check Overall Limit
@@ -1677,7 +1849,10 @@ export const transcribeVideoWithGemini = onCall(
             | undefined;
           const overallLimitEnabled =
             globalPerm?.config?.dailyLimitEnabled !== false;
-          const overallLimit = globalPerm?.config?.dailyLimit ?? 20;
+          // W7: external callers get the lower external cap; org/internal
+          // callers keep `config.dailyLimit ?? 20` (unchanged). The per-feature
+          // transcription cap below is separate and stays untouched.
+          const overallLimit = pickOverallLimit(globalPerm?.config, isExternal);
 
           const overallUsageDoc = await transaction.get(overallUsageRef);
           const currentOverallUsage =

--- a/functions/src/aiQuotaExternalLimit.test.ts
+++ b/functions/src/aiQuotaExternalLimit.test.ts
@@ -1,0 +1,276 @@
+/**
+ * W7 (external availability rollout) — AI daily-quota external/org split.
+ *
+ * Verifies the helpers that decide a caller's OVERALL daily AI cap:
+ *   - `isExternalCaller`  — classifies a caller as external (no org) or org,
+ *     from the VERIFIED token, fail-safe toward "org".
+ *   - `pickOverallLimit`  — picks the external vs org cap from the config.
+ *
+ * Asserts the four required behaviors:
+ *   (a) an orgless caller is capped at the lower external limit;
+ *   (b) an org caller still uses `config.dailyLimit` (UNCHANGED);
+ *   (c) admins are exempt (the call sites skip the limit entirely — modeled
+ *       here by never invoking the helpers for admins, see the assertion that
+ *       `pickOverallLimit` is only ever consulted for non-admins);
+ *   (d) an org user is NOT misclassified as external (no false external cap).
+ *
+ * Firestore is never really touched: `resolveOrgIdForDomain` is the only
+ * Firestore hop and is mocked, mirroring `resolveOrgForUser.test.ts`. The
+ * `firebase-*` modules are mocked so importing `aiGeneration.ts` (which runs
+ * `functionsInit` + `defineSecret` at module load) stays pure.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const resolveOrgIdForDomainMock = vi.fn();
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  firestore: () => ({}),
+}));
+
+vi.mock('firebase-functions/v2', () => ({
+  setGlobalOptions: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/https', () => {
+  class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+      this.name = 'HttpsError';
+    }
+  }
+  return {
+    HttpsError,
+    onCall: (_options: unknown, handler: unknown) => handler,
+  };
+});
+
+vi.mock('firebase-functions/params', () => ({
+  defineSecret: (name: string) => ({ value: () => `mock-${name}`, name }),
+}));
+
+// Only `resolveOrgIdForDomain` + `ALLOWED_ORIGINS` are pulled from
+// classlinkShared by aiGeneration.ts. Mock the domain lookup; the resolution
+// precedence (`resolveDomainCandidates`) is the REAL implementation from
+// resolveOrgForUser.ts, which calls `normalizeEmailDomain` — mirror it here.
+vi.mock('./classlinkShared', () => ({
+  ALLOWED_ORIGINS: [],
+  normalizeEmailDomain: (email: string): string | null => {
+    const at = email.lastIndexOf('@');
+    if (at < 0 || at === email.length - 1) return null;
+    return '@' + email.slice(at + 1).toLowerCase();
+  },
+  resolveOrgIdForDomain: (...args: unknown[]): Promise<string | null> =>
+    resolveOrgIdForDomainMock(...args) as Promise<string | null>,
+}));
+
+import {
+  __isExternalCaller,
+  __pickOverallLimit,
+  __resolveOrgIdForToken,
+  __resetOrgResolutionCache,
+  __DEFAULT_EXTERNAL_DAILY_LIMIT,
+  __DEFAULT_DAILY_LIMIT,
+} from './aiGeneration';
+
+// A throwaway Firestore handle — the real reads go through the mocked
+// `resolveOrgIdForDomain`, so the value is never dereferenced.
+const db = {} as Parameters<typeof __isExternalCaller>[0];
+
+describe('W7 external AI quota — defaults', () => {
+  it('external default is lower than the org default', () => {
+    expect(__DEFAULT_EXTERNAL_DAILY_LIMIT).toBeLessThan(__DEFAULT_DAILY_LIMIT);
+  });
+
+  it('org default is unchanged (20) and external default is 5', () => {
+    expect(__DEFAULT_DAILY_LIMIT).toBe(20);
+    expect(__DEFAULT_EXTERNAL_DAILY_LIMIT).toBe(5);
+  });
+});
+
+describe('pickOverallLimit', () => {
+  it('(b) org caller uses config.dailyLimit (admin-configured value, unchanged)', () => {
+    expect(__pickOverallLimit({ dailyLimit: 50 }, false)).toBe(50);
+  });
+
+  it('(b) org caller falls back to DEFAULT_DAILY_LIMIT when unset', () => {
+    expect(__pickOverallLimit(undefined, false)).toBe(__DEFAULT_DAILY_LIMIT);
+    expect(__pickOverallLimit({}, false)).toBe(__DEFAULT_DAILY_LIMIT);
+  });
+
+  it('(a) external caller uses config.externalDailyLimit when set', () => {
+    expect(__pickOverallLimit({ externalDailyLimit: 3 }, true)).toBe(3);
+  });
+
+  it('(a) external caller falls back to DEFAULT_EXTERNAL_DAILY_LIMIT when unset', () => {
+    expect(__pickOverallLimit(undefined, true)).toBe(
+      __DEFAULT_EXTERNAL_DAILY_LIMIT
+    );
+    expect(__pickOverallLimit({ dailyLimit: 50 }, true)).toBe(
+      __DEFAULT_EXTERNAL_DAILY_LIMIT
+    );
+  });
+
+  it('external branch never reads the org dailyLimit (and vice versa)', () => {
+    // An org with a high dailyLimit must not leak into the external cap.
+    expect(
+      __pickOverallLimit({ dailyLimit: 999, externalDailyLimit: 5 }, true)
+    ).toBe(5);
+    // An external cap must not leak into the org path.
+    expect(
+      __pickOverallLimit({ dailyLimit: 20, externalDailyLimit: 5 }, false)
+    ).toBe(20);
+  });
+});
+
+describe('isExternalCaller', () => {
+  beforeEach(() => {
+    resolveOrgIdForDomainMock.mockReset();
+    __resetOrgResolutionCache();
+  });
+
+  it('(a) orgless caller (gmail) is classified external', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue(null);
+    const external = await __isExternalCaller(db, {
+      email: 'someone@gmail.com',
+    });
+    expect(external).toBe(true);
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '@gmail.com'
+    );
+  });
+
+  it('(d) org caller (verified domain → org) is NOT misclassified as external', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue('orono');
+    const external = await __isExternalCaller(db, {
+      email: 'teacher@orono.k12.mn.us',
+    });
+    expect(external).toBe(false);
+  });
+
+  it('(d) org caller via hd claim is internal even when email domain differs', async () => {
+    // hd resolves to an org on the first lookup → internal, no fallback needed.
+    resolveOrgIdForDomainMock.mockResolvedValueOnce('orono');
+    const external = await __isExternalCaller(db, {
+      hd: 'orono.k12.mn.us',
+      email: 'teacher@alias-domain.com',
+    });
+    expect(external).toBe(false);
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledTimes(1);
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '@orono.k12.mn.us'
+    );
+  });
+
+  it('(d) falls back to the email domain when hd is unregistered, then finds the org', async () => {
+    resolveOrgIdForDomainMock
+      .mockResolvedValueOnce(null) // hd domain — not registered
+      .mockResolvedValueOnce('orono'); // email domain — org
+    const external = await __isExternalCaller(db, {
+      hd: 'alias-domain.com',
+      email: 'teacher@orono.k12.mn.us',
+    });
+    expect(external).toBe(false);
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fail-safe: missing email → treated as org (NOT external)', async () => {
+    const external = await __isExternalCaller(db, { email: undefined });
+    expect(external).toBe(false);
+    expect(resolveOrgIdForDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('fail-safe: undefined token → treated as org (NOT external)', async () => {
+    const external = await __isExternalCaller(db, undefined);
+    expect(external).toBe(false);
+    expect(resolveOrgIdForDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('fail-safe: lookup error → treated as org (NOT external)', async () => {
+    resolveOrgIdForDomainMock.mockRejectedValue(new Error('firestore down'));
+    const external = await __isExternalCaller(db, {
+      email: 'teacher@orono.k12.mn.us',
+    });
+    // An org user must NEVER be throttled to the external cap on a transient
+    // lookup failure — fail safe toward the org path.
+    expect(external).toBe(false);
+  });
+
+  it('caches the domain→org resolution across calls (single lookup)', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue('orono');
+    await __isExternalCaller(db, { email: 'a@orono.k12.mn.us' });
+    await __isExternalCaller(db, { email: 'b@orono.k12.mn.us' });
+    // Two callers, same domain → one collectionGroup lookup.
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a negative (orgless) resolution too', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue(null);
+    expect(await __isExternalCaller(db, { email: 'x@gmail.com' })).toBe(true);
+    expect(await __isExternalCaller(db, { email: 'y@gmail.com' })).toBe(true);
+    expect(resolveOrgIdForDomainMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('end-to-end limit selection (isExternalCaller → pickOverallLimit)', () => {
+  beforeEach(() => {
+    resolveOrgIdForDomainMock.mockReset();
+    __resetOrgResolutionCache();
+  });
+
+  it('(a) orgless caller is capped at the lower external limit', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue(null);
+    const config = { dailyLimit: 20, externalDailyLimit: 5 };
+    const external = await __isExternalCaller(db, { email: 'p@gmail.com' });
+    expect(__pickOverallLimit(config, external)).toBe(5);
+  });
+
+  it('(b) org caller still uses config.dailyLimit (unchanged)', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue('orono');
+    const config = { dailyLimit: 20, externalDailyLimit: 5 };
+    const external = await __isExternalCaller(db, {
+      email: 'p@orono.k12.mn.us',
+    });
+    expect(__pickOverallLimit(config, external)).toBe(20);
+  });
+
+  it('(d) org caller with no externalDailyLimit configured is unaffected', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue('orono');
+    const external = await __isExternalCaller(db, {
+      email: 'p@orono.k12.mn.us',
+    });
+    // org path → DEFAULT_DAILY_LIMIT (20), never the external default (5).
+    expect(__pickOverallLimit({}, external)).toBe(__DEFAULT_DAILY_LIMIT);
+  });
+});
+
+describe('resolveOrgIdForToken (raw resolution, behind isExternalCaller)', () => {
+  beforeEach(() => {
+    resolveOrgIdForDomainMock.mockReset();
+    __resetOrgResolutionCache();
+  });
+
+  it('returns the resolved orgId for a registered domain', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue('orono');
+    expect(
+      await __resolveOrgIdForToken(db, { email: 'teacher@orono.k12.mn.us' })
+    ).toBe('orono');
+  });
+
+  it('returns null for an unregistered domain', async () => {
+    resolveOrgIdForDomainMock.mockResolvedValue(null);
+    expect(await __resolveOrgIdForToken(db, { email: 'x@gmail.com' })).toBe(
+      null
+    );
+  });
+
+  it('returns null without a lookup when the token has no domain', async () => {
+    expect(await __resolveOrgIdForToken(db, {})).toBe(null);
+    expect(resolveOrgIdForDomainMock).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/shared.ts
+++ b/functions/src/shared.ts
@@ -8,6 +8,15 @@
 export interface GlobalPermConfig {
   dailyLimit?: number;
   dailyLimitEnabled?: boolean;
+  /**
+   * Separate, lower daily AI cap for no-org / external (free-tier) callers.
+   * Org/internal users always read `dailyLimit`; this field only ever gates
+   * a caller whose verified email domain resolves to NO organization. When
+   * unset, `DEFAULT_EXTERNAL_DAILY_LIMIT` (aiGeneration.ts) applies. The
+   * existing `dailyLimitEnabled` flag governs both caps — if daily limiting
+   * is turned off, neither org nor external callers are capped.
+   */
+  externalDailyLimit?: number;
 }
 
 export interface GlobalPermission {

--- a/hooks/useAdminBuildings.ts
+++ b/hooks/useAdminBuildings.ts
@@ -16,9 +16,17 @@ import {
  *      (`/organizations/{orgId}/buildings`), use those — they're the
  *      source of truth now that buildings are manageable from
  *      Admin Settings &gt; Organization &gt; Buildings.
- *   2. Otherwise fall back to the hardcoded {@link BUILDINGS} seed list so
- *      the UI still renders during the initial snapshot load, in tests, or
- *      for orgs that haven't migrated their building data yet.
+ *   2. If the user has NO org (`orgId == null` — external/free-tier, or a
+ *      provider-less test render), return an EMPTY list. Buildings are an
+ *      org concept; falling back to the Orono seed here would leak another
+ *      district's real school names to a no-org user. The genuine
+ *      org-set-but-loading window (orgId present, snapshot not yet in) is
+ *      handled by case 3.
+ *   3. Otherwise (an org IS set but its buildings snapshot is empty — initial
+ *      load, or an org that hasn't migrated its building data) fall back to
+ *      the hardcoded {@link BUILDINGS} seed list so the UI still renders. Orono
+ *      reaches this only briefly during its first snapshot, after which its
+ *      Firestore-hydrated buildings (case 1) take over — so Orono is unaffected.
  *
  * The hook intentionally returns the same `Building` shape that
  * `config/buildings.ts` already exports, so existing panels can adopt it by
@@ -32,16 +40,25 @@ import {
 export function useAdminBuildings(): Building[] {
   // Use useContext directly rather than useAuth() so the hook still works in
   // test setups (e.g. WidgetBuildingToggle) that render without AuthProvider.
-  // If no provider is mounted, fall back to the legacy BUILDINGS seed list.
+  // If no provider is mounted, `orgId` is undefined — treated like "no org" so
+  // a provider-less render yields an empty list rather than another district's
+  // seed names.
   const auth = useContext(AuthContext);
   const orgBuildings = auth?.orgBuildings;
+  const orgId = auth?.orgId ?? null;
 
   return useMemo(() => {
-    if (!orgBuildings || orgBuildings.length === 0) {
-      return BUILDINGS;
+    if (orgBuildings && orgBuildings.length > 0) {
+      return orgBuildings.map(buildingRecordToBuilding);
     }
-    return orgBuildings.map(buildingRecordToBuilding);
-  }, [orgBuildings]);
+    // No org (external/free-tier or provider-less): never leak the Orono seed.
+    if (orgId === null) return [];
+    // An org IS set but its buildings snapshot hasn't landed yet (or is empty):
+    // keep the seed so the admin UI renders during the org-set-but-loading
+    // window. Orono only hits this transiently before its Firestore buildings
+    // hydrate.
+    return BUILDINGS;
+  }, [orgBuildings, orgId]);
 }
 
 /**
@@ -63,18 +80,22 @@ export function useAdminBuildingsState(): {
 } {
   const auth = useContext(AuthContext);
   const orgBuildings = auth?.orgBuildings;
+  const orgId = auth?.orgId ?? null;
   // `orgBuildingsLoaded` flips to true after the first snapshot (or the
-  // "no org" reset). The seed fallback is returned in the loading window so
-  // the UI never shows blank, but consumers can suppress destructive actions
-  // (like removing orphan chips) until the list is confirmed.
+  // "no org" reset). The seed fallback is returned in the org-set-but-loading
+  // window so the UI never shows blank, but consumers can suppress destructive
+  // actions (like removing orphan chips) until the list is confirmed.
   const orgBuildingsLoaded = auth?.orgBuildingsLoaded ?? false;
 
   const buildings = useMemo(() => {
-    if (!orgBuildings || orgBuildings.length === 0) {
-      return BUILDINGS;
+    if (orgBuildings && orgBuildings.length > 0) {
+      return orgBuildings.map(buildingRecordToBuilding);
     }
-    return orgBuildings.map(buildingRecordToBuilding);
-  }, [orgBuildings]);
+    // No org (external/free-tier or provider-less): empty, never the Orono seed.
+    if (orgId === null) return [];
+    // Org set but buildings snapshot not yet landed: seed placeholder.
+    return BUILDINGS;
+  }, [orgBuildings, orgId]);
 
   return { buildings, isLoading: !orgBuildingsLoaded };
 }

--- a/hooks/useClassLinkEnabled.ts
+++ b/hooks/useClassLinkEnabled.ts
@@ -8,13 +8,25 @@ import { ClassesGlobalConfig } from '@/types';
  * Looks up the `classes` feature permission's `buildingDefaults[buildingId]`
  * setting, which is managed by the admin `ClassesConfigurationPanel`. Defaults
  * to enabled when no building is selected or no override is configured.
+ *
+ * External (no-org/free-tier) users never see ClassLink: it's a roster-import
+ * integration tied to an org's SSO/roster provider. The gate is keyed on
+ * `orgId`, NOT on `selectedBuildings` — an Orono (org) teacher who hasn't
+ * picked a building yet must still see ClassLink exactly as before, so we must
+ * not conflate "no building selected" with "no org". Orono always resolves a
+ * non-null `orgId`. `orgId` is null both for genuine no-org users and during
+ * the brief membership-loading window; treating the loading window as "no
+ * ClassLink" is the safe default (the button simply appears once membership
+ * resolves for an org member — same late-appearance as every other
+ * snapshot-driven affordance).
  */
 export function useClassLinkEnabled(buildingId?: string): boolean {
-  const { featurePermissions } = useAuth();
+  const { featurePermissions, orgId } = useAuth();
   return useMemo(() => {
+    if (orgId === null) return false;
     if (!buildingId) return true;
     const perm = featurePermissions.find((p) => p.widgetType === 'classes');
     const config = perm?.config as Partial<ClassesGlobalConfig> | undefined;
     return config?.buildingDefaults?.[buildingId]?.classLinkEnabled ?? true;
-  }, [featurePermissions, buildingId]);
+  }, [featurePermissions, buildingId, orgId]);
 }

--- a/hooks/usePlcs.ts
+++ b/hooks/usePlcs.ts
@@ -509,6 +509,17 @@ export const usePlcs = (options?: UsePlcsOptions): UsePlcsResult => {
       if (!email) {
         throw new Error(i18n.t('plc.errors.accountEmailRequired'));
       }
+      // Refuse to create an untenanted PLC for a no-org (external/free-tier)
+      // caller. PLCs are an org-only collaboration surface; the Sidebar (W1)
+      // already hides the entry point for external users, so this is
+      // defense-in-depth against any other caller. Orono / org members always
+      // resolve a non-null `orgId`, so they are unaffected. `createPlc` is
+      // invoked from a user gesture (the "Create PLC" form) where membership
+      // has long since resolved, so a null `orgId` here is a genuine "no org"
+      // — not the transient loading window.
+      if (orgId === null) {
+        throw new Error(i18n.t('plc.errors.orgRequired'));
+      }
       const displayName = user.displayName ?? '';
       // Inherit the creator's tenancy so the new PLC surfaces in the
       // org/building directory right away (Decision 1.1). Building resolution

--- a/locales/de.json
+++ b/locales/de.json
@@ -282,7 +282,8 @@
       "targetNotActiveMember": "Du kannst die Leitung nur an ein aktives Mitglied übertragen.",
       "cannotDemoteLead": "Verwende „Leitung übertragen“, um zu ändern, wer die PLC leitet.",
       "invalidRole": "Das ist keine gültige PLC-Rolle.",
-      "alreadyLead": "Dieses Mitglied leitet diese PLC bereits."
+      "alreadyLead": "Dieses Mitglied leitet diese PLC bereits.",
+      "orgRequired": "PLCs stehen nur Mitgliedern einer Organisation zur Verfügung."
     }
   },
   "plcDashboard": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -282,7 +282,8 @@
       "targetNotActiveMember": "You can only transfer leadership to an active member.",
       "cannotDemoteLead": "Use \"Transfer leadership\" to change who leads the PLC.",
       "invalidRole": "That is not a valid PLC role.",
-      "alreadyLead": "That member is already the lead of this PLC."
+      "alreadyLead": "That member is already the lead of this PLC.",
+      "orgRequired": "PLCs are only available to members of an organization."
     }
   },
   "plcDashboard": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -282,7 +282,8 @@
       "targetNotActiveMember": "Solo puedes transferir el liderazgo a un miembro activo.",
       "cannotDemoteLead": "Usa «Transferir liderazgo» para cambiar quién lidera la PLC.",
       "invalidRole": "Ese no es un rol válido de la PLC.",
-      "alreadyLead": "Ese miembro ya es el líder de esta PLC."
+      "alreadyLead": "Ese miembro ya es el líder de esta PLC.",
+      "orgRequired": "Las PLC solo están disponibles para los miembros de una organización."
     }
   },
   "plcDashboard": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -282,7 +282,8 @@
       "targetNotActiveMember": "Vous ne pouvez transférer la direction qu'à un membre actif.",
       "cannotDemoteLead": "Utilisez « Transférer la direction » pour changer le responsable de la CAP.",
       "invalidRole": "Ce n'est pas un rôle de CAP valide.",
-      "alreadyLead": "Ce membre est déjà le responsable de cette CAP."
+      "alreadyLead": "Ce membre est déjà le responsable de cette CAP.",
+      "orgRequired": "Les CAP sont réservées aux membres d'une organisation."
     }
   },
   "plcDashboard": {

--- a/scripts/migrateAnnouncements.js
+++ b/scripts/migrateAnnouncements.js
@@ -1,0 +1,153 @@
+/**
+ * One-time backfill: stamp `orgId: 'orono'` onto every `/announcements/{id}`
+ * document that lacks an `orgId` field.
+ *
+ * WHY: announcements is a single global collection with no per-tenant scope.
+ * Org-isolation (work item W6) gates the dashboard overlay listener on the
+ * caller's distribution tier and filters client-side / in the Firestore read
+ * rule by `orgId`, but EXISTING announcements were created before the field
+ * existed. Those legacy docs are deliberately treated as "global" (visible to
+ * all authenticated users) so Orono's announcements keep showing unchanged.
+ * Before the External launch we want every legacy announcement explicitly
+ * scoped to the operator org ('orono') so a future external/no-org user can
+ * never read them — at which point the read rule's org-membership branch
+ * applies instead of the legacy "visible to all" branch.
+ *
+ * 'For Paul to run against prod before the External launch.'  DO NOT auto-run.
+ *
+ * Safe to re-run — it only writes the `orgId` field on docs that are MISSING
+ * it, leaving any already-stamped doc untouched (idempotent). It never
+ * overwrites a non-'orono' orgId, so it won't clobber a future multi-org doc.
+ *
+ * Usage:
+ *   node scripts/migrateAnnouncements.js [--dry-run] [--org=<id>]
+ *
+ *   --dry-run   Report what WOULD change without writing.
+ *   --org=<id>  Org id to stamp onto legacy docs (default: 'orono').
+ *
+ * Requires firebase-admin credentials:
+ *   - FIREBASE_SERVICE_ACCOUNT env var (JSON string), OR
+ *   - scripts/service-account-key.json file (gitignored)
+ *
+ * Outputs:
+ *   - A JSON report at scripts/output/announcements-migration-{timestamp}.json
+ *   - Stderr summary to console
+ */
+
+import { initializeApp, cert } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { readFileSync, mkdirSync, writeFileSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const DEFAULT_ORG_ID = 'orono';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const orgId =
+  args.find((a) => a.startsWith('--org='))?.split('=')[1] ?? DEFAULT_ORG_ID;
+
+function loadCredentials() {
+  const envCreds = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (envCreds) {
+    try {
+      return JSON.parse(envCreds);
+    } catch (e) {
+      throw new Error(
+        `FIREBASE_SERVICE_ACCOUNT env var is set but not valid JSON: ${e.message}`
+      );
+    }
+  }
+  const filePath = join(__dirname, 'service-account-key.json');
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `No credentials. Set FIREBASE_SERVICE_ACCOUNT env var or place service-account-key.json in scripts/.`
+    );
+  }
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+async function main() {
+  const creds = loadCredentials();
+  initializeApp({ credential: cert(creds) });
+  const db = getFirestore();
+
+  const report = {
+    startedAt: new Date().toISOString(),
+    dryRun,
+    orgId,
+    total: 0,
+    stamped: [],
+    wouldStamp: [],
+    /** Docs already carrying an orgId — left untouched (idempotent re-run). */
+    alreadyScoped: [],
+    errors: [],
+  };
+
+  const snap = await db.collection('announcements').get();
+  report.total = snap.size;
+
+  for (const docSnap of snap.docs) {
+    const id = docSnap.id;
+    const data = docSnap.data();
+    try {
+      // Only stamp docs MISSING orgId. A doc that already has any orgId value
+      // (including a future non-'orono' org) is left exactly as-is so this
+      // backfill stays idempotent and never reassigns tenancy.
+      const existing = data.orgId;
+      if (typeof existing === 'string' && existing.length > 0) {
+        report.alreadyScoped.push({ id, orgId: existing });
+        continue;
+      }
+      if (dryRun) {
+        report.wouldStamp.push({ id, name: data.name ?? null });
+        continue;
+      }
+      await db
+        .collection('announcements')
+        .doc(id)
+        .set({ orgId, updatedAt: Date.now() }, { merge: true });
+      report.stamped.push({ id, name: data.name ?? null });
+      console.log(`  ✓ ${id} → orgId='${orgId}'`);
+    } catch (err) {
+      report.errors.push({ id, error: err.message ?? String(err) });
+      console.error(`  ✗ ${id}: ${err.message ?? err}`);
+    }
+  }
+
+  report.finishedAt = new Date().toISOString();
+
+  const outDir = join(__dirname, 'output');
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  const outPath = join(
+    outDir,
+    `announcements-migration-${report.startedAt.replace(/[:.]/g, '-')}.json`
+  );
+  writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.log(`\nReport: ${outPath}`);
+  console.log(
+    `Summary: ${report.total} announcement(s) — ${
+      dryRun
+        ? report.wouldStamp.length + ' would stamp'
+        : report.stamped.length + ' stamped'
+    }, ${report.alreadyScoped.length} already scoped, ${report.errors.length} errors.`
+  );
+
+  // Exit non-zero on errors so a partially-failed backfill isn't mistaken for
+  // success by a `&&`-chained shell or CI step. The report file is still
+  // written, so the operator can diff and re-run (the script is idempotent).
+  if (report.errors.length > 0) {
+    console.error(
+      `\nFAILED: ${report.errors.length} error(s) — see report at ${outPath}.`
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/tests/components/announcements/AnnouncementOverlay.test.tsx
+++ b/tests/components/announcements/AnnouncementOverlay.test.tsx
@@ -55,12 +55,18 @@ import { useAuth } from '@/context/useAuth';
 
 const MOCK_USER = { uid: 'user-1', email: 'test@example.com' };
 
-function mockAuth(selectedBuildings: string[] = []) {
+function mockAuth(
+  selectedBuildings: string[] = [],
+  opts: { userTier?: 'internal' | 'org' | 'free'; orgId?: string | null } = {}
+) {
   vi.mocked(useAuth).mockReturnValue({
     user: MOCK_USER,
     selectedBuildings,
     isAdmin: false,
     loading: false,
+    // Default to 'internal' so existing behavior-tests subscribe (Orono path).
+    userTier: opts.userTier ?? 'internal',
+    orgId: opts.orgId ?? null,
   } as ReturnType<typeof useAuth>);
 }
 
@@ -550,5 +556,81 @@ describe('AnnouncementOverlay', () => {
     render(<AnnouncementOverlay />);
     emitAnnouncements([{ ...BASE_ANNOUNCEMENT, dismissalType: 'admin' }]);
     expect(screen.getByText(/Admin only/i)).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Multi-tenant org isolation (work item W6 — the CRITICAL leak)
+  // -------------------------------------------------------------------------
+
+  describe('org isolation', () => {
+    it('never subscribes to the announcements collection for free-tier users', () => {
+      // A no-org ("free") teacher must NOT open the global listener at all.
+      // firestoreCallback stays null because the onSnapshot effect early-returns.
+      mockAuth([], { userTier: 'free', orgId: null });
+      const { container } = render(<AnnouncementOverlay />);
+      expect(firestoreCallback).toBeNull();
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('subscribes for org/internal users (Orono path unchanged)', () => {
+      mockAuth([], { userTier: 'internal', orgId: 'orono' });
+      render(<AnnouncementOverlay />);
+      // The listener opened — callback captured — and legacy (no orgId) docs render.
+      emitAnnouncements([BASE_ANNOUNCEMENT]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('shows a legacy (no orgId) announcement to an org user — Orono zero-change', () => {
+      mockAuth([], { userTier: 'internal', orgId: 'orono' });
+      render(<AnnouncementOverlay />);
+      // BASE_ANNOUNCEMENT has no orgId field (legacy / pre-isolation).
+      emitAnnouncements([BASE_ANNOUNCEMENT]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('shows an announcement whose orgId matches the user org', () => {
+      mockAuth([], { userTier: 'internal', orgId: 'orono' });
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([{ ...BASE_ANNOUNCEMENT, orgId: 'orono' }]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('does NOT hide an org-stamped announcement while orgId is still resolving (Orono no-flicker)', () => {
+      // userTier resolves to 'internal' from the email domain immediately, so
+      // the listener is open and streams Orono's orgId:'orono' docs — but the
+      // membership snapshot hasn't landed yet, so useAuth().orgId is still null.
+      // The client filter must NOT hide the doc during this window, otherwise
+      // post-backfill an Orono user sees their announcement flicker off then on.
+      mockAuth([], { userTier: 'internal', orgId: null });
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([{ ...BASE_ANNOUNCEMENT, orgId: 'orono' }]);
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('hides an announcement whose orgId belongs to a different org', () => {
+      mockAuth([], { userTier: 'org', orgId: 'orono' });
+      render(<AnnouncementOverlay />);
+      emitAnnouncements([{ ...BASE_ANNOUNCEMENT, orgId: 'other-district' }]);
+      expect(screen.queryByText('Test Announcement')).not.toBeInTheDocument();
+    });
+
+    it('shows legacy docs but hides foreign-org docs in the same snapshot', () => {
+      mockAuth([], { userTier: 'internal', orgId: 'orono' });
+      render(<AnnouncementOverlay />);
+      const legacy: Announcement = {
+        ...BASE_ANNOUNCEMENT,
+        id: 'ann-legacy',
+        name: 'Legacy Broadcast',
+      };
+      const foreign: Announcement = {
+        ...BASE_ANNOUNCEMENT,
+        id: 'ann-foreign',
+        name: 'Foreign Org',
+        orgId: 'other-district',
+      };
+      emitAnnouncements([legacy, foreign]);
+      expect(screen.getByText('Legacy Broadcast')).toBeInTheDocument();
+      expect(screen.queryByText('Foreign Org')).not.toBeInTheDocument();
+    });
   });
 });

--- a/tests/components/widgets/QuizResults.regenerate.test.tsx
+++ b/tests/components/widgets/QuizResults.regenerate.test.tsx
@@ -23,6 +23,8 @@ vi.mock('@/context/useAuth', () => ({
     googleAccessToken: 'token-1',
     user: { uid: 'user-1' },
     orgId: null,
+    // Non-external user so the Export-to-Sheets affordance under test renders.
+    isExternalUser: false,
   }),
 }));
 const clearPlcSharedSheetUrl = vi.fn().mockResolvedValue(undefined);

--- a/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
+++ b/tests/components/widgets/QuizResults.schemaMismatch.test.tsx
@@ -22,6 +22,8 @@ vi.mock('@/context/useAuth', () => ({
     googleAccessToken: 'token-1',
     user: { uid: 'user-1' },
     orgId: null,
+    // Non-external user so the Export-to-Sheets affordance under test renders.
+    isExternalUser: false,
   }),
 }));
 vi.mock('@/hooks/usePlcs', () => ({

--- a/tests/components/widgets/QuizResults.soloReExport.test.tsx
+++ b/tests/components/widgets/QuizResults.soloReExport.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/context/useAuth', () => ({
     googleAccessToken: 'token-1',
     user: { uid: 'teacher-self' },
     orgId: null,
+    // Export-to-Sheets is hidden for external (free-tier) users; this suite
+    // exercises the export path, so the user is a non-external (org/internal)
+    // teacher who has the feature.
+    isExternalUser: false,
   }),
 }));
 vi.mock('@/hooks/usePlcs', () => ({

--- a/tests/context/AuthContext.userTier.test.tsx
+++ b/tests/context/AuthContext.userTier.test.tsx
@@ -22,6 +22,17 @@ vi.mock('firebase/auth', async () => {
   };
 });
 
+// `resolveOrgIdForUser` calls the `resolveOrgForUser` callable. By default we
+// make it reject so the membership effect takes its operator-org fallback (the
+// path every existing org-member test relies on). Individual tests can override
+// `httpsCallableImpl` — e.g. the "membership still resolving" case below returns
+// a never-settling promise so `membershipResolved` stays false.
+let httpsCallableImpl: () => Promise<{ data: { orgId: string | null } }> = () =>
+  Promise.reject(new Error('callable unavailable in test'));
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => () => httpsCallableImpl(),
+}));
+
 vi.mock('firebase/firestore', () => ({
   doc: vi.fn((_db: unknown, ...segments: string[]) => ({
     __path: segments.join('/'),
@@ -54,7 +65,10 @@ function getCtx(): AuthContextType {
   return ctxHolder.current;
 }
 
-function buildFakeUser(email: string): User {
+function buildFakeUser(
+  email: string,
+  claims: Record<string, unknown> = {}
+): User {
   return {
     uid: 'test-uid',
     email,
@@ -70,7 +84,7 @@ function buildFakeUser(email: string): User {
     delete: vi.fn(),
     getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
     getIdTokenResult: vi.fn().mockResolvedValue({
-      claims: {},
+      claims,
       authTime: '',
       issuedAtTime: '',
       expirationTime: '',
@@ -157,6 +171,8 @@ async function mountAs(opts: {
   isOrgMember?: boolean;
   globalPerms?: GlobalFeaturePermission[];
   featurePerms?: FeaturePermission[];
+  /** Custom claims to stamp on the fake user's ID token (e.g. studentRole). */
+  claims?: Record<string, unknown>;
 }): Promise<void> {
   ctxHolder.current = null;
   setupGetDoc({ adminEmail: opts.isAdmin ? opts.email : null });
@@ -179,7 +195,7 @@ async function mountAs(opts: {
   const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
   if (!lastCall) throw new Error('onAuthStateChanged was never called');
   const listener = lastCall[1] as (u: User | null) => void;
-  const user = buildFakeUser(opts.email);
+  const user = buildFakeUser(opts.email, opts.claims);
   Object.defineProperty(auth, 'currentUser', {
     configurable: true,
     writable: true,
@@ -199,6 +215,10 @@ async function mountAs(opts: {
 beforeEach(() => {
   vi.clearAllMocks();
   ctxHolder.current = null;
+  // Default: the org-resolver callable rejects, so the membership effect falls
+  // back to the operator org and `deliverSnapshots` drives `membershipResolved`.
+  httpsCallableImpl = () =>
+    Promise.reject(new Error('callable unavailable in test'));
 });
 
 const INTERNAL_EMAIL = 'teacher@orono.k12.mn.us';
@@ -232,12 +252,40 @@ describe('AuthContext — minTier on canAccessFeature', () => {
     ...(minTier ? { minTier } : {}),
   });
 
-  it('defaults to available when no doc exists', async () => {
+  it('defaults to default-public for a pre-tier feature with no doc', async () => {
+    // `live-session` has no `defaultMinTier`, so the missing-doc path is the
+    // historical public-by-default behavior even for a free-tier external.
     await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().canAccessFeature('live-session')).toBe(true);
+  });
+
+  it('default-denies google-classroom for a free user when no doc exists', async () => {
+    // W5 / wide-distro Phase 3: Google-API-backed features carry an in-code
+    // `defaultMinTier: 'org'`, so the missing-doc path now denies free-tier
+    // users without an admin authoring a doc.
+    await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().canAccessFeature('google-classroom')).toBe(false);
+  });
+
+  it('default-allows google-classroom for an org member when no doc exists', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL, isOrgMember: true });
+    expect(getCtx().canAccessFeature('google-classroom')).toBe(true);
+  });
+
+  it('default-allows google-classroom for an internal user when no doc exists', async () => {
+    await mountAs({ email: INTERNAL_EMAIL });
+    expect(getCtx().canAccessFeature('google-classroom')).toBe(true);
+  });
+
+  it('admin bypasses the default google-classroom tier floor (no doc)', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL, isAdmin: true });
     expect(getCtx().canAccessFeature('google-classroom')).toBe(true);
   });
 
   it('undefined minTier keeps existing docs unrestricted (back-compat)', async () => {
+    // An admin-persisted doc with no `minTier` is authoritative and imposes no
+    // floor — the in-code `defaultMinTier` applies ONLY to the missing-doc
+    // path, so a real doc without minTier stays unrestricted even for free.
     await mountAs({ email: EXTERNAL_EMAIL, globalPerms: [gated(undefined)] });
     expect(getCtx().canAccessFeature('google-classroom')).toBe(true);
   });
@@ -334,5 +382,104 @@ describe('AuthContext — minTier on canAccessWidget', () => {
       featurePerms: [widgetPerm('internal')],
     });
     expect(getCtx().canAccessWidget('clock')).toBe(true);
+  });
+
+  it('default-denies the calendar (Events) widget for a free user (no doc)', async () => {
+    // W5 / wide-distro Phase 3: `WIDGET_DEFAULT_MIN_TIER.calendar = 'org'`, so
+    // the Google-Calendar-backed widget is denied to free-tier users on the
+    // missing-doc path without an admin authoring a permission doc.
+    await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().canAccessWidget('calendar')).toBe(false);
+  });
+
+  it('default-allows the calendar widget for an org member (no doc)', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL, isOrgMember: true });
+    expect(getCtx().canAccessWidget('calendar')).toBe(true);
+  });
+
+  it('default-allows the calendar widget for an internal user (no doc)', async () => {
+    await mountAs({ email: INTERNAL_EMAIL });
+    expect(getCtx().canAccessWidget('calendar')).toBe(true);
+  });
+
+  it('admin bypasses the default calendar tier floor (no doc)', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL, isAdmin: true });
+    expect(getCtx().canAccessWidget('calendar')).toBe(true);
+  });
+
+  it('leaves a pre-tier widget (clock) public by default for free (no doc)', async () => {
+    // `clock` has no WIDGET_DEFAULT_MIN_TIER entry, so the historical
+    // public-by-default behavior is unchanged for free-tier users.
+    await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().canAccessWidget('clock')).toBe(true);
+  });
+});
+
+describe('AuthContext — isExternalUser / hasOrg', () => {
+  it('is external for a fully-resolved free user with no org', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().isExternalUser).toBe(true);
+    expect(getCtx().hasOrg).toBe(false);
+  });
+
+  it('is NOT external for an org member', async () => {
+    await mountAs({ email: EXTERNAL_EMAIL, isOrgMember: true });
+    expect(getCtx().isExternalUser).toBe(false);
+    expect(getCtx().hasOrg).toBe(true);
+  });
+
+  it('is NOT external for an internal (Orono) user', async () => {
+    // Orono resolves an org member doc, so hasOrg is true and isExternalUser
+    // is false — internal users must notice zero change.
+    await mountAs({ email: INTERNAL_EMAIL, isOrgMember: true });
+    expect(getCtx().isExternalUser).toBe(false);
+    expect(getCtx().hasOrg).toBe(true);
+  });
+
+  it('is NOT external while org membership is still resolving (no-flicker guard)', async () => {
+    // The org-resolver callable never settles, so `subscribeToMembership` is
+    // never reached and `membershipResolved` stays false — the in-flight
+    // loading window. An Orono member sits here briefly on every load, and
+    // `isExternalUser` must stay false the whole time so their org surfaces
+    // (My PLCs / My Building(s)) never blink off. `hasOrg` is also false here
+    // because `orgId` hasn't resolved yet — which is exactly why callers must
+    // prefer `isExternalUser` over `!hasOrg` to gate org-only UI.
+    // A promise that never settles — keeps the membership effect mid-resolve.
+    httpsCallableImpl = () =>
+      new Promise(() => {
+        /* never resolves or rejects */
+      });
+    await mountAs({ email: EXTERNAL_EMAIL });
+    expect(getCtx().isExternalUser).toBe(false);
+    expect(getCtx().hasOrg).toBe(false);
+  });
+
+  it('is NOT external for an SSO student even with a resolved no-org membership', async () => {
+    // A `studentRole: true` token claim marks an SSO student. Their membership
+    // resolves to orgId=null (no member doc), which would satisfy the first two
+    // conditions — but the `!isStudentRole` guard keeps them out of the
+    // external bucket so student sessions never hit the external-user gates.
+    await mountAs({ email: EXTERNAL_EMAIL, claims: { studentRole: true } });
+    await waitFor(() => {
+      expect(getCtx().isStudentRole).toBe(true);
+    });
+    expect(getCtx().hasOrg).toBe(false);
+    expect(getCtx().isExternalUser).toBe(false);
+  });
+
+  it('is NOT external for a member-doc-less Orono user (internal tier, orgId null)', async () => {
+    // The decisive zero-change guard. A brand-new / not-yet-backfilled Orono
+    // teacher has no `members/{email}` doc yet, so membership resolves with
+    // orgId=null — but their email DOMAIN still derives userTier='internal'.
+    // The `userTier === 'free'` condition keeps them OUT of the external bucket,
+    // so their org surfaces are never hidden even before a member doc exists.
+    // Without that guard, orgId===null alone would wrongly classify them
+    // external and hide My PLCs / My Building(s) / etc. — a real regression.
+    await mountAs({ email: INTERNAL_EMAIL });
+    await waitFor(() => {
+      expect(getCtx().userTier).toBe('internal');
+    });
+    expect(getCtx().hasOrg).toBe(false);
+    expect(getCtx().isExternalUser).toBe(false);
   });
 });

--- a/tests/hooks/usePlcs.test.ts
+++ b/tests/hooks/usePlcs.test.ts
@@ -432,8 +432,12 @@ function render() {
 
 describe('usePlcs - createPlc writes the members map + indexes', () => {
   it('writes members map, denormalized indexes, and serverTimestamps', async () => {
+    // An org member (orgId set) — createPlc requires a non-null orgId (W2).
+    // Building resolution is exercised separately below; here neither a UI
+    // selection nor an org-assigned building is present, so buildingId is null.
     useAuthMock.mockReturnValue({
       user: { uid: LEAD_UID, email: 'Lead@X.com', displayName: 'Lead' },
+      orgId: 'orono',
     } as ReturnType<typeof useAuthMock>);
     mockCollection.mockReturnValue('plcs');
     mockDoc.mockReturnValue('plcs/new-id');
@@ -458,8 +462,33 @@ describe('usePlcs - createPlc writes the members map + indexes', () => {
     // All timestamps are serverTimestamp(), not Date.now() numbers.
     expect(payload.createdAt).toBe(SERVER_TS);
     expect(payload.updatedAt).toBe(SERVER_TS);
-    expect(payload.orgId).toBeNull();
+    expect(payload.orgId).toBe('orono');
+    // No UI-selected or org-assigned building ⇒ untenanted building.
     expect(payload.buildingId).toBeNull();
+  });
+
+  it('refuses to create an untenanted PLC for a no-org caller (W2)', async () => {
+    // A fully-resolved no-org caller: createPlc is defense-in-depth and must
+    // reject rather than write an org-less PLC. The hook destructures
+    // `orgId = null`, so omitting orgId from the mock reproduces the real
+    // no-org case. The sync throw inside the async callback rejects its promise.
+    useAuthMock.mockReturnValue({
+      user: { uid: LEAD_UID, email: 'Lead@X.com', displayName: 'Lead' },
+    } as ReturnType<typeof useAuthMock>);
+    mockCollection.mockReturnValue('plcs');
+    mockDoc.mockReturnValue('plcs/new-id');
+    mockSetDoc.mockResolvedValue(undefined);
+
+    const { result } = render();
+
+    await expect(
+      act(async () => {
+        await result.current.createPlc('My PLC');
+      })
+    ).rejects.toThrow('plc.errors.orgRequired');
+
+    // No Firestore write happened — the guard fired before setDoc.
+    expect(mockSetDoc).not.toHaveBeenCalled();
   });
 
   it('inherits the creator org + building so the PLC is discoverable', async () => {

--- a/tests/rules/firestore-rules-external-user.test.ts
+++ b/tests/rules/firestore-rules-external-user.test.ts
@@ -1,0 +1,366 @@
+// Firestore security-rules tests for the no-org (external) user persona.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+// which wraps this file in `firebase emulators:exec --only firestore`.
+//
+// Background — external-availability rollout (work item W9):
+// The app is opening up beyond Orono. A signed-in Google user whose email
+// domain maps to NO organization resolves, in the client, to userTier 'free'
+// with orgId === null. From the security-rules' point of view this person is
+// simply an authenticated user who is NOT a member of any org (no
+// `/organizations/{orgId}/members/{email}` doc exists for them) and is neither
+// an admin nor a super admin. There is no separate "external" flag in the
+// rules — `isOrgMember()` only checks for the existence of a member doc — so
+// this persona is the absence of membership, full stop.
+//
+// HARD CONSTRAINT (unchanged for Orono): existing org/internal users must see
+// ZERO behavior change. This suite is purely additive — it pins down what the
+// no-org persona CAN and CANNOT do without touching the rules themselves.
+//
+// Covers, for a signed-in user whose email domain maps to no org:
+//   - CAN CRUD their OWN /users/{uid}/** subcollections (dashboards, rosters,
+//     quizzes, notebooks, …).
+//   - CAN read the global/shared catalogs the app reads for everyone
+//     (feature_permissions, global_permissions, instructional_routines,
+//     dashboard_templates, global_video_activities, global_pdfs,
+//     global_mini_apps, a public custom_widget, and getById on
+//     shared_quizzes / shared_assignments / synced_quizzes).
+//   - CANNOT read another org's /organizations/** subtree (members, buildings,
+//     domains, invitations) — EXCEPT the own-absent-member self-probe, which
+//     mirrors the existing organizations suite (useAuth bootstraps with it).
+//   - Announcements: CAN read a legacy announcement with NO orgId; CANNOT read
+//     an announcement whose orgId belongs to an org they're not in; a member
+//     of that org CAN.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, updateDoc, deleteDoc, getDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-rules-test';
+const ORG_ID = 'orono';
+
+// The external persona: a signed-in Google user whose email domain maps to NO
+// organization. They have no member doc anywhere, are not an admin, and are
+// not a super admin → the client resolves them to orgId=null / tier 'free'.
+const EXTERNAL_UID = 'external-uid';
+const EXTERNAL_EMAIL = 'teacher@noorg.example.com';
+
+// An org member of `orono`, used to contrast announcement visibility.
+const MEMBER_UID = 'member-uid';
+const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
+
+// ESM-safe path resolution — the repo is `"type": "module"`, so __dirname is
+// not defined and we locate firestore.rules via import.meta.url instead.
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+
+  // Seed everything the read-path assertions depend on using a privileged
+  // (rules-disabled) context: an org with one member, the global/shared
+  // catalogs, and three announcement variants.
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+
+    // --- Org `orono` with a single member (NOT the external user). ---
+    await setDoc(doc(db, `organizations/${ORG_ID}`), {
+      id: ORG_ID,
+      name: 'Orono',
+      plan: 'full',
+      aiEnabled: true,
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`), {
+      email: MEMBER_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'teacher',
+      status: 'active',
+      buildingIds: ['high'],
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/buildings/high`), {
+      id: 'high',
+      orgId: ORG_ID,
+      name: 'Orono High',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/domains/primary`), {
+      id: 'primary',
+      orgId: ORG_ID,
+      domain: '@orono.k12.mn.us',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/invitations/token-1`), {
+      email: 'invitee@orono.k12.mn.us',
+      orgId: ORG_ID,
+    });
+
+    // --- Global / shared catalogs the app reads for everyone. ---
+    await setDoc(doc(db, 'feature_permissions/time-tool'), {
+      accessLevel: 'public',
+      enabled: true,
+    });
+    await setDoc(doc(db, 'global_permissions/some-feature'), {
+      enabled: true,
+    });
+    await setDoc(doc(db, 'instructional_routines/routine-1'), {
+      name: 'Think-Pair-Share',
+    });
+    await setDoc(doc(db, 'dashboard_templates/template-1'), {
+      name: 'Morning Meeting',
+    });
+    await setDoc(doc(db, 'global_video_activities/activity-1'), {
+      title: 'Photosynthesis',
+    });
+    await setDoc(doc(db, 'global_pdfs/pdf-1'), {
+      title: 'Lab Safety',
+    });
+    await setDoc(doc(db, 'global_mini_apps/app-1'), {
+      title: 'Fraction Tiles',
+    });
+    // custom_widgets read is conditional: published + enabled + public.
+    await setDoc(doc(db, 'custom_widgets/widget-1'), {
+      published: true,
+      enabled: true,
+      accessLevel: 'public',
+      betaUsers: [],
+    });
+    // share/synced catalogs expose a per-id `get` (not `list`); seed one of each.
+    await setDoc(doc(db, 'shared_quizzes/share-1'), {
+      originalAuthor: 'some-author-uid',
+      title: 'Shared Quiz',
+    });
+    await setDoc(doc(db, 'shared_assignments/share-2'), {
+      originalAuthor: 'some-author-uid',
+      title: 'Shared Assignment',
+    });
+    await setDoc(doc(db, 'synced_quizzes/group-1'), {
+      id: 'group-1',
+      version: 1,
+      title: 'Synced Quiz',
+      questions: [],
+      participants: { 'some-author-uid': { joinedAt: 0 } },
+      updatedBy: 'some-author-uid',
+    });
+
+    // --- Announcements: three visibility variants. ---
+    // Legacy doc (no orgId) — readable by ANY authenticated user.
+    await setDoc(doc(db, 'announcements/legacy'), {
+      title: 'Legacy announcement',
+      body: 'No orgId field — predates tenant isolation.',
+    });
+    // Org-scoped doc — readable only by a member of `orono` (or an admin).
+    await setDoc(doc(db, 'announcements/orono-scoped'), {
+      title: 'Orono only',
+      body: 'Scoped to the orono org.',
+      orgId: ORG_ID,
+    });
+  });
+});
+
+const asExternal = () =>
+  testEnv
+    .authenticatedContext(EXTERNAL_UID, { email: EXTERNAL_EMAIL })
+    .firestore();
+const asMember = () =>
+  testEnv.authenticatedContext(MEMBER_UID, { email: MEMBER_EMAIL }).firestore();
+
+// Path to the external user's own user-scoped subtree.
+const ownDoc = (db: ReturnType<typeof asExternal>, subpath: string) =>
+  doc(db, `users/${EXTERNAL_UID}/${subpath}`);
+
+describe('external (no-org) user — owns their /users/{uid}/** subtree', () => {
+  it('can create, read, update, and delete their own dashboard', async () => {
+    const db = asExternal();
+    const ref = ownDoc(db, 'dashboards/dash-1');
+    await assertSucceeds(
+      setDoc(ref, { id: 'dash-1', name: 'My Board', widgets: [] })
+    );
+    await assertSucceeds(getDoc(ref));
+    await assertSucceeds(updateDoc(ref, { name: 'Renamed' }));
+    await assertSucceeds(deleteDoc(ref));
+  });
+
+  it('can CRUD their own rosters', async () => {
+    const db = asExternal();
+    const ref = ownDoc(db, 'rosters/roster-1');
+    await assertSucceeds(setDoc(ref, { id: 'roster-1', name: 'Period 1' }));
+    await assertSucceeds(getDoc(ref));
+    await assertSucceeds(deleteDoc(ref));
+  });
+
+  it('can CRUD their own quizzes', async () => {
+    const db = asExternal();
+    const ref = ownDoc(db, 'quizzes/quiz-1');
+    await assertSucceeds(setDoc(ref, { id: 'quiz-1', title: 'Pop Quiz' }));
+    await assertSucceeds(getDoc(ref));
+    await assertSucceeds(deleteDoc(ref));
+  });
+
+  it('can CRUD their own notebooks', async () => {
+    const db = asExternal();
+    const ref = ownDoc(db, 'notebooks/note-1');
+    await assertSucceeds(setDoc(ref, { id: 'note-1', title: 'Notes' }));
+    await assertSucceeds(getDoc(ref));
+    await assertSucceeds(deleteDoc(ref));
+  });
+
+  it("cannot read or write ANOTHER user's /users/{uid}/** subtree", async () => {
+    const db = asExternal();
+    await assertFails(
+      getDoc(doc(db, `users/${MEMBER_UID}/dashboards/their-dash`))
+    );
+    await assertFails(
+      setDoc(doc(db, `users/${MEMBER_UID}/dashboards/their-dash`), {
+        id: 'their-dash',
+        name: 'Hijack',
+        widgets: [],
+      })
+    );
+  });
+});
+
+describe('external (no-org) user — reads global/shared catalogs', () => {
+  it('can read feature_permissions and global_permissions', async () => {
+    const db = asExternal();
+    await assertSucceeds(getDoc(doc(db, 'feature_permissions/time-tool')));
+    await assertSucceeds(getDoc(doc(db, 'global_permissions/some-feature')));
+  });
+
+  it('can read instructional_routines and dashboard_templates', async () => {
+    const db = asExternal();
+    await assertSucceeds(getDoc(doc(db, 'instructional_routines/routine-1')));
+    await assertSucceeds(getDoc(doc(db, 'dashboard_templates/template-1')));
+  });
+
+  it('can read the global video-activity / pdf / mini-app libraries', async () => {
+    const db = asExternal();
+    await assertSucceeds(getDoc(doc(db, 'global_video_activities/activity-1')));
+    await assertSucceeds(getDoc(doc(db, 'global_pdfs/pdf-1')));
+    await assertSucceeds(getDoc(doc(db, 'global_mini_apps/app-1')));
+  });
+
+  it('can read a published+enabled+public custom widget', async () => {
+    await assertSucceeds(getDoc(doc(asExternal(), 'custom_widgets/widget-1')));
+  });
+
+  it('can get-by-id shared_quizzes, shared_assignments, and synced_quizzes', async () => {
+    const db = asExternal();
+    await assertSucceeds(getDoc(doc(db, 'shared_quizzes/share-1')));
+    await assertSucceeds(getDoc(doc(db, 'shared_assignments/share-2')));
+    await assertSucceeds(getDoc(doc(db, 'synced_quizzes/group-1')));
+  });
+
+  it('cannot WRITE to any admin-owned global catalog', async () => {
+    const db = asExternal();
+    await assertFails(
+      setDoc(doc(db, 'feature_permissions/time-tool'), {
+        accessLevel: 'admin',
+        enabled: false,
+      })
+    );
+    await assertFails(
+      setDoc(doc(db, 'instructional_routines/sneaky'), { name: 'Nope' })
+    );
+    await assertFails(
+      setDoc(doc(db, 'dashboard_templates/sneaky'), { name: 'Nope' })
+    );
+  });
+});
+
+describe("external (no-org) user — cannot read another org's subtree", () => {
+  it('cannot read the org doc', async () => {
+    await assertFails(getDoc(doc(asExternal(), `organizations/${ORG_ID}`)));
+  });
+
+  it('cannot read org buildings, domains, or roles', async () => {
+    const db = asExternal();
+    await assertFails(
+      getDoc(doc(db, `organizations/${ORG_ID}/buildings/high`))
+    );
+    await assertFails(
+      getDoc(doc(db, `organizations/${ORG_ID}/domains/primary`))
+    );
+  });
+
+  it("cannot read another user's member doc", async () => {
+    await assertFails(
+      getDoc(
+        doc(asExternal(), `organizations/${ORG_ID}/members/${MEMBER_EMAIL}`)
+      )
+    );
+  });
+
+  it('cannot read org invitations (Cloud-Function-only collection)', async () => {
+    await assertFails(
+      getDoc(doc(asExternal(), `organizations/${ORG_ID}/invitations/token-1`))
+    );
+  });
+
+  it('CAN read their own (absent) member doc to bootstrap useAuth', async () => {
+    // Mirrors the organizations suite: the self-probe branch lets a non-member
+    // read members/{their-own-email} (which does not exist) so useAuth can
+    // resolve them to orgId=null rather than hard-failing on a denied read.
+    await assertSucceeds(
+      getDoc(
+        doc(
+          asExternal(),
+          `organizations/${ORG_ID}/members/${EXTERNAL_EMAIL.toLowerCase()}`
+        )
+      )
+    );
+  });
+});
+
+describe('external (no-org) user — announcement tenant scoping', () => {
+  it('CAN read a legacy announcement with no orgId', async () => {
+    await assertSucceeds(getDoc(doc(asExternal(), 'announcements/legacy')));
+  });
+
+  it("CANNOT read an announcement scoped to an org they're not in", async () => {
+    await assertFails(getDoc(doc(asExternal(), 'announcements/orono-scoped')));
+  });
+
+  it('a member of that org CAN read the org-scoped announcement', async () => {
+    await assertSucceeds(getDoc(doc(asMember(), 'announcements/orono-scoped')));
+  });
+
+  it('the org member can also read the legacy announcement', async () => {
+    // Sanity: legacy docs stay readable for everyone, member included.
+    await assertSucceeds(getDoc(doc(asMember(), 'announcements/legacy')));
+  });
+
+  it('the external user cannot write announcements (admin-only)', async () => {
+    await assertFails(
+      setDoc(doc(asExternal(), 'announcements/spoof'), {
+        title: 'Spoof',
+        body: 'nope',
+      })
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -6543,6 +6543,17 @@ export interface Announcement {
   updatedAt: number;
   /** Email of the admin who created/last modified this announcement */
   createdBy: string;
+  /**
+   * The organization this announcement belongs to (multi-tenant isolation).
+   * Stamped to the creating admin's `orgId` at create time (Orono = 'orono').
+   * OMITTED for legacy docs created before org-isolation shipped — an absent
+   * value is treated as operator-org/global and stays visible to all
+   * authenticated users (the overlay's client filter and the Firestore read
+   * rule both keep legacy docs readable, preserving existing behavior).
+   * A backfill script (scripts/migrateAnnouncements.js) stamps 'orono' onto
+   * every legacy doc before the External launch.
+   */
+  orgId?: string;
 }
 
 export const DEFAULT_GLOBAL_STYLE: GlobalStyle = {


### PR DESCRIPTION
## Summary
Opens SpartBoard to **open self-serve external (non-org / free-tier) Google users** with org-only surfaces hidden, AI rate-limited, and announcements tenant-isolated — with **ZERO behavior change for existing Orono org/internal users**. Every gate keys on `isExternalUser`/`userTier`/`orgId` (all of which resolve non-external for Orono) and treats the membership-loading window as not-external.

Builds on the already-shipped wide-distro work (dynamic org resolution, `internal|org|free` tier model, public landing). Full plan, decisions, and **launch gates** live in [`docs/external-availability-journal.md`](https://github.com/OPS-PIvers/SpartBoard/blob/feat/external-availability-rollout/docs/external-availability-journal.md).

## Work items
- **W1** AuthContext exposes `isExternalUser` (`membershipResolved && orgId===null && userTier==='free' && !isStudentRole`) + `hasOrg`; Sidebar hides My Classes/ClassLink, PLCs, Buildings, What's New, Google Drive for external users.
- **W2** `usePlcs.createPlc` refuses orgless PLC creation.
- **W3** `useAdminBuildings` returns `[]` for no-org users (stops the Orono building-seed leak); ShareLinkCreatorModal seed fallback gated on `hasOrg`.
- **W4** `useClassLinkEnabled` false when `orgId===null` (keyed on org, not building — Orono teachers without a selected building are unaffected).
- **W5** default-deny Google-API features for free tier via `defaultMinTier`/`WIDGET_DEFAULT_MIN_TIER` on the missing-doc path (calendar widget, google-classroom, ai-file-context) + hide Sheets-export affordances; pre-tier docs stay unrestricted (back-compat).
- **W6** `/announcements` org-isolation: `Announcement.orgId`; create stamps + edit self-heals the admin's org; overlay listener gated to `userTier!=='free'` + render guard + client tenant filter; `firestore.rules` read tightened (legacy docs stay readable; org-stamped readable by members/admins only); `scripts/migrateAnnouncements.js` backfill **(NOT run)**. `MULTI-TENANT TODO`: scope the listener query before a 2nd org has active announcements.
- **W7** `functions/aiGeneration.ts`: external/no-org callers get a lower daily AI cap (`DEFAULT_EXTERNAL_DAILY_LIMIT=5` / `config.externalDailyLimit`) via cached `resolveOrgIdForDomain` over the verified token, **fail-safe toward the org path**; admins exempt; org users unchanged.
- **W9** `tests/rules/firestore-rules-external-user.test.ts` (no-org persona).
- **W10** `/privacy` + `/terms` external-eligibility **DRAFT** copy (gated on counsel, not published) + legal-review + OAuth verification runbook docs.

## Validation
`type-check:all`, `lint` (--max-warnings 0), `format:check`, `build`, and **6,440 unit tests** (root 5,747 + functions 693) all green. `test:rules` pending CI (no local emulator). Two adversarial reviews: **zero Orono zero-change violations, no open data leak**.

## Safe to land now
The `firestore.rules` change is **dormant** (no prod announcement has `orgId` yet → all stay legacy-readable, identical to today); the W7 functions change is fail-safe toward the org path; external users **cannot sign in at all** until the OAuth consent screen flips. See the journal's **Launch gates** for the gated, Paul-owned steps (district counsel sign-off, OAuth verification, `CLASSROOM_ASSIGN_ENABLED`, announcements backfill, `dev-paul → main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)