### PR TITLE
fix(pr-review): address unresolved review comments on #2072

### DIFF
--- a/components/admin/Organization/views/UsersView.tsx
+++ b/components/admin/Organization/views/UsersView.tsx
@@ -379,12 +379,9 @@ export const UsersView: React.FC<Props> = ({
           {canManageUsers && (
             <>
               {(() => {
-                const invitedSelected = Array.from(selected)
-                  .map((id) => users.find((u) => u.id === id))
-                  .filter(
-                    (u): u is UserRecord =>
-                      u !== undefined && u.status === 'invited'
-                  );
+                const invitedSelected = users.filter(
+                  (u) => selected.has(u.id) && u.status === 'invited'
+                );
                 return (
                   <button
                     type="button"

--- a/components/widgets/Checklist/Settings.tsx
+++ b/components/widgets/Checklist/Settings.tsx
@@ -66,8 +66,16 @@ export const ChecklistSettings: React.FC<{ widget: WidgetData }> = ({
   // eslint-disable-next-line react-hooks/refs
   itemsRef.current = safeItems;
 
-  // updateWidget from DashboardContext is a stable identity (stableActions,
-  // empty-dep useMemo + liveActionsRef forwarding) — no ref-mirror needed.
+  // `useDashboard().updateWidget` is NOT the genuinely-stable action: it's a
+  // useCallback with a `[saveWidgetConfig]` dep (which itself depends on the
+  // auth `user`), so its identity can change (e.g. on token refresh). The
+  // truly stable variant lives in `useDashboardActions()`. To keep the
+  // debounced save closure below pointing at the freshest callback, mirror it
+  // into a ref in the render body (same pattern as configRef/itemsRef above).
+  const updateWidgetRef = React.useRef(updateWidget);
+  // eslint-disable-next-line react-hooks/refs
+  updateWidgetRef.current = updateWidget;
+
   const handleBulkChange = (text: string) => {
     setLocalText(text);
 
@@ -98,7 +106,7 @@ export const ChecklistSettings: React.FC<{ widget: WidgetData }> = ({
         });
 
       setSkipNextSync(true);
-      updateWidget(widget.id, {
+      updateWidgetRef.current(widget.id, {
         config: { ...configRef.current, items: newItems },
       });
     }, 500);

--- a/components/widgets/Checklist/Widget.test.tsx
+++ b/components/widgets/Checklist/Widget.test.tsx
@@ -531,6 +531,16 @@ describe('ChecklistSettings Nexus Connection', () => {
     });
 
     render(<ChecklistSettings widget={mockWidget} />);
+
+    const importButton = within(
+      screen.getByText('Import Routine').closest('.bg-indigo-50') as HTMLElement
+    ).getByRole('button', { name: /Sync/i });
+    fireEvent.click(importButton);
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      'Active routine has no steps to import.',
+      'info'
+    );
     expect(mockUpdateWidget).not.toHaveBeenCalled();
   });
 });

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -785,10 +785,14 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
         await batch.commit();
       } catch (err) {
         console.error('[QuizWidget] Failed to persist reorder:', err);
+        // A concurrently-deleted quiz makes batch.update() throw NOT_FOUND.
+        // useSortableReorder catches the re-throw and reverts the visual order;
+        // surface a toast so the teacher knows why their drag snapped back.
+        addToast('Could not save the new order. Please try again.', 'error');
         throw err;
       }
     },
-    [user?.uid]
+    [user?.uid, addToast]
   );
 
   // ─── Guard: not signed in ──────────────────────────────────────────────────

--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -428,7 +428,10 @@ const LIBRARY_INITIAL_SORT = { key: 'updated', dir: 'desc' as const };
 
 const QUIZ_GET_ID = (q: QuizMetadata): string => q.id;
 
-const SORT_COMPARATORS: Record<
+// Exported so tests exercise the real comparator rather than a re-declared
+// lambda. Constant export on a component file is intentional here.
+// eslint-disable-next-line react-refresh/only-export-components
+export const SORT_COMPARATORS: Record<
   string,
   (a: QuizMetadata, b: QuizMetadata, dir: 'asc' | 'desc') => number
 > = {
@@ -738,7 +741,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
   const onReorderCommit = useCallback(
     async (orderedIds: string[]) => {
       if (onReorderQuizzes) {
-        await Promise.resolve(onReorderQuizzes(orderedIds));
+        await onReorderQuizzes(orderedIds);
       }
     },
     [onReorderQuizzes]
@@ -1337,7 +1340,7 @@ export const QuizManager: React.FC<QuizManagerProps> = ({
     async (nextOrderedIds: string[]): Promise<void> => {
       if (!onReorderQuizzes) return;
       if (libraryView.reorderLocked) return;
-      await Promise.resolve(onReorderQuizzes(nextOrderedIds));
+      await onReorderQuizzes(nextOrderedIds);
     },
     [libraryView.reorderLocked, onReorderQuizzes]
   );

--- a/tests/components/widgets/QuizManager.reorder.test.tsx
+++ b/tests/components/widgets/QuizManager.reorder.test.tsx
@@ -15,7 +15,10 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { QuizManager } from '@/components/widgets/QuizWidget/components/QuizManager';
+import {
+  QuizManager,
+  SORT_COMPARATORS,
+} from '@/components/widgets/QuizWidget/components/QuizManager';
 import type { QuizConfig, QuizMetadata } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -132,13 +135,13 @@ describe('QuizManager reorder — backward-compat (no order fields)', () => {
 // ---------------------------------------------------------------------------
 
 describe('QuizManager reorder — manual comparator', () => {
-  it('orders quizzes by order field ascending when manual sort is applied', () => {
-    // Import the comparator directly from the module's exported constant.
-    // The comparator is module-level so we exercise it in isolation.
-    // Simulate the comparator behaviour: manual: (a, b) => (a.order ?? 0) - (b.order ?? 0)
-    const manualComparator = (a: QuizMetadata, b: QuizMetadata): number =>
-      (a.order ?? 0) - (b.order ?? 0);
+  // Exercise the ACTUAL production comparator (exported from QuizManager) so a
+  // regression in `SORT_COMPARATORS.manual` is caught here rather than slipping
+  // past a locally-redefined lambda.
+  const manualComparator = (a: QuizMetadata, b: QuizMetadata): number =>
+    SORT_COMPARATORS.manual(a, b, 'asc');
 
+  it('orders quizzes by order field ascending when manual sort is applied', () => {
     const quizzes: QuizMetadata[] = [
       makeQuizMeta({ id: 'q3', order: 2 }),
       makeQuizMeta({ id: 'q1', order: 0 }),
@@ -150,9 +153,6 @@ describe('QuizManager reorder — manual comparator', () => {
   });
 
   it('treats missing order as 0 (stable for quizzes never reordered)', () => {
-    const manualComparator = (a: QuizMetadata, b: QuizMetadata): number =>
-      (a.order ?? 0) - (b.order ?? 0);
-
     const quizzes: QuizMetadata[] = [
       makeQuizMeta({ id: 'qa' }), // order undefined → treated as 0
       makeQuizMeta({ id: 'qb', order: 1 }),


### PR DESCRIPTION
Lands fixes for the 7 unresolved review comments on #2072 onto the `dev-paul` PR branch (direct git push to `dev-paul` is blocked by org policy, so this forwards the verified commit via PR).

**Fixes**
- **UsersView**: bulk "Resend invite" now filters `users` once with an O(1) `Set` lookup instead of O(N·M) `find`-per-id (gemini).
- **QuizManager**: dropped redundant `Promise.resolve(...)` — `await` handles sync/void returns directly (gemini, x2).
- **Checklist Settings**: restored the `updateWidgetRef` mirror. `useDashboard().updateWidget` is a `useCallback([saveWidgetConfig])` whose identity can change (saveWidgetConfig depends on the auth `user`), so the debounced-save closure could capture a stale callback. The genuinely-stable variant lives in `useDashboardActions()` (claude).
- **QuizWidget**: reorder persistence now shows an error toast before re-throwing, so a NOT_FOUND from a concurrently-deleted quiz no longer makes the drag silently snap back (claude).
- **QuizManager test**: exported `SORT_COMPARATORS` and the reorder test now exercises the real production comparator instead of a re-declared lambda (claude).
- **Checklist Widget test**: the "no steps" case now clicks Sync and asserts the info toast instead of trivially passing (claude).

Validated locally: `type-check`, `lint`, `prettier --check`, and affected vitest suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5Z3YSUFobW6inDtYUBe8P)_