### PR TITLE
Rules/auth hardening: M1 lockout, M2, LO2, LO4, LO10 + M4 bulk actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Firestore rules are size-capped (256 KiB compiled) and deployed verbatim from
+# the working tree. On Windows with core.autocrlf=true, CRLF line endings inflate
+# the byte count (~+1 byte/line, ~+4.6 KiB for this file) — enough to push a
+# local `firebase deploy --only firestore:rules` over the cap even though the
+# committed blob (LF) and CI (Linux/LF) deploys are comfortably under it. Force
+# LF so every environment measures the same bytes.
+*.rules text eol=lf

--- a/App.tsx
+++ b/App.tsx
@@ -142,6 +142,11 @@ const LoginScreen = lazy(() =>
     default: module.LoginScreen,
   }))
 );
+const DeactivatedScreen = lazy(() =>
+  import('./components/auth/DeactivatedScreen').then((module) => ({
+    default: module.DeactivatedScreen,
+  }))
+);
 const InviteAcceptance = lazy(() =>
   import('./components/auth/InviteAcceptance').then((module) => ({
     default: module.InviteAcceptance,
@@ -257,7 +262,33 @@ function usePathname(): string {
 const AuthenticatedApp: React.FC<{ isRemote?: boolean }> = ({
   isRemote = false,
 }) => {
-  const { user, loading } = useAuth();
+  const { user, loading, accessDeactivated, signOut } = useAuth();
+
+  // M1 full sign-in lockout: the membership snapshot latched `accessDeactivated`
+  // because this user's org member doc is `status: 'inactive'`. Sign them out
+  // (idempotent — signOut no-ops once `user` is already null) and show the
+  // DeactivatedScreen. The screen is rendered on the sticky flag below
+  // REGARDLESS of `user`, so signing out doesn't bounce them to the login page
+  // and lose the deactivation message. Effect is the right tool here: signOut
+  // is an external-system (Firebase Auth) side-effect, not derived state.
+  useEffect(() => {
+    if (accessDeactivated && user) {
+      void signOut().catch((err) => {
+        console.error(
+          '[AuthenticatedApp] sign-out on deactivation failed',
+          err
+        );
+      });
+    }
+  }, [accessDeactivated, user, signOut]);
+
+  if (accessDeactivated) {
+    return (
+      <Suspense fallback={<FullPageLoader />}>
+        <DeactivatedScreen />
+      </Suspense>
+    );
+  }
 
   if (!user) {
     // While the persisted session resolves, show a plain loader so returning

--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -673,10 +673,18 @@ export const PopoverOption: React.FC<{
   icon?: React.ReactNode;
   label: string;
   description?: string;
-}> = ({ onClick, selected, icon, label, description }) => (
+  /**
+   * Opt-in single-select semantics for screen readers. Set this when the
+   * option lives inside a `role="group"` single-select list (e.g. the bulk
+   * "Change role" picker) so AT announces the selected state. Left undefined
+   * for menu-context usages, which keep plain button semantics.
+   */
+  ariaPressed?: boolean;
+}> = ({ onClick, selected, icon, label, description, ariaPressed }) => (
   <button
     type="button"
     onClick={onClick}
+    aria-pressed={ariaPressed}
     className="w-full text-left px-3 py-2 flex items-start gap-2.5 rounded-lg hover:bg-slate-50 focus:bg-slate-50 focus:outline-none"
   >
     {icon && <span className="mt-0.5">{icon}</span>}

--- a/components/admin/Organization/views/UsersView.tsx
+++ b/components/admin/Organization/views/UsersView.tsx
@@ -614,7 +614,7 @@ const BulkRoleModal: React.FC<{
           {count === 1 ? '' : 's'}.
         </p>
         <div
-          role="radiogroup"
+          role="group"
           aria-label="Role"
           className="rounded-lg border border-slate-200 divide-y divide-slate-100"
         >
@@ -623,6 +623,7 @@ const BulkRoleModal: React.FC<{
               key={r.id}
               onClick={() => setRole(r.id)}
               selected={role === r.id}
+              ariaPressed={role === r.id}
               label={r.name}
               description={r.blurb}
               icon={

--- a/components/admin/Organization/views/UsersView.tsx
+++ b/components/admin/Organization/views/UsersView.tsx
@@ -13,6 +13,8 @@ import {
   Check,
   X,
   AlertTriangle,
+  UserCog,
+  Building2,
 } from 'lucide-react';
 import type {
   BuildingRecord,
@@ -36,6 +38,7 @@ import {
   ViewHeader,
   LocalModal,
   Textarea,
+  Confirm,
 } from '../components/primitives';
 import { parseInvitesCsv, type InviteIntent } from '@/utils/csvImport';
 
@@ -91,15 +94,14 @@ const STATUS_META: Record<UserStatus, { label: string; description: string }> =
       description: 'Invitation sent; awaiting first sign-in.',
     },
     inactive: {
-      // Phase 4: 'inactive' removes admin powers via the
-      // organizationMembersSync CF (the /admins/{email} doc is deleted) but
-      // does NOT block the user from signing in — Firestore rules and
-      // AuthContext don't gate on member.status yet. Full sign-in lockout is
-      // on the Phase 4.1 backlog. Copy here deliberately says "admin access"
-      // rather than "account" so admins don't expect a power they don't have.
+      // M1 full sign-in lockout: 'inactive' both removes admin powers (via the
+      // organizationMembersSync CF deleting /admins/{email}) AND blocks the
+      // user from using the app — AuthContext signs an inactive member out and
+      // Firestore rules deny their teacher-data reads/writes (firestore.rules
+      // notDeactivated gate). Reactivation restores access on their next
+      // sign-in.
       label: 'Inactive',
-      description:
-        'Revokes admin access. User can still sign in (full lockout coming in a future release).',
+      description: 'Blocks sign-in and revokes all access.',
     },
   };
 
@@ -145,6 +147,9 @@ export const UsersView: React.FC<Props> = ({
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [showInvite, setShowInvite] = useState(false);
   const [showImport, setShowImport] = useState(false);
+  // M4 bulk actions: pickers for "Change role" / "Move to building".
+  const [showBulkRole, setShowBulkRole] = useState(false);
+  const [showBulkBuilding, setShowBulkBuilding] = useState(false);
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const editingUser = useMemo(
     () => users.find((u) => u.id === editingUserId) ?? null,
@@ -398,19 +403,15 @@ export const UsersView: React.FC<Props> = ({
               })()}
               <button
                 type="button"
-                disabled
-                aria-disabled="true"
-                title="Coming soon"
-                className="text-xs font-semibold text-white/50 cursor-not-allowed"
+                onClick={() => setShowBulkRole(true)}
+                className="text-xs font-semibold hover:text-white/80"
               >
                 Change role
               </button>
               <button
                 type="button"
-                disabled
-                aria-disabled="true"
-                title="Coming soon"
-                className="text-xs font-semibold text-white/50 cursor-not-allowed"
+                onClick={() => setShowBulkBuilding(true)}
+                className="text-xs font-semibold hover:text-white/80"
               >
                 Move to building
               </button>
@@ -534,7 +535,229 @@ export const UsersView: React.FC<Props> = ({
           setShowImport(false);
         }}
       />
+
+      <BulkRoleModal
+        isOpen={showBulkRole}
+        count={selected.size}
+        roles={roles}
+        onClose={() => setShowBulkRole(false)}
+        onApply={(role) => {
+          onBulkUpdate(Array.from(selected), { role });
+          setSelected(new Set());
+          setShowBulkRole(false);
+        }}
+      />
+
+      <BulkBuildingModal
+        isOpen={showBulkBuilding}
+        count={selected.size}
+        buildings={visibleBuildings}
+        onClose={() => setShowBulkBuilding(false)}
+        onApply={(buildingIds) => {
+          onBulkUpdate(Array.from(selected), { buildingIds });
+          setSelected(new Set());
+          setShowBulkBuilding(false);
+        }}
+      />
     </div>
+  );
+};
+
+// ---------- Bulk "Change role" modal (M4) ----------
+
+/**
+ * Single-select role picker for the bulk "Change role" action. Reuses the
+ * roles list + PopoverOption-style rows inside a LocalModal. Applies the picked
+ * role to every selected user via `onBulkUpdate(ids, { role })` in the parent.
+ */
+const BulkRoleModal: React.FC<{
+  isOpen: boolean;
+  count: number;
+  roles: RoleRecord[];
+  onClose: () => void;
+  onApply: (role: string) => void;
+}> = ({ isOpen, count, roles, onClose, onApply }) => {
+  const [role, setRole] = useState<string>('');
+
+  // Reset the picked role each time the modal opens. Per CLAUDE.md, adjust
+  // state during render rather than reaching for useEffect.
+  const [wasOpen, setWasOpen] = useState(false);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    if (isOpen) setRole('');
+  }
+
+  return (
+    <LocalModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Change role"
+      icon={<UserCog size={18} />}
+      footer={
+        <>
+          <Btn variant="ghost" onClick={onClose}>
+            Cancel
+          </Btn>
+          <Btn
+            variant="primary"
+            disabled={!role}
+            onClick={() => role && onApply(role)}
+          >
+            Apply to {count} user{count === 1 ? '' : 's'}
+          </Btn>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-slate-600">
+          Pick a role to assign to the {count} selected user
+          {count === 1 ? '' : 's'}.
+        </p>
+        <div
+          role="radiogroup"
+          aria-label="Role"
+          className="rounded-lg border border-slate-200 divide-y divide-slate-100"
+        >
+          {roles.map((r) => (
+            <PopoverOption
+              key={r.id}
+              onClick={() => setRole(r.id)}
+              selected={role === r.id}
+              label={r.name}
+              description={r.blurb}
+              icon={
+                <span
+                  className={`h-5 w-5 rounded flex items-center justify-center text-[10px] font-bold ${(() => {
+                    const c = ROLE_COLOR[r.id];
+                    return c
+                      ? ROLE_ICON_CLASSES[c]
+                      : 'bg-slate-100 text-slate-700';
+                  })()}`}
+                >
+                  {r.name[0]}
+                </span>
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </LocalModal>
+  );
+};
+
+// ---------- Bulk "Move to building" modal (M4) ----------
+
+/**
+ * Building picker for the bulk "Move to building" action. DECIDED semantics =
+ * REPLACE: the picked buildings overwrite each selected user's current building
+ * assignments (not merge). A confirm step spells out the replacement impact
+ * before the write fires. Reuses the Checkbox primitive + Confirm dialog.
+ */
+const BulkBuildingModal: React.FC<{
+  isOpen: boolean;
+  count: number;
+  buildings: BuildingRecord[];
+  onClose: () => void;
+  onApply: (buildingIds: string[]) => void;
+}> = ({ isOpen, count, buildings, onClose, onApply }) => {
+  const [picked, setPicked] = useState<string[]>([]);
+  const [confirming, setConfirming] = useState(false);
+
+  // Reset picks/confirm state each time the modal opens (adjust-in-render).
+  const [wasOpen, setWasOpen] = useState(false);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
+    if (isOpen) {
+      setPicked([]);
+      setConfirming(false);
+    }
+  }
+
+  const pickedNames = buildings
+    .filter((b) => picked.includes(b.id))
+    .map((b) => b.name);
+
+  return (
+    <>
+      <LocalModal
+        isOpen={isOpen && !confirming}
+        onClose={onClose}
+        title="Move to building"
+        icon={<Building2 size={18} />}
+        footer={
+          <>
+            <Btn variant="ghost" onClick={onClose}>
+              Cancel
+            </Btn>
+            <Btn
+              variant="primary"
+              disabled={picked.length === 0}
+              onClick={() => setConfirming(true)}
+            >
+              Continue
+            </Btn>
+          </>
+        }
+      >
+        <div className="space-y-3">
+          <p className="text-sm text-slate-600">
+            Pick the building(s) to assign. This <strong>replaces</strong> each
+            selected user&apos;s current building assignments.
+          </p>
+          <div
+            role="group"
+            aria-label="Buildings"
+            className="max-h-56 overflow-y-auto rounded-lg border border-slate-300 bg-white divide-y divide-slate-100"
+          >
+            {buildings.length === 0 && (
+              <div className="px-3 py-4 text-sm text-slate-500">
+                No buildings available.
+              </div>
+            )}
+            {buildings.map((b) => {
+              const checked = picked.includes(b.id);
+              const inputId = `bulk-building-${b.id}`;
+              return (
+                <label
+                  key={b.id}
+                  htmlFor={inputId}
+                  className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 cursor-pointer"
+                >
+                  <Checkbox
+                    id={inputId}
+                    checked={checked}
+                    onChange={(e) =>
+                      setPicked((prev) =>
+                        e.target.checked
+                          ? [...prev, b.id]
+                          : prev.filter((id) => id !== b.id)
+                      )
+                    }
+                  />
+                  <span className="flex-1 truncate">{b.name}</span>
+                  <Badge color="slate">{b.grades}</Badge>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      </LocalModal>
+
+      <Confirm
+        isOpen={isOpen && confirming}
+        title="Replace building assignments?"
+        message={
+          <>
+            Move {count} user{count === 1 ? '' : 's'} to{' '}
+            <strong>{pickedNames.join(', ')}</strong>, replacing their current
+            building assignments. This can&apos;t be undone in bulk.
+          </>
+        }
+        confirmLabel="Move users"
+        onCancel={() => setConfirming(false)}
+        onConfirm={() => onApply(picked)}
+      />
+    </>
   );
 };
 

--- a/components/auth/DeactivatedScreen.tsx
+++ b/components/auth/DeactivatedScreen.tsx
@@ -41,7 +41,11 @@ export const DeactivatedScreen: React.FC = () => {
 
         <button
           onClick={() => {
-            void signInWithGoogle();
+            // signInWithGoogle() re-throws (incl. popup-closed-by-user). Swallow
+            // the rejection here so a cancelled popup doesn't surface as an
+            // unhandledrejection. Staying on DeactivatedScreen is the intended
+            // outcome when sign-in doesn't complete.
+            void signInWithGoogle().catch(() => undefined);
           }}
           className="w-full bg-white text-slate-700 py-3.5 rounded-2xl font-bold border border-slate-200 hover:bg-slate-50 transition-colors active:scale-[0.98]"
         >

--- a/components/auth/DeactivatedScreen.tsx
+++ b/components/auth/DeactivatedScreen.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { ShieldOff } from 'lucide-react';
+import { APP_NAME } from '@/config/constants';
+import { useAuth } from '@/context/useAuth';
+
+/**
+ * Full-page screen shown when the signed-in user's organization membership has
+ * been deactivated (M1 full sign-in lockout). The membership snapshot in
+ * AuthContext latches `accessDeactivated` and signs the user out; this screen
+ * renders on that sticky flag REGARDLESS of `user`, so the deactivated teacher
+ * gets a clear, actionable reason instead of being silently bounced to the
+ * login page.
+ *
+ * Light surface (mirrors LoginScreen / student / login UI), so the muted-text
+ * contrast guidance for DARK surfaces does not apply here — slate-500/600 on a
+ * white card is correct.
+ */
+export const DeactivatedScreen: React.FC = () => {
+  const { signInWithGoogle } = useAuth();
+
+  return (
+    <div className="relative h-screen w-screen flex items-center justify-center bg-slate-50 overflow-hidden font-sans">
+      {/* Subtle radial dotted background (matches LoginScreen) */}
+      <div className="absolute inset-0 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] [background-size:16px_16px] opacity-50" />
+      <div className="absolute -bottom-1/4 -right-1/4 w-[500px] h-[500px] bg-brand-red-primary/10 rounded-full blur-[100px]" />
+
+      <div className="relative z-10 bg-white/80 backdrop-blur-xl p-10 sm:p-12 rounded-3xl shadow-[0_8px_30px_rgb(0,0,0,0.04)] border border-slate-100/60 ring-1 ring-slate-900/5 max-w-md w-full mx-4 text-center">
+        <div className="mx-auto w-16 h-16 bg-gradient-to-br from-brand-red-primary to-brand-red-dark rounded-2xl flex items-center justify-center shadow-lg shadow-brand-red-primary/20 mb-8">
+          <ShieldOff className="w-8 h-8 text-white" strokeWidth={2.5} />
+        </div>
+
+        <h1 className="text-2xl sm:text-3xl font-black text-slate-800 tracking-tight mb-3">
+          Access deactivated
+        </h1>
+        <p className="text-slate-600 mb-2 font-medium text-sm sm:text-base">
+          Your access to {APP_NAME} has been deactivated.
+        </p>
+        <p className="text-slate-500 mb-10 text-sm">
+          Please contact your administrator if you believe this is a mistake.
+        </p>
+
+        <button
+          onClick={() => {
+            void signInWithGoogle();
+          }}
+          className="w-full bg-white text-slate-700 py-3.5 rounded-2xl font-bold border border-slate-200 hover:bg-slate-50 transition-colors active:scale-[0.98]"
+        >
+          Sign in with a different account
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/components/student/StudentContexts.tsx
+++ b/components/student/StudentContexts.tsx
@@ -79,6 +79,7 @@ const mockAuth: AuthContextType = {
   orgId: null,
   roleId: null,
   isStudentRole: false,
+  accessDeactivated: false,
   roleResolved: true,
   buildingIds: [],
   orgBuildings: [],

--- a/components/widgets/Embed/Widget.test.tsx
+++ b/components/widgets/Embed/Widget.test.tsx
@@ -441,6 +441,7 @@ describe('EmbedWidget', () => {
         orgId: null,
         roleId: null,
         isStudentRole: false,
+        accessDeactivated: false,
         roleResolved: true,
         buildingIds: [],
         orgBuildings: [],

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -82,6 +82,7 @@ const mockAuthContext = (
   orgId: null,
   roleId: null,
   isStudentRole: false,
+  accessDeactivated: false,
   roleResolved: true,
   buildingIds: [],
   orgBuildings: [],

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -333,6 +333,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const [roleId, setRoleId] = useState<string | null>(
     isAuthBypass ? 'super_admin' : null
   );
+  // Sticky, session-scoped "this account has been deactivated" flag (M1 full
+  // sign-in lockout). Set true the moment the org-member snapshot reports
+  // `status === 'inactive'`; once true it STAYS true for the rest of the JS
+  // session even after we sign the user out. That stickiness is deliberate:
+  // signOut() nulls `user`, which would otherwise drop the app back to the
+  // LoginScreen and lose the "your access was deactivated" message. The
+  // consumer (AuthenticatedApp) renders a dedicated DeactivatedScreen on this
+  // flag REGARDLESS of `user`, so the deactivated teacher gets a clear reason
+  // rather than a silent bounce. A fresh sign-in attempt clears it (see
+  // signInWithGoogle).
+  const [accessDeactivated, setAccessDeactivated] = useState<boolean>(false);
   const [isStudentRole, setIsStudentRole] = useState<boolean>(false);
   // Two-part "have we figured out who this user is" gate. Both flags must be
   // true for `roleResolved` to flip true. They're reset synchronously when
@@ -1254,6 +1265,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
             setOrgId(resolvedOrgId);
             setRoleId(member.roleId ?? null);
             setBuildingIds(member.buildingIds ?? []);
+            // M1 full sign-in lockout: a member explicitly marked 'inactive'
+            // is locked out of the app entirely (not just stripped of admin).
+            // Latch the sticky flag — AuthenticatedApp signs them out and
+            // shows the DeactivatedScreen. We never UN-set it here: if an
+            // admin reactivates the member mid-session the next snapshot would
+            // clear it, but by then we've already signed the user out and the
+            // listener is torn down, so reactivation simply takes effect on
+            // their next sign-in. Setting (not clearing) here keeps the lockout
+            // strictly one-way within a session, which is the safe direction.
+            if (member.status === 'inactive') {
+              setAccessDeactivated(true);
+            }
             // Record that this session has resolved a real org at least once,
             // so a later transient snapshot error can safely preserve the
             // last-known state (vs. clearing on a never-resolved first load).
@@ -2267,11 +2290,17 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         betaUsers.some((e) => e.toLowerCase() === lowerEmail) ||
         (userRoles?.betaTeachers?.some((e) => e.toLowerCase() === lowerEmail) ??
           false) ||
+        // LO2 harmonization: super admins get beta access from EITHER source —
+        // the legacy admin_settings/user_roles.superAdmins[] list OR a member
+        // doc with roleId 'super_admin'. The legacy list is KEPT as an
+        // additional accepted source (a Paul-gated migration retires it later);
+        // this mirrors OrganizationPanel.resolveActorRole, which reads both.
         (userRoles?.superAdmins?.some((e) => e.toLowerCase() === lowerEmail) ??
-          false)
+          false) ||
+        roleId === 'super_admin'
       );
     },
-    [userRoles]
+    [userRoles, roleId]
   );
 
   // Distribution tier (docs/wide-distro-plan.md Phase 3). Org membership
@@ -2527,6 +2556,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [user, globalPermissions, isAdmin, resolvePermissionAccess]);
 
   const signInWithGoogle = async () => {
+    // A fresh sign-in attempt clears any sticky deactivation from a prior
+    // session on this device (e.g. a different, deactivated account signed in
+    // earlier, or the same account that has since been reactivated). The
+    // membership snapshot re-evaluates status after sign-in and re-latches the
+    // flag if they're still inactive.
+    setAccessDeactivated(false);
     if (isAuthBypass) {
       console.warn('Bypassing Google Sign In');
       try {
@@ -2650,6 +2685,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         orgId,
         roleId,
         isStudentRole,
+        accessDeactivated,
         roleResolved,
         buildingIds,
         orgBuildings,

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -2561,7 +2561,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     // earlier, or the same account that has since been reactivated). The
     // membership snapshot re-evaluates status after sign-in and re-latches the
     // flag if they're still inactive.
-    setAccessDeactivated(false);
+    //
+    // Clear the flag only AFTER a sign-in actually succeeds — clearing it up
+    // front would drop the deactivation context if the user cancels the popup
+    // (signInWithPopup throws), leaving a deactivated user on the login screen
+    // instead of the DeactivatedScreen.
     if (isAuthBypass) {
       console.warn('Bypassing Google Sign In');
       try {
@@ -2577,10 +2581,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
         (Date.now() + GOOGLE_TOKEN_TTL_MS).toString()
       );
       setIsAdmin(true); // Restore admin status on sign in
+      setAccessDeactivated(false);
       return;
     }
     try {
       const result = await signInWithPopup(auth, googleProvider);
+      // Sign-in succeeded — safe to clear the sticky deactivation flag now.
+      setAccessDeactivated(false);
       const credential = GoogleAuthProvider.credentialFromResult(result);
       if (credential) {
         const token = credential.accessToken ?? null;

--- a/context/AuthContextValue.ts
+++ b/context/AuthContextValue.ts
@@ -205,6 +205,16 @@ export interface AuthContextType {
    */
   isStudentRole: boolean;
   /**
+   * True when the signed-in user's organization member doc reports
+   * `status === 'inactive'` (M1 full sign-in lockout). Sticky for the JS
+   * session: once latched it stays true even after `signOut()` clears `user`,
+   * so the app can render a "your access has been deactivated" screen rather
+   * than silently bouncing the user back to the login page. Cleared by a fresh
+   * `signInWithGoogle()` attempt. Always false in auth-bypass mode and for
+   * users with no org member doc.
+   */
+  accessDeactivated: boolean;
+  /**
    * True once both `isStudentRole` (from the token claim) AND `roleId` (from
    * the org-members snapshot, or short-circuited when the user has no email)
    * have settled to their final values for the current user. Consumers that

--- a/firestore.rules
+++ b/firestore.rules
@@ -98,16 +98,32 @@ service cloud.firestore {
 
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
-    // Super admins are listed on the legacy admin_settings/user_roles doc.
-    // Phase 1 also upserts them as /organizations/{orgId}/members with roleId
-    // 'super_admin', but because super-admin checks run globally (not scoped
-    // to a single org) the rules keep reading the legacy list here.
+    // Super admins are recognized from EITHER source (LO2 harmonization):
+    //   1. The legacy admin_settings/user_roles.superAdmins[] list, AND
+    //   2. An operator-org member doc with roleId == 'super_admin'.
+    // This mirrors OrganizationPanel.resolveActorRole, which already accepts
+    // both sources on the client. The legacy list is KEPT as an additional
+    // accepted source (NOT retired) — a Paul-gated migration removes it later.
+    //
+    // Super-admin checks run globally (not scoped to a single org), so the
+    // roleId source is read from the operator org (`orono`) by fixed path —
+    // the same constraint that forces operatorMemberStatus() / notDeactivated()
+    // to use a hardcoded org (CEL cannot resolve the caller's org dynamically).
     function isSuperAdmin() {
       return request.auth != null &&
              request.auth.token.email != null &&
-             exists(/databases/$(database)/documents/admin_settings/user_roles) &&
+             (isLegacySuperAdmin() || isMemberSuperAdmin());
+    }
+
+    function isLegacySuperAdmin() {
+      return exists(/databases/$(database)/documents/admin_settings/user_roles) &&
              request.auth.token.email.lower() in
                get(/databases/$(database)/documents/admin_settings/user_roles).data.get('superAdmins', []);
+    }
+
+    function isMemberSuperAdmin() {
+      return exists(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())) &&
+             get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())).data.get('roleId', '') == 'super_admin';
     }
 
     // Returns the caller's /organizations/{orgId}/members/{email} doc data.
@@ -204,6 +220,37 @@ service cloud.firestore {
     function isOrgMember(orgId) {
       return request.auth != null && request.auth.token.email != null &&
              exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower()));
+    }
+
+    // ---- M1 full sign-in lockout (deny-by-status) ----
+    //
+    // The operator org id. Rules cannot resolve a user's org dynamically from
+    // their email domain (that lives in the `resolveOrgForUser` Cloud Function,
+    // not in CEL), and CEL cannot enumerate orgs. The operator org is the one
+    // org we can check by a fixed path, and it is where the active user base
+    // lives, so the deactivation gate is enforced against it. Mirrors the
+    // OPERATOR_ORG_ID fallback in context/AuthContext.tsx.
+    //
+    // NOTE (multi-org follow-up): a member deactivated in a *second/third* org
+    // is blocked at sign-in by AuthContext (which resolves their real org) but
+    // is not yet denied by these rules, because the rule can't know their org
+    // from the /users/{uid} path. A per-uid org-index doc (readable by path)
+    // would let this gate cover every org; tracked as an M1 rules follow-up.
+    function operatorMemberStatus() {
+      return get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())).data.get('status', 'active');
+    }
+
+    // True UNLESS the caller is an operator-org member explicitly marked
+    // 'inactive'. Defaults to ALLOW (true) for everyone without an operator-org
+    // member doc — anonymous/PIN students (no email), SSO students, no-org /
+    // other-org teachers — so this gate only ever subtracts access from a
+    // member an admin deliberately deactivated. The email-presence guard avoids
+    // a CEL throw on tokens with no `email` claim (anonymous PIN students).
+    function notDeactivated() {
+      return !(request.auth != null &&
+               request.auth.token.get('email', '') != '' &&
+               isOrgMember('orono') &&
+               operatorMemberStatus() == 'inactive');
     }
 
     // ---- Organizations collection (Phase 3: scoped writes enabled) ----
@@ -495,7 +542,8 @@ service cloud.firestore {
     match /users/{userId}/dashboards/{dashboardId} {
       allow read, write: if request.auth != null
                          && request.auth.uid == userId
-                         && !isStudentRoleUser();
+                         && !isStudentRoleUser()
+                         && notDeactivated();
 
       // Phase 2 PR 2.6: DrawingWidget object content moves off the dashboard
       // document into a page-nested subcollection so a single Firestore write
@@ -509,19 +557,22 @@ service cloud.firestore {
       match /drawings/{widgetId}/pages/{pageId} {
         allow read, write: if request.auth != null
                            && request.auth.uid == userId
-                           && !isStudentRoleUser();
+                           && !isStudentRoleUser()
+                           && notDeactivated();
 
         match /objects/{objectId} {
           allow read, write: if request.auth != null
                              && request.auth.uid == userId
-                             && !isStudentRoleUser();
+                             && !isStudentRoleUser()
+                             && notDeactivated();
         }
       }
     }
 
     // Rosters - users can only access their own rosters in their subcollection
     match /users/{userId}/rosters/{rosterId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && notDeactivated();
 
       // Phase 3 — non-PII PIN index sidecar. Bridges PIN-joining
       // students into the SSO uid space via `pinLoginV1`. The cloud
@@ -582,7 +633,8 @@ service cloud.firestore {
 
     // Mini Apps - users can only access their own mini apps in their subcollection
     match /users/{userId}/miniapps/{appId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && notDeactivated();
     }
 
     // Saved Widgets - per-user "Save as widget" shortcuts (frozen widget configs
@@ -593,17 +645,20 @@ service cloud.firestore {
 
     // Notebooks - users can only access their own notebooks in their subcollection
     match /users/{userId}/notebooks/{notebookId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && notDeactivated();
     }
 
     // PDFs - users can only access their own PDFs in their subcollection
     match /users/{userId}/pdfs/{pdfId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && notDeactivated();
     }
 
     // Quiz metadata - users can only access their own quiz metadata
     match /users/{userId}/quizzes/{quizId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && notDeactivated();
     }
 
     // Activity Wall library - per-user reusable activity definitions.

--- a/firestore.rules
+++ b/firestore.rules
@@ -116,13 +116,13 @@ service cloud.firestore {
     }
 
     function isLegacySuperAdmin() {
-      return exists(/databases/$(database)/documents/admin_settings/user_roles) &&
+      return get(/databases/$(database)/documents/admin_settings/user_roles) != null &&
              request.auth.token.email.lower() in
                get(/databases/$(database)/documents/admin_settings/user_roles).data.get('superAdmins', []);
     }
 
     function isMemberSuperAdmin() {
-      return exists(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())) &&
+      return get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())) != null &&
              get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())).data.get('roleId', '') == 'super_admin';
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -154,6 +154,25 @@ service cloud.firestore {
            : [buildingId];
     }
 
+    // Alias-aware overlap between two building-id lists. CEL has no `.map()`,
+    // so the two stored lists can't be canonicalized element-wise. Instead we
+    // bridge across each known alias group: lists overlap if (a) they share a
+    // raw id, or (b) for any alias group, BOTH lists contain at least one form
+    // from that group (e.g. one stores 'high', the other 'orono-high-school').
+    // Unknown/unaliased ids only match via the raw-overlap branch, which is
+    // correct (no canonical form to bridge). Symmetric in a and b.
+    function buildingListsOverlap(a, b) {
+      return a.hasAny(b) ||
+        (a.hasAny(['high', 'orono-high-school']) &&
+         b.hasAny(['high', 'orono-high-school'])) ||
+        (a.hasAny(['middle', 'orono-middle-school']) &&
+         b.hasAny(['middle', 'orono-middle-school'])) ||
+        (a.hasAny(['intermediate', 'orono-intermediate-school']) &&
+         b.hasAny(['intermediate', 'orono-intermediate-school'])) ||
+        (a.hasAny(['schumann', 'schumann-elementary']) &&
+         b.hasAny(['schumann', 'schumann-elementary']));
+    }
+
     // The caller's roleId within an org, or empty string when not a member.
     function memberRole(orgId, emailLower) {
       return exists(/databases/$(database)/documents/organizations/$(orgId)/members/$(emailLower))
@@ -380,22 +399,18 @@ service cloud.firestore {
              'roleId', 'buildingIds', 'status', 'name', 'invitedAt', 'lastActive'
            ])) ||
           // Building admin can flip `status` on a member whose buildingIds
-          // overlap their own. `hasAny([])` returns false, so a newly
-          // invited member with `buildingIds: []` is *not* editable by a
-          // building admin — the domain admin must assign a building first.
-          // This is intentional: building admins shouldn't be able to act on
-          // members who haven't been scoped into their building yet.
-          //
-          // KNOWN GAP (follow-up): this list-vs-list overlap is NOT alias-aware
-          // like the building-doc rule's `manages()` helper, so if the target
-          // member and the acting admin store buildingIds in mismatched
-          // canonical/legacy formats the overlap can falsely fail (false DENIAL
-          // only — never a false grant). Canonicalizing two lists in CEL has no
-          // clean form (no `.map()`), unlike the single-id `buildingIdAliasGroup`
-          // case. Low incidence since member buildingIds are canonicalized on
-          // write; tracked for a dedicated rules pass. See config/buildings.ts.
+          // overlap their own. The overlap is alias-aware via
+          // buildingListsOverlap(), so a target member and acting admin storing
+          // buildingIds in mismatched canonical/legacy formats (e.g. 'high' vs
+          // 'orono-high-school') still match — closing the prior false-DENIAL
+          // gap without needing `.map()`. An empty list on either side yields no
+          // overlap, so a newly invited member with `buildingIds: []` is *not*
+          // editable by a building admin — the domain admin must assign a
+          // building first. This is intentional: building admins shouldn't act
+          // on members who haven't been scoped into their building yet.
+          // See config/buildings.ts for the canonical alias table.
           (isBuildingAdmin(orgId) &&
-           resource.data.buildingIds.hasAny(orgMember(orgId).buildingIds) &&
+           buildingListsOverlap(resource.data.buildingIds, orgMember(orgId).buildingIds) &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])) ||
           // Self-write: the signed-in user may stamp their own `lastActive`
           // on their own member doc. Bound strictly — email/orgId must match

--- a/firestore.rules
+++ b/firestore.rules
@@ -3369,26 +3369,37 @@ service cloud.firestore {
         // Teacher ownership is looked up from the parent session doc because
         // the sessionId is no longer the teacher's uid. This adds one get()
         // per response write (~50ms, $0 at class scale).
+        //
+        // Read-count optimization (LO4): all of the session field helpers
+        // below derive from the SAME parent session doc. Instead of each
+        // helper issuing its own get() on quiz_sessions/$(sessionId), they all
+        // read off a single sessionData() snapshot. This mirrors the
+        // orgMember() precedent above (one get().data, fields via .get()).
+        // Authorization behavior is unchanged — only the document-read count
+        // per request is reduced.
+        function sessionData() {
+          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data;
+        }
         function sessionTeacherUid() {
-          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.teacherUid;
+          return sessionData().teacherUid;
         }
         function sessionClassId() {
-          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classId', '');
+          return sessionData().get('classId', '');
         }
         function sessionClassIds() {
-          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('classIds', []);
+          return sessionData().get('classIds', []);
         }
         // Defense in depth — block response writes on view-only sessions.
         // Pre-feature sessions without a `mode` field default to 'submissions'.
         function sessionMode() {
-          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('mode', 'submissions');
+          return sessionData().get('mode', 'submissions');
         }
         // Server-side attempt cap. The client also enforces this in the
         // join + submit transactions; the rule is the last line of defense
         // against a race, a buggy client, or a hostile caller. Returns
         // null when the session has no cap (legacy or explicitly unlimited).
         function sessionAttemptLimit() {
-          return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.get('attemptLimit', null);
+          return sessionData().get('attemptLimit', null);
         }
 
         // Student branch allows `resource == null` so the student-app join

--- a/firestore.rules
+++ b/firestore.rules
@@ -107,7 +107,7 @@ service cloud.firestore {
     //
     // Super-admin checks run globally (not scoped to a single org), so the
     // roleId source is read from the operator org (`orono`) by fixed path —
-    // the same constraint that forces operatorMemberStatus() / notDeactivated()
+    // the same constraint that forces operatorMember() / notDeactivated()
     // to use a hardcoded org (CEL cannot resolve the caller's org dynamically).
     function isSuperAdmin() {
       return request.auth != null &&
@@ -236,8 +236,14 @@ service cloud.firestore {
     // is not yet denied by these rules, because the rule can't know their org
     // from the /users/{uid} path. A per-uid org-index doc (readable by path)
     // would let this gate cover every org; tracked as an M1 rules follow-up.
-    function operatorMemberStatus() {
-      return get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower())).data.get('status', 'active');
+    // The caller's operator-org member doc, or null when it does not exist.
+    // A single get() (Firestore caches repeated get()s to the same path within
+    // one rule evaluation, and get() returns null for a missing doc) replaces
+    // the prior exists()+get() pair: it both tests membership (via != null) and
+    // reads status in one document access, halving the baseline read cost on the
+    // ~15 owner collections gated by notDeactivated().
+    function operatorMember() {
+      return get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower()));
     }
 
     // True UNLESS the caller is an operator-org member explicitly marked
@@ -249,8 +255,8 @@ service cloud.firestore {
     function notDeactivated() {
       return !(request.auth != null &&
                request.auth.token.get('email', '') != '' &&
-               isOrgMember('orono') &&
-               operatorMemberStatus() == 'inactive');
+               operatorMember() != null &&
+               operatorMember().data.get('status', 'active') == 'inactive');
     }
 
     // ---- Organizations collection (Phase 3: scoped writes enabled) ----
@@ -444,7 +450,16 @@ service cloud.firestore {
            request.resource.data.orgId == resource.data.orgId &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly([
              'roleId', 'buildingIds', 'status', 'name', 'invitedAt', 'lastActive'
-           ])) ||
+           ]) &&
+           // Anti-escalation: a domain admin must NOT be able to mint a super
+           // admin. roleId == 'super_admin' is a live isSuperAdmin() grant via
+           // isMemberSuperAdmin(), and this branch otherwise lets a domain admin
+           // write any roleId — including onto their own member doc — which would
+           // be a self-escalation path. Block writing 'super_admin' unless the
+           // doc already had it (so edits to an existing super-admin's other
+           // fields still pass). Only a super admin (first disjunct) can grant it.
+           (request.resource.data.get('roleId', '') != 'super_admin' ||
+            resource.data.get('roleId', '') == 'super_admin')) ||
           // Building admin can flip `status` on a member whose buildingIds
           // overlap their own. The overlap is alias-aware via
           // buildingListsOverlap(), so a target member and acting admin storing
@@ -457,7 +472,7 @@ service cloud.firestore {
           // on members who haven't been scoped into their building yet.
           // See config/buildings.ts for the canonical alias table.
           (isBuildingAdmin(orgId) &&
-           buildingListsOverlap(resource.data.buildingIds, orgMember(orgId).buildingIds) &&
+           buildingListsOverlap(resource.data.get('buildingIds', []), orgMember(orgId).get('buildingIds', [])) &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])) ||
           // Self-write: the signed-in user may stamp their own `lastActive`
           // on their own member doc. Bound strictly — email/orgId must match

--- a/firestore.rules
+++ b/firestore.rules
@@ -4439,13 +4439,23 @@ service cloud.firestore {
         function awSessionClassId() {
           return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('classId', '');
         }
+        // Phase-5A multi-class targeting field. Mirrors the quiz/VA/GL/miniapp
+        // session shape so the create gate below can use the compat helper.
+        function awSessionClassIds() {
+          return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('classIds', []);
+        }
 
         // Any authenticated user (including anonymous) can create a submission.
         // Photo submissions may include Firebase storage metadata for later Drive archiving.
-        // studentRole (GIS) users must be enrolled in the session's class.
+        // studentRole (GIS) users must be enrolled in the session's class. Uses
+        // the Phase-5A compat gate (classIds list ?? legacy classId) so a
+        // session migrated to multi-class targeting still gates correctly —
+        // matching every other session type (quiz/VA/GL/miniapp). The legacy
+        // single-classId path is preserved for pre-5A sessions that only carry
+        // `classId`.
         allow create: if request.auth != null &&
           exists(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)) &&
-          passesStudentClassGate(awSessionClassId()) &&
+          passesStudentClassGateCompat(awSessionClassIds(), awSessionClassId()) &&
           request.resource.data.id is string &&
           request.resource.data.content is string &&
           request.resource.data.content.size() > 0 &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -540,10 +540,8 @@ service cloud.firestore {
     // it, a studentRole user calling Firestore directly could still create a
     // dashboard doc under their own uid.
     match /users/{userId}/dashboards/{dashboardId} {
-      allow read, write: if request.auth != null
-                         && request.auth.uid == userId
-                         && !isStudentRoleUser()
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId
+                         && !isStudentRoleUser() && notDeactivated();
 
       // Phase 2 PR 2.6: DrawingWidget object content moves off the dashboard
       // document into a page-nested subcollection so a single Firestore write
@@ -555,24 +553,19 @@ service cloud.firestore {
       // subcollection inherits dashboard semantics without a separate
       // top-level match.
       match /drawings/{widgetId}/pages/{pageId} {
-        allow read, write: if request.auth != null
-                           && request.auth.uid == userId
-                           && !isStudentRoleUser()
-                           && notDeactivated();
+        allow read, write: if request.auth != null && request.auth.uid == userId
+                           && !isStudentRoleUser() && notDeactivated();
 
         match /objects/{objectId} {
-          allow read, write: if request.auth != null
-                             && request.auth.uid == userId
-                             && !isStudentRoleUser()
-                             && notDeactivated();
+          allow read, write: if request.auth != null && request.auth.uid == userId
+                             && !isStudentRoleUser() && notDeactivated();
         }
       }
     }
 
     // Rosters - users can only access their own rosters in their subcollection
     match /users/{userId}/rosters/{rosterId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
 
       // Phase 3 — non-PII PIN index sidecar. Bridges PIN-joining
       // students into the SSO uid space via `pinLoginV1`. The cloud
@@ -604,9 +597,11 @@ service cloud.firestore {
     // cap below prevents a single doc from being weaponized as unbounded
     // storage.
     match /users/{userId}/plc_layouts/{plcId} {
-      allow read, delete: if request.auth != null && request.auth.uid == userId;
+      allow read, delete: if request.auth != null && request.auth.uid == userId
+                          && notDeactivated();
       allow write: if request.auth != null
                    && request.auth.uid == userId
+                   && notDeactivated()
                    && request.resource.data.keys().hasOnly(['tiles', 'updatedAt'])
                    && request.resource.data.tiles is list
                    && request.resource.data.tiles.size() <= 50
@@ -621,9 +616,11 @@ service cloud.firestore {
     // field, which dual-accepts `int || timestamp` during the serverTimestamp
     // rollout (§3.2).
     match /users/{userId}/plc_state/{plcId} {
-      allow read, delete: if request.auth != null && request.auth.uid == userId;
+      allow read, delete: if request.auth != null && request.auth.uid == userId
+                          && notDeactivated();
       allow create, update: if request.auth != null
                    && request.auth.uid == userId
+                   && notDeactivated()
                    && request.resource.data.keys().hasOnly(['lastSeenAt'])
                    && (
                         request.resource.data.lastSeenAt is int
@@ -633,32 +630,28 @@ service cloud.firestore {
 
     // Mini Apps - users can only access their own mini apps in their subcollection
     match /users/{userId}/miniapps/{appId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Saved Widgets - per-user "Save as widget" shortcuts (frozen widget configs
     // surfaced as dock/library entries). Owner-only.
     match /users/{userId}/saved_widgets/{savedWidgetId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Notebooks - users can only access their own notebooks in their subcollection
     match /users/{userId}/notebooks/{notebookId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // PDFs - users can only access their own PDFs in their subcollection
     match /users/{userId}/pdfs/{pdfId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Quiz metadata - users can only access their own quiz metadata
     match /users/{userId}/quizzes/{quizId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId
-                         && notDeactivated();
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Activity Wall library - per-user reusable activity definitions.
@@ -666,7 +659,7 @@ service cloud.firestore {
     // moving them here lets teachers reuse the same activity across widgets
     // and survive widget removal. Owner-only.
     match /users/{userId}/activity_wall_activities/{activityId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Quiz assignments - archive of past/current assignments of a quiz. Per-user.
@@ -674,13 +667,16 @@ service cloud.firestore {
     // those are relied on by ownership checks elsewhere (session rules, shared
     // assignment author checks). Keep teacherUid and id immutable after create.
     match /users/{userId}/quiz_assignments/{assignmentId} {
-      allow read, delete: if request.auth != null && request.auth.uid == userId;
+      allow read, delete: if request.auth != null && request.auth.uid == userId
+                          && notDeactivated();
       allow create: if request.auth != null
                     && request.auth.uid == userId
+                    && notDeactivated()
                     && request.resource.data.teacherUid == userId
                     && request.resource.data.id == assignmentId;
       allow update: if request.auth != null
                     && request.auth.uid == userId
+                    && notDeactivated()
                     && request.resource.data.teacherUid == resource.data.teacherUid
                     && request.resource.data.id == resource.data.id;
     }
@@ -934,7 +930,7 @@ service cloud.firestore {
 
     // Guided Learning
     match /users/{userId}/guided_learning/{setId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     match /building_guided_learning/{setId} {
@@ -4228,7 +4224,7 @@ service cloud.firestore {
 
     // Video Activity metadata — stored per teacher user
     match /users/{userId}/video_activities/{activityId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
@@ -4604,20 +4600,20 @@ service cloud.firestore {
     // === Video Activity assignments (Wave 2-VA) ===
     // Per-teacher archive of video activity assignments — mirrors quiz_assignments.
     match /users/{userId}/video_activity_assignments/{id} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // === Wave 2 library assignment archives (appended) ===
     // MiniApp assignment archive (Wave 2-MA).
     match /users/{userId}/miniapp_assignments/{id} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
     // === /Wave 2 library assignment archives ===
 
     // === Guided Learning assignments (Wave 2-GL) ===
     // Per-teacher archive of guided learning assignments. Owner-only read/write.
     match /users/{userId}/guided_learning_assignments/{id} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // === Library folders (Wave 3) ===
@@ -4627,19 +4623,19 @@ service cloud.firestore {
     // the *_assignments pattern above. Wave 3-A ships the rules + schema;
     // Wave 3-B wires the UI.
     match /users/{userId}/collections/{collectionId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
     match /users/{userId}/quiz_folders/{folderId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
     match /users/{userId}/video_activity_folders/{folderId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
     match /users/{userId}/guided_learning_folders/{folderId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
     match /users/{userId}/miniapp_folders/{folderId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }
 
     // Default deny all other collections

--- a/tests/components/admin/Organization/UsersView.bulkRoleBuilding.test.tsx
+++ b/tests/components/admin/Organization/UsersView.bulkRoleBuilding.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Focused unit tests for the M4 bulk "Change role" and "Move to building"
+ * actions in UsersView.
+ *
+ * Verifies:
+ * - "Change role": picking a role calls onBulkUpdate(ids, { role }) and clears
+ *   the selection.
+ * - "Move to building": picking building(s) → Continue → confirm calls
+ *   onBulkUpdate(ids, { buildingIds }) with REPLACE semantics and clears the
+ *   selection.
+ * - Both actions are hidden for building_admin (canManageUsers === false).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { UsersView } from '@/components/admin/Organization/views/UsersView';
+import type {
+  BuildingRecord,
+  RoleRecord,
+  UserRecord,
+} from '@/types/organization';
+
+vi.mock('@/utils/csvImport', () => ({
+  parseInvitesCsv: vi.fn(() => ({ valid: [], errors: [] })),
+}));
+
+const TEACHER_ROLE: RoleRecord = {
+  id: 'teacher',
+  name: 'Teacher',
+  blurb: 'Classroom teacher',
+  color: 'emerald',
+  system: true,
+  perms: {} as RoleRecord['perms'],
+};
+const COACH_ROLE: RoleRecord = {
+  id: 'building_admin',
+  name: 'Building admin',
+  blurb: 'Manages a building',
+  color: 'violet',
+  system: true,
+  perms: {} as RoleRecord['perms'],
+};
+
+const BUILDING_A: BuildingRecord = {
+  id: 'b1',
+  orgId: 'org1',
+  name: 'High School',
+  type: 'high',
+  address: '',
+  grades: '9-12',
+  users: 3,
+  adminEmails: [],
+};
+const BUILDING_B: BuildingRecord = {
+  id: 'b2',
+  orgId: 'org1',
+  name: 'Middle School',
+  type: 'middle',
+  address: '',
+  grades: '6-8',
+  users: 2,
+  adminEmails: [],
+};
+
+const makeUser = (id: string): UserRecord => ({
+  id,
+  orgId: 'org1',
+  name: `User ${id}`,
+  email: `${id}@example.com`,
+  role: 'teacher',
+  buildingIds: ['b1'],
+  status: 'active',
+  lastActive: null,
+});
+
+const USERS = [makeUser('u1'), makeUser('u2')];
+
+const makeProps = (
+  overrides: Partial<Parameters<typeof UsersView>[0]> = {}
+) => ({
+  users: USERS,
+  roles: [TEACHER_ROLE, COACH_ROLE],
+  buildings: [BUILDING_A, BUILDING_B],
+  actorRole: 'domain_admin' as const,
+  actorBuildingIds: ['b1', 'b2'],
+  activityPartial: false,
+  onUpdate: vi.fn(),
+  onBulkUpdate: vi.fn(),
+  onRemove: vi.fn(),
+  onInvite: vi.fn(),
+  onBulkInvite: vi.fn(),
+  onResendInvite: vi.fn(),
+  onResetPassword: vi.fn(),
+  ...overrides,
+});
+
+function selectAll() {
+  fireEvent.click(screen.getByRole('checkbox', { name: /select all/i }));
+}
+
+describe('UsersView — bulk Change role', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('applies the picked role to all selected users and clears selection', () => {
+    const onBulkUpdate = vi.fn();
+    render(<UsersView {...makeProps({ onBulkUpdate })} />);
+
+    selectAll();
+    // Open the bulk "Change role" picker.
+    fireEvent.click(screen.getByRole('button', { name: /^change role$/i }));
+
+    // The role picker modal is open — pick "Building admin".
+    const dialog = screen.getByRole('dialog', { name: /change role/i });
+    fireEvent.click(within(dialog).getByText('Building admin'));
+
+    // Apply.
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /apply to 2 users/i })
+    );
+
+    expect(onBulkUpdate).toHaveBeenCalledTimes(1);
+    expect(onBulkUpdate).toHaveBeenCalledWith(['u1', 'u2'], {
+      role: 'building_admin',
+    });
+    // Selection cleared — toolbar gone.
+    expect(screen.queryByText(/2 selected/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('UsersView — bulk Move to building (REPLACE)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('replaces building assignments after confirm, then clears selection', () => {
+    const onBulkUpdate = vi.fn();
+    render(<UsersView {...makeProps({ onBulkUpdate })} />);
+
+    selectAll();
+    fireEvent.click(screen.getByRole('button', { name: /move to building/i }));
+
+    // Pick "Middle School" in the building picker.
+    const pickerDialog = screen.getByRole('dialog', {
+      name: /move to building/i,
+    });
+    // The <label> wraps the checkbox + a grade badge, so its accessible name is
+    // "Middle School 6-8". Click the visible building name to toggle the row.
+    fireEvent.click(within(pickerDialog).getByText('Middle School'));
+    fireEvent.click(
+      within(pickerDialog).getByRole('button', { name: /continue/i })
+    );
+
+    // Confirm dialog spells out the replace impact.
+    const confirmDialog = screen.getByRole('dialog', {
+      name: /replace building assignments/i,
+    });
+    fireEvent.click(
+      within(confirmDialog).getByRole('button', { name: /move users/i })
+    );
+
+    expect(onBulkUpdate).toHaveBeenCalledTimes(1);
+    expect(onBulkUpdate).toHaveBeenCalledWith(['u1', 'u2'], {
+      buildingIds: ['b2'],
+    });
+    expect(screen.queryByText(/2 selected/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('UsersView — bulk actions gating', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hides Change role / Move to building for building_admin', () => {
+    render(
+      <UsersView
+        {...makeProps({
+          actorRole: 'building_admin',
+          actorBuildingIds: ['b1'],
+        })}
+      />
+    );
+    selectAll();
+    expect(
+      screen.queryByRole('button', { name: /^change role$/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /move to building/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/context/AuthContext.deactivation.test.tsx
+++ b/tests/context/AuthContext.deactivation.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import * as firebaseAuth from 'firebase/auth';
+import * as firestore from 'firebase/firestore';
+import type { User } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import { AuthProvider } from '@/context/AuthContext';
+import { useAuth } from '@/context/useAuth';
+import type { AuthContextType } from '@/context/AuthContextValue';
+
+// M1 full sign-in lockout: when the org-member snapshot reports
+// `status === 'inactive'`, AuthContext latches the sticky `accessDeactivated`
+// flag. The consumer (AuthenticatedApp) signs the user out and shows the
+// DeactivatedScreen; these tests assert the AuthContext half of that contract:
+//   - inactive member  → accessDeactivated flips true
+//   - active member    → accessDeactivated stays false
+//   - signInWithGoogle → clears the sticky flag for a fresh attempt
+//
+// Mirrors the harness in AuthContext.membershipError.test.tsx.
+
+vi.mock('firebase/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('firebase/auth')>('firebase/auth');
+  return {
+    ...actual,
+    onAuthStateChanged: vi.fn(),
+    signInWithPopup: vi.fn().mockResolvedValue({ user: {} }),
+    signInAnonymously: vi.fn(),
+    signOut: vi.fn().mockResolvedValue(undefined),
+    GoogleAuthProvider: Object.assign(
+      vi.fn(() => ({ addScope: vi.fn(), setCustomParameters: vi.fn() })),
+      { credentialFromResult: vi.fn(() => null) }
+    ),
+  };
+});
+
+let httpsCallableImpl: () => Promise<{ data: { orgId: string | null } }> = () =>
+  Promise.resolve({ data: { orgId: 'acme' } });
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => () => httpsCallableImpl(),
+}));
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  collection: vi.fn((_db: unknown, ...segments: string[]) => ({
+    __path: segments.join('/'),
+  })),
+  getDoc: vi.fn(),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  onSnapshot: vi.fn(() => () => undefined),
+  getDocs: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+  query: vi.fn((c: unknown) => c),
+  limit: vi.fn(() => undefined),
+}));
+
+const ctxHolder: { current: AuthContextType | null } = { current: null };
+
+const Probe: React.FC = () => {
+  const ctx = useAuth();
+  React.useEffect(() => {
+    ctxHolder.current = ctx;
+  });
+  return null;
+};
+
+function getCtx(): AuthContextType {
+  if (!ctxHolder.current) throw new Error('AuthContext not captured');
+  return ctxHolder.current;
+}
+
+function buildFakeUser(email: string): User {
+  return {
+    uid: 'test-uid',
+    email,
+    displayName: 'Test',
+    photoURL: null,
+    emailVerified: true,
+    isAnonymous: false,
+    providerData: [],
+    refreshToken: '',
+    metadata: {} as User['metadata'],
+    providerId: 'firebase',
+    tenantId: null,
+    delete: vi.fn(),
+    getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
+    getIdTokenResult: vi.fn().mockResolvedValue({
+      claims: {},
+      authTime: '',
+      issuedAtTime: '',
+      expirationTime: '',
+      signInProvider: '',
+      signInSecondFactor: null,
+      token: 'mock-id-token',
+    }),
+    reload: vi.fn(),
+    toJSON: () => ({}),
+    phoneNumber: null,
+  } as unknown as User;
+}
+
+interface PathRef {
+  __path?: string;
+}
+type DocSnap = Awaited<ReturnType<typeof firestore.getDoc>>;
+
+const EMAIL = 'teacher@example.com';
+const MEMBER_PATH = `organizations/acme/members/${EMAIL}`;
+
+let memberOnNext: ((snap: unknown) => void) | null = null;
+
+function setupGetDoc(): void {
+  vi.mocked(firestore.getDoc).mockImplementation((ref) => {
+    const path = (ref as unknown as PathRef).__path ?? '';
+    if (path.endsWith('userProfile/profile')) {
+      return Promise.resolve({
+        exists: () => true,
+        data: () => ({ selectedBuildings: [] }),
+      } as unknown as DocSnap);
+    }
+    return Promise.resolve({
+      exists: () => false,
+      data: () => undefined,
+    } as unknown as DocSnap);
+  });
+}
+
+function wireSnapshots(): void {
+  memberOnNext = null;
+  vi.mocked(firestore.onSnapshot).mockImplementation((ref, onNext) => {
+    const path = (ref as unknown as PathRef).__path ?? '';
+    const fire = (snapshot: unknown) =>
+      (onNext as unknown as (s: unknown) => void)(snapshot);
+    if (path === 'global_permissions' || path === 'feature_permissions') {
+      fire({ forEach: () => undefined });
+    } else if (path === MEMBER_PATH) {
+      memberOnNext = (snap: unknown) =>
+        (onNext as unknown as (s: unknown) => void)(snap);
+    }
+    return () => undefined;
+  });
+}
+
+async function mount(): Promise<void> {
+  ctxHolder.current = null;
+  setupGetDoc();
+  wireSnapshots();
+
+  const onAuthMock = vi.mocked(firebaseAuth.onAuthStateChanged);
+  onAuthMock.mockImplementation(() => () => undefined);
+
+  render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>
+  );
+
+  const lastCall = onAuthMock.mock.calls[onAuthMock.mock.calls.length - 1];
+  if (!lastCall) throw new Error('onAuthStateChanged was never called');
+  const listener = lastCall[1] as (u: User | null) => void;
+  const user = buildFakeUser(EMAIL);
+  Object.defineProperty(auth, 'currentUser', {
+    configurable: true,
+    writable: true,
+    value: user,
+  });
+  act(() => {
+    listener(user);
+  });
+
+  await waitFor(() => {
+    expect(memberOnNext).not.toBeNull();
+  });
+}
+
+function fireMemberStatus(status: string): void {
+  act(() => {
+    memberOnNext?.({
+      exists: () => true,
+      data: () => ({
+        orgId: 'acme',
+        roleId: 'teacher',
+        buildingIds: ['b1'],
+        status,
+      }),
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ctxHolder.current = null;
+  httpsCallableImpl = () => Promise.resolve({ data: { orgId: 'acme' } });
+});
+
+describe('AuthContext — M1 deactivation lockout', () => {
+  it('latches accessDeactivated true when member status is inactive', async () => {
+    await mount();
+    fireMemberStatus('inactive');
+    await waitFor(() => {
+      expect(getCtx().accessDeactivated).toBe(true);
+    });
+  });
+
+  it('leaves accessDeactivated false for an active member', async () => {
+    await mount();
+    fireMemberStatus('active');
+    await waitFor(() => {
+      expect(getCtx().orgId).toBe('acme');
+    });
+    expect(getCtx().accessDeactivated).toBe(false);
+  });
+
+  it('signInWithGoogle clears the sticky deactivation flag', async () => {
+    await mount();
+    fireMemberStatus('inactive');
+    await waitFor(() => {
+      expect(getCtx().accessDeactivated).toBe(true);
+    });
+
+    await act(async () => {
+      await getCtx().signInWithGoogle();
+    });
+    await waitFor(() => {
+      expect(getCtx().accessDeactivated).toBe(false);
+    });
+  });
+});

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1153,6 +1153,68 @@ describe('organizations/members — writes', () => {
     );
   });
 
+  // M2 / F6 follow-up — the building-admin member status overlap is now
+  // alias-aware via buildingListsOverlap(). The acting building admin stores
+  // buildingIds: ['high']; these tests cover a target member stored in the
+  // LEGACY alias format and an unrelated member.
+  it('building admin can update status for a member stored in a legacy building-id alias (alias-aware overlap)', async () => {
+    const ALIAS_MEMBER_EMAIL = 'alias.member@orono.k12.mn.us';
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `organizations/${ORG_ID}/members/${ALIAS_MEMBER_EMAIL}`
+        ),
+        {
+          email: ALIAS_MEMBER_EMAIL,
+          orgId: ORG_ID,
+          roleId: 'teacher',
+          status: 'active',
+          // Legacy alias of 'high' — building admin manages canonical 'high'.
+          buildingIds: ['orono-high-school'],
+        }
+      );
+    });
+    await assertSucceeds(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${ALIAS_MEMBER_EMAIL}`
+        ),
+        { status: 'inactive' }
+      )
+    );
+  });
+
+  it('building admin is still denied on a member in an unrelated building (alias-aware denial)', async () => {
+    const UNRELATED_MEMBER_EMAIL = 'unrelated.member@orono.k12.mn.us';
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `organizations/${ORG_ID}/members/${UNRELATED_MEMBER_EMAIL}`
+        ),
+        {
+          email: UNRELATED_MEMBER_EMAIL,
+          orgId: ORG_ID,
+          roleId: 'teacher',
+          status: 'active',
+          // No alias bridges to 'high'; building admin must stay denied.
+          buildingIds: ['schumann', 'orono-middle-school'],
+        }
+      );
+    });
+    await assertFails(
+      updateDoc(
+        doc(
+          asBuildingAdmin(),
+          `organizations/${ORG_ID}/members/${UNRELATED_MEMBER_EMAIL}`
+        ),
+        { status: 'inactive' }
+      )
+    );
+  });
+
   it('building admin cannot change roleId even within scope', async () => {
     await assertFails(
       updateDoc(

--- a/tests/rules/firestore-rules-organizations.test.ts
+++ b/tests/rules/firestore-rules-organizations.test.ts
@@ -1090,6 +1090,43 @@ describe('organizations/members — writes', () => {
     );
   });
 
+  it('domain admin CANNOT escalate a member to super_admin (anti-escalation guard)', async () => {
+    // roleId == 'super_admin' is a live isSuperAdmin() grant via
+    // isMemberSuperAdmin(). The member-update whitelist permits writing
+    // `roleId`, so without the value guard a domain admin could mint a super
+    // admin — including onto their own doc. This must be denied.
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`
+        ),
+        { roleId: 'super_admin' }
+      )
+    );
+  });
+
+  it('domain admin CANNOT self-escalate to super_admin on their own member doc', async () => {
+    await assertFails(
+      updateDoc(
+        doc(
+          asDomainAdmin(),
+          `organizations/${ORG_ID}/members/${DOMAIN_ADMIN_EMAIL}`
+        ),
+        { roleId: 'super_admin' }
+      )
+    );
+  });
+
+  it('super admin CAN grant super_admin (only super admins may mint super admins)', async () => {
+    await assertSucceeds(
+      updateDoc(
+        doc(asSuper(), `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`),
+        { roleId: 'super_admin' }
+      )
+    );
+  });
+
   it('domain admin cannot spoof member identity (email, orgId, uid)', async () => {
     await assertFails(
       updateDoc(

--- a/tests/rules/inactiveMemberLockout.test.ts
+++ b/tests/rules/inactiveMemberLockout.test.ts
@@ -1,0 +1,192 @@
+// Firestore security-rules tests for the M1 full sign-in lockout.
+//
+// `notDeactivated()` in firestore.rules denies teacher-data reads/writes to an
+// operator-org member whose member doc is `status: 'inactive'`. Active members
+// (and users with no operator-org member doc) are unaffected.
+//
+// The gate is checked against the operator org (`orono`) by a fixed path —
+// see the function comment in firestore.rules for why rules can't resolve the
+// caller's org dynamically.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-inactive-lockout';
+const ORG_ID = 'orono';
+
+const ACTIVE_UID = 'active-teacher-uid';
+const ACTIVE_EMAIL = 'active.teacher@orono.k12.mn.us';
+const INACTIVE_UID = 'inactive-teacher-uid';
+const INACTIVE_EMAIL = 'inactive.teacher@orono.k12.mn.us';
+const NOORG_UID = 'noorg-teacher-uid';
+const NOORG_EMAIL = 'teacher@somewhere-else.edu';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+// Spell out every claim the rules touch so test contexts match the production
+// token surface (the emulator throws "Property X is undefined" on direct claim
+// access when a claim is absent, even behind a short-circuit).
+const asActive = () =>
+  testEnv
+    .authenticatedContext(ACTIVE_UID, {
+      email: ACTIVE_EMAIL,
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asInactive = () =>
+  testEnv
+    .authenticatedContext(INACTIVE_UID, {
+      email: INACTIVE_EMAIL,
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const asNoOrg = () =>
+  testEnv
+    .authenticatedContext(NOORG_UID, {
+      email: NOORG_EMAIL,
+      studentRole: false,
+      classIds: [],
+      firebase: { sign_in_provider: 'google.com' },
+    })
+    .firestore();
+
+const dashboardPath = (uid: string) => `users/${uid}/dashboards/dash-1`;
+
+const dashboardFields = () => ({
+  id: 'dash-1',
+  name: 'My Board',
+  background: 'bg-slate-900',
+  widgets: [],
+  createdAt: 1000,
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    // Operator-org member docs: one active, one inactive. No doc for the
+    // no-org teacher (their domain isn't in this org).
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${ACTIVE_EMAIL}`), {
+      email: ACTIVE_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'teacher',
+      buildingIds: ['high'],
+      status: 'active',
+    });
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${INACTIVE_EMAIL}`), {
+      email: INACTIVE_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'teacher',
+      buildingIds: ['high'],
+      status: 'inactive',
+    });
+    // Seed dashboards under each uid so reads have a doc to find.
+    await setDoc(doc(db, dashboardPath(ACTIVE_UID)), dashboardFields());
+    await setDoc(doc(db, dashboardPath(INACTIVE_UID)), dashboardFields());
+    await setDoc(doc(db, dashboardPath(NOORG_UID)), dashboardFields());
+  });
+});
+
+describe('M1 full sign-in lockout — notDeactivated() gate', () => {
+  it('active member can read their own dashboard', async () => {
+    await assertSucceeds(getDoc(doc(asActive(), dashboardPath(ACTIVE_UID))));
+  });
+
+  it('active member can write their own dashboard', async () => {
+    await assertSucceeds(
+      setDoc(doc(asActive(), dashboardPath(ACTIVE_UID)), {
+        ...dashboardFields(),
+        name: 'Renamed',
+      })
+    );
+  });
+
+  it('inactive member is DENIED reading their own dashboard', async () => {
+    await assertFails(getDoc(doc(asInactive(), dashboardPath(INACTIVE_UID))));
+  });
+
+  it('inactive member is DENIED writing their own dashboard', async () => {
+    await assertFails(
+      setDoc(doc(asInactive(), dashboardPath(INACTIVE_UID)), {
+        ...dashboardFields(),
+        name: 'Smuggled',
+      })
+    );
+  });
+
+  it('inactive member is DENIED reading their own rosters', async () => {
+    await assertFails(
+      getDoc(doc(asInactive(), `users/${INACTIVE_UID}/rosters/r1`))
+    );
+  });
+
+  it('a user with no operator-org member doc is unaffected (allowed)', async () => {
+    await assertSucceeds(getDoc(doc(asNoOrg(), dashboardPath(NOORG_UID))));
+    await assertSucceeds(
+      setDoc(doc(asNoOrg(), dashboardPath(NOORG_UID)), {
+        ...dashboardFields(),
+        name: 'Still works',
+      })
+    );
+  });
+
+  it('reactivating an inactive member restores access', async () => {
+    // Flip the member back to active (admin path bypasses rules here).
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(
+          ctx.firestore(),
+          `organizations/${ORG_ID}/members/${INACTIVE_EMAIL}`
+        ),
+        {
+          email: INACTIVE_EMAIL,
+          orgId: ORG_ID,
+          roleId: 'teacher',
+          buildingIds: ['high'],
+          status: 'active',
+        }
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asInactive(), dashboardPath(INACTIVE_UID)))
+    );
+  });
+});

--- a/tests/rules/inactiveMemberLockout.test.ts
+++ b/tests/rules/inactiveMemberLockout.test.ts
@@ -81,6 +81,22 @@ const dashboardFields = () => ({
   createdAt: 1000,
 });
 
+const guidedLearningPath = (uid: string) => `users/${uid}/guided_learning/gl-1`;
+
+const guidedLearningFields = () => ({
+  id: 'gl-1',
+  name: 'My GL Set',
+  createdAt: 1000,
+});
+
+const videoActivityPath = (uid: string) => `users/${uid}/video_activities/va-1`;
+
+const videoActivityFields = () => ({
+  id: 'va-1',
+  name: 'My Video Activity',
+  createdAt: 1000,
+});
+
 beforeAll(async () => {
   testEnv = await initializeTestEnvironment({
     projectId: PROJECT_ID,
@@ -122,6 +138,21 @@ beforeEach(async () => {
     await setDoc(doc(db, dashboardPath(ACTIVE_UID)), dashboardFields());
     await setDoc(doc(db, dashboardPath(INACTIVE_UID)), dashboardFields());
     await setDoc(doc(db, dashboardPath(NOORG_UID)), dashboardFields());
+    // Seed guided_learning + video_activities under the active/inactive uids so
+    // the corresponding read cases have a doc to find.
+    await setDoc(
+      doc(db, guidedLearningPath(ACTIVE_UID)),
+      guidedLearningFields()
+    );
+    await setDoc(
+      doc(db, guidedLearningPath(INACTIVE_UID)),
+      guidedLearningFields()
+    );
+    await setDoc(doc(db, videoActivityPath(ACTIVE_UID)), videoActivityFields());
+    await setDoc(
+      doc(db, videoActivityPath(INACTIVE_UID)),
+      videoActivityFields()
+    );
   });
 });
 
@@ -155,6 +186,66 @@ describe('M1 full sign-in lockout — notDeactivated() gate', () => {
   it('inactive member is DENIED reading their own rosters', async () => {
     await assertFails(
       getDoc(doc(asInactive(), `users/${INACTIVE_UID}/rosters/r1`))
+    );
+  });
+
+  it('active member can read their own guided_learning set', async () => {
+    await assertSucceeds(
+      getDoc(doc(asActive(), guidedLearningPath(ACTIVE_UID)))
+    );
+  });
+
+  it('active member can write their own guided_learning set', async () => {
+    await assertSucceeds(
+      setDoc(doc(asActive(), guidedLearningPath(ACTIVE_UID)), {
+        ...guidedLearningFields(),
+        name: 'Renamed',
+      })
+    );
+  });
+
+  it('inactive member is DENIED reading their own guided_learning set', async () => {
+    await assertFails(
+      getDoc(doc(asInactive(), guidedLearningPath(INACTIVE_UID)))
+    );
+  });
+
+  it('inactive member is DENIED writing their own guided_learning set', async () => {
+    await assertFails(
+      setDoc(doc(asInactive(), guidedLearningPath(INACTIVE_UID)), {
+        ...guidedLearningFields(),
+        name: 'Smuggled',
+      })
+    );
+  });
+
+  it('active member can read their own video_activities', async () => {
+    await assertSucceeds(
+      getDoc(doc(asActive(), videoActivityPath(ACTIVE_UID)))
+    );
+  });
+
+  it('active member can write their own video_activities', async () => {
+    await assertSucceeds(
+      setDoc(doc(asActive(), videoActivityPath(ACTIVE_UID)), {
+        ...videoActivityFields(),
+        name: 'Renamed',
+      })
+    );
+  });
+
+  it('inactive member is DENIED reading their own video_activities', async () => {
+    await assertFails(
+      getDoc(doc(asInactive(), videoActivityPath(INACTIVE_UID)))
+    );
+  });
+
+  it('inactive member is DENIED writing their own video_activities', async () => {
+    await assertFails(
+      setDoc(doc(asInactive(), videoActivityPath(INACTIVE_UID)), {
+        ...videoActivityFields(),
+        name: 'Smuggled',
+      })
     );
   });
 

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -881,6 +881,79 @@ describe('activity_wall_sessions/submissions — student-role gate', () => {
 });
 
 // ---------------------------------------------------------------------------
+// activity_wall_sessions/submissions — Phase-5A compat gate (LO10)
+// ---------------------------------------------------------------------------
+// Mirrors the quiz/VA/GL/miniapp compat-gate coverage: activity_wall_sessions
+// now uses passesStudentClassGateCompat(classIds, classId), so a session
+// migrated to the multi-value `classIds` list gates on the list while pre-5A
+// sessions carrying only `classId` keep working (see the legacy-shape block
+// above, which seeds `classId` and still passes unchanged).
+describe('activity_wall_sessions/submissions — Phase-5A compat (classIds list)', () => {
+  const col = 'activity_wall_sessions';
+  const validSub = () => ({
+    id: 'sub-1',
+    content: 'Hello world',
+    submittedAt: 1000,
+    status: 'pending' as const,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `admins/${ADMIN_EMAIL}`), { email: ADMIN_EMAIL });
+      // Phase-5A shape: multi-value classIds list, no single classId field.
+      await setDoc(doc(db, `${col}/${SESSION_A}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_A],
+        status: 'active',
+      });
+      await setDoc(doc(db, `${col}/${SESSION_B}`), {
+        teacherUid: TEACHER_UID,
+        classIds: [CLASS_B],
+        status: 'active',
+      });
+    });
+  });
+
+  it('student in class-A can submit to a classIds-list session-A', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asStudentA(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('student in class-A cannot submit to a classIds-list session-B (wrong class)', async () => {
+    await assertFails(
+      addDoc(
+        collection(asStudentA(), `${col}/${SESSION_B}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('student with empty classIds cannot submit to a classIds-list session', async () => {
+    await assertFails(
+      addDoc(
+        collection(asStudentEmpty(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+
+  it('anonymous PIN student can still submit to a classIds-list session', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asAnonStudent(), `${col}/${SESSION_A}/submissions`),
+        validSub()
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // mini_app_sessions/submissions — create/update gate + payload validation
 // ---------------------------------------------------------------------------
 

--- a/tests/rules/superAdminRoleId.test.ts
+++ b/tests/rules/superAdminRoleId.test.ts
@@ -1,0 +1,133 @@
+// Firestore security-rules tests for LO2 dual super-admin resolution.
+//
+// `isSuperAdmin()` in firestore.rules now accepts EITHER source:
+//   1. the legacy admin_settings/user_roles.superAdmins[] list, OR
+//   2. an operator-org member doc with roleId == 'super_admin'.
+//
+// This test covers source (2) in isolation: a member with roleId
+// 'super_admin' who is NOT in the legacy list must still be granted
+// super-admin-gated access (e.g. creating an organization, which is
+// super-admin-only). It also confirms a plain teacher member is denied, so
+// the new branch doesn't over-grant.
+//
+// Requires a running Firestore emulator. Invoke via:
+//   pnpm run test:rules
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  type RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { setDoc, getDoc, doc } from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-superadmin-roleid';
+const ORG_ID = 'orono';
+const NEW_ORG_ID = 'brand-new-org';
+
+const ROLE_SUPER_EMAIL = 'role.super@orono.k12.mn.us';
+const TEACHER_EMAIL = 'plain.teacher@orono.k12.mn.us';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+const asRoleSuper = () =>
+  testEnv
+    .authenticatedContext('role-super-uid', { email: ROLE_SUPER_EMAIL })
+    .firestore();
+
+const asTeacher = () =>
+  testEnv
+    .authenticatedContext('teacher-uid', { email: TEACHER_EMAIL })
+    .firestore();
+
+const orgFields = (id: string) => ({
+  id,
+  name: 'New Org',
+  shortName: 'New',
+  shortCode: 'NEW',
+  state: 'MN',
+  plan: 'basic',
+  aiEnabled: false,
+  primaryAdminEmail: ROLE_SUPER_EMAIL,
+  createdAt: '2026-01-01',
+  users: 0,
+  buildings: 0,
+  status: 'active',
+  seedColor: 'bg-indigo-600',
+});
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    // A super_admin BY MEMBER ROLE ONLY — deliberately NOT in the legacy list.
+    await setDoc(
+      doc(db, `organizations/${ORG_ID}/members/${ROLE_SUPER_EMAIL}`),
+      {
+        email: ROLE_SUPER_EMAIL,
+        orgId: ORG_ID,
+        roleId: 'super_admin',
+        buildingIds: [],
+        status: 'active',
+      }
+    );
+    // A plain teacher member — must NOT be treated as super admin.
+    await setDoc(doc(db, `organizations/${ORG_ID}/members/${TEACHER_EMAIL}`), {
+      email: TEACHER_EMAIL,
+      orgId: ORG_ID,
+      roleId: 'teacher',
+      buildingIds: ['high'],
+      status: 'active',
+    });
+    // Legacy list exists but is EMPTY — proves the grant comes from roleId.
+    await setDoc(doc(db, 'admin_settings/user_roles'), { superAdmins: [] });
+  });
+});
+
+describe('LO2 — super admin via member roleId (not in legacy list)', () => {
+  it('member with roleId super_admin can create an organization (super-admin-only)', async () => {
+    await assertSucceeds(
+      setDoc(
+        doc(asRoleSuper(), `organizations/${NEW_ORG_ID}`),
+        orgFields(NEW_ORG_ID)
+      )
+    );
+  });
+
+  it('member with roleId super_admin can read any org', async () => {
+    await assertSucceeds(getDoc(doc(asRoleSuper(), `organizations/${ORG_ID}`)));
+  });
+
+  it('plain teacher member is NOT granted super-admin access (org create denied)', async () => {
+    await assertFails(
+      setDoc(
+        doc(asTeacher(), `organizations/${NEW_ORG_ID}`),
+        orgFields(NEW_ORG_ID)
+      )
+    );
+  });
+});


### PR DESCRIPTION
## What (Cluster-1 + M4 — backlog `docs/remaining-todos-audit.md`)

Six security/admin items on one branch (they all share `firestore.rules` / `AuthContext` / `UsersView`, so splitting them would force conflict-prone stacking — per the agreed PR plan). Per-item commits below.

| Item | Commit | Summary |
| --- | --- | --- |
| **M2** | `1d08aa2f` | Building-admin member-status overlap check made **alias-aware** (`buildingListsOverlap`). Fixes a false-**denial** only (no security hole); raw `hasAny` preserved as first disjunct. |
| **LO4** | `126d8c4a` | Collapse duplicate session `get()` reads in `quiz_sessions/responses` onto one `sessionData()` snapshot. Authorization byte-identical; fewer billable reads. |
| **LO10** | `7741b47f` | Migrate `activity_wall_sessions` onto `passesStudentClassGateCompat` (matches quiz/VA/GL/miniapp); pre-5A classId-only sessions fall through unchanged. |
| **M1** | `4cdfa11f` + `3a892353` | **Inactive-member full sign-in lockout.** Client: `AuthContext` latches `accessDeactivated` when the org member doc is `status:'inactive'` → `AuthenticatedApp` signs out + shows `DeactivatedScreen` (regardless of `user`, so no bounce-to-login). Rules: `notDeactivated()` gate on **all owner teacher-content collections**. |
| **LO2** | `4cdfa11f` + `3b7f6bc0` | Harmonize dual super-admin resolution **additively** — rules + `AuthContext` now honor member `roleId:'super_admin'` **in addition to** the legacy `superAdmins[]` list. Legacy list **kept** (retiring it is a deferred, Paul-gated migration). |
| **M4** | `3b7f6bc0` | Bulk **Change role** + **Move to building** in `UsersView` (the two "coming soon" buttons). "Move" = **replace** buildingIds, behind a confirm dialog showing impact. |

## Review fixes applied (this branch)
- The first build gated `notDeactivated()` on only 6 collections. Completed it across **all ~15 owner-writable teacher-content collections** (`guided_learning`, `video_activities`, `quiz_assignments`, `saved_widgets`, `activity_wall_activities`, `plc_layouts/state`, `collections`, the 4 `*_folders`, the 3 `*_assignments`) — an incomplete isolation gate is worse than none. `userProfile`/`lti_seen_sections`/`private` intentionally left alone. (`3a892353`)
- Dropped two **review false-positives**: `lastActiveThrottle.ts` + the `lastActive` self-write rule are **pre-existing on dev-paul**, not introduced here — left untouched.

## ⚠️ firestore.rules is near the 256 KiB cap — please read
After this + #2080 merge, `firestore.rules` is ~258 KB / 262 KB (**~98.5%**, LF). It still deploys cleanly via CI (Linux/LF, ~3.8 KB headroom). **But** a Windows CRLF working tree inflates the byte count ~+4.6 KB and would fail a **local** `firebase deploy`. Fixed at the root by `.gitattributes` (`*.rules text eol=lf`, commit `031fd155`) so every environment measures LF. **A follow-up to slim the rules file is queued** — the next rules feature will need the headroom.

## Validation (mine)
`pnpm type-check` ✓ · `pnpm build` ✓ · `vitest` ✓ (AuthContext deactivation + UsersView bulk role/building) · `firebase ... --dry-run` rules compile ✓.

## Residual / for you
- **Rules tests are CI-validated only** — no local Firestore emulator here. New suites: `inactiveMemberLockout.test.ts` (incl. guided_learning + video_activities cases), `superAdminRoleId.test.ts`, `firestore-rules-organizations.test.ts` (M2), `studentRoleClassGate.test.ts` (LO10). **Please confirm `pnpm run test:rules` is green in CI before merge.**
- **Manual QA** the deactivation flow in a real browser: (a) active user deactivated mid-session → signed out + sees DeactivatedScreen, no loop; (b) "sign in with a different account" works; (c) normal active users unaffected; (d) auth-bypass never deactivated.
- **You deploy rules** (CI on merge to main, or `firebase deploy --only firestore:rules`). This PR does not deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)