### PR TITLE
chore(verification): Search Console domain token + carry 256MiB functions fix to main

### DIFF
--- a/functions/src/lti/endpoints.ts
+++ b/functions/src/lti/endpoints.ts
@@ -16,7 +16,8 @@ import { TOOL_PUBLIC_JWKS } from './toolJwks';
  * https://spartboard.web.app/.well-known/jwks.json via a hosting rewrite.
  */
 export const ltiJwks = onRequest(
-  { region: 'us-central1', cors: true, memory: '128MiB' },
+  // 256MiB: a 128MiB instance OOMs on the bundled nodejs24 cold-start (~140MiB).
+  { region: 'us-central1', cors: true, memory: '256MiB' },
   (_req, res) => {
     res.set('Cache-Control', 'public, max-age=3600');
     res.status(200).json(TOOL_PUBLIC_JWKS);

--- a/functions/src/organizationInvites.ts
+++ b/functions/src/organizationInvites.ts
@@ -971,7 +971,9 @@ export interface ClaimOrganizationInviteResponse {
 
 export const claimOrganizationInvite = onCall(
   {
-    memory: '128MiB',
+    // 256MiB: a 128MiB instance OOMs on the nodejs24 + firebase-admin cold-start
+    // (~140MiB) and fails the readiness check, so the callable returns `internal`.
+    memory: '256MiB',
     timeoutSeconds: 30,
   },
   async (request): Promise<ClaimOrganizationInviteResponse> => {

--- a/functions/src/resolveOrgForUser.ts
+++ b/functions/src/resolveOrgForUser.ts
@@ -64,7 +64,11 @@ export function resolveDomainCandidates(
 
 export const resolveOrgForUser = onCall(
   {
-    memory: '128MiB',
+    // 256MiB: the nodejs24 + firebase-admin cold-start footprint is ~135-144MiB,
+    // which OOMs a 128MiB instance during the startup readiness check (the
+    // instance never starts → every call returns `internal`). 256MiB is the
+    // codebase standard and leaves comfortable headroom.
+    memory: '256MiB',
     timeoutSeconds: 15,
   },
   async (request): Promise<ResolveOrgForUserResponse> => {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Google Search Console domain-ownership verification (OAuth verification prerequisite for spartboard.web.app) -->
+    <meta
+      name="google-site-verification"
+      content="gqdaK8uR_5TEzffCIYSPUFD1gzZaP3zaTw6Vhcazwpo"
+    />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/favicon.png" />
     <meta

--- a/public/googleaf862638ebbe8a36.html
+++ b/public/googleaf862638ebbe8a36.html
@@ -1,0 +1,1 @@
+google-site-verification: googleaf862638ebbe8a36.html


### PR DESCRIPTION
Unblocks the OAuth branding/scope verification, which requires proving ownership of `spartboard.web.app` in Google Search Console.

**Changes (both safe, isolated):**
1. **Search Console verification token** — `<meta name="google-site-verification">` in `index.html` + `public/googleaf862638ebbe8a36.html` (served at the site root). Deploys both methods so either "Verify" works.
2. **Carries the `resolveOrgForUser`/`claimOrganizationInvite`/`ltiJwks` 128→256MiB cold-start-OOM fix to `main`** (cherry-pick of 5958fd06). This is already live in prod (deployed directly); bringing it to `main` so the `firebase-deploy.yml` `functions` deploy is a **no-op** rather than reverting prod to 128MiB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)