### PR TITLE
feat(link-shortener): Phase 2 — Links analytics panel + inline Shorten-URL button (LO11)

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -1765,6 +1765,58 @@ export const AnalyticsManager: React.FC = () => {
     { id: 'links', label: 'Links', icon: <Link2 className="w-4 h-4" /> },
   ];
 
+  // The tab bar is rendered both inside the data-backed view and in the
+  // links-only early return below, so it lives here as a single source of
+  // truth. It depends only on `tabs`/`selectedTab`/`setSelectedTab` — never on
+  // the analytics snapshot.
+  const tabBar = (
+    <div
+      className="sticky top-0 z-10 bg-slate-100 rounded-xl border border-slate-200 p-1.5"
+      role="tablist"
+    >
+      <div className="flex gap-1">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            aria-label={tab.label}
+            aria-selected={selectedTab === tab.id}
+            id={`tab-${tab.id}`}
+            aria-controls={`panel-${tab.id}`}
+            tabIndex={selectedTab === tab.id ? 0 : -1}
+            onClick={() => setSelectedTab(tab.id)}
+            className={`flex-1 flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold border transition-colors ${
+              selectedTab === tab.id
+                ? 'bg-white border-slate-300 text-slate-900 shadow-sm'
+                : 'bg-transparent border-transparent text-slate-500 hover:text-slate-700 hover:bg-white/60'
+            }`}
+          >
+            {tab.icon}
+            <span className="sr-only sm:not-sr-only sm:inline">
+              {tab.label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+
+  // The Links tab reads Firestore independently via `useShortLinks` (inside
+  // LinksPanel) and does NOT depend on the analytics HTTP snapshot. Render it
+  // regardless of the analytics loading/error/cold-start state below, so it is
+  // always reachable. All other tabs remain gated on a loaded snapshot.
+  if (selectedTab === 'links') {
+    return (
+      <div className="space-y-5 pb-12">
+        {tabBar}
+        <div role="tabpanel" id="panel-links" aria-labelledby="tab-links">
+          <LinksPanel />
+        </div>
+      </div>
+    );
+  }
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -1873,36 +1925,7 @@ export const AnalyticsManager: React.FC = () => {
         <SnapshotFreshnessBadge meta={data?.meta} />
       </div>
 
-      <div
-        className="sticky top-0 z-10 bg-slate-100 rounded-xl border border-slate-200 p-1.5"
-        role="tablist"
-      >
-        <div className="flex gap-1">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              role="tab"
-              type="button"
-              aria-label={tab.label}
-              aria-selected={selectedTab === tab.id}
-              id={`tab-${tab.id}`}
-              aria-controls={`panel-${tab.id}`}
-              tabIndex={selectedTab === tab.id ? 0 : -1}
-              onClick={() => setSelectedTab(tab.id)}
-              className={`flex-1 flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold border transition-colors ${
-                selectedTab === tab.id
-                  ? 'bg-white border-slate-300 text-slate-900 shadow-sm'
-                  : 'bg-transparent border-transparent text-slate-500 hover:text-slate-700 hover:bg-white/60'
-              }`}
-            >
-              {tab.icon}
-              <span className="sr-only sm:not-sr-only sm:inline">
-                {tab.label}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
+      {tabBar}
 
       {selectedTab === 'overview' && (
         <div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview">
@@ -1934,11 +1957,6 @@ export const AnalyticsManager: React.FC = () => {
       {selectedTab === 'users' && (
         <div role="tabpanel" id="panel-users" aria-labelledby="tab-users">
           <UsersPanel data={data} />
-        </div>
-      )}
-      {selectedTab === 'links' && (
-        <div role="tabpanel" id="panel-links" aria-labelledby="tab-links">
-          <LinksPanel />
         </div>
       )}
 

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -29,6 +29,7 @@ import {
   Clock,
   Info,
   LayoutGrid,
+  Link2,
   School,
   Search,
   Users,
@@ -45,6 +46,7 @@ import {
   type Building,
 } from '@/config/buildings';
 import { TOOLS } from '@/config/tools';
+import { LinksPanel } from './LinksPanel';
 
 interface EngagementCounts {
   total: number;
@@ -132,7 +134,7 @@ type AnalyticsErrorState =
   | { kind: 'cold-start'; message: string }
   | { kind: 'fatal'; message: string };
 
-type AnalyticsTab = 'overview' | 'widgets' | 'ai' | 'users';
+type AnalyticsTab = 'overview' | 'widgets' | 'ai' | 'users' | 'links';
 
 const WIDGET_LABELS: Record<string, string> = TOOLS.reduce(
   (acc, tool) => {
@@ -1760,6 +1762,7 @@ export const AnalyticsManager: React.FC = () => {
     },
     { id: 'ai', label: 'AI Usage', icon: <WandSparkles className="w-4 h-4" /> },
     { id: 'users', label: 'Users', icon: <School className="w-4 h-4" /> },
+    { id: 'links', label: 'Links', icon: <Link2 className="w-4 h-4" /> },
   ];
 
   if (loading) {
@@ -1931,6 +1934,11 @@ export const AnalyticsManager: React.FC = () => {
       {selectedTab === 'users' && (
         <div role="tabpanel" id="panel-users" aria-labelledby="tab-users">
           <UsersPanel data={data} />
+        </div>
+      )}
+      {selectedTab === 'links' && (
+        <div role="tabpanel" id="panel-links" aria-labelledby="tab-links">
+          <LinksPanel />
         </div>
       )}
 

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -1820,6 +1820,7 @@ export const AnalyticsManager: React.FC = () => {
   if (loading) {
     return (
       <div className="space-y-4">
+        {tabBar}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <div
@@ -1842,23 +1843,29 @@ export const AnalyticsManager: React.FC = () => {
       // copy ("ready at 5:00 AM Central daily"); render it in a calm slate
       // surface, not red.
       return (
-        <div className="bg-slate-50 border border-slate-200 text-slate-700 p-6 rounded-2xl flex items-start gap-3">
-          <Info className="w-6 h-6 shrink-0 mt-0.5 text-slate-400" />
-          <div>
-            <h3 className="font-bold mb-1 text-slate-900">
-              Analytics not ready yet
-            </h3>
-            <p className="text-sm">{error.message}</p>
+        <div className="space-y-4">
+          {tabBar}
+          <div className="bg-slate-50 border border-slate-200 text-slate-700 p-6 rounded-2xl flex items-start gap-3">
+            <Info className="w-6 h-6 shrink-0 mt-0.5 text-slate-400" />
+            <div>
+              <h3 className="font-bold mb-1 text-slate-900">
+                Analytics not ready yet
+              </h3>
+              <p className="text-sm">{error.message}</p>
+            </div>
           </div>
         </div>
       );
     }
     return (
-      <div className="bg-red-50 border border-red-200 text-red-800 p-6 rounded-2xl flex items-start gap-3">
-        <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" />
-        <div>
-          <h3 className="font-bold mb-1">Failed to Load Analytics</h3>
-          <p className="text-sm">{error.message}</p>
+      <div className="space-y-4">
+        {tabBar}
+        <div className="bg-red-50 border border-red-200 text-red-800 p-6 rounded-2xl flex items-start gap-3">
+          <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-bold mb-1">Failed to Load Analytics</h3>
+            <p className="text-sm">{error.message}</p>
+          </div>
         </div>
       </div>
     );

--- a/components/admin/Analytics/LinksPanel.tsx
+++ b/components/admin/Analytics/LinksPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Link2,
   MousePointerClick,
@@ -8,7 +8,7 @@ import {
   Loader2,
 } from 'lucide-react';
 
-import { useShortLinks } from '@/hooks/useShortLinks';
+import { useShortLinks, ADMIN_LIST_LIMIT } from '@/hooks/useShortLinks';
 import { buildShortUrl } from '@/utils/shortLinkValidation';
 import { ShortLink } from '@/types';
 
@@ -34,9 +34,12 @@ const formatDate = (epoch: number | null | undefined): string => {
   });
 };
 
-const formatRelative = (epoch: number | null | undefined): string => {
+const formatRelative = (
+  epoch: number | null | undefined,
+  now: number
+): string => {
   if (!epoch) return 'Never';
-  const diff = Date.now() - epoch;
+  const diff = now - epoch;
   const minute = 60 * 1000;
   const hour = 60 * minute;
   const day = 24 * hour;
@@ -146,8 +149,16 @@ const LinkCell: React.FC<{ link: ShortLink }> = ({ link }) => (
 
 export const LinksPanel: React.FC = () => {
   const { links, loading, error } = useShortLinks();
+  // Stable per-mount "now" so relative timestamps and the 7-day KPI cutoff
+  // don't re-evaluate Date.now() on every render (React purity).
+  const [now] = useState(() => Date.now());
 
-  const kpis = useMemo(() => computeLinksKpis(links), [links]);
+  const kpis = useMemo(() => computeLinksKpis(links, now), [links, now]);
+
+  // The admin listing is capped at ADMIN_LIST_LIMIT, so once a district has
+  // more links than that, "Total Links" / "Total Clicks" reflect only the most
+  // recent page. Surface that so the numbers aren't read as district totals.
+  const isTruncated = links.length >= ADMIN_LIST_LIMIT;
 
   const topLinks = useMemo(
     () =>
@@ -206,6 +217,9 @@ export const LinksPanel: React.FC = () => {
         <KpiCard
           title="Total Links"
           value={formatNumber(kpis.totalLinks)}
+          subtitle={
+            isTruncated ? `Showing most recent ${ADMIN_LIST_LIMIT}` : undefined
+          }
           accentColor="#2d3f89"
           accentBg="#e0e7ff"
           icon={<Link2 className="w-5 h-5 text-brand-blue-primary" />}
@@ -213,6 +227,7 @@ export const LinksPanel: React.FC = () => {
         <KpiCard
           title="Total Clicks"
           value={formatNumber(kpis.totalClicks)}
+          subtitle={isTruncated ? 'Across most recent links' : undefined}
           accentColor="#10b981"
           accentBg="#d1fae5"
           icon={<MousePointerClick className="w-5 h-5 text-emerald-600" />}
@@ -272,7 +287,7 @@ export const LinksPanel: React.FC = () => {
                     {formatNumber(link.clicks ?? 0)}
                   </td>
                   <td className="px-4 py-3 align-top text-slate-500">
-                    {formatRelative(link.lastClickedAt)}
+                    {formatRelative(link.lastClickedAt, now)}
                   </td>
                 </tr>
               ))}
@@ -323,7 +338,7 @@ export const LinksPanel: React.FC = () => {
                       </a>
                     </td>
                     <td className="px-4 py-3 align-top text-slate-500">
-                      {formatRelative(link.lastClickedAt)}
+                      {formatRelative(link.lastClickedAt, now)}
                     </td>
                     <td className="px-4 py-3 align-top text-right font-semibold text-slate-800">
                       {formatNumber(link.clicks ?? 0)}

--- a/components/admin/Analytics/LinksPanel.tsx
+++ b/components/admin/Analytics/LinksPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react';
 
 import { useShortLinks } from '@/hooks/useShortLinks';
-import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+import { buildShortUrl } from '@/utils/shortLinkValidation';
 import { ShortLink } from '@/types';
 
 // LinksPanel surfaces the click data the link shortener (phase 1) already
@@ -24,11 +24,6 @@ const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 const NUMBER_FORMATTER = new Intl.NumberFormat();
 const formatNumber = (value: number) => NUMBER_FORMATTER.format(value);
-
-const buildShortUrl = (code: string): string => {
-  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
-  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
-};
 
 const formatDate = (epoch: number | null | undefined): string => {
   if (!epoch) return '—';
@@ -172,8 +167,8 @@ export const LinksPanel: React.FC = () => {
   if (loading) {
     return (
       <div className="px-5 py-12 flex items-center justify-center text-slate-500">
-        <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading link
-        analytics…
+        <Loader2 className="w-5 h-5 animate-spin mr-2" aria-hidden="true" />{' '}
+        Loading link analytics…
       </div>
     );
   }
@@ -181,7 +176,7 @@ export const LinksPanel: React.FC = () => {
   if (error) {
     return (
       <div className="bg-red-50 border border-red-200 text-red-800 p-6 rounded-2xl flex items-start gap-3">
-        <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" />
+        <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" aria-hidden="true" />
         <div>
           <h3 className="font-bold mb-1">Failed to Load Link Analytics</h3>
           <p className="text-sm">{error}</p>

--- a/components/admin/Analytics/LinksPanel.tsx
+++ b/components/admin/Analytics/LinksPanel.tsx
@@ -1,0 +1,345 @@
+import React, { useMemo } from 'react';
+import {
+  Link2,
+  MousePointerClick,
+  Sparkles,
+  AlertCircle,
+  ExternalLink,
+  Loader2,
+} from 'lucide-react';
+
+import { useShortLinks } from '@/hooks/useShortLinks';
+import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+import { ShortLink } from '@/types';
+
+// LinksPanel surfaces the click data the link shortener (phase 1) already
+// collects on each `short_links/{code}` doc. It is read-only analytics — no
+// edit/delete here; admins manage links from the dedicated Link Shortener tab.
+//
+// Deliberately NO time-series chart: a clicks-over-time view needs the
+// per-click event log (phase 2 PR2), which isn't shipped. All we have today
+// is a lifetime `clicks` counter, so bucketing by date would be misleading.
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+const NUMBER_FORMATTER = new Intl.NumberFormat();
+const formatNumber = (value: number) => NUMBER_FORMATTER.format(value);
+
+const buildShortUrl = (code: string): string => {
+  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
+  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
+};
+
+const formatDate = (epoch: number | null | undefined): string => {
+  if (!epoch) return '—';
+  return new Date(epoch).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+const formatRelative = (epoch: number | null | undefined): string => {
+  if (!epoch) return 'Never';
+  const diff = Date.now() - epoch;
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return 'Just now';
+  if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
+  if (diff < day) return `${Math.floor(diff / hour)}h ago`;
+  if (diff < 7 * day) return `${Math.floor(diff / day)}d ago`;
+  return formatDate(epoch);
+};
+
+// Local KPI card mirroring AnalyticsManager's `KpiCard` visual language so the
+// Links panel matches every other analytics panel. Kept local (the wrapper in
+// AnalyticsManager isn't exported) — a tiny presentational duplication that
+// keeps panels independent.
+const KpiCard: React.FC<{
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  accentColor: string;
+  accentBg: string;
+  icon: React.ReactNode;
+}> = ({ title, value, subtitle, accentColor, accentBg, icon }) => (
+  <div className="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm relative overflow-hidden">
+    <div
+      className="absolute left-0 top-0 bottom-0 w-1 rounded-l-2xl"
+      style={{ background: accentColor }}
+    />
+    <div className="flex items-start justify-between gap-3">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          {title}
+        </p>
+        <p className="text-3xl font-black text-slate-900 mt-1">{value}</p>
+        {subtitle && <p className="text-sm text-slate-500 mt-1">{subtitle}</p>}
+      </div>
+      <div className="p-3 rounded-xl" style={{ background: accentBg }}>
+        {icon}
+      </div>
+    </div>
+  </div>
+);
+
+const PanelCard: React.FC<React.PropsWithChildren<{ title: string }>> = ({
+  title,
+  children,
+}) => (
+  <div className="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm">
+    <h3 className="text-sm font-bold text-slate-700 uppercase tracking-wider mb-4">
+      {title}
+    </h3>
+    {children}
+  </div>
+);
+
+interface LinksKpis {
+  totalLinks: number;
+  totalClicks: number;
+  createdLast7Days: number;
+  zeroClickLinks: number;
+}
+
+/**
+ * Pure KPI math, exported so unit tests can exercise it directly without
+ * mounting the component or the Firestore-backed hook.
+ */
+export const computeLinksKpis = (
+  links: ShortLink[],
+  now: number = Date.now()
+): LinksKpis => {
+  const cutoff = now - SEVEN_DAYS_MS;
+  let totalClicks = 0;
+  let createdLast7Days = 0;
+  let zeroClickLinks = 0;
+  for (const link of links) {
+    totalClicks += link.clicks ?? 0;
+    if (typeof link.createdAt === 'number' && link.createdAt >= cutoff) {
+      createdLast7Days += 1;
+    }
+    if (!link.clicks) {
+      zeroClickLinks += 1;
+    }
+  }
+  return {
+    totalLinks: links.length,
+    totalClicks,
+    createdLast7Days,
+    zeroClickLinks,
+  };
+};
+
+const LinkCell: React.FC<{ link: ShortLink }> = ({ link }) => (
+  <td className="px-4 py-3 align-top">
+    <a
+      href={buildShortUrl(link.code)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-mono text-sm text-slate-800 hover:text-brand-blue-primary"
+    >
+      /r/{link.code}
+      <ExternalLink className="w-3 h-3 shrink-0 text-slate-400" />
+    </a>
+    {link.label && (
+      <div className="text-xs text-slate-500 mt-0.5">{link.label}</div>
+    )}
+  </td>
+);
+
+export const LinksPanel: React.FC = () => {
+  const { links, loading, error } = useShortLinks();
+
+  const kpis = useMemo(() => computeLinksKpis(links), [links]);
+
+  const topLinks = useMemo(
+    () =>
+      [...links].sort((a, b) => (b.clicks ?? 0) - (a.clicks ?? 0)).slice(0, 10),
+    [links]
+  );
+
+  const recentLinks = useMemo(
+    () =>
+      [...links]
+        .filter((link) => link.lastClickedAt != null)
+        .sort((a, b) => (b.lastClickedAt ?? 0) - (a.lastClickedAt ?? 0))
+        .slice(0, 10),
+    [links]
+  );
+
+  if (loading) {
+    return (
+      <div className="px-5 py-12 flex items-center justify-center text-slate-500">
+        <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading link
+        analytics…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-800 p-6 rounded-2xl flex items-start gap-3">
+        <AlertCircle className="w-6 h-6 shrink-0 mt-0.5" />
+        <div>
+          <h3 className="font-bold mb-1">Failed to Load Link Analytics</h3>
+          <p className="text-sm">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (links.length === 0) {
+    return (
+      <div className="bg-white border border-slate-200 rounded-2xl p-10 text-center">
+        <div className="inline-flex p-3 rounded-2xl bg-slate-100 text-slate-400 mb-3">
+          <Link2 className="w-6 h-6" />
+        </div>
+        <h3 className="font-bold text-slate-800 mb-1">No short links yet</h3>
+        <p className="text-sm text-slate-500 max-w-md mx-auto">
+          Create short links from the Link Shortener tab. Once teachers start
+          clicking them, usage analytics will appear here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard
+          title="Total Links"
+          value={formatNumber(kpis.totalLinks)}
+          accentColor="#2d3f89"
+          accentBg="#e0e7ff"
+          icon={<Link2 className="w-5 h-5 text-brand-blue-primary" />}
+        />
+        <KpiCard
+          title="Total Clicks"
+          value={formatNumber(kpis.totalClicks)}
+          accentColor="#10b981"
+          accentBg="#d1fae5"
+          icon={<MousePointerClick className="w-5 h-5 text-emerald-600" />}
+        />
+        <KpiCard
+          title="Created (7 days)"
+          value={formatNumber(kpis.createdLast7Days)}
+          subtitle="New links this week"
+          accentColor="#3b82f6"
+          accentBg="#dbeafe"
+          icon={<Sparkles className="w-5 h-5 text-blue-600" />}
+        />
+        <KpiCard
+          title="Zero Clicks"
+          value={formatNumber(kpis.zeroClickLinks)}
+          subtitle="Cleanup candidates"
+          accentColor="#f59e0b"
+          accentBg="#fef3c7"
+          icon={<AlertCircle className="w-5 h-5 text-amber-600" />}
+        />
+      </div>
+
+      <PanelCard title="Top Links by Clicks">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="text-left px-4 py-2 font-semibold">Short URL</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Destination
+                </th>
+                <th className="text-right px-4 py-2 font-semibold">Clicks</th>
+                <th className="text-left px-4 py-2 font-semibold">
+                  Last clicked
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {topLinks.map((link) => (
+                <tr
+                  key={link.code}
+                  className="border-t border-slate-100 hover:bg-slate-50/50"
+                >
+                  <LinkCell link={link} />
+                  <td className="px-4 py-3 align-top max-w-md">
+                    <a
+                      href={link.destination}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block truncate text-slate-700 hover:text-brand-blue-primary"
+                      title={link.destination}
+                    >
+                      {link.destination}
+                    </a>
+                  </td>
+                  <td className="px-4 py-3 align-top text-right font-semibold text-slate-800">
+                    {formatNumber(link.clicks ?? 0)}
+                  </td>
+                  <td className="px-4 py-3 align-top text-slate-500">
+                    {formatRelative(link.lastClickedAt)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </PanelCard>
+
+      <PanelCard title="Recent Activity">
+        {recentLinks.length === 0 ? (
+          <p className="text-sm text-slate-500 px-1 py-4">
+            No clicks recorded yet. Activity appears here once a short link is
+            visited.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="text-left px-4 py-2 font-semibold">
+                    Short URL
+                  </th>
+                  <th className="text-left px-4 py-2 font-semibold">
+                    Destination
+                  </th>
+                  <th className="text-left px-4 py-2 font-semibold">
+                    Last clicked
+                  </th>
+                  <th className="text-right px-4 py-2 font-semibold">Clicks</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentLinks.map((link) => (
+                  <tr
+                    key={link.code}
+                    className="border-t border-slate-100 hover:bg-slate-50/50"
+                  >
+                    <LinkCell link={link} />
+                    <td className="px-4 py-3 align-top max-w-md">
+                      <a
+                        href={link.destination}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="block truncate text-slate-700 hover:text-brand-blue-primary"
+                        title={link.destination}
+                      >
+                        {link.destination}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 align-top text-slate-500">
+                      {formatRelative(link.lastClickedAt)}
+                    </td>
+                    <td className="px-4 py-3 align-top text-right font-semibold text-slate-800">
+                      {formatNumber(link.clicks ?? 0)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </PanelCard>
+    </div>
+  );
+};

--- a/components/admin/Announcements/EmbedConfigEditor.tsx
+++ b/components/admin/Announcements/EmbedConfigEditor.tsx
@@ -20,11 +20,14 @@ import { EmbedTab } from './types';
 
 import { EmbedConfig } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
+import { ShortenUrlButton } from '@/components/admin/ShortenUrlButton';
 
 export const EmbedConfigEditor: React.FC<{
   config: Partial<EmbedConfig>;
   onChange: (config: Partial<EmbedConfig>) => void;
-}> = ({ config, onChange }) => {
+  /** Surrounding context (e.g. announcement title) used as the short-link label. */
+  label?: string;
+}> = ({ config, onChange, label }) => {
   const [activeTab, setActiveTab] = useState<EmbedTab>(() => {
     const mode = config.mode as EmbedTab | undefined;
     return mode === 'url' || mode === 'code' ? mode : 'url';
@@ -99,6 +102,16 @@ export const EmbedConfigEditor: React.FC<{
       }
       onChange(next);
     }
+  };
+
+  // Replace the field with a freshly-created short URL. A `/r/:code` link is
+  // never a YouTube watch URL, so drop any start-at offset to stay consistent
+  // with `applyUrl`.
+  const applyShortUrl = (shortUrl: string) => {
+    setRawUrl(shortUrl);
+    const next: Partial<EmbedConfig> = { ...config, url: shortUrl };
+    delete next.startAtSeconds;
+    onChange(next);
   };
 
   const copyToClipboard = (text: string) => {
@@ -228,14 +241,22 @@ export const EmbedConfigEditor: React.FC<{
           <label className="block text-xs font-semibold text-slate-700">
             URL to Embed
           </label>
-          <input
-            type="url"
-            value={rawUrl}
-            onChange={(e) => setRawUrl(e.target.value)}
-            onBlur={applyUrl}
-            className="w-full px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
-            placeholder="YouTube, Google Drive, Docs, Slides, Forms…"
-          />
+          <div className="flex items-start gap-2">
+            <input
+              type="url"
+              value={rawUrl}
+              onChange={(e) => setRawUrl(e.target.value)}
+              onBlur={applyUrl}
+              className="flex-1 px-3 py-2 text-sm border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-blue-primary"
+              placeholder="YouTube, Google Drive, Docs, Slides, Forms…"
+            />
+            <ShortenUrlButton
+              url={rawUrl}
+              label={label}
+              onShortened={applyShortUrl}
+              className="shrink-0"
+            />
+          </div>
           {wasConverted && (
             <div className="flex items-start gap-2 p-2 bg-emerald-50 border border-emerald-200 rounded-lg">
               <Check className="w-3.5 h-3.5 text-emerald-600 shrink-0 mt-0.5" />

--- a/components/admin/Announcements/EmbedConfigEditor.tsx
+++ b/components/admin/Announcements/EmbedConfigEditor.tsx
@@ -251,7 +251,11 @@ export const EmbedConfigEditor: React.FC<{
               placeholder="YouTube, Google Drive, Docs, Slides, Forms…"
             />
             <ShortenUrlButton
-              url={rawUrl}
+              // Shorten the embeddable form (same as applyUrl/onBlur), not the
+              // raw input — otherwise clicking before blurring would capture a
+              // YouTube watch URL (which YouTube blocks from embedding) and the
+              // /r/code redirect would render a blank iframe.
+              url={embedUrl || rawUrl.trim()}
               label={label}
               onShortened={applyShortUrl}
               className="shrink-0"

--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -344,6 +344,7 @@ function renderConfigEditor(
       return (
         <EmbedConfigEditor
           config={form.widgetConfig}
+          label={form.name}
           onChange={(config) =>
             handleConfigChange(config as Record<string, unknown>)
           }

--- a/components/admin/LinkShortenerManager.tsx
+++ b/components/admin/LinkShortenerManager.tsx
@@ -17,13 +17,8 @@ import { useShortLinks } from '@/hooks/useShortLinks';
 import { useDialog } from '@/context/useDialog';
 import { Toast } from '@/components/common/Toast';
 import { logError } from '@/utils/logError';
-import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+import { buildShortUrl } from '@/utils/shortLinkValidation';
 import { ShortLink } from '@/types';
-
-const buildShortUrl = (code: string): string => {
-  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
-  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
-};
 
 const formatDate = (epoch: number | null | undefined): string => {
   if (!epoch) return '—';

--- a/components/admin/ShortenUrlButton.tsx
+++ b/components/admin/ShortenUrlButton.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Link2, Loader2, Check } from 'lucide-react';
+
+import { useAuth } from '@/context/useAuth';
+import { useShortLinks } from '@/hooks/useShortLinks';
+import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
+
+const buildShortUrl = (code: string): string => {
+  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
+  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
+};
+
+interface ShortenUrlButtonProps {
+  /** The long URL to shorten. Button is disabled when blank. */
+  url: string;
+  /** Called with the resulting `/r/:code` short URL on success. */
+  onShortened: (shortUrl: string) => void;
+  /**
+   * Optional contextual label stored on the new short link (e.g. the
+   * announcement title or widget label) so the admin link table is readable.
+   */
+  label?: string;
+  /** Optional extra classes for the wrapper. */
+  className?: string;
+}
+
+/**
+ * Inline "Shorten this URL" button placed next to URL inputs across the admin
+ * surface. On click it creates a `short_links/{code}` doc via `createShortLink`
+ * and hands the resulting `/r/:code` URL back to the parent via `onShortened`,
+ * which decides whether to replace the field value.
+ *
+ * Admin-gated: renders `null` for non-admins, so teachers keep entering raw
+ * URLs exactly as before. It never auto-replaces — the parent owns that.
+ */
+export const ShortenUrlButton: React.FC<ShortenUrlButtonProps> = ({
+  url,
+  onShortened,
+  label,
+  className,
+}) => {
+  const { isAdmin } = useAuth();
+  const { createShortLink } = useShortLinks();
+  const [state, setState] = useState<'idle' | 'working' | 'done'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  // Non-admins never see the button. Firestore rules also reject the write,
+  // but hiding it keeps the teacher-facing surface clean.
+  if (!isAdmin) return null;
+
+  const trimmed = url.trim();
+  const disabled = state === 'working' || trimmed === '';
+
+  const handleClick = async () => {
+    if (disabled) return;
+    setError(null);
+    setState('working');
+    try {
+      const result = await createShortLink({
+        destination: trimmed,
+        label: label?.trim() || undefined,
+      });
+      if (!result.ok) {
+        setError(result.reason);
+        setState('idle');
+        return;
+      }
+      onShortened(buildShortUrl(result.link.code));
+      setState('done');
+      window.setTimeout(() => setState('idle'), 1500);
+    } catch {
+      setError('Failed to shorten URL.');
+      setState('idle');
+    }
+  };
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => void handleClick()}
+        disabled={disabled}
+        title="Create a short /r/ link for this URL"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-300 bg-white text-xs font-semibold text-slate-600 hover:bg-slate-50 hover:text-brand-blue-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {state === 'working' ? (
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+        ) : state === 'done' ? (
+          <Check className="w-3.5 h-3.5 text-emerald-600" />
+        ) : (
+          <Link2 className="w-3.5 h-3.5" />
+        )}
+        {state === 'done' ? 'Shortened' : 'Shorten URL'}
+      </button>
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+};

--- a/components/admin/ShortenUrlButton.tsx
+++ b/components/admin/ShortenUrlButton.tsx
@@ -3,12 +3,7 @@ import { Link2, Loader2, Check } from 'lucide-react';
 
 import { useAuth } from '@/context/useAuth';
 import { useShortLinks } from '@/hooks/useShortLinks';
-import { SHORT_LINK_PREFIX } from '@/utils/shortLinkValidation';
-
-const buildShortUrl = (code: string): string => {
-  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
-  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
-};
+import { buildShortUrl } from '@/utils/shortLinkValidation';
 
 interface ShortenUrlButtonProps {
   /** The long URL to shorten. Button is disabled when blank. */
@@ -84,11 +79,11 @@ export const ShortenUrlButton: React.FC<ShortenUrlButtonProps> = ({
         className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-slate-300 bg-white text-xs font-semibold text-slate-600 hover:bg-slate-50 hover:text-brand-blue-primary disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
       >
         {state === 'working' ? (
-          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
         ) : state === 'done' ? (
-          <Check className="w-3.5 h-3.5 text-emerald-600" />
+          <Check className="w-3.5 h-3.5 text-emerald-600" aria-hidden="true" />
         ) : (
-          <Link2 className="w-3.5 h-3.5" />
+          <Link2 className="w-3.5 h-3.5" aria-hidden="true" />
         )}
         {state === 'done' ? 'Shortened' : 'Shorten URL'}
       </button>

--- a/components/admin/ShortenUrlButton.tsx
+++ b/components/admin/ShortenUrlButton.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link2, Loader2, Check } from 'lucide-react';
 
 import { useAuth } from '@/context/useAuth';
-import { useShortLinks } from '@/hooks/useShortLinks';
+import { useCreateShortLink } from '@/hooks/useShortLinks';
 import { buildShortUrl } from '@/utils/shortLinkValidation';
 
 interface ShortenUrlButtonProps {
@@ -35,9 +35,20 @@ export const ShortenUrlButton: React.FC<ShortenUrlButtonProps> = ({
   className,
 }) => {
   const { isAdmin } = useAuth();
-  const { createShortLink } = useShortLinks();
+  const { createShortLink } = useCreateShortLink();
   const [state, setState] = useState<'idle' | 'working' | 'done'>('idle');
   const [error, setError] = useState<string | null>(null);
+  // Track the "done → idle" reset timer so it can be cancelled if the editor
+  // unmounts within the 1.5s window (avoids a setState on an unmounted node).
+  const resetTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    },
+    []
+  );
 
   // Non-admins never see the button. Firestore rules also reject the write,
   // but hiding it keeps the teacher-facing surface clean.
@@ -62,7 +73,10 @@ export const ShortenUrlButton: React.FC<ShortenUrlButtonProps> = ({
       }
       onShortened(buildShortUrl(result.link.code));
       setState('done');
-      window.setTimeout(() => setState('idle'), 1500);
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+      resetTimerRef.current = window.setTimeout(() => setState('idle'), 1500);
     } catch {
       setError('Failed to shorten URL.');
       setState('idle');

--- a/hooks/useShortLinks.ts
+++ b/hooks/useShortLinks.ts
@@ -41,8 +41,9 @@ const COLLECTION = SHORT_LINKS_COLLECTION;
 const MAX_CODE_GENERATION_RETRIES = 5;
 // Cap admin listings — keeps the read quota predictable and the table
 // responsive once a district has hundreds of links. Pagination/search UI
-// for larger sets is a phase 2 concern.
-const ADMIN_LIST_LIMIT = 100;
+// for larger sets is a phase 2 concern. Exported so analytics surfaces can
+// flag when a listing is truncated at this cap.
+export const ADMIN_LIST_LIMIT = 100;
 
 /**
  * Thrown inside the create transaction when the target slug already
@@ -116,74 +117,16 @@ const createShortLinkAtomic = async (
 };
 
 /**
- * Admin-side hook. Subscribes to all short links (small collection,
- * admin-only audience) and exposes create/update/delete helpers.
+ * Subscription-free create helper. Carved out of `useShortLinks` so callers
+ * that only ever create a link (e.g. the inline `ShortenUrlButton`) don't pay
+ * for the `onSnapshot` listener over up to `ADMIN_LIST_LIMIT` docs — and don't
+ * trigger a 100-doc re-delivery to a listener that discards it every time they
+ * write. `useShortLinks` reuses this so the create logic lives in one place.
  */
-export const useShortLinks = (): UseShortLinksResult => {
+export const useCreateShortLink = (): {
+  createShortLink: (input: CreateShortLinkInput) => Promise<CreateResult>;
+} => {
   const { user, isAdmin } = useAuth();
-  const [links, setLinks] = useState<ShortLink[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!isAdmin) {
-      setLinks([]);
-      setLoading(false);
-      // Clear any stale admin-only error so it doesn't linger after a
-      // sign-out / role drop.
-      setError(null);
-      return;
-    }
-
-    setLoading(true);
-    const q = query(
-      collection(db, COLLECTION),
-      orderBy('createdAt', 'desc'),
-      limit(ADMIN_LIST_LIMIT)
-    );
-    const unsubscribe = onSnapshot(
-      q,
-      (snapshot) => {
-        const next: ShortLink[] = [];
-        snapshot.forEach((docSnap) => {
-          next.push(docSnap.data() as ShortLink);
-        });
-        setLinks(next);
-        setLoading(false);
-        setError(null);
-      },
-      (err) => {
-        logError('useShortLinks.snapshot', err);
-        setError('Failed to load short links.');
-        setLoading(false);
-      }
-    );
-
-    return () => unsubscribe();
-  }, [isAdmin]);
-
-  const refresh = useCallback(async () => {
-    if (!isAdmin) return;
-    try {
-      setLoading(true);
-      const snapshot = await getDocs(
-        query(
-          collection(db, COLLECTION),
-          orderBy('createdAt', 'desc'),
-          limit(ADMIN_LIST_LIMIT)
-        )
-      );
-      const next: ShortLink[] = [];
-      snapshot.forEach((docSnap) => next.push(docSnap.data() as ShortLink));
-      setLinks(next);
-      setError(null);
-    } catch (err) {
-      logError('useShortLinks.refresh', err);
-      setError('Failed to load short links.');
-    } finally {
-      setLoading(false);
-    }
-  }, [isAdmin]);
 
   const createShortLink = useCallback(
     async (input: CreateShortLinkInput): Promise<CreateResult> => {
@@ -273,6 +216,80 @@ export const useShortLinks = (): UseShortLinksResult => {
     },
     [user, isAdmin]
   );
+
+  return { createShortLink };
+};
+
+/**
+ * Admin-side hook. Subscribes to all short links (small collection,
+ * admin-only audience) and exposes create/update/delete helpers.
+ */
+export const useShortLinks = (): UseShortLinksResult => {
+  const { isAdmin } = useAuth();
+  const { createShortLink } = useCreateShortLink();
+  const [links, setLinks] = useState<ShortLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setLinks([]);
+      setLoading(false);
+      // Clear any stale admin-only error so it doesn't linger after a
+      // sign-out / role drop.
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    const q = query(
+      collection(db, COLLECTION),
+      orderBy('createdAt', 'desc'),
+      limit(ADMIN_LIST_LIMIT)
+    );
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const next: ShortLink[] = [];
+        snapshot.forEach((docSnap) => {
+          next.push(docSnap.data() as ShortLink);
+        });
+        setLinks(next);
+        setLoading(false);
+        setError(null);
+      },
+      (err) => {
+        logError('useShortLinks.snapshot', err);
+        setError('Failed to load short links.');
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [isAdmin]);
+
+  const refresh = useCallback(async () => {
+    if (!isAdmin) return;
+    try {
+      setLoading(true);
+      const snapshot = await getDocs(
+        query(
+          collection(db, COLLECTION),
+          orderBy('createdAt', 'desc'),
+          limit(ADMIN_LIST_LIMIT)
+        )
+      );
+      const next: ShortLink[] = [];
+      snapshot.forEach((docSnap) => next.push(docSnap.data() as ShortLink));
+      setLinks(next);
+      setError(null);
+    } catch (err) {
+      logError('useShortLinks.refresh', err);
+      setError('Failed to load short links.');
+    } finally {
+      setLoading(false);
+    }
+  }, [isAdmin]);
 
   const updateShortLink = useCallback(
     async (

--- a/tests/components/admin/LinksPanel.test.tsx
+++ b/tests/components/admin/LinksPanel.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ShortLink } from '@/types';
+
+import {
+  computeLinksKpis,
+  LinksPanel,
+} from '@/components/admin/Analytics/LinksPanel';
+
+// Mutable hook return so each test can stage its own short-link set / loading
+// / error state without remounting providers.
+const hookValue: {
+  links: ShortLink[];
+  loading: boolean;
+  error: string | null;
+} = {
+  links: [],
+  loading: false,
+  error: null,
+};
+
+vi.mock('@/hooks/useShortLinks', () => ({
+  useShortLinks: () => hookValue,
+}));
+
+const makeLink = (overrides: Partial<ShortLink>): ShortLink => ({
+  code: 'abc',
+  destination: 'https://example.com/very/long/path',
+  createdBy: 'uid-1',
+  createdByEmail: 'admin@example.com',
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  clicks: 0,
+  lastClickedAt: null,
+  ...overrides,
+});
+
+describe('computeLinksKpis', () => {
+  it('sums clicks, counts recent + zero-click links', () => {
+    const now = 1_000_000_000_000;
+    const day = 24 * 60 * 60 * 1000;
+    const links: ShortLink[] = [
+      makeLink({ code: 'a', clicks: 5, createdAt: now - 1 * day }), // recent, clicked
+      makeLink({ code: 'b', clicks: 10, createdAt: now - 30 * day }), // old, clicked
+      makeLink({ code: 'c', clicks: 0, createdAt: now - 2 * day }), // recent, zero
+      makeLink({ code: 'd', clicks: 0, createdAt: now - 100 * day }), // old, zero
+    ];
+
+    const kpis = computeLinksKpis(links, now);
+
+    expect(kpis.totalLinks).toBe(4);
+    expect(kpis.totalClicks).toBe(15);
+    expect(kpis.createdLast7Days).toBe(2); // a + c
+    expect(kpis.zeroClickLinks).toBe(2); // c + d
+  });
+
+  it('returns all-zero KPIs for an empty list', () => {
+    expect(computeLinksKpis([], Date.now())).toEqual({
+      totalLinks: 0,
+      totalClicks: 0,
+      createdLast7Days: 0,
+      zeroClickLinks: 0,
+    });
+  });
+
+  it('treats a link created exactly 7 days ago as within the window', () => {
+    const now = 1_000_000_000_000;
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    const kpis = computeLinksKpis(
+      [makeLink({ createdAt: now - sevenDays })],
+      now
+    );
+    expect(kpis.createdLast7Days).toBe(1);
+  });
+});
+
+describe('LinksPanel', () => {
+  beforeEach(() => {
+    hookValue.links = [];
+    hookValue.loading = false;
+    hookValue.error = null;
+  });
+
+  it('renders a graceful empty state when there are no links', () => {
+    hookValue.links = [];
+    render(<LinksPanel />);
+    expect(screen.getByText('No short links yet')).toBeInTheDocument();
+  });
+
+  it('renders KPI values and the top-links table when links exist', () => {
+    hookValue.links = [
+      makeLink({ code: 'top', clicks: 42, lastClickedAt: Date.now() }),
+      makeLink({ code: 'mid', clicks: 7, lastClickedAt: Date.now() - 1000 }),
+    ];
+    render(<LinksPanel />);
+
+    // Total clicks KPI (42 + 7 = 49) is surfaced.
+    expect(screen.getByText('49')).toBeInTheDocument();
+    // Top link code appears in the table (top + recent tables both list it).
+    expect(screen.getAllByText('/r/top').length).toBeGreaterThan(0);
+  });
+
+  it('renders an error surface when the hook reports an error', () => {
+    hookValue.error = 'Failed to load short links.';
+    render(<LinksPanel />);
+    expect(
+      screen.getByText('Failed to Load Link Analytics')
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/admin/LinksPanel.test.tsx
+++ b/tests/components/admin/LinksPanel.test.tsx
@@ -22,6 +22,7 @@ const hookValue: {
 
 vi.mock('@/hooks/useShortLinks', () => ({
   useShortLinks: () => hookValue,
+  ADMIN_LIST_LIMIT: 100,
 }));
 
 const makeLink = (overrides: Partial<ShortLink>): ShortLink => ({

--- a/tests/components/admin/ShortenUrlButton.test.tsx
+++ b/tests/components/admin/ShortenUrlButton.test.tsx
@@ -18,6 +18,9 @@ const createShortLinkMock =
     (input: { destination: string; label?: string }) => Promise<CreateResult>
   >();
 vi.mock('@/hooks/useShortLinks', () => ({
+  // The button now uses the subscription-free `useCreateShortLink`; keep
+  // `useShortLinks` mocked too in case the shared module is imported elsewhere.
+  useCreateShortLink: () => ({ createShortLink: createShortLinkMock }),
   useShortLinks: () => ({ createShortLink: createShortLinkMock }),
 }));
 

--- a/tests/components/admin/ShortenUrlButton.test.tsx
+++ b/tests/components/admin/ShortenUrlButton.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ShortenUrlButton } from '@/components/admin/ShortenUrlButton';
+import type { CreateResult } from '@/hooks/useShortLinks';
+
+// Mutable auth value so each test can flip admin status.
+const authValue: { isAdmin: boolean } = { isAdmin: true };
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => authValue,
+}));
+
+// createShortLink is a spy whose resolution is staged per-test.
+const createShortLinkMock =
+  vi.fn<
+    (input: { destination: string; label?: string }) => Promise<CreateResult>
+  >();
+vi.mock('@/hooks/useShortLinks', () => ({
+  useShortLinks: () => ({ createShortLink: createShortLinkMock }),
+}));
+
+describe('ShortenUrlButton', () => {
+  beforeEach(() => {
+    authValue.isAdmin = true;
+    createShortLinkMock.mockReset();
+  });
+
+  it('renders nothing for non-admins', () => {
+    authValue.isAdmin = false;
+    const { container } = render(
+      <ShortenUrlButton url="https://example.com" onShortened={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is disabled when the url is blank', () => {
+    render(<ShortenUrlButton url="   " onShortened={vi.fn()} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('calls onShortened with the /r/ short URL on success', async () => {
+    const user = userEvent.setup();
+    createShortLinkMock.mockResolvedValue({
+      ok: true,
+      link: {
+        code: 'lesson-1',
+        destination: 'https://example.com/doc',
+        createdBy: 'uid-1',
+        createdByEmail: 'admin@example.com',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        clicks: 0,
+        lastClickedAt: null,
+      },
+    });
+    const onShortened = vi.fn();
+
+    render(
+      <ShortenUrlButton
+        url="https://example.com/doc"
+        label="Lesson 1"
+        onShortened={onShortened}
+      />
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(onShortened).toHaveBeenCalledTimes(1));
+    expect(createShortLinkMock).toHaveBeenCalledWith({
+      destination: 'https://example.com/doc',
+      label: 'Lesson 1',
+    });
+    const shortUrl = onShortened.mock.calls[0][0] as string;
+    expect(shortUrl).toMatch(/\/r\/lesson-1$/);
+  });
+
+  it('surfaces an error and does not call onShortened on failure', async () => {
+    const user = userEvent.setup();
+    createShortLinkMock.mockResolvedValue({
+      ok: false,
+      reason: '"taken" is already taken.',
+    });
+    const onShortened = vi.fn();
+
+    render(
+      <ShortenUrlButton url="https://example.com" onShortened={onShortened} />
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    await waitFor(() =>
+      expect(screen.getByText('"taken" is already taken.')).toBeInTheDocument()
+    );
+    expect(onShortened).not.toHaveBeenCalled();
+  });
+});

--- a/utils/shortLinkValidation.ts
+++ b/utils/shortLinkValidation.ts
@@ -7,6 +7,17 @@
 import { slugify } from './slug';
 
 export const SHORT_LINK_PREFIX = '/r/';
+
+/**
+ * Build the user-facing short URL for a given code. In the browser this is an
+ * absolute URL on the current origin; in non-browser contexts (SSR/tests) it
+ * falls back to the bare `/r/{code}` path.
+ */
+export const buildShortUrl = (code: string): string => {
+  if (typeof window === 'undefined') return SHORT_LINK_PREFIX + code;
+  return `${window.location.origin}${SHORT_LINK_PREFIX}${code}`;
+};
+
 export const MIN_SLUG_LENGTH = 2;
 export const MAX_SLUG_LENGTH = 32;
 export const MAX_DESTINATION_LENGTH = 2048;


### PR DESCRIPTION
## What (LO11 — backlog `docs/remaining-todos-audit.md`; follows `docs/link-shortener-phase-2.md`)

Two of the three Phase-2 slices — the **no-new-infra** ones. PR2 (per-click event log + scheduled CF + new collection + TTL) was deliberately **deferred to a spec**, not built.

**PR1 — Links analytics panel** (`components/admin/Analytics/LinksPanel.tsx`): new "Links" tab in `AnalyticsManager`. KPIs (total links, total clicks, links created last 7 days, zero-click links), top-links table (by clicks), recent activity (by lastClickedAt). Pure read of existing `short_links` data via `useShortLinks` — **$0 infra**.

**PR3 — inline "Shorten this URL" button** (`components/admin/ShortenUrlButton.tsx`): admin-only button next to URL inputs; integrated in the Announcements `EmbedConfigEditor`. Returns `null` for non-admins.

## Fixes applied after adversarial review (in `64f60f37`)
- **(major)** The Links tab was unreachable during the analytics HTTP cold-start/loading/error states (the panel renders independently via `useShortLinks`, so it shouldn't be gated on the analytics snapshot). Hoisted the tab bar + added an early return for the `links` tab before the analytics guards.
- **(DRY)** `buildShortUrl` was duplicated in 3 files → exported once from `utils/shortLinkValidation.ts`.
- **(a11y)** `aria-hidden` on decorative icons (matches repo convention).

## Validation (mine)
`pnpm type-check` ✓ · `pnpm build` ✓ · `vitest` ✓ (LinksPanel + ShortenUrlButton — 10 tests: KPI math, empty state, admin gating, onShortened callback, error surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)