### PR TITLE
fix: remove .animate-spin from reduced-motion suppression in index.css

### DIFF
--- a/index.css
+++ b/index.css
@@ -186,9 +186,12 @@ body.is-dragging-widget video {
 
 /* Respect reduced motion preferences (WCAG 2.1 SC 2.3.3).
    Only suppress decorative/looping animations — preserve functional
-   transitions (color, opacity, position) and entrance animations. */
+   transitions (color, opacity, position) and entrance animations.
+   NOTE: .animate-spin is intentionally OMITTED here. Loading spinners
+   (Loader2 etc.) are essential status indicators — freezing them makes
+   async operations appear stalled. The tailwind.config.js
+   reducedMotionPlugin also excludes it for the same reason. */
 @media (prefers-reduced-motion: reduce) {
-  .animate-spin,
   .animate-spin-slow,
   .animate-pulse,
   .animate-jiggle,

--- a/tests/indexCss.reducedMotion.test.ts
+++ b/tests/indexCss.reducedMotion.test.ts
@@ -22,10 +22,10 @@
  */
 
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
 
-const CSS_PATH = resolve(__dirname, '../index.css');
+const CSS_PATH = fileURLToPath(new URL('../index.css', import.meta.url));
 
 /**
  * Extract the body of every `@media (prefers-reduced-motion: reduce)` block

--- a/tests/indexCss.reducedMotion.test.ts
+++ b/tests/indexCss.reducedMotion.test.ts
@@ -56,7 +56,7 @@ function extractReducedMotionBlocks(css: string): string {
 }
 
 describe('index.css — reduced-motion safety', () => {
-  const css = readFileSync(CSS_PATH, 'utf-8');
+  const css = readFileSync(CSS_PATH, 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
   const reducedMotionCSS = extractReducedMotionBlocks(css);
 
   it('does NOT suppress .animate-spin inside prefers-reduced-motion blocks', () => {

--- a/tests/indexCss.reducedMotion.test.ts
+++ b/tests/indexCss.reducedMotion.test.ts
@@ -22,10 +22,10 @@
  */
 
 import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { resolve } from 'path';
 import { describe, it, expect } from 'vitest';
 
-const CSS_PATH = fileURLToPath(new URL('../index.css', import.meta.url));
+const CSS_PATH = resolve(__dirname, '../index.css');
 
 /**
  * Extract the body of every `@media (prefers-reduced-motion: reduce)` block

--- a/tests/indexCss.reducedMotion.test.ts
+++ b/tests/indexCss.reducedMotion.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression test for the `.animate-spin` / `prefers-reduced-motion` bug in
+ * index.css.
+ *
+ * BUG: `index.css` contained a `@media (prefers-reduced-motion: reduce)` block
+ * that suppressed `.animate-spin` with `animation: none !important`.  That
+ * block appears AFTER the `@tailwind base` directive in source order, so it
+ * overrides the intentional exclusion in tailwind.config.js's
+ * `reducedMotionPlugin`.  The result: users with reduced-motion enabled see
+ * loading spinners (Loader2 etc.) frozen at a static position, making async
+ * operations appear stalled — directly contradicting WCAG 2.3.3 (essential
+ * animations must be preserved).
+ *
+ * FIX: Remove `.animate-spin` from the index.css reduced-motion block so the
+ * tailwind.config.js decision (which deliberately excludes it) is not
+ * silently overridden by a later source-order rule.
+ *
+ * The tailwind.config.js `reducedMotionPlugin` comment explains the rationale:
+ *   "Freezing a spinner reads as 'stalled' and removes the only in-progress
+ *   affordance on async screens, so it keeps spinning even under
+ *   reduced-motion (an essential animation under SC 2.3.3)."
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+
+const CSS_PATH = resolve(__dirname, '../index.css');
+
+/**
+ * Extract the body of every `@media (prefers-reduced-motion: reduce)` block
+ * from a CSS string.  Returns the concatenated inner text of all such blocks.
+ */
+function extractReducedMotionBlocks(css: string): string {
+  const blocks: string[] = [];
+  // Match @media (prefers-reduced-motion: reduce) { ... }
+  // Uses a simple brace-depth counter so nested braces are handled correctly.
+  const prefix = '@media (prefers-reduced-motion: reduce)';
+  let searchFrom = 0;
+  while (true) {
+    const startIdx = css.indexOf(prefix, searchFrom);
+    if (startIdx === -1) break;
+    const braceStart = css.indexOf('{', startIdx);
+    if (braceStart === -1) break;
+    let depth = 1;
+    let i = braceStart + 1;
+    while (i < css.length && depth > 0) {
+      if (css[i] === '{') depth++;
+      else if (css[i] === '}') depth--;
+      i++;
+    }
+    blocks.push(css.slice(braceStart + 1, i - 1));
+    searchFrom = i;
+  }
+  return blocks.join('\n');
+}
+
+describe('index.css — reduced-motion safety', () => {
+  const css = readFileSync(CSS_PATH, 'utf-8');
+  const reducedMotionCSS = extractReducedMotionBlocks(css);
+
+  it('does NOT suppress .animate-spin inside prefers-reduced-motion blocks', () => {
+    // .animate-spin must NOT appear as a selector in any reduced-motion block.
+    // We check for the selector text rather than the full rule so the test
+    // doesn't accidentally pass if `.animate-spin-slow` is present but
+    // `.animate-spin` alone is absent (they share a common prefix).
+    //
+    // BEFORE FIX: index.css listed `.animate-spin` in the reduced-motion
+    // block, overriding tailwind.config.js which deliberately excludes it.
+    // AFTER FIX: `.animate-spin` is absent from all reduced-motion blocks.
+    //
+    // The regex matches `.animate-spin` as a discrete selector: preceded by
+    // a rule boundary (comma, newline, or block open) and followed by a
+    // comma, whitespace, or block-close — so `.animate-spin-slow` does not
+    // trigger a false positive.
+    const spinSelectorRegex = /(?:^|[,{\n\s])\.animate-spin(?:[,\s}]|$)/m;
+    expect(reducedMotionCSS).not.toMatch(spinSelectorRegex);
+  });
+
+  it('DOES suppress .animate-spin-slow inside prefers-reduced-motion blocks', () => {
+    // Sanity check: the decorative slow-spin IS correctly suppressed.
+    expect(reducedMotionCSS).toContain('.animate-spin-slow');
+  });
+
+  it('DOES suppress .animate-dice-jitter inside prefers-reduced-motion blocks', () => {
+    // Sanity check: the decorative dice-jitter IS correctly suppressed.
+    expect(reducedMotionCSS).toContain('.animate-dice-jitter');
+  });
+});


### PR DESCRIPTION
## Root cause

`index.css` contained a `@media (prefers-reduced-motion: reduce)` block (line 190) listing `.animate-spin` alongside decorative animations. Because `@tailwind base` (which expands `tailwind.config.js`'s `reducedMotionPlugin`) appears at line 1 of `index.css`, the manual block at line 190 wins the CSS cascade by source order — silently overriding the intentional decision in `tailwind.config.js` to preserve `.animate-spin`.

`tailwind.config.js` contains explicit documentation explaining the intent:

> "Freezing a spinner reads as 'stalled' and removes the only in-progress affordance on async screens, so it keeps spinning even under reduced-motion (an essential animation under SC 2.3.3)."

**Effect**: All users with `prefers-reduced-motion: reduce` (typically motion-sensitive users who opt in via OS accessibility settings) saw `Loader2` icons and all other `animate-spin` elements **frozen** during any async operation — saves, uploads, network requests — making the UI appear stalled. This contradicts both WCAG 2.3.3 and the project's documented design decision.

## Fix

Removed `.animate-spin` from the `index.css` `@media (prefers-reduced-motion: reduce)` block. Added a comment documenting the intentional exclusion so the decision is visible to future editors at both the Tailwind config and CSS levels.

## Band-aid rejected

Moving the `index.css` block before `@tailwind base` would cause the Tailwind plugin to win the cascade, but only by reversing source order — fragile and confusing. The root fix is aligning `index.css` with the authoritative decision in `tailwind.config.js`.

## Regression test

`tests/indexCss.reducedMotion.test.ts` (3 tests): parses every `@media (prefers-reduced-motion: reduce)` block in `index.css` and asserts `.animate-spin` does not appear as a selector. Sanity checks confirm `.animate-spin-slow` and `.animate-dice-jitter` remain correctly suppressed.

**Before fix:** 1 test fails — `.animate-spin` found in reduced-motion block  
**After fix:** 3/3 pass

## Risk: contained

One selector removed from one CSS media block. No JS/TS source changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQstk7Xs6yb3sSFNkKGgrc)_