### PR TITLE
fix(i18n): correct verbatim-EN clock font/style labels in DE and FR

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1345,7 +1345,7 @@
       "styles": {
         "default": "Standard",
         "lcd": "LCD-Panel",
-        "minimal": "Minimal"
+        "minimal": "Minimalistisch"
       }
     },
     "seatingChart": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1338,14 +1338,14 @@
       "glow": "Lueur",
       "fonts": {
         "inherit": "Hériter",
-        "digital": "Digital",
+        "digital": "Numérique",
         "modern": "Moderne",
         "school": "École"
       },
       "styles": {
         "default": "Par défaut",
         "lcd": "Panneau LCD",
-        "minimal": "Minimal"
+        "minimal": "Minimaliste"
       }
     },
     "seatingChart": {

--- a/tests/i18n/widgetClockVerbatimLocales.test.ts
+++ b/tests/i18n/widgetClockVerbatimLocales.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for verbatim-English values stored in FR (and for
+ * styles.minimal also in DE) for widgets.clock.fonts.digital and
+ * widgets.clock.styles.minimal.
+ *
+ * BUG SUMMARY
+ * -----------
+ *
+ * 1. FR widgets.clock.fonts.digital = "Digital"  (verbatim EN)
+ *    Proof of error: within the same FR locale file, widgets.timeTool.digital
+ *    is correctly set to "Numérique".  The clock variant was never updated —
+ *    a copy-paste oversight.
+ *    Correct value: "Numérique"
+ *
+ * 2. DE widgets.clock.styles.minimal = "Minimal"  (verbatim EN)
+ *    FR widgets.clock.styles.minimal = "Minimal"  (verbatim EN)
+ *    Proof of error: ES correctly translates this as "Minimalista" while DE
+ *    and FR both kept the untranslated EN placeholder.
+ *    Correct values: DE → "Minimalistisch", FR → "Minimaliste"
+ *
+ * WHY THESE ARE LOUD BUGS (no silent fallback)
+ * --------------------------------------------
+ * Both keys are used via t() WITHOUT a defaultValue fallback in two
+ * components, meaning i18next renders whatever is stored in the locale file
+ * verbatim — including a wrong-language placeholder:
+ *
+ *   components/widgets/ClockWidget/Settings.tsx:
+ *     t('widgets.clock.fonts.digital')     — line 52   (no defaultValue)
+ *     t('widgets.clock.styles.minimal')    — line 66   (no defaultValue)
+ *
+ *   components/widgets/TimeTool/Settings.tsx:
+ *     t('widgets.clock.fonts.digital')     — line 457  (no defaultValue)
+ *     t('widgets.clock.styles.minimal')    — line 469  (no defaultValue)
+ *
+ * French and German teachers see English text in the Clock and TimeTool
+ * widget settings panels whenever they open the font or style selectors.
+ *
+ * This test loads locale JSON files directly so assertions fire before the
+ * i18next runtime would attempt (and silently skip) any fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+
+// ─── EN baseline ─────────────────────────────────────────────────────────────
+
+describe('EN locale — widgets.clock.fonts.digital and styles.minimal baseline', () => {
+  it('has widgets.clock.fonts.digital', () => {
+    expect(en.widgets.clock.fonts).toHaveProperty('digital');
+  });
+
+  it('has widgets.clock.styles.minimal', () => {
+    expect(en.widgets.clock.styles).toHaveProperty('minimal');
+  });
+});
+
+// ─── FR: clock.fonts.digital must be "Numérique", not "Digital" ──────────────
+//
+// The same locale correctly translates widgets.timeTool.digital as "Numérique".
+// The clock variant was left at the EN placeholder — an obvious oversight.
+
+describe('FR locale — widgets.clock.fonts.digital must not be verbatim EN', () => {
+  it('fr: widgets.clock.fonts.digital is present', () => {
+    expect(fr, 'fr.widgets.clock.fonts.digital is missing').toHaveProperty([
+      'widgets',
+      'clock',
+      'fonts',
+      'digital',
+    ]);
+  });
+
+  it('fr: widgets.clock.fonts.digital is NOT the verbatim English value "Digital"', () => {
+    expect(
+      fr.widgets.clock.fonts.digital,
+      'fr.widgets.clock.fonts.digital is still the English placeholder — ' +
+        "t('widgets.clock.fonts.digital') has no defaultValue in " +
+        'ClockWidget/Settings.tsx:52 and TimeTool/Settings.tsx:457, so ' +
+        'FR users see English text in the font selector. ' +
+        'Note: fr.widgets.timeTool.digital is already correctly set to ' +
+        '"Numérique" — this key was simply missed.'
+    ).not.toBe(en.widgets.clock.fonts.digital);
+  });
+});
+
+// ─── DE + FR: clock.styles.minimal must be localised, not verbatim EN ────────
+//
+// ES already has "Minimalista" — DE and FR kept "Minimal" (the EN value).
+
+describe.each([
+  { code: 'de', locale: de },
+  { code: 'fr', locale: fr },
+])(
+  '$code locale — widgets.clock.styles.minimal must not be verbatim EN',
+  ({ code, locale }) => {
+    it(`${code}: widgets.clock.styles.minimal is present`, () => {
+      expect(
+        locale,
+        `${code}.widgets.clock.styles.minimal is missing`
+      ).toHaveProperty(['widgets', 'clock', 'styles', 'minimal']);
+    });
+
+    it(`${code}: widgets.clock.styles.minimal is NOT the verbatim English value "Minimal"`, () => {
+      expect(
+        (locale as typeof en).widgets.clock.styles.minimal,
+        `${code}.widgets.clock.styles.minimal is still the English placeholder — ` +
+          `t('widgets.clock.styles.minimal') has no defaultValue in ` +
+          `ClockWidget/Settings.tsx:66 and TimeTool/Settings.tsx:469, so ` +
+          `${code} users see English text in the style selector. ` +
+          `ES already has the correct localised value ("Minimalista").`
+      ).not.toBe(en.widgets.clock.styles.minimal);
+    });
+  }
+);
+
+// ─── ES sanity check — must not regress ──────────────────────────────────────
+
+describe('ES locale — widgets.clock sanity check (must not regress)', () => {
+  it('es: widgets.clock.styles.minimal is not verbatim EN ("Minimalista")', () => {
+    expect(
+      es.widgets.clock.styles.minimal,
+      'es.widgets.clock.styles.minimal regressed to the English value'
+    ).not.toBe(en.widgets.clock.styles.minimal);
+  });
+
+  it('es: widgets.clock.fonts.digital is present', () => {
+    // ES uses "Digital" as well — it is an accepted Spanish loanword.
+    // We only guard that the key is present for ES.
+    expect(es.widgets.clock.fonts).toHaveProperty('digital');
+  });
+});


### PR DESCRIPTION
## Root cause

When the `widgets.clock` namespace was added to DE and FR, three font/style sub-keys were copy-pasted from EN as verbatim English placeholders:

| Key | Locale | Stored (wrong) | Correct |
|-----|--------|---------------|---------|
| `widgets.clock.fonts.digital` | FR | `"Digital"` | `"Numérique"` |
| `widgets.clock.styles.minimal` | DE | `"Minimal"` | `"Minimalistisch"` |
| `widgets.clock.styles.minimal` | FR | `"Minimal"` | `"Minimaliste"` |

Both keys are called in `ClockWidget/Settings.tsx` and `TimeTool/Settings.tsx` with **no `defaultValue` parameter**. When no fallback is provided, i18next resolves whatever is stored — so French and German teachers saw English text ("Digital" / "Minimal") in the font and style selectors for both the Clock and TimeTool widgets.

Cross-locale signal: `fr.widgets.timeTool.digital` was already `"Numérique"` (correct); `es.widgets.clock.styles.minimal` was already `"Minimalista"` — confirming localisation was intended; DE and FR were simply missed.

## Fix

- `locales/fr.json`: `widgets.clock.fonts.digital` → `"Numérique"`, `widgets.clock.styles.minimal` → `"Minimaliste"`
- `locales/de.json`: `widgets.clock.styles.minimal` → `"Minimalistisch"`

## Band-aid rejected

Adding `defaultValue` fallbacks at the call sites would suppress visible key-path errors but leave the wrong translations stored — non-EN teachers would still see English.

## Regression test

`tests/i18n/widgetClockVerbatimLocales.test.ts` (10 tests): checks key presence AND `value !== en.value` for the font/style sub-keys across all three non-EN locales. Extends the pattern from prior runs (#1936, #1964) to catch verbatim-EN values, not just missing keys.

**Before fix:** 3 tests fail (the three wrong values)  
**After fix:** 10/10 pass

## Risk: contained

Three locale JSON string values only. No source code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQstk7Xs6yb3sSFNkKGgrc)_