### PR TITLE
feat(subs): finish Collections in /subs — board view + Drive grants (M5)

### DIFF
--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -1,8 +1,9 @@
 import { type FC, useState, useId, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Folder, Copy, UserCheck } from 'lucide-react';
+import { Folder, Copy, UserCheck, Mail, Plus, Trash2 } from 'lucide-react';
 import type { Collection, Dashboard } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
+import { usePresetSubEmails } from '@/hooks/usePresetSubEmails';
 import { BUILDINGS } from '@/config/buildings';
 import { logError } from '@/utils/logError';
 
@@ -18,6 +19,11 @@ type ModeChoice = 'copy' | 'substitute';
 type CopyState = 'unknown' | 'copied' | 'failed';
 
 const BUILDING_IDS = new Set(BUILDINGS.map((b) => b.id));
+const ORONO_EMAIL_DOMAIN = '@orono.k12.mn.us';
+
+function isValidOronoEmail(email: string): boolean {
+  return /^[^\s@]+@orono\.k12\.mn\.us$/i.test(email.trim());
+}
 
 const SUB_TTL_PRESETS: { label: string; ms: number }[] = [
   { label: '4 hours', ms: 4 * 60 * 60 * 1000 },
@@ -30,15 +36,43 @@ export const ShareCollectionLinkCreatorModal: FC<
   ShareCollectionLinkCreatorModalProps
 > = ({ isOpen, collection, boards, onClose }) => {
   const { t } = useTranslation();
-  const { shareCollection, shareSubstituteCollection, addToast } =
-    useDashboard();
+  const {
+    shareCollection,
+    shareSubstituteCollection,
+    addToast,
+    rosters,
+    activeRosterId,
+  } = useDashboard();
   const [mode, setMode] = useState<ModeChoice>('copy');
   const [ttlMs, setTtlMs] = useState<number>(SUB_TTL_PRESETS[1].ms);
   const [buildingId, setBuildingId] = useState<string>('');
+  const [subEmails, setSubEmails] = useState<string[]>([]);
+  const [subEmailDraft, setSubEmailDraft] = useState('');
+  const [subEmailError, setSubEmailError] = useState<string | null>(null);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<CopyState>('unknown');
   const [busy, setBusy] = useState(false);
   const headingId = useId();
+
+  const { emails: presetEmails } = usePresetSubEmails(buildingId);
+
+  const handleAddSubEmail = useCallback(() => {
+    const trimmed = subEmailDraft.trim();
+    if (!trimmed) return;
+    if (!isValidOronoEmail(trimmed)) {
+      setSubEmailError(
+        t('shareLinkCreatorModal.substitute.invalidEmail', {
+          defaultValue: `Must end with ${ORONO_EMAIL_DOMAIN}`,
+        })
+      );
+      return;
+    }
+    setSubEmails((prev) =>
+      prev.includes(trimmed) ? prev : [...prev, trimmed]
+    );
+    setSubEmailDraft('');
+    setSubEmailError(null);
+  }, [subEmailDraft, t]);
 
   const handleCreate = useCallback(async () => {
     if (!collection) return;
@@ -49,6 +83,16 @@ export const ShareCollectionLinkCreatorModal: FC<
         addToast(
           t('shareCollection.buildingRequired', {
             defaultValue: 'Select a building before sharing with a sub.',
+          }),
+          'error'
+        );
+        return;
+      }
+      const invalidEmail = subEmails.find((e) => !isValidOronoEmail(e));
+      if (invalidEmail) {
+        addToast(
+          t('shareLinkCreatorModal.substitute.invalidEmail', {
+            defaultValue: `Must end with ${ORONO_EMAIL_DOMAIN}`,
           }),
           'error'
         );
@@ -66,12 +110,23 @@ export const ShareCollectionLinkCreatorModal: FC<
         if (mode === 'copy') {
           shareId = await shareCollection({ collection, boards });
         } else {
+          // Mirror the single-board substitute share: surface the active
+          // roster's Drive file to the listed subs (read-only, auto-revoked
+          // on expiry). v1 = active roster only; empty list is fine (share
+          // still works, just without sub-readable roster names).
+          const activeRoster = rosters.find((r) => r.id === activeRosterId);
+          const rosterDriveFileIds =
+            subEmails.length > 0 && activeRoster?.driveFileId
+              ? [activeRoster.driveFileId]
+              : undefined;
           shareId = await shareSubstituteCollection({
             collection,
             boards,
             collectionId: collection.id,
             expiresAt: Date.now() + ttlMs,
             buildingId,
+            ...(subEmails.length > 0 ? { subEmails } : {}),
+            ...(rosterDriveFileIds ? { rosterDriveFileIds } : {}),
           });
         }
       } catch (err) {
@@ -109,6 +164,9 @@ export const ShareCollectionLinkCreatorModal: FC<
     mode,
     ttlMs,
     buildingId,
+    subEmails,
+    rosters,
+    activeRosterId,
     collection,
     boards,
     shareCollection,
@@ -241,6 +299,110 @@ export const ShareCollectionLinkCreatorModal: FC<
                     </option>
                   ))}
                 </select>
+
+                <label className="block text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  {t('shareCollection.shareRosters', {
+                    defaultValue: 'Share rosters with sub(s)?',
+                  })}{' '}
+                  <span className="text-slate-400 font-normal normal-case">
+                    {t('shareLinkCreatorModal.plcScope.optional', {
+                      defaultValue: '(optional)',
+                    })}
+                  </span>
+                </label>
+                <p className="text-[10px] text-slate-500 -mt-1 leading-relaxed">
+                  {t('shareCollection.shareRostersHint', {
+                    defaultValue:
+                      'Listed subs get read-only Google Drive access to your active roster until expiration. Auto-revoked then. Must be @orono.k12.mn.us.',
+                  })}
+                </p>
+
+                {presetEmails.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {presetEmails.map((email) => {
+                      const added = subEmails.includes(email);
+                      return (
+                        <button
+                          key={email}
+                          type="button"
+                          disabled={added}
+                          onClick={() =>
+                            setSubEmails((prev) => [...prev, email])
+                          }
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
+                            added
+                              ? 'bg-emerald-100 text-emerald-700 cursor-default'
+                              : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
+                          }`}
+                        >
+                          <Plus className="w-3 h-3" />
+                          {email}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {subEmails.length > 0 && (
+                  <ul className="space-y-1">
+                    {subEmails.map((email) => (
+                      <li
+                        key={email}
+                        className="flex items-center gap-2 rounded-md bg-white border border-slate-200 px-2 py-1 text-xs text-slate-700"
+                      >
+                        <Mail className="w-3.5 h-3.5 text-slate-400 shrink-0" />
+                        <span className="truncate flex-1">{email}</span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setSubEmails((prev) =>
+                              prev.filter((e) => e !== email)
+                            )
+                          }
+                          aria-label={t(
+                            'shareLinkCreatorModal.substitute.removeEmail',
+                            { defaultValue: 'Remove email' }
+                          )}
+                          className="shrink-0 text-slate-400 hover:text-red-500"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                <div className="flex gap-1">
+                  <input
+                    type="email"
+                    value={subEmailDraft}
+                    onChange={(e) => {
+                      setSubEmailDraft(e.target.value);
+                      setSubEmailError(null);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleAddSubEmail();
+                      }
+                    }}
+                    placeholder={`name${ORONO_EMAIL_DOMAIN}`}
+                    className="flex-1 rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs text-slate-700"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAddSubEmail}
+                    className="shrink-0 inline-flex items-center gap-1 rounded-md bg-slate-100 hover:bg-slate-200 px-2.5 py-1.5 text-xs font-bold text-slate-700"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                    {t('shareLinkCreatorModal.substitute.addEmail', {
+                      defaultValue: 'Add',
+                    })}
+                  </button>
+                </div>
+                {subEmailError && (
+                  <p className="text-[10px] text-red-600">{subEmailError}</p>
+                )}
               </div>
             )}
 

--- a/components/subs/SubBoardScreen.tsx
+++ b/components/subs/SubBoardScreen.tsx
@@ -98,7 +98,13 @@ interface SubBoardScreenContentProps {
   onChangeBuilding: () => void;
 }
 
-const SubBoardScreenContent: React.FC<SubBoardScreenContentProps> = ({
+/**
+ * Shared inner chrome for any substitute board view (single-board shares AND
+ * Collection boards). Takes a fully-resolved `SubstituteShareDoc` and mounts
+ * the toolbar + scaled canvas. Exported so `SubCollectionBoardScreen` can
+ * reuse it without duplicating the toolbar / reset wiring.
+ */
+export const SubBoardScreenContent: React.FC<SubBoardScreenContentProps> = ({
   share,
   onBackToDirectory,
   onChangeBuilding,
@@ -147,7 +153,7 @@ const SubBoardScreenContent: React.FC<SubBoardScreenContentProps> = ({
   );
 };
 
-const ExpiredOrErrorPanel: React.FC<{
+export const ExpiredOrErrorPanel: React.FC<{
   message: string;
   onBack: () => void;
 }> = ({ message, onBack }) => (

--- a/components/subs/SubCollectionBoardScreen.tsx
+++ b/components/subs/SubCollectionBoardScreen.tsx
@@ -1,0 +1,87 @@
+/**
+ * SubCollectionBoardScreen — frozen, read-only-but-content-interactive view of
+ * a single Board that lives INSIDE a substitute-mode shared Collection.
+ *
+ * This is the Collection-board sibling of `SubBoardScreen`. The only
+ * difference is the data source: a single-board substitute share lives at
+ * `/shared_boards/{shareId}`, whereas a Collection board lives at
+ * `/shared_collections/{shareId}/boards/{boardId}` (with share-level metadata
+ * on the parent `/shared_collections/{shareId}` doc). `useSubstituteCollectionBoard`
+ * splices those two reads into the same `SubstituteShareDoc` shape, so once
+ * loaded we render the exact same `SubsDashboardProvider` + toolbar + canvas
+ * chrome via the shared `SubBoardScreenContent`.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useSubstituteCollectionBoard } from '@/hooks/useSubstituteShares';
+import { SubsDashboardProvider } from './SubsDashboardProvider';
+import { SubBoardScreenContent, ExpiredOrErrorPanel } from './SubBoardScreen';
+
+interface SubCollectionBoardScreenProps {
+  shareId: string;
+  boardId: string;
+  onBackToDirectory: () => void;
+  onChangeBuilding: () => void;
+}
+
+export const SubCollectionBoardScreen: React.FC<
+  SubCollectionBoardScreenProps
+> = ({ shareId, boardId, onBackToDirectory, onChangeBuilding }) => {
+  const { share, loading, error } = useSubstituteCollectionBoard(
+    shareId,
+    boardId
+  );
+  const [expired, setExpired] = useState(false);
+
+  // Mirror SubBoardScreen: imperative 60s tick so an idle sub gets bounced
+  // back when the share lapses while a board is open. Date.now() stays inside
+  // the effect, never in render.
+  const expiresAt = share?.expiresAt;
+  useEffect(() => {
+    if (!expiresAt) return;
+    const check = () => {
+      if (expiresAt <= Date.now()) setExpired(true);
+    };
+    check();
+    const id = window.setInterval(check, 60_000);
+    return () => window.clearInterval(id);
+  }, [expiresAt]);
+
+  useEffect(() => {
+    if (!expired) return;
+    const id = window.setTimeout(onBackToDirectory, 1500);
+    return () => window.clearTimeout(id);
+  }, [expired, onBackToDirectory]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white/60 bg-slate-900">
+        <Loader2 className="w-8 h-8 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!!error || !share || expired) {
+    return (
+      <div className="min-h-screen bg-slate-900">
+        <ExpiredOrErrorPanel
+          message={
+            expired ? 'This share has expired.' : (error ?? 'Board not found.')
+          }
+          onBack={onBackToDirectory}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <SubsDashboardProvider share={share}>
+      <SubBoardScreenContent
+        share={share}
+        onBackToDirectory={onBackToDirectory}
+        onChangeBuilding={onChangeBuilding}
+      />
+    </SubsDashboardProvider>
+  );
+};

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -9,10 +9,18 @@ import type { SharedCollection } from '@/types';
 
 interface SubCollectionsListProps {
   buildingId: string;
+  /**
+   * Open a Board that lives inside a shared Collection. Called with the
+   * Collection's shareId and the Board's id; the parent (SubsApp) navigates
+   * into the `collection-board` view, which loads the frozen snapshot via
+   * `useSubstituteCollectionBoard`.
+   */
+  onPickBoard: (shareId: string, boardId: string) => void;
 }
 
 export const SubCollectionsList: FC<SubCollectionsListProps> = ({
   buildingId,
+  onPickBoard,
 }) => {
   const { t } = useTranslation();
   const [collections, setCollections] = useState<SharedCollection[]>([]);
@@ -110,23 +118,16 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
               <button
                 key={boardId}
                 type="button"
-                disabled
-                title={t('subCollections.comingSoon', {
-                  defaultValue:
-                    'Board view in /subs coming soon — open in the teacher app for now',
+                onClick={() => onPickBoard(c.shareId, boardId)}
+                title={t('subCollections.openBoard', {
+                  defaultValue: 'Open this board',
                 })}
-                className="text-left px-2 py-1.5 text-xs rounded-md bg-slate-50 border border-slate-200 opacity-60 cursor-not-allowed flex flex-col gap-0.5"
-                aria-disabled="true"
+                className="text-left px-2 py-1.5 text-xs rounded-md bg-white/10 hover:bg-white/20 border border-white/15 hover:border-white/30 text-white transition-colors cursor-pointer flex items-center gap-1.5 focus:outline-none focus:ring-2 focus:ring-white/40"
               >
-                <span>
+                <span className="truncate">
                   {t('subCollections.boardPlaceholder', {
                     id: boardId.slice(-4),
                     defaultValue: 'Board …{{id}}',
-                  })}
-                </span>
-                <span className="text-[10px] text-slate-400 italic">
-                  {t('subCollections.comingSoonLabel', {
-                    defaultValue: 'Coming soon',
                   })}
                 </span>
               </button>

--- a/components/subs/SubCollectionsList.tsx
+++ b/components/subs/SubCollectionsList.tsx
@@ -32,17 +32,26 @@ export const SubCollectionsList: FC<SubCollectionsListProps> = ({
     const canonical = canonicalBuildingId(buildingId);
     void (async () => {
       try {
+        // expiresAt is filtered client-side (after the snapshot) rather than
+        // as a `where('expiresAt','>',Date.now())` query constraint: the read
+        // rule gates expiry per-document (it does NOT require the query to
+        // carry an expiresAt constraint — same as the shared_boards read), and
+        // a server-side `>` filter on a client clock can trip a clock-skew
+        // permission-denied. Mirrors useSubstituteShares.ts.
         const q = query(
           collection(db, 'shared_collections'),
           where('intendedMode', '==', 'substitute'),
-          where('buildingId', '==', canonical),
-          where('expiresAt', '>', Date.now())
+          where('buildingId', '==', canonical)
         );
         const snap = await getDocs(q);
         if (cancelled) return;
+        const now = Date.now();
         const docs: SharedCollection[] = [];
         snap.docs.forEach((d) => {
           const data = d.data() as SharedCollection;
+          const expiresAt =
+            typeof data.expiresAt === 'number' ? data.expiresAt : 0;
+          if (expiresAt <= now) return;
           docs.push({ ...data, shareId: d.id });
         });
         setCollections(docs);

--- a/components/subs/SubsApp.tsx
+++ b/components/subs/SubsApp.tsx
@@ -25,14 +25,16 @@ import { SubsAuthGate } from './SubsAuthGate';
 import { BuildingPickerScreen } from './BuildingPickerScreen';
 import { TeacherDirectoryScreen } from './TeacherDirectoryScreen';
 import { SubBoardScreen } from './SubBoardScreen';
+import { SubCollectionBoardScreen } from './SubCollectionBoardScreen';
 import { useAuth } from '@/context/useAuth';
 
 type SubsView =
   | { kind: 'building-picker' }
   | { kind: 'directory'; buildingId: string }
   | { kind: 'board'; buildingId: string; shareId: string }
-  // TODO(collections-plan-3): wire full Collection board view once
-  // SubsDashboardProvider supports loadSharedCollectionBoards.
+  // A single Board opened from inside a shared Collection. `shareId` is the
+  // Collection's `/shared_collections/{shareId}` id; `boardId` is the Board
+  // sub-doc id. SubCollectionBoardScreen loads + renders it.
   | {
       kind: 'collection-board';
       buildingId: string;
@@ -105,6 +107,14 @@ const SubsContent: React.FC = () => {
           onPickBoard={(shareId) =>
             setView({ kind: 'board', buildingId: view.buildingId, shareId })
           }
+          onPickCollectionBoard={(shareId, boardId) =>
+            setView({
+              kind: 'collection-board',
+              buildingId: view.buildingId,
+              shareId,
+              boardId,
+            })
+          }
           onChangeBuilding={() => setView({ kind: 'building-picker' })}
         />
       )}
@@ -119,11 +129,10 @@ const SubsContent: React.FC = () => {
         />
       )}
 
-      {/* TODO(collections-plan-3): replace stub with real Collection board view
-          once SubsDashboardProvider wires loadSharedCollectionBoards. */}
       {view.kind === 'collection-board' && (
-        <SubBoardScreen
+        <SubCollectionBoardScreen
           shareId={view.shareId}
+          boardId={view.boardId}
           onBackToDirectory={() =>
             setView({ kind: 'directory', buildingId: view.buildingId })
           }

--- a/components/subs/TeacherDirectoryScreen.tsx
+++ b/components/subs/TeacherDirectoryScreen.tsx
@@ -21,12 +21,15 @@ import { SubCollectionsList } from './SubCollectionsList';
 interface TeacherDirectoryScreenProps {
   buildingId: string;
   onPickBoard: (shareId: string) => void;
+  /** Open a Board nested inside a shared Collection (shareId + boardId). */
+  onPickCollectionBoard: (shareId: string, boardId: string) => void;
   onChangeBuilding: () => void;
 }
 
 export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
   buildingId,
   onPickBoard,
+  onPickCollectionBoard,
   onChangeBuilding,
 }) => {
   const adminBuildings = useAdminBuildings();
@@ -186,7 +189,10 @@ export const TeacherDirectoryScreen: React.FC<TeacherDirectoryScreenProps> = ({
 
           {/* Collections shared with subs — shown below individual boards. */}
           <div className="mt-10">
-            <SubCollectionsList buildingId={buildingId} />
+            <SubCollectionsList
+              buildingId={buildingId}
+              onPickBoard={onPickCollectionBoard}
+            />
           </div>
         </div>
       </main>

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3347,13 +3347,92 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     ): Promise<string> => {
       if (!user) throw new Error('Not authenticated');
-      return sharedCollectionApi.shareSubstituteCollection({
+
+      // Resolve Drive grants BEFORE the share write so they persist atomically
+      // on the parent doc — identical strategy to `handleShareSubstituteDashboard`.
+      // Drive's `permissions.create` is idempotent (same (file,email) returns
+      // the SAME permissionId), so we pre-list each file's permissions and
+      // reuse an existing grant when present. This lets the reconcile sweep's
+      // refcounting skip a revoke that another active share still depends on.
+      const driveGrants: SubstituteShareDriveGrant[] = [];
+      const subEmails = input.subEmails ?? [];
+      const fileIds = input.rosterDriveFileIds ?? [];
+      const driveSharingRequested = subEmails.length > 0 && fileIds.length > 0;
+      const failedPairs: Array<{ email: string; fileId: string }> = [];
+
+      if (driveSharingRequested && driveService) {
+        for (const fileId of fileIds) {
+          let existingPerms: Awaited<
+            ReturnType<typeof driveService.listFilePermissions>
+          > = [];
+          try {
+            existingPerms = await driveService.listFilePermissions(fileId);
+          } catch (err) {
+            console.error(
+              `[shareSubstituteCollection] listFilePermissions(${fileId}) failed; will fall back to grant calls:`,
+              err
+            );
+          }
+          for (const email of subEmails) {
+            const lower = email.toLowerCase();
+            const existing = existingPerms.find(
+              (p) =>
+                p.type === 'user' &&
+                p.emailAddress?.toLowerCase() === lower &&
+                typeof p.id === 'string'
+            );
+            if (existing) {
+              driveGrants.push({ email, fileId, permissionId: existing.id });
+              continue;
+            }
+            try {
+              const permissionId = await driveService.grantUserReaderPermission(
+                fileId,
+                email
+              );
+              driveGrants.push({ email, fileId, permissionId });
+            } catch (err) {
+              console.error(
+                `[shareSubstituteCollection] Drive grant failed for ${email} on ${fileId}:`,
+                err
+              );
+              failedPairs.push({ email, fileId });
+            }
+          }
+        }
+      } else if (driveSharingRequested && !driveService) {
+        for (const fileId of fileIds) {
+          for (const email of subEmails) {
+            failedPairs.push({ email, fileId });
+          }
+        }
+      }
+
+      const shareId = await sharedCollectionApi.shareSubstituteCollection({
         ...input,
         hostUid: user.uid,
         hostDisplayName: user.displayName,
+        driveGrants: driveGrants.length > 0 ? driveGrants : undefined,
       });
+
+      // Surface partial Drive-grant failures so the host can retry / hand-share
+      // rather than a sub silently lacking roster access (mirrors the
+      // single-board substitute-share toast).
+      if (failedPairs.length > 0) {
+        const missedEmails = Array.from(
+          new Set(failedPairs.map((p) => p.email))
+        );
+        addToast(
+          `Share created, but roster access could not be granted to: ${missedEmails.join(
+            ', '
+          )}. Reconnect Google Drive and retry, or share the roster file manually.`,
+          'error'
+        );
+      }
+
+      return shareId;
     },
-    [user, sharedCollectionApi]
+    [user, sharedCollectionApi, driveService, addToast]
   );
 
   const importSharedCollection = useCallback(

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -3417,7 +3417,9 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
       // Surface partial Drive-grant failures so the host can retry / hand-share
       // rather than a sub silently lacking roster access (mirrors the
-      // single-board substitute-share toast).
+      // single-board substitute-share toast). The share doc is already written
+      // and substitute shares are immutable post-create, so the remedy is to
+      // create a NEW share or hand-share — not "retry" against this one.
       if (failedPairs.length > 0) {
         const missedEmails = Array.from(
           new Set(failedPairs.map((p) => p.email))
@@ -3425,8 +3427,17 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         addToast(
           `Share created, but roster access could not be granted to: ${missedEmails.join(
             ', '
-          )}. Reconnect Google Drive and retry, or share the roster file manually.`,
+          )}. Reconnect Google Drive and create a new share, or share the roster file manually.`,
           'error'
+        );
+      } else if (subEmails.length > 0 && fileIds.length === 0) {
+        // Sub emails were entered but the active roster has no linked Drive
+        // file (e.g. ClassLink-imported, not Drive-synced), so no grant was
+        // even attempted. Without this the share is created with subEmails
+        // persisted but zero Drive access and no feedback to the host.
+        addToast(
+          'Share created, but your active roster has no linked Drive file — sub(s) will not get roster access. Share the roster file manually if they need it.',
+          'warning'
         );
       }
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -292,6 +292,14 @@
       ]
     },
     {
+      "collectionGroup": "shared_collections",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "intendedMode", "order": "ASCENDING" },
+        { "fieldPath": "expiresAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "responses",
       "queryScope": "COLLECTION_GROUP",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -1106,6 +1106,13 @@ service cloud.firestore {
       // substitute create rule. boardIds must be a non-empty list of
       // at most 500 entries; collection.name must be a non-empty string;
       // intendedMode must be in the legal set.
+      //
+      // Optional substitute fields `subEmails` and `driveGrants` (Drive
+      // roster grants, mirroring /shared_boards) are permitted at create
+      // time and PINNED thereafter by the UPDATE rule below (substitute
+      // Collection shares are fully immutable post-create), so a host can
+      // never silently retarget or rewrite them after a sub has opened a
+      // board — the same guarantee the per-field pins give on /shared_boards.
       allow create: if request.auth != null
         && request.resource.data.hostUid == request.auth.uid
         && request.resource.data.boardIds is list
@@ -1126,8 +1133,11 @@ service cloud.firestore {
         );
 
       // UPDATE: host-only, and ONLY allowed on copy shares (substitute
-      // shares are immutable post-creation). Admins bypass for emergency
-      // corrections.
+      // shares are immutable post-creation — this fully pins every
+      // substitute field, including `expiresAt`, `buildingId`, `subEmails`
+      // and `driveGrants`, matching the per-field pins on /shared_boards
+      // but more strictly: no substitute update is permitted at all).
+      // Admins bypass for emergency corrections.
       allow update: if request.auth != null
         && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin())
         && resource.data.get('intendedMode', null) == 'copy';

--- a/firestore.rules
+++ b/firestore.rules
@@ -1137,7 +1137,11 @@ service cloud.firestore {
       // substitute field, including `expiresAt`, `buildingId`, `subEmails`
       // and `driveGrants`, matching the per-field pins on /shared_boards
       // but more strictly: no substitute update is permitted at all).
-      // Admins bypass for emergency corrections.
+      // NOTE: admins are ALSO blocked from updating substitute shares — the
+      // `intendedMode == 'copy'` guard applies regardless of isAdmin(), so a
+      // substitute Collection share is fully immutable post-create for
+      // everyone. Emergency corrections must be made via the Firebase console
+      // / Admin SDK (which bypass security rules), not through this rule.
       allow update: if request.auth != null
         && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin())
         && resource.data.get('intendedMode', null) == 'copy';

--- a/functions/src/expireSubShares.ts
+++ b/functions/src/expireSubShares.ts
@@ -136,17 +136,29 @@ async function sweepCollection(
   // first so the parent delete doesn't orphan them. Done before the batched
   // parent delete because subcollections aren't cascaded by Firestore.
   if (deleteBoardsSubcollection) {
-    for (const doc of readyToDelete) {
-      const boardsSnap = await doc.ref.collection('boards').get();
-      if (boardsSnap.empty) continue;
-      const boardBatchSize = 250;
-      for (let i = 0; i < boardsSnap.docs.length; i += boardBatchSize) {
-        const batch = db.batch();
-        for (const b of boardsSnap.docs.slice(i, i + boardBatchSize)) {
-          batch.delete(b.ref);
-        }
-        await batch.commit();
-      }
+    // Reap each parent's boards/ subcollection. Parallelize across parents
+    // (with bounded concurrency) so a sweep that catches many expired
+    // Collection shares — each with its own get() + batch-commit chain —
+    // doesn't serialize toward the function timeout. The cap keeps us well
+    // under Firestore's per-client connection limits rather than fanning out
+    // all (up to MAX_DELETES_PER_RUN) parents at once.
+    const BOARD_CLEANUP_CONCURRENCY = 10;
+    const boardBatchSize = 250;
+    for (let i = 0; i < readyToDelete.length; i += BOARD_CLEANUP_CONCURRENCY) {
+      const group = readyToDelete.slice(i, i + BOARD_CLEANUP_CONCURRENCY);
+      await Promise.all(
+        group.map(async (doc) => {
+          const boardsSnap = await doc.ref.collection('boards').get();
+          if (boardsSnap.empty) return;
+          for (let j = 0; j < boardsSnap.docs.length; j += boardBatchSize) {
+            const batch = db.batch();
+            for (const b of boardsSnap.docs.slice(j, j + boardBatchSize)) {
+              batch.delete(b.ref);
+            }
+            await batch.commit();
+          }
+        })
+      );
     }
   }
 
@@ -181,7 +193,24 @@ export const expireSubShares = onSchedule(
     const db = admin.firestore();
     const now = Date.now();
 
-    await sweepCollection(db, 'shared_boards', now, 'originalAuthor', false);
-    await sweepCollection(db, 'shared_collections', now, 'hostUid', true);
+    // Run both sweeps independently: a failure in one (Firestore quota, a
+    // batch-commit error, a missing index) must not abort the other and leave
+    // its expired shares un-reaped for the hour.
+    const [boardsResult, collectionsResult] = await Promise.allSettled([
+      sweepCollection(db, 'shared_boards', now, 'originalAuthor', false),
+      sweepCollection(db, 'shared_collections', now, 'hostUid', true),
+    ]);
+    if (boardsResult.status === 'rejected') {
+      console.error(
+        '[expireSubShares] shared_boards sweep failed:',
+        boardsResult.reason
+      );
+    }
+    if (collectionsResult.status === 'rejected') {
+      console.error(
+        '[expireSubShares] shared_collections sweep failed:',
+        collectionsResult.reason
+      );
+    }
   }
 );

--- a/functions/src/expireSubShares.ts
+++ b/functions/src/expireSubShares.ts
@@ -200,16 +200,29 @@ export const expireSubShares = onSchedule(
       sweepCollection(db, 'shared_boards', now, 'originalAuthor', false),
       sweepCollection(db, 'shared_collections', now, 'hostUid', true),
     ]);
+    const failures: unknown[] = [];
     if (boardsResult.status === 'rejected') {
       console.error(
         '[expireSubShares] shared_boards sweep failed:',
         boardsResult.reason
       );
+      failures.push(boardsResult.reason);
     }
     if (collectionsResult.status === 'rejected') {
       console.error(
         '[expireSubShares] shared_collections sweep failed:',
         collectionsResult.reason
+      );
+      failures.push(collectionsResult.reason);
+    }
+    // Both sweeps have already completed (allSettled above guarantees neither
+    // aborted the other), so re-throwing here is safe and surfaces a persistent
+    // failure as a failed invocation — an error metric that can drive a Cloud
+    // Monitoring alert — instead of a silent success that lets expired shares
+    // accumulate until someone notices the logs.
+    if (failures.length > 0) {
+      throw new Error(
+        `[expireSubShares] ${failures.length} sweep(s) failed; see logged reasons above.`
       );
     }
   }

--- a/functions/src/expireSubShares.ts
+++ b/functions/src/expireSubShares.ts
@@ -1,7 +1,11 @@
 /**
- * Hourly sweep that deletes expired substitute-mode `/shared_boards`
- * docs so the substitute portal stays uncluttered and stale snapshots
- * don't sit in Firestore indefinitely.
+ * Hourly sweep that deletes expired substitute-mode `/shared_boards` AND
+ * `/shared_collections` docs so the substitute portal stays uncluttered and
+ * stale snapshots don't sit in Firestore indefinitely.
+ *
+ * Collection shares additionally carry a `boards/` subcollection of frozen
+ * Board snapshots; when a Collection parent is deleted, its board sub-docs are
+ * deleted first so nothing is orphaned.
  *
  * Two-stage delete (grace period):
  * --------------------------------------------------------------------
@@ -49,6 +53,123 @@ interface SubstituteShareData {
   }>;
 }
 
+type ExpiredDocSnap =
+  FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>;
+
+interface SweepResult {
+  deleted: number;
+  inGrace: number;
+  orphanedGrants: number;
+}
+
+/**
+ * Sweep one substitute-share collection. `hostField` is the doc field holding
+ * the host uid (`originalAuthor` on /shared_boards, `hostUid` on
+ * /shared_collections) — only used for logging. When `deleteBoardsSubcollection`
+ * is set, each doc's `boards/` subcollection is reaped before the parent.
+ */
+async function sweepCollection(
+  db: FirebaseFirestore.Firestore,
+  collectionName: string,
+  now: number,
+  hostField: 'originalAuthor' | 'hostUid',
+  deleteBoardsSubcollection: boolean
+): Promise<SweepResult> {
+  // Equality on intendedMode + range on expiresAt — requires a composite
+  // index on (intendedMode ASC, expiresAt ASC); declared in
+  // firestore.indexes.json for both collections.
+  const snap = await db
+    .collection(collectionName)
+    .where('intendedMode', '==', 'substitute')
+    .where('expiresAt', '<=', now)
+    .limit(MAX_DELETES_PER_RUN)
+    .get();
+
+  if (snap.empty) {
+    console.log(`[expireSubShares] no expired substitute ${collectionName}`);
+    return { deleted: 0, inGrace: 0, orphanedGrants: 0 };
+  }
+
+  // Bucket each expired doc into "ready to delete" vs "give the client
+  // revoker more time". A doc is ready when it has no grants OR it's
+  // been expired longer than the orphan-grace window.
+  const readyToDelete: ExpiredDocSnap[] = [];
+  let stillInGrace = 0;
+  let orphanedGrantCount = 0;
+
+  for (const doc of snap.docs) {
+    const data = doc.data() as SubstituteShareData & { hostUid?: string };
+    const grants = Array.isArray(data.driveGrants) ? data.driveGrants : [];
+    const expiredAt = typeof data.expiresAt === 'number' ? data.expiresAt : 0;
+    const inGrace = grants.length > 0 && expiredAt > now - ORPHAN_GRACE_MS;
+
+    if (inGrace) {
+      stillInGrace += 1;
+      continue;
+    }
+
+    // If we're deleting a doc that still has grants (i.e. grace expired),
+    // log the orphans so a Workspace admin can clean up by hand.
+    if (grants.length > 0) {
+      orphanedGrantCount += grants.length;
+      const host = data[hostField] ?? data.originalAuthor ?? data.hostUid;
+      console.warn(
+        `[expireSubShares] DELETING ${collectionName} share ${doc.id} (host ${host}) ` +
+          `with ${grants.length} unrevoked Drive permissions — host never ` +
+          `returned to clean up. Manual revocation needed for: ` +
+          grants
+            .map((g) => `${g.email}@${g.fileId}:${g.permissionId}`)
+            .join(', ')
+      );
+    }
+    readyToDelete.push(doc);
+  }
+
+  if (readyToDelete.length === 0) {
+    console.log(
+      `[expireSubShares] ${stillInGrace} expired ${collectionName} in grace window — waiting for host to clean up`
+    );
+    return { deleted: 0, inGrace: stillInGrace, orphanedGrants: 0 };
+  }
+
+  // Collection parents carry a `boards/` subcollection — reap those sub-docs
+  // first so the parent delete doesn't orphan them. Done before the batched
+  // parent delete because subcollections aren't cascaded by Firestore.
+  if (deleteBoardsSubcollection) {
+    for (const doc of readyToDelete) {
+      const boardsSnap = await doc.ref.collection('boards').get();
+      if (boardsSnap.empty) continue;
+      const boardBatchSize = 250;
+      for (let i = 0; i < boardsSnap.docs.length; i += boardBatchSize) {
+        const batch = db.batch();
+        for (const b of boardsSnap.docs.slice(i, i + boardBatchSize)) {
+          batch.delete(b.ref);
+        }
+        await batch.commit();
+      }
+    }
+  }
+
+  // Batched delete of parents. Firestore caps each batch at 500 ops which
+  // lines up with MAX_DELETES_PER_RUN; we still chunk defensively.
+  const batchSize = 250;
+  let deleted = 0;
+  for (let i = 0; i < readyToDelete.length; i += batchSize) {
+    const batch = db.batch();
+    const chunk = readyToDelete.slice(i, i + batchSize);
+    for (const doc of chunk) batch.delete(doc.ref);
+    await batch.commit();
+    deleted += chunk.length;
+  }
+
+  console.log(
+    `[expireSubShares] deleted ${deleted} expired substitute ${collectionName} ` +
+      `(${stillInGrace} still in ${ORPHAN_GRACE_DAYS}-day grace window; ` +
+      `${orphanedGrantCount} Drive permissions logged as needing manual revocation)`
+  );
+  return { deleted, inGrace: stillInGrace, orphanedGrants: orphanedGrantCount };
+}
+
 export const expireSubShares = onSchedule(
   {
     schedule: 'every 60 minutes',
@@ -60,78 +181,7 @@ export const expireSubShares = onSchedule(
     const db = admin.firestore();
     const now = Date.now();
 
-    // Equality on intendedMode + range on expiresAt — requires a composite
-    // index on (intendedMode ASC, expiresAt ASC); declared in
-    // firestore.indexes.json.
-    const snap = await db
-      .collection('shared_boards')
-      .where('intendedMode', '==', 'substitute')
-      .where('expiresAt', '<=', now)
-      .limit(MAX_DELETES_PER_RUN)
-      .get();
-
-    if (snap.empty) {
-      console.log('[expireSubShares] no expired substitute shares');
-      return;
-    }
-
-    // Bucket each expired doc into "ready to delete" vs "give the client
-    // revoker more time". A doc is ready when it has no grants OR it's
-    // been expired longer than the orphan-grace window.
-    const readyToDelete: typeof snap.docs = [];
-    const stillInGrace: typeof snap.docs = [];
-    let orphanedGrantCount = 0;
-
-    for (const doc of snap.docs) {
-      const data = doc.data() as SubstituteShareData;
-      const grants = Array.isArray(data.driveGrants) ? data.driveGrants : [];
-      const expiredAt = typeof data.expiresAt === 'number' ? data.expiresAt : 0;
-      const inGrace = grants.length > 0 && expiredAt > now - ORPHAN_GRACE_MS;
-
-      if (inGrace) {
-        stillInGrace.push(doc);
-        continue;
-      }
-
-      // If we're deleting a doc that still has grants (i.e. grace expired),
-      // log the orphans so a Workspace admin can clean up by hand.
-      if (grants.length > 0) {
-        orphanedGrantCount += grants.length;
-        console.warn(
-          `[expireSubShares] DELETING share ${doc.id} (host ${data.originalAuthor}) ` +
-            `with ${grants.length} unrevoked Drive permissions — host never ` +
-            `returned to clean up. Manual revocation needed for: ` +
-            grants
-              .map((g) => `${g.email}@${g.fileId}:${g.permissionId}`)
-              .join(', ')
-        );
-      }
-      readyToDelete.push(doc);
-    }
-
-    if (readyToDelete.length === 0) {
-      console.log(
-        `[expireSubShares] ${stillInGrace.length} expired shares in grace window — waiting for host to clean up`
-      );
-      return;
-    }
-
-    // Batched delete. Firestore caps each batch at 500 ops which lines up
-    // with MAX_DELETES_PER_RUN; we still chunk defensively.
-    const batchSize = 250;
-    let deleted = 0;
-    for (let i = 0; i < readyToDelete.length; i += batchSize) {
-      const batch = db.batch();
-      const chunk = readyToDelete.slice(i, i + batchSize);
-      for (const doc of chunk) batch.delete(doc.ref);
-      await batch.commit();
-      deleted += chunk.length;
-    }
-
-    console.log(
-      `[expireSubShares] deleted ${deleted} expired substitute shares ` +
-        `(${stillInGrace.length} still in ${ORPHAN_GRACE_DAYS}-day grace window; ` +
-        `${orphanedGrantCount} Drive permissions logged as needing manual revocation)`
-    );
+    await sweepCollection(db, 'shared_boards', now, 'originalAuthor', false);
+    await sweepCollection(db, 'shared_collections', now, 'hostUid', true);
   }
 );

--- a/hooks/useReconcileExpiredSubShares.test.ts
+++ b/hooks/useReconcileExpiredSubShares.test.ts
@@ -55,7 +55,7 @@ describe('useReconcileExpiredSubShares', () => {
     ).mockResolvedValue(undefined);
   });
 
-  it('reads shares via readAllDocsPaged (bounded), never an unbounded getDocs', async () => {
+  it('reads shares via readAllDocsPaged (bounded) for BOTH share surfaces, never an unbounded getDocs', async () => {
     (
       paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValue([]);
@@ -67,10 +67,13 @@ describe('useReconcileExpiredSubShares', () => {
       })
     );
 
+    // One paged read per surface: /shared_boards + /shared_collections.
     await waitFor(() =>
-      expect(paging.readAllDocsPaged).toHaveBeenCalledTimes(1)
+      expect(paging.readAllDocsPaged).toHaveBeenCalledTimes(2)
     );
-    // The unbounded path must not be used by this hook anymore.
+    // The unbounded path must not be used for the share LISTING — getDocs is
+    // only used to reap a Collection's `boards/` subcollection on delete,
+    // which doesn't happen when there are no expired docs.
     expect(firestore.getDocs).not.toHaveBeenCalled();
   });
 
@@ -86,9 +89,9 @@ describe('useReconcileExpiredSubShares', () => {
       expiresAt: now + 60_000,
       driveGrants: [{ email: 's@x', fileId: 'file-2', permissionId: 'perm-2' }],
     });
-    (
-      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValue([expired, active]);
+    (paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([expired, active]) // /shared_boards
+      .mockResolvedValueOnce([]); // /shared_collections
     const driveService = makeDriveService();
 
     renderHook(() =>
@@ -128,9 +131,9 @@ describe('useReconcileExpiredSubShares', () => {
         { email: 's@x', fileId: 'file-1', permissionId: 'perm-shared' },
       ],
     });
-    (
-      paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValue([expired, active]);
+    (paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([expired, active]) // /shared_boards
+      .mockResolvedValueOnce([]); // /shared_collections
     const driveService = makeDriveService();
 
     renderHook(() =>
@@ -141,6 +144,65 @@ describe('useReconcileExpiredSubShares', () => {
     // permission must be skipped because an active share still references it.
     await waitFor(() => expect(firestore.deleteDoc).toHaveBeenCalledTimes(1));
     expect(driveService.deletePermission).not.toHaveBeenCalled();
+  });
+
+  it('reaps a Collection share boards/ subcollection before deleting the parent, and refcounts grants across both surfaces', async () => {
+    const now = Date.now();
+    // Active board share references perm-shared — the expired Collection share
+    // references the SAME permissionId, so it must NOT be revoked.
+    const activeBoard = makeShareSnap({
+      id: 'active-board',
+      expiresAt: now + 60_000,
+      driveGrants: [
+        { email: 's@x', fileId: 'file-1', permissionId: 'perm-shared' },
+      ],
+    });
+    // Expired collection parent with a `boards/` subcollection. Its ref carries
+    // a `parent.id === 'shared_collections'` marker + a `collection('boards')`
+    // accessor so the production code can reap board sub-docs.
+    const boardDocRefs = [
+      { __board: 'b1' } as unknown as firestore.DocumentReference,
+      { __board: 'b2' } as unknown as firestore.DocumentReference,
+    ];
+    const collectionRef = {
+      id: 'expired-coll',
+      parent: { id: 'shared_collections' },
+      collection: vi.fn(() => ({ __boardsCol: true })),
+    } as unknown as firestore.DocumentReference;
+    const expiredCollection = {
+      id: 'expired-coll',
+      ref: collectionRef,
+      data: () => ({
+        expiresAt: now - 1000,
+        driveGrants: [
+          { email: 's@x', fileId: 'file-1', permissionId: 'perm-shared' },
+        ],
+      }),
+    };
+
+    (paging.readAllDocsPaged as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([activeBoard]) // /shared_boards
+      .mockResolvedValueOnce([expiredCollection]); // /shared_collections
+
+    // getDocs is used to enumerate the boards/ subcollection on delete.
+    (
+      firestore.getDocs as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ docs: boardDocRefs.map((ref) => ({ ref })) });
+
+    const driveService = makeDriveService();
+    renderHook(() =>
+      useReconcileExpiredSubShares({ uid: 'teacher-1', driveService })
+    );
+
+    // The parent doc is deleted once the (shared) grant is correctly skipped.
+    await waitFor(() =>
+      expect(firestore.deleteDoc).toHaveBeenCalledWith(collectionRef)
+    );
+    // Shared permission must NOT be revoked — an active board share still holds it.
+    expect(driveService.deletePermission).not.toHaveBeenCalled();
+    // Both board sub-docs were deleted before the parent.
+    expect(firestore.deleteDoc).toHaveBeenCalledWith(boardDocRefs[0]);
+    expect(firestore.deleteDoc).toHaveBeenCalledWith(boardDocRefs[1]);
   });
 
   it('honours the once-per-session guard for a given uid', async () => {

--- a/hooks/useReconcileExpiredSubShares.ts
+++ b/hooks/useReconcileExpiredSubShares.ts
@@ -1,7 +1,10 @@
 /**
  * useReconcileExpiredSubShares — once-per-session sweep that revokes Drive
  * permissions and deletes share docs for the signed-in teacher's expired
- * substitute shares.
+ * substitute shares. Covers BOTH single-board substitute shares
+ * (/shared_boards) and substitute Collection shares (/shared_collections,
+ * whose Drive grants live on the parent doc and whose `boards/` subcollection
+ * is reaped before the parent on cleanup).
  *
  * Why client-side: revoking permissions on a teacher's own Drive files
  * requires either their OAuth refresh token (we don't store one) or
@@ -35,7 +38,13 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { collection, deleteDoc, query, where } from 'firebase/firestore';
+import {
+  collection,
+  deleteDoc,
+  getDocs,
+  query,
+  where,
+} from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { readAllDocsPaged } from '@/utils/firestorePaging';
 import type { GoogleDriveService } from '@/utils/googleDriveService';
@@ -126,17 +135,33 @@ async function reconcileExpiredSubShares(
 ): Promise<void> {
   // Pull ALL of the host's substitute shares — both expired (candidates
   // for cleanup) and active (so we know which permissionIds are still
-  // referenced and must NOT be revoked).
-  const allQuery = query(
+  // referenced and must NOT be revoked). Drive grants live on TWO surfaces:
+  //   - single-board substitute shares: /shared_boards (keyed on
+  //     `originalAuthor`), and
+  //   - substitute Collection shares: /shared_collections (keyed on
+  //     `hostUid`), with grants on the parent doc.
+  // A roster file granted via both surfaces shares ONE Drive permissionId
+  // (permissions.create is idempotent), so we must refcount across BOTH
+  // before revoking anything.
+  const boardsQuery = query(
     collection(db, 'shared_boards'),
     where('originalAuthor', '==', uid),
+    where('intendedMode', '==', 'substitute')
+  );
+  const collectionsQuery = query(
+    collection(db, 'shared_collections'),
+    where('hostUid', '==', uid),
     where('intendedMode', '==', 'substitute')
   );
   // Read in bounded pages so a teacher with a large share history can't pull
   // the whole filtered result set into memory in a single unbounded read.
   // We iterate every doc below (to decide expired vs. still-referenced), so a
   // full paged read — not a capped limit() — is the right bound here.
-  const allDocs = await readAllDocsPaged(allQuery);
+  const [boardDocs, collectionDocs] = await Promise.all([
+    readAllDocsPaged(boardsQuery),
+    readAllDocsPaged(collectionsQuery),
+  ]);
+  const allDocs = [...boardDocs, ...collectionDocs];
   if (allDocs.length === 0) return;
 
   const now = Date.now();
@@ -196,6 +221,18 @@ async function reconcileExpiredSubShares(
       // Safe to clean up the share doc — every grant is either revoked
       // already or owned by another active share.
       try {
+        // Collection shares carry a `boards/` subcollection of frozen Board
+        // snapshots. Deleting only the parent would orphan those sub-docs
+        // (they're read-gated by the parent's expiresAt, but never reaped).
+        // Delete them first so the parent delete leaves nothing behind. The
+        // parent collection id distinguishes a Collection doc (path
+        // `shared_collections/{id}`) from a single-board share.
+        if (ref.parent?.id === 'shared_collections') {
+          const boardsSnap = await getDocs(collection(ref, 'boards'));
+          for (const boardDoc of boardsSnap.docs) {
+            await deleteDoc(boardDoc.ref);
+          }
+        }
         await deleteDoc(ref);
       } catch (err) {
         console.error('[reconcileExpiredSubShares] doc delete failed:', err);

--- a/hooks/useSharedCollection.ts
+++ b/hooks/useSharedCollection.ts
@@ -29,6 +29,7 @@ import type {
   SharedCollectionBoardDoc,
   Collection as CollectionType,
   CollectionSubstituteShareInput,
+  SubstituteShareDriveGrant,
 } from '@/types';
 
 const SHARED_COLLECTIONS_SUBPATH = 'shared_collections';
@@ -123,7 +124,16 @@ interface ShareCollectionInput {
 }
 
 type SubstituteShareInput = ShareCollectionInput &
-  CollectionSubstituteShareInput;
+  CollectionSubstituteShareInput & {
+    /**
+     * Resolved Drive permission grants. The caller (DashboardContext's
+     * `shareSubstituteCollection`) performs the actual Drive `permissions.create`
+     * calls BEFORE invoking this write, so the share doc lands with the grants
+     * atomically — mirroring `shareSubstituteDashboard`. May be omitted when
+     * no rosters are shared.
+     */
+    driveGrants?: SubstituteShareDriveGrant[];
+  };
 
 /**
  * Commit every Board snapshot under `/shared_collections/{shareId}/boards/`
@@ -270,9 +280,14 @@ export const useSharedCollection = () => {
   /**
    * Host action: substitute variant. Same parent-first write strategy as
    * shareCollection. Adds `expiresAt` + `buildingId` and sets
-   * `intendedMode: 'substitute'` on the parent payload. Drive grants are
-   * NOT implemented for Collection shares — see plan's "Known
-   * limitations" for rationale.
+   * `intendedMode: 'substitute'` on the parent payload.
+   *
+   * Drive grants: the caller resolves them (Drive `permissions.create`) BEFORE
+   * calling this and passes them in as `input.driveGrants`; they're persisted
+   * on the parent doc (share-level — a roster file is granted once per
+   * (file, email), not per board). The expiry sweeps
+   * (`useReconcileExpiredSubShares` + `expireSubShares`) revoke them. This
+   * mirrors the single-board `shareSubstituteDashboard` flow.
    *
    * See shareCollection for the write-order rationale (parent first, then
    * board sub-docs — the subcollection rule reads parent.hostUid).
@@ -300,6 +315,12 @@ export const useSharedCollection = () => {
         createdAt: now,
         expiresAt: input.expiresAt,
         buildingId: input.buildingId,
+        ...(input.subEmails && input.subEmails.length > 0
+          ? { subEmails: input.subEmails }
+          : {}),
+        ...(input.driveGrants && input.driveGrants.length > 0
+          ? { driveGrants: input.driveGrants }
+          : {}),
       };
 
       if (isAuthBypass) {

--- a/hooks/useSubstituteShares.ts
+++ b/hooks/useSubstituteShares.ts
@@ -11,13 +11,22 @@
  */
 
 import { useEffect, useState } from 'react';
-import { collection, doc, onSnapshot, query, where } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  getDoc,
+  onSnapshot,
+  query,
+  where,
+} from 'firebase/firestore';
 import { db } from '@/config/firebase';
 import { canonicalBuildingId } from '@/config/buildings';
 import { logError } from '@/utils/logError';
 import type {
   Dashboard,
   SharedBoardIntendedMode,
+  SharedCollection,
+  SharedCollectionBoardDoc,
   SubstituteShareFields,
   SubstituteShareDriveGrant,
 } from '@/types';
@@ -197,6 +206,166 @@ export function useSubstituteShare(
     return { share: null, loading: false, error: null };
   }
   if (!snapshot || snapshot.shareId !== shareId) {
+    return { share: null, loading: true, error: null };
+  }
+  return {
+    share: snapshot.share,
+    loading: false,
+    error: snapshot.error,
+  };
+}
+
+interface UseSubstituteCollectionBoardState {
+  share: SubstituteShareDoc | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface CollectionBoardSnapshot {
+  key: string;
+  share: SubstituteShareDoc | null;
+  error: string | null;
+}
+
+/**
+ * One-shot loader for a single Board inside a substitute-mode
+ * `/shared_collections/{shareId}` doc, shaped as a {@link SubstituteShareDoc}
+ * so it can be fed straight into `SubsDashboardProvider` / `SubBoardCanvas` —
+ * the exact same render pipeline a single-board substitute share uses.
+ *
+ * Unlike `useSubstituteShare`, this does NOT subscribe. Collection shares are
+ * frozen one-shot snapshots (see `useSharedCollection` — no onSnapshot), so a
+ * single `getDoc` pair (parent meta + the one board sub-doc) is the right read.
+ *
+ * The parent doc carries the share-level metadata (intendedMode, expiresAt,
+ * buildingId, hostDisplayName); the board sub-doc carries the frozen
+ * `Dashboard`. We splice them into the `SubstituteShareDoc` contract:
+ *   - widgets / background / settings / etc. come from the board's Dashboard
+ *   - expiresAt / buildingId / originalAuthor(+Name) come from the parent
+ *   - `initialState` is seeded from the board's widgets so the sub's
+ *     "Reset board" deep-clones from the same baseline.
+ */
+export function useSubstituteCollectionBoard(
+  shareId: string | null,
+  boardId: string | null
+): UseSubstituteCollectionBoardState {
+  const [snapshot, setSnapshot] = useState<CollectionBoardSnapshot | null>(
+    null
+  );
+
+  const key = shareId && boardId ? `${shareId}::${boardId}` : '';
+
+  useEffect(() => {
+    if (!shareId || !boardId) return;
+    let cancelled = false;
+    const requestKey = `${shareId}::${boardId}`;
+
+    void (async () => {
+      try {
+        const parentRef = doc(db, 'shared_collections', shareId);
+        const parentSnap = await getDoc(parentRef);
+        if (cancelled) return;
+        if (!parentSnap.exists()) {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: 'This Collection could not be found.',
+          });
+          return;
+        }
+        const parent = parentSnap.data() as SharedCollection;
+        if (parent.intendedMode !== 'substitute') {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: 'Not a substitute Collection share.',
+          });
+          return;
+        }
+        if (parent.expiresAt && parent.expiresAt <= Date.now()) {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: 'This share has expired.',
+          });
+          return;
+        }
+        if (!parent.boardIds.includes(boardId)) {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: 'This board is not part of the shared Collection.',
+          });
+          return;
+        }
+
+        const boardRef = doc(
+          db,
+          'shared_collections',
+          shareId,
+          'boards',
+          boardId
+        );
+        const boardSnap = await getDoc(boardRef);
+        if (cancelled) return;
+        if (!boardSnap.exists()) {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: 'This board could not be found in the Collection.',
+          });
+          return;
+        }
+        const boardData = boardSnap.data() as SharedCollectionBoardDoc;
+        const board = boardData.dashboard;
+        const widgets = Array.isArray(board.widgets) ? board.widgets : [];
+
+        // Splice parent metadata + frozen board into the SubstituteShareDoc
+        // shape SubsDashboardProvider already understands. `id` is omitted by
+        // the Omit<Dashboard,'id'> base; shareId stands in for it.
+        const { id: _boardDocId, ...boardWithoutId } = board;
+        const share: SubstituteShareDoc = {
+          ...boardWithoutId,
+          widgets,
+          shareId: parent.shareId,
+          intendedMode: 'substitute',
+          buildingId: parent.buildingId,
+          expiresAt: parent.expiresAt,
+          initialState: widgets,
+          originalAuthor: parent.hostUid,
+          ...(parent.hostDisplayName
+            ? { originalAuthorName: parent.hostDisplayName }
+            : {}),
+          name: board.name ?? parent.collection.name,
+        };
+
+        setSnapshot({ key: requestKey, share, error: null });
+      } catch (err) {
+        logError('useSubstituteCollectionBoard.load', err, {
+          shareId,
+          boardId,
+        });
+        if (!cancelled) {
+          setSnapshot({
+            key: requestKey,
+            share: null,
+            error: friendlySubShareError(
+              err as { code?: string; message?: string }
+            ),
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId, boardId]);
+
+  if (!shareId || !boardId) {
+    return { share: null, loading: false, error: null };
+  }
+  if (!snapshot || snapshot.key !== key) {
     return { share: null, loading: true, error: null };
   }
   return {

--- a/hooks/useSubstituteShares.ts
+++ b/hooks/useSubstituteShares.ts
@@ -282,7 +282,10 @@ export function useSubstituteCollectionBoard(
           });
           return;
         }
-        if (parent.expiresAt && parent.expiresAt <= Date.now()) {
+        // Substitute shares always carry `expiresAt` (enforced by the create
+        // rule), so a missing value means a malformed/out-of-band doc — treat
+        // it as expired rather than letting it load indefinitely.
+        if (!parent.expiresAt || parent.expiresAt <= Date.now()) {
           setSnapshot({
             key: requestKey,
             share: null,

--- a/locales/de.json
+++ b/locales/de.json
@@ -1521,8 +1521,7 @@
     "heading": "Sammlungen",
     "boardCount": "{{count}} Tafel(n)",
     "boardPlaceholder": "Tafel …{{id}}",
-    "comingSoon": "Tafelansicht in /subs kommt bald – öffne sie vorerst in der Lehrkraft-App",
-    "comingSoonLabel": "Demnächst verfügbar"
+    "openBoard": "Dieses Board öffnen"
   },
   "collectionMenu": {
     "share": "Sammlung teilen…",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1521,8 +1521,7 @@
     "heading": "Collections",
     "boardCount": "{{count}} board(s)",
     "boardPlaceholder": "Board …{{id}}",
-    "comingSoon": "Board view in /subs coming soon — open in the teacher app for now",
-    "comingSoonLabel": "Coming soon"
+    "openBoard": "Open this board"
   },
   "collectionMenu": {
     "share": "Share Collection…",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1521,8 +1521,7 @@
     "heading": "Colecciones",
     "boardCount": "{{count}} tablero(s)",
     "boardPlaceholder": "Tablero …{{id}}",
-    "comingSoon": "La vista de Tablero en /subs llegará pronto — por ahora ábrela en la app del profesor",
-    "comingSoonLabel": "Próximamente"
+    "openBoard": "Abrir este tablero"
   },
   "collectionMenu": {
     "share": "Compartir Colección…",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1521,8 +1521,7 @@
     "heading": "Collections",
     "boardCount": "{{count}} tableau(x)",
     "boardPlaceholder": "Tableau …{{id}}",
-    "comingSoon": "La vue Tableau dans /subs arrive bientôt — ouvrez-la dans l'app enseignant pour l'instant",
-    "comingSoonLabel": "Bientôt disponible"
+    "openBoard": "Ouvrir ce tableau"
   },
   "collectionMenu": {
     "share": "Partager la Collection…",

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -12,6 +12,12 @@ vi.mock('@/context/useDashboard', () => ({
   useDashboard: () => useDashboardMock() as ReturnType<typeof UseDashboardFn>,
 }));
 
+// usePresetSubEmails hits Firestore; stub it so the modal's optional sub-email
+// preset chips render without a live backend.
+vi.mock('@/hooks/usePresetSubEmails', () => ({
+  usePresetSubEmails: () => ({ emails: [] as string[] }),
+}));
+
 const collection = (): Collection => ({
   id: 'c1',
   name: 'Math',
@@ -34,6 +40,8 @@ const baseMockReturn = {
   shareCollection: vi.fn(),
   shareSubstituteCollection: vi.fn(),
   addToast: vi.fn(),
+  rosters: [],
+  activeRosterId: null,
 };
 
 beforeEach(() => {

--- a/tests/components/subs/SubCollectionsList.test.tsx
+++ b/tests/components/subs/SubCollectionsList.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { SubCollectionsList } from '@/components/subs/SubCollectionsList';
 import type { SharedCollection } from '@/types';
+
+const noop = () => undefined;
 
 const getDocsMock = vi.fn();
 
@@ -49,14 +52,16 @@ beforeEach(() => {
 describe('SubCollectionsList', () => {
   it('renders the loading state initially', () => {
     getDocsMock.mockReturnValueOnce(new Promise(() => undefined)); // never resolves
-    render(<SubCollectionsList buildingId="middle-school" />);
+    render(
+      <SubCollectionsList buildingId="middle-school" onPickBoard={noop} />
+    );
     expect(screen.getByText(/loading shared collections/i)).toBeInTheDocument();
   });
 
   it('renders nothing when no Collections are returned', async () => {
     getDocsMock.mockResolvedValueOnce(docsResponse());
     const { container } = render(
-      <SubCollectionsList buildingId="middle-school" />
+      <SubCollectionsList buildingId="middle-school" onPickBoard={noop} />
     );
     await waitFor(() => {
       expect(
@@ -75,7 +80,9 @@ describe('SubCollectionsList', () => {
         fakeCollection('s2', 'Reading', ['b3'])
       )
     );
-    render(<SubCollectionsList buildingId="middle-school" />);
+    render(
+      <SubCollectionsList buildingId="middle-school" onPickBoard={noop} />
+    );
     await waitFor(() => {
       expect(screen.getByText('Math')).toBeInTheDocument();
     });
@@ -85,18 +92,20 @@ describe('SubCollectionsList', () => {
     expect(screen.getByText('1 board(s)')).toBeInTheDocument();
   });
 
-  it('renders per-board buttons as disabled (full board-view in /subs deferred)', async () => {
+  it('renders per-board buttons as enabled and calls onPickBoard with (shareId, boardId)', async () => {
+    const onPickBoard = vi.fn();
     getDocsMock.mockResolvedValueOnce(
       docsResponse(fakeCollection('s1', 'Math', ['boardA-1234']))
     );
-    render(<SubCollectionsList buildingId="middle-school" />);
-    // The button now has two children: the board label and the "Coming soon" sub-label.
-    // findByRole searches accessible name which includes all text content.
-    const btn = await screen.findByRole('button', { name: /Board …1234/i });
-    expect(btn).toBeDisabled();
-    // Visible "Coming soon" sub-label should also be present inside the button.
-    expect(btn.querySelector('span:last-child')?.textContent).toMatch(
-      /coming soon/i
+    render(
+      <SubCollectionsList
+        buildingId="middle-school"
+        onPickBoard={onPickBoard}
+      />
     );
+    const btn = await screen.findByRole('button', { name: /Board …1234/i });
+    expect(btn).toBeEnabled();
+    await userEvent.click(btn);
+    expect(onPickBoard).toHaveBeenCalledWith('s1', 'boardA-1234');
   });
 });

--- a/tests/i18n/boardsModalCollectionLocales.test.ts
+++ b/tests/i18n/boardsModalCollectionLocales.test.ts
@@ -39,7 +39,7 @@
  *     t('quickAccess.title'), t('quickAccess.emptyResults'), etc.
  *
  *   components/subs/SubCollectionsList.tsx
- *     t('subCollections.loading'), t('subCollections.comingSoon'), etc.
+ *     t('subCollections.loading'), t('subCollections.openBoard'), etc.
  *
  *   components/boardsModal/CreateFromTemplateModal.tsx
  *     t('templatePicker.title'), t('templatePicker.loading'), etc.
@@ -162,7 +162,7 @@ const COLLECTION_MENU_TRANSLATED_KEYS: [string[], string][] = [
 const SUB_COLLECTIONS_TRANSLATED_KEYS: [string[], string][] = [
   [['subCollections', 'loading'], en.subCollections.loading],
   [['subCollections', 'loadError'], en.subCollections.loadError],
-  [['subCollections', 'comingSoon'], en.subCollections.comingSoon],
+  [['subCollections', 'openBoard'], en.subCollections.openBoard],
 ];
 
 /** templatePicker keys */

--- a/tests/i18n/collectionUiLocales.test.ts
+++ b/tests/i18n/collectionUiLocales.test.ts
@@ -92,7 +92,7 @@ const IMPORT_SHARED_COLLECTION_KEYS = [
 ] as const;
 
 /** subCollections keys that were untranslated */
-const SUB_COLLECTIONS_KEYS = ['loading', 'loadError', 'comingSoon'] as const;
+const SUB_COLLECTIONS_KEYS = ['loading', 'loadError', 'openBoard'] as const;
 
 /** collectionMenu keys that were untranslated */
 const COLLECTION_MENU_KEYS = ['saveAsTemplate'] as const;

--- a/tests/rules/sharedCollections.test.ts
+++ b/tests/rules/sharedCollections.test.ts
@@ -360,6 +360,50 @@ describe('shared_collections — create, substitute field constraints', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 12b. CREATE — substitute Drive-grant fields (subEmails / driveGrants)
+// ---------------------------------------------------------------------------
+// Drive roster grants live on the substitute Collection parent doc (M5),
+// mirroring /shared_boards. Create must accept them; the existing
+// substitute-immutability rule (case 14) then pins them — a host cannot
+// rewrite driveGrants after a sub has opened a board.
+
+describe('shared_collections — create, substitute Drive-grant fields', () => {
+  const driveGrants = [
+    { email: 'sub@orono.k12.mn.us', fileId: 'file-1', permissionId: 'perm-1' },
+  ];
+
+  it('substitute create accepted with subEmails + driveGrants', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asHost(), sharePath),
+        subShareDoc({
+          subEmails: ['sub@orono.k12.mn.us'],
+          driveGrants,
+        })
+      )
+    );
+  });
+
+  it('driveGrants are pinned post-create (host cannot rewrite them)', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), sharePath),
+        subShareDoc({ subEmails: ['sub@orono.k12.mn.us'], driveGrants })
+      );
+    });
+    // Substitute shares are fully immutable — any update (incl. driveGrants)
+    // is rejected even for the host.
+    await assertFails(
+      updateDoc(doc(asHost(), sharePath), {
+        driveGrants: [
+          { email: 'evil@orono.k12.mn.us', fileId: 'f', permissionId: 'p' },
+        ],
+      })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 13. CREATE — hostUid must match request.auth.uid
 // ---------------------------------------------------------------------------
 

--- a/types.ts
+++ b/types.ts
@@ -7364,6 +7364,16 @@ export interface SharedCollection {
   expiresAt?: number;
   /** Substitute-only: building id (config/buildings.ts) for /subs scoping. */
   buildingId?: string;
+  /** Substitute-only: @orono.k12.mn.us emails granted Drive roster access. */
+  subEmails?: string[];
+  /**
+   * Substitute-only: per-email/file Drive permission ids for revocation.
+   * Mirrors `SubstituteShareFields.driveGrants` on single-board shares — the
+   * grants are share-level (granted once per (roster file, sub email)), so
+   * they live on the Collection parent doc rather than on each board sub-doc.
+   * Swept by `useReconcileExpiredSubShares` / `expireSubShares` on expiry.
+   */
+  driveGrants?: SubstituteShareDriveGrant[];
 }
 
 /**


### PR DESCRIPTION
## What (M5 — backlog `docs/remaining-todos-audit.md`)

Finishes the `/subs` Collections experience, both parts (per your decision):

**Part 1 — board-view wiring** (`36bf1515`): subs can now open boards inside a shared Collection. New `SubCollectionBoardScreen`, `SubsDashboardProvider`/`DashboardContext` support for loading a collection's frozen board snapshots, and the previously-disabled `SubCollectionsList` buttons + `SubsApp` `collection-board` view are now live.

**Part 2 — Drive grants for Collection shares** (`88c07f06`): mirrors the existing `/shared_boards` substitute Drive-grant flow into the Collection path (`ShareCollectionLinkCreatorModal` + `useSharedCollection.shareSubstituteCollection`). Grants are **client-side** (host's existing Drive OAuth — no new scope, no CF); revocation is client-side with the hourly `expireSubShares` CF providing a grace window + orphan logging (now a generic `sweepCollection` over both `/shared_boards` and `/shared_collections`). The escape-hatch (spec-instead-of-build) was evaluated and **not** needed — there was no hard blocker.

## Fixes applied after adversarial review (`4888212f`, `81e2782a`)
- **(rules comment)** Corrected the `shared_collections` update-rule comment: substitute shares are immutable post-create for **everyone incl. admins** (the `intendedMode=='copy'` guard applies regardless of `isAdmin()`). **Comment-only — no rule predicate change.**
- **(robustness)** `SubCollectionsList` now filters expired shares **client-side** (removed the `where('expiresAt','>',now)` server filter) to avoid clock-skew `permission-denied`, mirroring `useSubstituteShares`. Verified the `shared_collections` read rule evaluates expiry per-document and does not require the query constraint.
- **(i18n)** Added `subCollections.openBoard`; removed the now-unused `comingSoon`/`comingSoonLabel` keys across en/de/es/fr + updated both i18n parity tests.

## ⚠️ Deploy notes (for you)
- **New composite index** in `firestore.indexes.json` (`shared_collections`: `intendedMode` + `expiresAt`) — **deploy `firebase deploy --only firestore:indexes`** before/with this, or the hourly expiry sweep errors until the index builds.
- `firestore.rules` change is **comment-only** (no behavior change), so no rules-deploy gate beyond the usual.

## Validation (mine)
`pnpm type-check` (root + functions) ✓ · `pnpm build` ✓ · root `vitest` ✓ (734 tests, incl. subs + both i18n parity suites) · functions `vitest` ✓ (76) · `firebase ... --dry-run` rules compile ✓.

## Residual
- `expireSubShares` Drive-revocation grace logic relies on type-check + the index barrel test + review; no dedicated unit test for the new `sweepCollection` grace-window branches (reasonable follow-up).
- New rules-test cases (`tests/rules/sharedCollections.test.ts`) are **CI-validated only** (no local Firestore emulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)