### PR TITLE
test(auth): deflake ensureGoogleScope GIS-call assertions

### DIFF
--- a/tests/context/AuthContext.ensureGoogleScope.test.tsx
+++ b/tests/context/AuthContext.ensureGoogleScope.test.tsx
@@ -41,6 +41,22 @@ vi.mock('firebase/auth', async () => {
   };
 });
 
+// DETERMINISM: stub the Drive service so AuthContext's mount-time
+// "returning-user" probe (`new GoogleDriveService(...).hasExistingAppFolder()`,
+// AuthContext.tsx) is inert. The real probe does a `fetch` to the Drive API that
+// fails in the test env, which trips `fetchWithRetry`'s `onTokenExpire` →
+// `refreshGoogleToken(true)` → an extra silent UNION-scope (`prompt:'none'`) GIS
+// request. Once a test has granted `spreadsheets`, that stray background request
+// carries `spreadsheets` too and defeats this suite's scope-based call isolation
+// (the SECOND flake source, alongside the faked startup interval poll). Resolving
+// the probe to `false` with no network keeps every GIS call in these tests
+// attributable to the call under test.
+vi.mock('@/utils/googleDriveService', () => ({
+  GoogleDriveService: class {
+    hasExistingAppFolder = vi.fn().mockResolvedValue(false);
+  },
+}));
+
 vi.mock('firebase/firestore', () => ({
   doc: vi.fn((_db: unknown, ...segments: string[]) => ({
     __path: segments.join('/'),
@@ -201,6 +217,20 @@ async function mountSignedIn(email: string): Promise<void> {
 }
 
 beforeEach(() => {
+  // DETERMINISM: freeze ONLY `setInterval` so AuthContext's startup GIS-ready
+  // poll (`setInterval(…, 200)` → fire-and-forget `refreshGoogleToken(true)`)
+  // and the ~60s proactive-refresh interval CANNOT fire during a test. On slow
+  // CI those real intervals fired mid-assertion and injected an extra silent
+  // (`prompt:'none'`) GIS request for the UNION scope; once a test had granted
+  // `spreadsheets`, that background request carried `spreadsheets` too and
+  // defeated this suite's scope-based call isolation (flaky `expected 2 to be 1`
+  // / `['none','']` vs `['']`). `setTimeout`/`Date`/microtasks stay REAL so
+  // React 19's passive-effect flushing, `await act()`, `Date.now()`-based expiry
+  // seeding, and `waitFor`'s synchronous first check all behave exactly as
+  // before — every awaited condition here is already satisfied after its
+  // preceding `act`, so `waitFor` resolves without needing the (faked) interval.
+  // No test relies on an interval actually firing (the GIS stub is synchronous).
+  vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
   vi.clearAllMocks();
   ctxHolder.current = null;
   localStorage.clear();
@@ -211,6 +241,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
   localStorage.clear();


### PR DESCRIPTION
## What

Makes `tests/context/AuthContext.ensureGoogleScope.test.tsx` deterministic. These two tests intermittently failed the **production deploy gate** on slower CI runs (`firebase-deploy.yml` runs unit tests before deploying), repeatedly blocking the external-availability scope-elimination rollout from going live:

- `early return: an already-granted-this-session scope…` → `expected 2 to be 1`
- `decline: interactive popup dismissed → null…` → `['none','']` vs `['']`

## Root cause (test-only; production logic is correct)

The suite asserts exact GIS `requestAccessToken` sequences and isolates "its own" call by the **unique on-demand scope** (`spreadsheets`/`calendar`). That isolation holds only until a test *grants* an on-demand scope — after which every background silent refresh re-mints the **union** token and carries that scope too. On slow CI, two background refreshes fired mid-assertion and polluted the captured calls:

1. **Startup GIS-ready poll** — `setInterval(…, 200)` → fire-and-forget `refreshGoogleToken(true)`.
2. **Returning-user Drive probe** — mount-time `new GoogleDriveService(...).hasExistingAppFolder()`; its Drive `fetch` fails in the test env → `fetchWithRetry`'s `onTokenExpire` → `refreshGoogleToken(true)`.

Locally both settle *after* the assertions (fast), so it only flaked on CI.

## Fix

Test-only; **no production change**:

- Fake **only** `setInterval`/`clearInterval` so the poll + the 60s proactive interval can't fire. `setTimeout`/`Date`/microtasks stay real, so React 19 passive-effect flushing, `await act()`, `Date.now()`-based expiry seeding, and `waitFor`'s synchronous first check all behave exactly as before.
- Mock `@/utils/googleDriveService` so the mount-time probe is inert (no network, no `onTokenExpire`-driven refresh).

## Verification

- Deterministically **reproduced** the flake (forced the poll to fire inside the assertion window → failure), then confirmed the fix **holds under the same forced delay**.
- Full file green **5×**; all **145** context tests pass; `type-check` + `eslint` + `prettier` clean.
- Sibling `AuthContext.gisRefreshErrors.test.tsx` analyzed and **left untouched**: it never sets a token (Drive probe bails) and its `toContain`/`not.toContain` log assertions are already robust to a stray same-mode background refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)