### PR TITLE
fix(imports): PLC Wave 5 cross-subdir relative imports → @/ alias (D4 run 18)

### DIFF
--- a/components/plc/bodies/NotesBody.tsx
+++ b/components/plc/bodies/NotesBody.tsx
@@ -24,7 +24,7 @@ import { usePlcSoftDelete } from '@/hooks/usePlcTrash';
 import { logError } from '@/utils/logError';
 import { NotesMarkdown } from './notesMarkdown';
 import { buildMeetingNoteTemplate } from './notesTemplate';
-import { PlcViewerReadOnlyBadge } from '../viewer/PlcViewerReadOnlyBadge';
+import { PlcViewerReadOnlyBadge } from '@/components/plc/viewer/PlcViewerReadOnlyBadge';
 
 interface NotesBodyProps {
   plc: Plc;

--- a/components/plc/bodies/PlcQuizLibraryBody.tsx
+++ b/components/plc/bodies/PlcQuizLibraryBody.tsx
@@ -80,9 +80,9 @@ import type { SharedAssignmentImportMode } from '@/hooks/useQuizAssignments';
 import { logError } from '@/utils/logError';
 import { canEditPlcContent, getPlcMemberEmail } from '@/utils/plc';
 import { getQuizBehavior } from '@/utils/quizBehavior';
-import { PlcVersionHistoryPanel } from '../versions/PlcVersionHistoryPanel';
-import { PlcViewerReadOnlyBadge } from '../viewer/PlcViewerReadOnlyBadge';
-import { PlcSyncConflictPrompt } from '../sync/PlcSyncConflictPrompt';
+import { PlcVersionHistoryPanel } from '@/components/plc/versions/PlcVersionHistoryPanel';
+import { PlcViewerReadOnlyBadge } from '@/components/plc/viewer/PlcViewerReadOnlyBadge';
+import { PlcSyncConflictPrompt } from '@/components/plc/sync/PlcSyncConflictPrompt';
 import { PlcAssignmentImportModal } from '../PlcAssignmentImportModal';
 import { PlcQuizImportModal } from '../PlcQuizImportModal';
 import {

--- a/components/plc/bodies/PlcVideoActivitiesBody.tsx
+++ b/components/plc/bodies/PlcVideoActivitiesBody.tsx
@@ -81,9 +81,9 @@ import { usePlcAutoPullSync } from '@/hooks/usePlcAutoPullSync';
 import { logError } from '@/utils/logError';
 import { canEditPlcContent, getPlcMemberEmail } from '@/utils/plc';
 import { getVideoActivityBehavior } from '@/utils/videoActivityBehavior';
-import { PlcVersionHistoryPanel } from '../versions/PlcVersionHistoryPanel';
-import { PlcViewerReadOnlyBadge } from '../viewer/PlcViewerReadOnlyBadge';
-import { PlcSyncConflictPrompt } from '../sync/PlcSyncConflictPrompt';
+import { PlcVersionHistoryPanel } from '@/components/plc/versions/PlcVersionHistoryPanel';
+import { PlcViewerReadOnlyBadge } from '@/components/plc/viewer/PlcViewerReadOnlyBadge';
+import { PlcSyncConflictPrompt } from '@/components/plc/sync/PlcSyncConflictPrompt';
 import { PlcVideoActivityImportModal } from '../PlcVideoActivityImportModal';
 import {
   PlcSharePickerModal,

--- a/components/plc/bodies/TodosBody.tsx
+++ b/components/plc/bodies/TodosBody.tsx
@@ -7,7 +7,7 @@ import { useCanEditPlcContent } from '@/context/usePlcContext';
 import { usePlcTodos } from '@/hooks/usePlcTodos';
 import { usePlcSoftDelete } from '@/hooks/usePlcTrash';
 import { logError } from '@/utils/logError';
-import { PlcViewerReadOnlyBadge } from '../viewer/PlcViewerReadOnlyBadge';
+import { PlcViewerReadOnlyBadge } from '@/components/plc/viewer/PlcViewerReadOnlyBadge';
 
 interface TodosBodyProps {
   plc: Plc;

--- a/components/plc/docs/PlcDocsBody.tsx
+++ b/components/plc/docs/PlcDocsBody.tsx
@@ -26,7 +26,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { useCanEditPlcContent } from '@/context/usePlcContext';
 import { convertToEmbedUrl, ensureProtocol } from '@/utils/urlHelpers';
 import { PlcDocPicker, type PlcDocPickerHandle } from './PlcDocPicker';
-import { PlcViewerReadOnlyBadge } from '../viewer/PlcViewerReadOnlyBadge';
+import { PlcViewerReadOnlyBadge } from '@/components/plc/viewer/PlcViewerReadOnlyBadge';
 
 interface PlcDocsBodyProps {
   plc: Plc;

--- a/components/plc/home/PlcHome.tsx
+++ b/components/plc/home/PlcHome.tsx
@@ -30,8 +30,8 @@ import { RecentDocsCard } from './cards/RecentDocsCard';
 import { MembersHeaderCluster } from './cards/MembersHeaderCluster';
 import { SinceYouWereHereCard } from './cards/SinceYouWereHereCard';
 import { YourActionItemsCard } from './cards/YourActionItemsCard';
-import { PlcPresenceStrip } from '../presence/PlcPresenceStrip';
-import { PlcActivityFeed } from '../activity/PlcActivityFeed';
+import { PlcPresenceStrip } from '@/components/plc/presence/PlcPresenceStrip';
+import { PlcActivityFeed } from '@/components/plc/activity/PlcActivityFeed';
 
 interface PlcHomeProps {
   plc: Plc;

--- a/components/plc/tabs/PlcSettingsTab.tsx
+++ b/components/plc/tabs/PlcSettingsTab.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/types';
 import { usePlcs } from '@/hooks/usePlcs';
 import { useDashboard } from '@/context/useDashboard';
-import { PlcTrashBody } from '../settings/PlcTrashBody';
+import { PlcTrashBody } from '@/components/plc/settings/PlcTrashBody';
 
 interface PlcSettingsTabProps {
   plc: Plc;


### PR DESCRIPTION
## Canonical Form
All cross-directory imports use the `@/` alias. `'../subdir/Component'` imports that jump between sibling subdirectories within `components/plc/` are the anti-pattern.

## Instances Unified
12 cross-subdir imports across 7 files — same recurring pattern fixed in run 17 (plc/meeting/) and run 7 (plc/tabs↔bodies/):

| File | Import converted |
|------|-----------------|
| `plc/bodies/NotesBody.tsx:27` | `../viewer/PlcViewerReadOnlyBadge` |
| `plc/bodies/TodosBody.tsx:10` | `../viewer/PlcViewerReadOnlyBadge` |
| `plc/bodies/PlcQuizLibraryBody.tsx:83-85` | `../versions/PlcVersionHistoryPanel`, `../viewer/PlcViewerReadOnlyBadge`, `../sync/PlcSyncConflictPrompt` |
| `plc/bodies/PlcVideoActivitiesBody.tsx:84-86` | `../versions/PlcVersionHistoryPanel`, `../viewer/PlcViewerReadOnlyBadge`, `../sync/PlcSyncConflictPrompt` |
| `plc/docs/PlcDocsBody.tsx:29` | `../viewer/PlcViewerReadOnlyBadge` |
| `plc/home/PlcHome.tsx:33-34` | `../presence/PlcPresenceStrip`, `../activity/PlcActivityFeed` |
| `plc/tabs/PlcSettingsTab.tsx:21` | `../settings/PlcTrashBody` |

Gray-zone plc-root imports (`../PlcXxx`, `../sections`) intentionally preserved (D4-E2).

## Enforcement
D4's canonical enforcement is the nightly unifier run — this recurring PLC-wave regression is flagged within one day of introduction. No additional lint rule added (same rationale as runs 13/17: the pattern appears only after feature waves, not continuously).

## Behavior Preservation
**Risk: mechanical** — purely syntactic. TypeScript confirmed zero type errors (all 12 module references resolve to identical exports). No logic, component behavior, or types altered.

🤖 Nightly unifier run 18 — D4 dimension

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5THfaLAnWqPGGAxchQ8ay)_