### PR TITLE
docs(skill): fix admin-widget-config reference to SpecialistSchedule Settings path

### DIFF
--- a/.agents/skills/admin-widget-config/SKILL.md
+++ b/.agents/skills/admin-widget-config/SKILL.md
@@ -182,7 +182,7 @@ When a widget is added to a dashboard, its initial `config` is typically populat
 1. The user's `selectedBuildings[0]` from `useAuth()`
 2. The `featurePermissions` array from `useAuth()` → find the permission for the widget type → read `.config.buildingDefaults[buildingId]`
 
-Make sure the widget's initialization code in `DashboardContext.tsx` or the widget component itself reads from `featurePermissions`. Reference how `SpecialistScheduleSettings.tsx` reads `featurePermissions` for a working example:
+Make sure the widget's initialization code in `DashboardContext.tsx` or the widget component itself reads from `featurePermissions`. Reference how `components/widgets/SpecialistSchedule/Settings.tsx` reads `featurePermissions` for a working example:
 ```tsx
 const globalConfig = useMemo(() => {
   const perm = featurePermissions.find(p => p.widgetType === 'your-widget-type');

--- a/.claude/skills/admin-widget-config/SKILL.md
+++ b/.claude/skills/admin-widget-config/SKILL.md
@@ -219,7 +219,7 @@ When a widget is added to a dashboard, its initial `config` is typically populat
 1. The user's `selectedBuildings[0]` from `useAuth()`
 2. The `featurePermissions` array from `useAuth()` → find the permission for the widget type → read `.config.buildingDefaults[buildingId]`
 
-Make sure the widget's initialization code in `DashboardContext.tsx` or the widget component itself reads from `featurePermissions`. Reference how `SpecialistScheduleSettings.tsx` reads `featurePermissions` for a working example:
+Make sure the widget's initialization code in `DashboardContext.tsx` or the widget component itself reads from `featurePermissions`. Reference how `components/widgets/SpecialistSchedule/Settings.tsx` reads `featurePermissions` for a working example:
 
 ```tsx
 const globalConfig = useMemo(() => {


### PR DESCRIPTION
## Summary

Resolves the MEDIUM skill-freshness journal item (detected 2026-04-14): the `admin-widget-config` skill referenced a non-existent file `SpecialistScheduleSettings.tsx` as its working example of reading `featurePermissions` in a widget settings component.

No file named `SpecialistScheduleSettings.tsx` exists anywhere in the codebase. The actual file is `components/widgets/SpecialistSchedule/Settings.tsx` (verified to read `featurePermissions` at `Settings.tsx:48`). A developer following the skill literally could not locate the referenced file.

## Changes

- Updated `.claude/skills/admin-widget-config/SKILL.md` and the mirrored `.agents/skills/admin-widget-config/SKILL.md` to reference the correct path `components/widgets/SpecialistSchedule/Settings.tsx`.

Documentation-only change, Prettier clean. **PR diff is intentionally minimal (skill files only).** The journal record (moving the item to Completed) lives on the `scheduled-tasks` branch, following the same pattern as the prior `qs` override fix (#1991) — this avoids carrying the overlapping `docs/scheduled-tasks/*` journal updates that would conflict with #2057.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTpR8xf99b3K8CwjmSUAb7