### PR TITLE
fix(D4): @/ alias for cross-subdir imports in plc/meeting and plc/bodies

### DIFF
--- a/components/plc/bodies/NotesDocsBody.tsx
+++ b/components/plc/bodies/NotesDocsBody.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { FileText, StickyNote } from 'lucide-react';
 import type { Plc } from '@/types';
 import { NotesBody } from './NotesBody';
-import { PlcDocsBody } from '../docs/PlcDocsBody';
+import { PlcDocsBody } from '@/components/plc/docs/PlcDocsBody';
 
 interface NotesDocsBodyProps {
   plc: Plc;

--- a/components/plc/meeting/PlcMeetingMode.tsx
+++ b/components/plc/meeting/PlcMeetingMode.tsx
@@ -69,13 +69,13 @@ import {
   latestContributionByAggregateId,
   type AssessmentDataCard,
   type SharedDataTeamMember,
-} from '../sharedData/sharedDataSelectors';
+} from '@/components/plc/sharedData/sharedDataSelectors';
 import {
   exportPlcMeeting,
   type PlcMeetingExportContext,
   type PlcMeetingExportFormat,
 } from '@/utils/plcMeetingExport';
-import type { PlcSectionId } from '../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 import { PlcMeetingReviewCard } from './PlcMeetingReviewCard';
 import {
   MeetingStepRail,

--- a/components/plc/meeting/PlcMeetingRecordView.tsx
+++ b/components/plc/meeting/PlcMeetingRecordView.tsx
@@ -40,7 +40,7 @@ import {
 } from '@/context/usePlcContext';
 import { usePlcMeetings } from '@/hooks/usePlcMeetings';
 import { buildPlcPath, spaNavigate } from '@/utils/plcPath';
-import { weakestQuestions } from '../sharedData/sharedDataSelectors';
+import { weakestQuestions } from '@/components/plc/sharedData/sharedDataSelectors';
 import { MeetingExportButtons } from './PlcMeetingMode';
 
 function scoreToneClass(percent: number): string {

--- a/components/plc/meeting/PlcMeetingReviewCard.tsx
+++ b/components/plc/meeting/PlcMeetingReviewCard.tsx
@@ -33,7 +33,7 @@ import {
   Video,
 } from 'lucide-react';
 import { PlcCommentsThread } from '@/components/plc/comments/PlcCommentsThread';
-import type { AssessmentDataCard } from '../sharedData/sharedDataSelectors';
+import type { AssessmentDataCard } from '@/components/plc/sharedData/sharedDataSelectors';
 
 /** Calm, glanceable score tone — shared with the Shared Data palette. */
 function scoreToneClass(percent: number): string {

--- a/components/plc/meeting/PlcMeetingSteps.tsx
+++ b/components/plc/meeting/PlcMeetingSteps.tsx
@@ -31,7 +31,7 @@ import type { PlcMeeting } from '@/types';
 import type {
   AssessmentDataCard,
   SharedDataTeamMember,
-} from '../sharedData/sharedDataSelectors';
+} from '@/components/plc/sharedData/sharedDataSelectors';
 
 // ---------------------------------------------------------------------------
 // Step model + rail


### PR DESCRIPTION
## Canonical Form

Use `@/components/plc/...` for all cross-subdirectory imports within `components/plc/`. Relative `'../sibling-dir/...'` imports crossing from one plc/ subdirectory into another are the anti-pattern (same issue previously fixed in run 7, PR #1823 for tabs↔bodies).

## Instances Unified

6 import paths in 5 newly added files (PLC Wave 3/4, committed since 2026-06-15):

| File | Line | Before | After |
|------|------|--------|-------|
| `components/plc/meeting/PlcMeetingMode.tsx` | 72 | `'../sharedData/sharedDataSelectors'` | `'@/components/plc/sharedData/sharedDataSelectors'` |
| `components/plc/meeting/PlcMeetingMode.tsx` | 78 | `'../sections'` | `'@/components/plc/sections'` |
| `components/plc/meeting/PlcMeetingRecordView.tsx` | 43 | `'../sharedData/sharedDataSelectors'` | `'@/components/plc/sharedData/sharedDataSelectors'` |
| `components/plc/meeting/PlcMeetingReviewCard.tsx` | 36 | `'../sharedData/sharedDataSelectors'` | `'@/components/plc/sharedData/sharedDataSelectors'` |
| `components/plc/meeting/PlcMeetingSteps.tsx` | 34 | `'../sharedData/sharedDataSelectors'` | `'@/components/plc/sharedData/sharedDataSelectors'` |
| `components/plc/bodies/NotesDocsBody.tsx` | 6 | `'../docs/PlcDocsBody'` | `'@/components/plc/docs/PlcDocsBody'` |

Same-directory `./` imports were correctly left unchanged (D4-E1).

## Enforcement

None added beyond the existing pattern: D4 staleness checks catch regressions on newly added files each nightly run. These violations were detected 8 days after the files were merged.

## Behavior-Preservation Evidence

- Pure import path substitutions — no logic changes whatsoever
- `pnpm exec tsc --noEmit`: 0 errors (clean output)
- `pnpm run validate`: exit code 0 (697 tests passing)
- Pre-commit hook (lint-staged) ran cleanly on commit

## Risk Tag

**mechanical** — pure path equivalence; TypeScript verified the targets resolve correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxXyR8Zs7HVEeyvYaXuKC7)_