### PR TITLE
fix(quizDriveService): dedup questions before solo-mode stats section

### DIFF
--- a/tests/utils/quizDriveService.test.ts
+++ b/tests/utils/quizDriveService.test.ts
@@ -497,6 +497,58 @@ describe('QuizDriveService.exportResultsToSheet — column shape', () => {
     expect(dataRows[1][3]).toBe('Zeta, Alex');
   });
 
+  it('emits exactly one Question Analysis row per unique question id when questions contains duplicates', async () => {
+    // Regression: Drive-sync duplication and arrayUnion races can write the same
+    // question id twice into `quiz.questions`. Before the fix, the solo-mode
+    // stats section iterated the raw (un-deduped) array and emitted a duplicate
+    // row for every repeated id, producing a malformed "Question Analysis" table.
+    // The grade-data section (buildResultsSheetDataShared) was already correct
+    // because it deduplicates internally; only the stats block was missing the
+    // guard.
+    const fetchSpy = queueFetchResponses([
+      {
+        json: () =>
+          Promise.resolve({
+            spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/abc',
+          }),
+      },
+    ]);
+
+    const dup = makeQuestion('q1'); // same id as the unique one below
+    await service.exportResultsToSheet(
+      'Dup Test',
+      [makeResponse({ pin: '01', answers: [{ questionId: 'q1', answer: 'A', answeredAt: 0 }] })],
+      // Two entries with the same id 'q1' — simulates a Drive-sync duplicate.
+      [makeQuestion('q1'), dup],
+    );
+
+    const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls as Array<[string, RequestInit]>;
+    const body = parseBody(calls[0][1]);
+    const sheets = body.sheets as Array<{
+      data: Array<{
+        rowData: Array<{
+          values: Array<{ userEnteredValue: { stringValue: string } }>;
+        }>;
+      }>;
+    }>;
+    const allRows = sheets[0].data[0].rowData.map((row) =>
+      row.values.map((v) => v.userEnteredValue.stringValue)
+    );
+
+    // The Question Analysis block starts with a blank row, then 'Question Analysis',
+    // then a header row, then one data row per UNIQUE question. With a single unique
+    // question 'q1', there should be exactly 1 data row — not 2.
+    const analysisHeaderIdx = allRows.findIndex((r) => r[0] === 'Question Analysis');
+    expect(analysisHeaderIdx).toBeGreaterThan(-1);
+    // Skip: 'Question Analysis' label, column headers. Data rows follow.
+    const analysisDataRows = allRows.slice(analysisHeaderIdx + 2);
+    // Only 1 unique question — must produce exactly 1 stats data row.
+    expect(analysisDataRows).toHaveLength(1);
+    // Verify the single row describes 'q1'.
+    expect(analysisDataRows[0][0]).toBe('Question q1'); // q.text
+  });
+
   it('throws PlcSheetSchemaMismatchError when appending to an old-schema PLC sheet', async () => {
     queueFetchResponses([
       // Tab metadata

--- a/tests/utils/quizDriveService.test.ts
+++ b/tests/utils/quizDriveService.test.ts
@@ -517,9 +517,14 @@ describe('QuizDriveService.exportResultsToSheet — column shape', () => {
     const dup = makeQuestion('q1'); // same id as the unique one below
     await service.exportResultsToSheet(
       'Dup Test',
-      [makeResponse({ pin: '01', answers: [{ questionId: 'q1', answer: 'A', answeredAt: 0 }] })],
+      [
+        makeResponse({
+          pin: '01',
+          answers: [{ questionId: 'q1', answer: 'A', answeredAt: 0 }],
+        }),
+      ],
       // Two entries with the same id 'q1' — simulates a Drive-sync duplicate.
-      [makeQuestion('q1'), dup],
+      [makeQuestion('q1'), dup]
     );
 
     const calls = (fetchSpy as unknown as { mock: { calls: unknown[][] } }).mock
@@ -539,7 +544,9 @@ describe('QuizDriveService.exportResultsToSheet — column shape', () => {
     // The Question Analysis block starts with a blank row, then 'Question Analysis',
     // then a header row, then one data row per UNIQUE question. With a single unique
     // question 'q1', there should be exactly 1 data row — not 2.
-    const analysisHeaderIdx = allRows.findIndex((r) => r[0] === 'Question Analysis');
+    const analysisHeaderIdx = allRows.findIndex(
+      (r) => r[0] === 'Question Analysis'
+    );
     expect(analysisHeaderIdx).toBeGreaterThan(-1);
     // Skip: 'Question Analysis' label, column headers. Data rows follow.
     const analysisDataRows = allRows.slice(analysisHeaderIdx + 2);

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -679,6 +679,20 @@ export class QuizDriveService {
 
     // Solo mode: create a new spreadsheet with full results + stats
 
+    // Deduplicate by question id before all stats math. Drive-sync duplication
+    // and arrayUnion races can write the same question id twice into `questions`.
+    // Without this guard the Question Analysis section emits a duplicate row per
+    // dup id — the same bug `buildResultsSheetDataShared` already guards against
+    // in the grade-data section (where it rebinds the local `questions` variable).
+    // The stats block runs against the original caller-supplied array, so it needs
+    // its own fence. Mirrors the identical dedup in `buildResultsSheetDataShared`.
+    const seenStatsIds = new Set<string>();
+    const dedupedQuestions = questions.filter((q) => {
+      if (seenStatsIds.has(q.id)) return false;
+      seenStatsIds.add(q.id);
+      return true;
+    });
+
     // Question-level stats
     const statsRows: string[][] = [];
     statsRows.push([]);
@@ -693,12 +707,12 @@ export class QuizDriveService {
       '% Correct',
     ]);
     const statsMap = new Map<string, { answered: number; correct: number }>();
-    for (const q of questions) {
+    for (const q of dedupedQuestions) {
       statsMap.set(q.id, { answered: 0, correct: 0 });
     }
 
     const questionMap = new Map<string, QuizQuestion>(
-      questions.map((q) => [q.id, q])
+      dedupedQuestions.map((q) => [q.id, q])
     );
 
     for (const r of responses) {
@@ -725,7 +739,7 @@ export class QuizDriveService {
       }
     }
 
-    for (const q of questions) {
+    for (const q of dedupedQuestions) {
       const stats = statsMap.get(q.id) ?? { answered: 0, correct: 0 };
       const pct =
         stats.answered > 0


### PR DESCRIPTION
## Root cause

`QuizDriveService.exportResultsToSheet` solo-mode stats block iterated the raw caller-supplied `questions` array when building the Question Analysis section. Drive-sync races and `arrayUnion` can write the same question ID twice into `quiz.questions`. Without a dedup fence, a question whose ID appears N times produces N duplicate rows in the exported stats table — inflating row counts and producing a malformed sheet that misrepresents per-question accuracy.

The grade-data section (via `buildResultsSheetDataShared`) already guarded against this by locally rebinding its `questions` variable via a dedup filter. The stats block operated on the original caller-supplied array, so it needed its own fence.

## Fix

Added a `seenStatsIds: Set<string>` + `dedupedQuestions` filter at the top of the solo-mode stats block (before any stats math). Changed all three loops in the stats section — `statsMap` initialization, `questionMap` construction, and stats-row emission — from `questions` to `dedupedQuestions`.

Same `Set<string>` dedup pattern as #1728, #1777, #1787, #1803, #1827, #1855, #1935 (7th instance).

## Band-aid rejected

Adding a dedup only on the `statsMap` initialization (but not `questionMap` or the row-emission loop) would suppress duplicate stats-map entries but leave duplicate rows in the final sheet output — the visible symptom. All three loops must operate on the same deduplicated array.

## Regression test

New test in `tests/utils/quizDriveService.test.ts`: passes `[makeQuestion('q1'), makeQuestion('q1')]` (duplicate ID), then asserts the Question Analysis block emits exactly 1 data row.

**Before fix:** `Expected length: 1, Received length: 2` — 1 test fails  
**After fix:** 19/19 tests pass

## Risk: contained

Only touches the solo-mode stats section of `QuizDriveService.exportResultsToSheet`. No shared primitives changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQstk7Xs6yb3sSFNkKGgrc)_