### PR TITLE
feat(quiz): unify edit-modal class picker on rosterIds (M6)

### DIFF
--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -2024,7 +2024,32 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
           onClose={() => setEditingAssignment(null)}
           onSave={async (patch) => {
             try {
-              await updateAssignmentSettings(editingAssignment.id, patch);
+              // Class targeting must be dual-written to BOTH the assignment
+              // doc AND the live session doc (rosterIds/classIds/classId/
+              // classPeriodByClassId) so SSO + PIN join keep working after an
+              // edit — `updateAssignmentSettings` only mirrors periodNames to
+              // the session doc, which would leave `sessionData.rosterIds`
+              // stale and break `pinLoginV1`. Route targeting through
+              // `setAssignmentRosters` (the same dual-write the create flow
+              // uses), and send the remaining settings through
+              // `updateAssignmentSettings`.
+              const { rosterIds } = patch;
+              const settingsPatch = { ...patch };
+              delete settingsPatch.rosterIds;
+              delete settingsPatch.periodName;
+              delete settingsPatch.periodNames;
+              if (rosterIds !== undefined) {
+                const targets = deriveSessionTargetsFromRosters(
+                  rosters.filter((r) => rosterIds.includes(r.id))
+                );
+                await setAssignmentRosters(editingAssignment.id, targets);
+              }
+              if (Object.keys(settingsPatch).length > 0) {
+                await updateAssignmentSettings(
+                  editingAssignment.id,
+                  settingsPatch
+                );
+              }
               addToast('Assignment settings saved.', 'success');
               setEditingAssignment(null);
             } catch (err) {

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -2033,11 +2033,16 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               // `setAssignmentRosters` (the same dual-write the create flow
               // uses), and send the remaining settings through
               // `updateAssignmentSettings`.
-              const { rosterIds } = patch;
-              const settingsPatch = { ...patch };
-              delete settingsPatch.rosterIds;
-              delete settingsPatch.periodName;
-              delete settingsPatch.periodNames;
+              // Destructure (rather than delete) so `settingsPatch` is
+              // type-narrowed to exclude the targeting fields — a future
+              // targeting field added to the patch can't silently leak into
+              // `updateAssignmentSettings`.
+              const {
+                rosterIds,
+                periodName: _periodName,
+                periodNames: _periodNames,
+                ...settingsPatch
+              } = patch;
               // These are two separate writeBatch.commit()s, not one
               // transaction. To keep the non-atomic window benign, apply the
               // secondary settings FIRST and the class targeting LAST. Targeting

--- a/components/widgets/QuizWidget/Widget.tsx
+++ b/components/widgets/QuizWidget/Widget.tsx
@@ -2038,17 +2038,29 @@ export const QuizWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
               delete settingsPatch.rosterIds;
               delete settingsPatch.periodName;
               delete settingsPatch.periodNames;
-              if (rosterIds !== undefined) {
-                const targets = deriveSessionTargetsFromRosters(
-                  rosters.filter((r) => rosterIds.includes(r.id))
-                );
-                await setAssignmentRosters(editingAssignment.id, targets);
-              }
+              // These are two separate writeBatch.commit()s, not one
+              // transaction. To keep the non-atomic window benign, apply the
+              // secondary settings FIRST and the class targeting LAST. Targeting
+              // (rosterIds/classIds on the session doc, which pinLoginV1 + SSO
+              // join read) moves as a single all-or-nothing batch inside
+              // setAssignmentRosters, so if its commit fails the assignment
+              // keeps its prior targeting intact — students still join with the
+              // old classes — and the modal stays open for retry. The only
+              // residual inconsistency is updated settings against old
+              // targeting, which is harmless. Folding both into one batch
+              // (a combined hook method) is a tracked follow-up.
               if (Object.keys(settingsPatch).length > 0) {
                 await updateAssignmentSettings(
                   editingAssignment.id,
                   settingsPatch
                 );
+              }
+              if (rosterIds !== undefined) {
+                const selectedRosterIds = new Set(rosterIds);
+                const targets = deriveSessionTargetsFromRosters(
+                  rosters.filter((r) => selectedRosterIds.has(r.id))
+                );
+                await setAssignmentRosters(editingAssignment.id, targets);
               }
               addToast('Assignment settings saved.', 'success');
               setEditingAssignment(null);

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -21,7 +21,14 @@ import type {
 } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
 import { AssignModal, ToggleRow } from '@/components/common/library';
+import { AssignClassPicker } from '@/components/common/AssignClassPicker';
+import {
+  makeEmptyPickerValue,
+  resolveSelectedRosters,
+  type AssignClassPickerValue,
+} from '@/components/common/AssignClassPicker.helpers';
 import { formatBehaviorSummary } from '@/utils/quizBehavior';
+import { deriveSessionTargetsFromRosters } from '@/utils/resolveAssignmentTargets';
 import {
   DEFAULT_DUE_TIME,
   dueInputsToEpoch,
@@ -48,7 +55,8 @@ interface SettingsOptions {
   className: string;
   plcMode: boolean;
   teacherName: string;
-  selectedPeriodNames: string[];
+  /** Unified roster picker state (rosterIds[]). */
+  picker: AssignClassPickerValue;
   plcSheetUrl: string;
   /** 'YYYY-MM-DD' local, or '' for no due date */
   dueDate: string;
@@ -56,8 +64,43 @@ interface SettingsOptions {
   dueTime: string;
 }
 
+/**
+ * Hydrate the unified picker value from a (possibly legacy) assignment.
+ *
+ * Precedence:
+ *   1. `a.rosterIds` — new post-unification assignments store these directly.
+ *   2. legacy fallback — derive rosterIds from the stored `periodNames`
+ *      (match against `roster.name`) so an existing assignment opens with the
+ *      right classes preselected. Quiz assignments never carried `classIds`
+ *      on the assignment doc (legacy ClassLink targeting lived on the session
+ *      doc), so there's nothing to recover via `mapLegacyClassIdsToRosterIds`
+ *      here — name-matching is the only legacy path.
+ *
+ * Unknown roster IDs / names simply drop out — the picker only shows rosters
+ * the teacher still has, mirroring `resolveAssignmentTargets`.
+ */
+function hydratePickerValue(
+  a: QuizAssignment,
+  rosters: ClassRoster[]
+): AssignClassPickerValue {
+  if (a.rosterIds && a.rosterIds.length > 0) {
+    const existing = new Set(rosters.map((r) => r.id));
+    const matched = a.rosterIds.filter((id) => existing.has(id));
+    return matched.length > 0 ? { rosterIds: matched } : makeEmptyPickerValue();
+  }
+
+  const legacyNames = a.periodNames ?? (a.periodName ? [a.periodName] : []);
+  const byName = new Set(legacyNames);
+  const fromNames = rosters.filter((r) => byName.has(r.name)).map((r) => r.id);
+
+  return fromNames.length > 0
+    ? { rosterIds: fromNames }
+    : makeEmptyPickerValue();
+}
+
 function initialOptionsFor(
   a: QuizAssignment,
+  rosters: ClassRoster[],
   defaultTeacherName?: string
 ): SettingsOptions {
   const due = splitDueAtToInputs(a.dueAt ?? null, a.dueAtHasTime);
@@ -65,7 +108,7 @@ function initialOptionsFor(
     className: a.className ?? '',
     plcMode: !!a.plc,
     teacherName: a.teacherName ?? defaultTeacherName ?? '',
-    selectedPeriodNames: a.periodNames ?? (a.periodName ? [a.periodName] : []),
+    picker: hydratePickerValue(a, rosters),
     plcSheetUrl: a.plc?.sheetUrl ?? '',
     dueDate: due.date,
     dueTime: due.time,
@@ -76,7 +119,7 @@ export const QuizAssignmentSettingsModal: React.FC<
   QuizAssignmentSettingsModalProps
 > = ({ assignment, rosters, onClose, onSave, defaultTeacherName }) => {
   const [options, setOptions] = useState<SettingsOptions>(() =>
-    initialOptionsFor(assignment, defaultTeacherName)
+    initialOptionsFor(assignment, rosters, defaultTeacherName)
   );
 
   // "Auto-Generated PLC Sheet" toggle — defaults ON when:
@@ -137,6 +180,16 @@ export const QuizAssignmentSettingsModal: React.FC<
           : { ...assignment.plc, sheetUrl: trimmedSheetUrl }
         : undefined;
 
+    // Unified targeting: derive both `rosterIds` (new source of truth) and
+    // `periodNames` (back-compat read path) from the selected rosters. Writing
+    // BOTH keeps existing readers (period-name fallback) working while moving
+    // the assignment into roster-ID space — `deriveSessionTargetsFromRosters`
+    // is the same derivation the create flow uses, so the two paths stay in
+    // lock-step on dedup. Unknown picked IDs (roster deleted after selection)
+    // drop out via the lookup.
+    const selectedRosters = resolveSelectedRosters(options.picker, rosters);
+    const targets = deriveSessionTargetsFromRosters(selectedRosters);
+
     // Freeze-live: behavior fields (sessionMode, sessionOptions, attemptLimit)
     // are intentionally OMITTED from the patch. They were frozen at create
     // time and must only change by editing the source quiz (affects future
@@ -145,8 +198,9 @@ export const QuizAssignmentSettingsModal: React.FC<
       className: options.className.trim(),
       plc: plcPatch,
       teacherName: options.teacherName.trim(),
-      periodName: options.selectedPeriodNames[0] ?? '',
-      periodNames: options.selectedPeriodNames,
+      rosterIds: targets.rosterIds,
+      periodName: targets.periodNames[0] ?? '',
+      periodNames: targets.periodNames,
       dueAt: dueInputsToEpoch(options.dueDate, options.dueTime),
       // The time picker always yields an explicit local time, so mark the value
       // as time-bearing (when a date is set) — distinguishes it from legacy
@@ -178,56 +232,11 @@ export const QuizAssignmentSettingsModal: React.FC<
       extraSlot={
         <>
           <div>
-            <label className="block text-xxs font-bold text-slate-400 uppercase tracking-widest mb-1">
-              Class Periods
-            </label>
-            {rosters.length > 0 ? (
-              <div className="space-y-1.5 max-h-36 overflow-y-auto rounded-lg border border-slate-200 bg-white p-2">
-                {rosters.map((r) => {
-                  const checked = options.selectedPeriodNames.includes(r.name);
-                  return (
-                    <label
-                      key={r.id}
-                      className="flex items-center gap-2 cursor-pointer hover:bg-slate-50 rounded px-1.5 py-1"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() =>
-                          setOptions((p) => ({
-                            ...p,
-                            selectedPeriodNames: checked
-                              ? p.selectedPeriodNames.filter(
-                                  (n) => n !== r.name
-                                )
-                              : [...p.selectedPeriodNames, r.name],
-                          }))
-                        }
-                        className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
-                      />
-                      <span className="text-sm text-slate-800">{r.name}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            ) : (
-              <input
-                type="text"
-                value={options.selectedPeriodNames.join(', ')}
-                onChange={(e) => {
-                  const names = e.target.value
-                    .split(',')
-                    .map((n) => n.trim())
-                    .filter(Boolean);
-                  setOptions((p) => ({
-                    ...p,
-                    selectedPeriodNames: [...new Set(names)],
-                  }));
-                }}
-                placeholder="e.g. Period 1, Period 2"
-                className="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-slate-800 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              />
-            )}
+            <AssignClassPicker
+              rosters={rosters}
+              value={options.picker}
+              onChange={(picker) => setOptions((prev) => ({ ...prev, picker }))}
+            />
             <p className="text-xxs text-slate-400 mt-0.5">
               Select class periods for this assignment. Students will choose
               their class when joining.

--- a/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
+++ b/components/widgets/QuizWidget/components/QuizAssignmentSettingsModal.tsx
@@ -83,7 +83,11 @@ function hydratePickerValue(
   a: QuizAssignment,
   rosters: ClassRoster[]
 ): AssignClassPickerValue {
-  if (a.rosterIds && a.rosterIds.length > 0) {
+  // An explicit `rosterIds` (including `[]`) is authoritative and must
+  // short-circuit before the legacy periodNames path: `[]` means "no rosters
+  // selected", not "fall back to name-matching". Only an absent field
+  // (undefined) consults the legacy periodNames below.
+  if (a.rosterIds !== undefined) {
     const existing = new Set(rosters.map((r) => r.id));
     const matched = a.rosterIds.filter((id) => existing.has(id));
     return matched.length > 0 ? { rosterIds: matched } : makeEmptyPickerValue();

--- a/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
@@ -286,6 +286,31 @@ describe('QuizAssignmentSettingsModal — unified class picker (rosterIds)', () 
     expect(checkboxes[1]).toBeChecked(); // Period 2 (matched by name)
   });
 
+  it('an explicit empty rosterIds short-circuits the legacy periodNames fallback', () => {
+    // rosterIds: [] means "no classes selected" and must NOT fall through to
+    // name-matching periodNames — even when periodNames is non-empty (e.g. a
+    // legacy field left on a doc whose targeting was later cleared).
+    const rosters = [
+      makeRoster({ id: 'r1', name: 'Period 1' }),
+      makeRoster({ id: 'r2', name: 'Period 2' }),
+    ];
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          rosterIds: [],
+          periodNames: ['Period 1', 'Period 2'],
+        })}
+        rosters={rosters}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Nothing preselected despite the non-empty legacy periodNames.
+    expect(checkboxes[0]).not.toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
   it('writes BOTH rosterIds AND periodNames (derived from selected rosters) on save', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     const rosters = [

--- a/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
+++ b/tests/components/widgets/QuizAssignmentSettingsModal.test.tsx
@@ -34,6 +34,18 @@ function makePlcAssignment(
   } as unknown as QuizAssignment;
 }
 
+function makeRoster(overrides: Partial<ClassRoster> = {}): ClassRoster {
+  return {
+    id: 'r1',
+    name: 'Period 1',
+    driveFileId: null,
+    studentCount: 0,
+    createdAt: 1,
+    students: [],
+    ...overrides,
+  } as ClassRoster;
+}
+
 describe('QuizAssignmentSettingsModal — behavior is read-only (freeze-live)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -218,6 +230,115 @@ describe('QuizAssignmentSettingsModal — behavior is read-only (freeze-live)', 
     const summary = screen.getByTestId('assignment-behavior-summary');
     expect(summary.textContent).toContain('Auto-progress');
     expect(summary.textContent).toContain('unlimited attempts');
+  });
+});
+
+describe('QuizAssignmentSettingsModal — unified class picker (rosterIds)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hydrates the picker from assignment.rosterIds (new path)', () => {
+    const rosters = [
+      makeRoster({ id: 'r1', name: 'Period 1' }),
+      makeRoster({ id: 'r2', name: 'Period 2' }),
+      makeRoster({ id: 'r3', name: 'Period 3' }),
+    ];
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          // periodNames intentionally stale/empty to prove rosterIds wins.
+          rosterIds: ['r1', 'r3'],
+          periodNames: [],
+        })}
+        rosters={rosters}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Three rosters → three checkboxes; r1 and r3 preselected, r2 not.
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0]).toBeChecked(); // r1
+    expect(checkboxes[1]).not.toBeChecked(); // r2
+    expect(checkboxes[2]).toBeChecked(); // r3
+  });
+
+  it('hydrates the picker from legacy periodNames by matching roster.name', () => {
+    const rosters = [
+      makeRoster({ id: 'r1', name: 'Period 1' }),
+      makeRoster({ id: 'r2', name: 'Period 2' }),
+    ];
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          // Legacy assignment: no rosterIds, only stored period names.
+          rosterIds: undefined,
+          periodNames: ['Period 2'],
+        })}
+        rosters={rosters}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).not.toBeChecked(); // Period 1
+    expect(checkboxes[1]).toBeChecked(); // Period 2 (matched by name)
+  });
+
+  it('writes BOTH rosterIds AND periodNames (derived from selected rosters) on save', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const rosters = [
+      makeRoster({ id: 'r1', name: 'Period 1' }),
+      makeRoster({ id: 'r2', name: 'Period 2' }),
+    ];
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          rosterIds: ['r1'],
+          periodNames: ['Period 1'],
+        })}
+        rosters={rosters}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    // Add Period 2 to the selection.
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patch = onSave.mock.calls[0][0] as Record<string, unknown>;
+    // rosterIds: both selected rosters, derived via deriveSessionTargetsFromRosters.
+    expect(patch.rosterIds).toEqual(['r1', 'r2']);
+    // periodNames: derived from the selected rosters' names (back-compat).
+    expect(patch.periodNames).toEqual(['Period 1', 'Period 2']);
+    // periodName mirrors periodNames[0].
+    expect(patch.periodName).toBe('Period 1');
+  });
+
+  it('writes empty rosterIds + periodNames when all classes are deselected', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const rosters = [makeRoster({ id: 'r1', name: 'Period 1' })];
+    render(
+      <QuizAssignmentSettingsModal
+        assignment={makePlcAssignment({
+          rosterIds: ['r1'],
+          periodNames: ['Period 1'],
+        })}
+        rosters={rosters}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // deselect
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const patch = onSave.mock.calls[0][0] as Record<string, unknown>;
+    expect(patch.rosterIds).toEqual([]);
+    expect(patch.periodNames).toEqual([]);
+    expect(patch.periodName).toBe('');
   });
 });
 

--- a/types.ts
+++ b/types.ts
@@ -3947,6 +3947,14 @@ export interface QuizAssignmentSettings {
   /** Selected class period roster names. Replaces singular periodName. */
   periodNames?: string[];
   /**
+   * Unified roster targeting (new post-unification assignments). Written
+   * additively alongside `periodNames` for back-compat: the edit modal
+   * derives both fields from the selected rosters on save. Legacy
+   * assignments without `rosterIds` continue to read via `periodNames`
+   * (and session `classIds`). No backfill of existing assignments.
+   */
+  rosterIds?: string[];
+  /**
    * Max completed submissions allowed per student. `null`/`undefined` means
    * unlimited (legacy). `1` (default for new assignments) means one-and-done.
    * Enforced at `joinQuizSession` time by checking the student's own existing
@@ -3983,9 +3991,6 @@ export interface QuizAssignment extends QuizAssignmentSettings {
   status: QuizAssignmentStatus;
   createdAt: number;
   updatedAt: number;
-  /** Unified roster targeting (new post-unification assignments). Legacy
-   *  assignments read via `periodNames` / session `classIds` only. */
-  rosterIds?: string[];
   /**
    * URL of the Google Sheet produced by the teacher's last Results → Export.
    * Persisted so re-entering the Results view after navigating away keeps the


### PR DESCRIPTION
## What (M6 — backlog `docs/remaining-todos-audit.md`)

Brings the **quiz assignment edit modal** to parity with the create flow:
- `QuizAssignmentSettingsModal` now uses the unified `<AssignClassPicker>` (multi-select, Select-All, ClassLink badges, smart roster filtering) instead of the inline period-name checkbox list.
- Adds `rosterIds?: string[]` to the assignment shape (additive). The modal hydrates the picker from `rosterIds` (falling back to mapping legacy `periodNames` → rosters by name), and on save **writes both `rosterIds` and `periodNames`** via `deriveSessionTargetsFromRosters` — the same derivation the create flow uses.

**Decided scope:** additive + back-compat. `periodNames[]` is kept for read-time fallback; **no backfill** of existing assignments; the read-fallback removal is a deferred, Paul-gated cleanup.

## Critical fix included (caught by adversarial review)

The first build routed the modal's save through `updateAssignmentSettings()`, which only mirrors `periodNames` to the live session doc — leaving `sessionData.rosterIds`/`classIds`/`classId`/`classPeriodByClassId` **stale after an edit**, which breaks SSO + PIN join (`pinLoginV1` reads `sessionData.rosterIds`). Fixed by routing class targeting through the existing `setAssignmentRosters()` (the create-flow dual-write) and the remaining settings through `updateAssignmentSettings()`. See commit `396ae005`.

## Validation
- `pnpm type-check` ✓ · `pnpm build` ✓ · `vitest` ✓ (QuizAssignmentSettingsModal.test + useQuizAssignments.test — 53 tests, incl. 4 new: hydrate-from-rosterIds, hydrate-from-legacy-periodNames, write-both-on-save, clear-all).

## Reviewer notes / residual
- The 5-line `onSave` wiring in `Widget.tsx` isn't covered by an isolated unit test (Widget is heavy to render); both halves it composes — modal patch shape and `setAssignmentRosters` session dual-write — are individually tested. Integration test is a reasonable follow-up.
- Edge case: editing an assignment whose targeted roster was since **renamed/deleted** will drop that target on save (the picker can't rehydrate it). This is marginally more correct than the old verbatim period-name round-trip, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)