### PR TITLE
Slim firestore.rules comments to reclaim cap headroom

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,18 +3,11 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Helper function to check if user is an admin.
-    //
-    // Uses `request.auth.token.get('email', '')` rather than direct
-    // `.email` access. The rules engine throws "Property email is
-    // undefined" when the claim is absent (production Firebase anonymous
-    // tokens carry no `email`), even behind a `!= null` guard on
-    // `request.auth`. After the `.get(...) != ''` check succeeds, the
-    // claim is guaranteed to exist, so the subsequent direct `.email`
-    // access below is safe. Matters for `allow update` on quiz responses
-    // (`isAdmin()` sits before the student branch in the OR chain there,
-    // so any throw during isAdmin evaluation could block anon PIN answer
-    // submission depending on CEL semantics).
+    // True if the caller's email has an /admins/{email} doc.
+    // token.get('email','') (not direct .email) avoids a CEL "undefined" throw
+    // on tokens with no email claim (anon PIN), even behind a != null guard —
+    // load-bearing because isAdmin() runs before the anon-student branch in the
+    // quiz-response update OR chain.
     function isAdmin() {
       return request.auth != null &&
              request.auth.token.get('email', '') != '' &&
@@ -22,19 +15,14 @@ service cloud.firestore {
     }
 
     // ---- Student (GIS/ClassLink) auth helpers ----
-    //
-    // GIS-authenticated students are signed in via custom tokens minted by
-    // studentLoginV1. The custom claims carry `studentRole: true` plus a
-    // `classIds` list of ClassLink class sourcedIds the student is enrolled
-    // in. These helpers let session rules restrict student-role access to
-    // their own classes without affecting any other auth path (teachers,
-    // admins, or anonymous PIN students).
+    // GIS students sign in via studentLoginV1 custom tokens carrying
+    // `studentRole: true` + a `classIds` list of their ClassLink sections.
+    // These gate student-role access to their own classes without touching any
+    // other auth path (teachers, admins, anon PIN students).
 
-    // Uses .get(key, default) rather than direct token.studentRole access.
-    // The rules engine throws "Property studentRole is undefined" when a claim
-    // is absent (e.g. on anon PIN tokens), even behind a `!= null` short-circuit;
-    // .get(...) returns the default instead. Without this guard, every
-    // passesStudentClassGate() callsite denies anon PIN students.
+    // token.get('studentRole', false) (not direct access): the engine throws on
+    // a missing claim (anon PIN tokens) even behind a != null guard, which would
+    // make every passesStudentClassGate() callsite deny anon PIN students.
     function isStudentRoleUser() {
       return request.auth != null && request.auth.token.get('studentRole', false) == true;
     }
@@ -50,16 +38,10 @@ service cloud.firestore {
              classId in request.auth.token.classIds;
     }
 
-    // Gate helper used inside session rules: passes when the caller is NOT a
-    // studentRole user, when the session has no class targeting (empty/missing
-    // classId — treat as "open to any studentRole holder with the PIN"), or
-    // when the session's classId is in their classIds claim.
-    //
-    // The untargeted-open branch mirrors the policy already documented on
-    // passesStudentClassGateList. Without it, a studentRole token (real SSO
-    // student or test-class-bypass super admin) joining a session whose
-    // creator did not pick a ClassLink class is denied — the per-join PIN is
-    // the secret in that path, not class membership.
+    // Session gate: passes when the caller is NOT a studentRole user, the
+    // session has no class targeting (empty/missing classId — open to any
+    // studentRole holder with the PIN, which is the secret in that path), or the
+    // session's classId is in their classIds claim.
     function passesStudentClassGate(sessionClassId) {
       return !isStudentRoleUser() ||
              !(sessionClassId is string) ||
@@ -67,12 +49,10 @@ service cloud.firestore {
              studentRoleCanAccessClass(sessionClassId);
     }
 
-    // List-aware variant: passes when the caller is not a studentRole user,
-    // when the session has no class targeting (empty/missing list — the
-    // mini-app flow treats class selection as metadata rather than a hard
-    // gate, so untargeted sessions are open to any studentRole user with
-    // the link), or when any of the session's classIds appears in the
-    // caller's classIds claim. Used by mini_app_sessions.
+    // List-aware variant (used by mini_app_sessions): passes for non-studentRole
+    // users, for sessions with no class targeting (empty/missing list — open to
+    // any studentRole user with the link), or when any session classId is in the
+    // caller's classIds claim.
     function passesStudentClassGateList(sessionClassIds) {
       return !isStudentRoleUser() ||
              !(sessionClassIds is list) ||
@@ -81,15 +61,10 @@ service cloud.firestore {
               sessionClassIds.hasAny(request.auth.token.classIds));
     }
 
-    // Phase 5A transitional compatibility helper. Sessions created after
-    // Phase 5A write a multi-value `classIds` list; sessions created before
-    // Phase 5A write the single `classId` field. This helper selects the
-    // right gate based on which field is populated on the session doc:
-    //   - if `classIds` is a non-empty list, use `passesStudentClassGateList`
-    //   - otherwise, fall back to the legacy single-class gate
-    // Callers pass `resource.data.get('classIds', [])` and
-    // `resource.data.get('classId', '')` so the field-absent case safely
-    // falls through (empty list / empty string → no-op gate).
+    // Phase 5A compat: post-5A sessions write a `classIds` list, pre-5A sessions
+    // write a single `classId`. Picks the list gate when `classIds` is non-empty,
+    // else the legacy single-class gate. Callers pass get(...) defaults so an
+    // absent field falls through to a no-op gate.
     function passesStudentClassGateCompat(sessionClassIds, sessionClassId) {
       return sessionClassIds is list && sessionClassIds.size() > 0
              ? passesStudentClassGateList(sessionClassIds)
@@ -98,17 +73,12 @@ service cloud.firestore {
 
     // ---- Organization helpers (see docs/organization_wiring_implementation.md) ----
 
-    // Super admins are recognized from EITHER source (LO2 harmonization):
-    //   1. The legacy admin_settings/user_roles.superAdmins[] list, AND
-    //   2. An operator-org member doc with roleId == 'super_admin'.
-    // This mirrors OrganizationPanel.resolveActorRole, which already accepts
-    // both sources on the client. The legacy list is KEPT as an additional
-    // accepted source (NOT retired) — a Paul-gated migration removes it later.
-    //
-    // Super-admin checks run globally (not scoped to a single org), so the
-    // roleId source is read from the operator org (`orono`) by fixed path —
-    // the same constraint that forces operatorMember() / notDeactivated()
-    // to use a hardcoded org (CEL cannot resolve the caller's org dynamically).
+    // Super admins recognized from EITHER source (LO2): the legacy
+    // admin_settings/user_roles.superAdmins[] list, OR an operator-org member doc
+    // with roleId == 'super_admin'. Mirrors OrganizationPanel.resolveActorRole;
+    // legacy list kept as an accepted source until a Paul-gated migration. Checks
+    // run globally, so roleId is read from the operator org (`orono`) by fixed
+    // path — CEL cannot resolve the caller's org dynamically.
     function isSuperAdmin() {
       return request.auth != null &&
              request.auth.token.email != null &&
@@ -132,12 +102,10 @@ service cloud.firestore {
       return get(/databases/$(database)/documents/organizations/$(orgId)/members/$(request.auth.token.email.lower())).data;
     }
 
-    // Maps a legacy long-form building id to its canonical short id.
-    // MUST stay in sync with BUILDING_ID_ALIASES in config/buildings.ts —
-    // the client canonicalizes member.buildingIds and building doc ids via
-    // canonicalBuildingId() there, and CEL cannot reuse the JS map, so the
-    // table is mirrored here. A mismatch re-introduces false denials/grants
-    // in the building-admin update rule. Unknown ids pass through unchanged.
+    // Maps a legacy long-form building id to its canonical short id. MUST stay in
+    // sync with BUILDING_ID_ALIASES in config/buildings.ts (CEL can't reuse the JS
+    // map) — a mismatch re-introduces false denials/grants in the building-admin
+    // update rule. Unknown ids pass through unchanged.
     function canonicalBuildingId(id) {
       return id == 'orono-high-school' ? 'high'
            : id == 'orono-middle-school' ? 'middle'
@@ -170,13 +138,10 @@ service cloud.firestore {
            : [buildingId];
     }
 
-    // Alias-aware overlap between two building-id lists. CEL has no `.map()`,
-    // so the two stored lists can't be canonicalized element-wise. Instead we
-    // bridge across each known alias group: lists overlap if (a) they share a
-    // raw id, or (b) for any alias group, BOTH lists contain at least one form
-    // from that group (e.g. one stores 'high', the other 'orono-high-school').
-    // Unknown/unaliased ids only match via the raw-overlap branch, which is
-    // correct (no canonical form to bridge). Symmetric in a and b.
+    // Alias-aware overlap of two building-id lists. CEL has no .map() to
+    // canonicalize element-wise, so lists overlap if (a) they share a raw id, or
+    // (b) for any alias group both lists contain some form of it (e.g. 'high' vs
+    // 'orono-high-school'). Unknown ids match only via raw overlap. Symmetric.
     function buildingListsOverlap(a, b) {
       return a.hasAny(b) ||
         (a.hasAny(['high', 'orono-high-school']) &&
@@ -223,35 +188,26 @@ service cloud.firestore {
     }
 
     // ---- M1 full sign-in lockout (deny-by-status) ----
-    //
-    // The operator org id. Rules cannot resolve a user's org dynamically from
-    // their email domain (that lives in the `resolveOrgForUser` Cloud Function,
-    // not in CEL), and CEL cannot enumerate orgs. The operator org is the one
-    // org we can check by a fixed path, and it is where the active user base
-    // lives, so the deactivation gate is enforced against it. Mirrors the
-    // OPERATOR_ORG_ID fallback in context/AuthContext.tsx.
-    //
-    // NOTE (multi-org follow-up): a member deactivated in a *second/third* org
-    // is blocked at sign-in by AuthContext (which resolves their real org) but
-    // is not yet denied by these rules, because the rule can't know their org
-    // from the /users/{uid} path. A per-uid org-index doc (readable by path)
-    // would let this gate cover every org; tracked as an M1 rules follow-up.
-    // The caller's operator-org member doc, or null when it does not exist.
-    // A single get() (Firestore caches repeated get()s to the same path within
-    // one rule evaluation, and get() returns null for a missing doc) replaces
-    // the prior exists()+get() pair: it both tests membership (via != null) and
-    // reads status in one document access, halving the baseline read cost on the
+    // Rules can't resolve a user's org dynamically (that's the resolveOrgForUser
+    // CF, not CEL) and can't enumerate orgs, so the gate is enforced against the
+    // operator org (`orono`) — the one org checkable by fixed path, where the
+    // active user base lives. Mirrors OPERATOR_ORG_ID in context/AuthContext.tsx.
+    // Follow-up: a member deactivated in a 2nd/3rd org is blocked at sign-in by
+    // AuthContext but not yet by these rules (a per-uid org-index doc would close
+    // that gap).
+    // operatorMember(): caller's operator-org member doc, or null if absent. One
+    // get() (Firestore caches same-path get()s per evaluation; missing → null)
+    // both tests membership (!= null) and reads status, halving read cost on the
     // ~15 owner collections gated by notDeactivated().
     function operatorMember() {
       return get(/databases/$(database)/documents/organizations/orono/members/$(request.auth.token.email.lower()));
     }
 
     // True UNLESS the caller is an operator-org member explicitly marked
-    // 'inactive'. Defaults to ALLOW (true) for everyone without an operator-org
-    // member doc — anonymous/PIN students (no email), SSO students, no-org /
-    // other-org teachers — so this gate only ever subtracts access from a
-    // member an admin deliberately deactivated. The email-presence guard avoids
-    // a CEL throw on tokens with no `email` claim (anonymous PIN students).
+    // 'inactive'. Defaults ALLOW for anyone without an operator-org member doc
+    // (anon/PIN, SSO students, no-org/other-org teachers), so it only subtracts
+    // access from a deliberately deactivated member. The email guard avoids a CEL
+    // throw on tokens with no email claim.
     function notDeactivated() {
       return !(request.auth != null &&
                request.auth.token.get('email', '') != '' &&
@@ -260,34 +216,25 @@ service cloud.firestore {
     }
 
     // ---- Organizations collection (Phase 3: scoped writes enabled) ----
-    // Rules enforce role scoping; the client additionally gates UI via the
-    // `org-admin-writes` feature flag so ramp-up stays controlled. Writes that
-    // bypass the client gate still land in these rules.
-    //
-    // Scoping summary:
+    // Rules enforce role scoping; the client also gates UI via the
+    // `org-admin-writes` flag. Scoping summary:
     //   - Super admins: any field, any org.
-    //   - Domain admins: org-wide writes for their org (except AI/plan flags
-    //     reserved to super admins) — create/update/delete on buildings,
-    //     domains, roles (custom only), members, studentPageConfig.
-    //   - Building admins: read-only almost everywhere; on members, may
-    //     update `status` for a member whose existing buildingIds intersect
-    //     the actor's own buildingIds. Never roleId.
-    //   - System roles (`system: true`) are immutable from clients —
-    //     migration script seeds them once; clone-to-customize is the path.
-
-    // Short-circuit ordering note: `isOrgMember()` performs a single targeted
-    // `exists()` against the caller's member doc, while `isSuperAdmin()` runs
-    // `exists()` + `get()` on `admin_settings/user_roles`. Checking membership
-    // first keeps the common teacher path cheap and falls back to the super-
-    // admin lookup only for non-members.
+    //   - Domain admins: org-wide writes for their org (except AI/plan flags,
+    //     super-admin only) on buildings, domains, roles (custom only),
+    //     members, studentPageConfig.
+    //   - Building admins: read-only except member `status` for a member whose
+    //     buildingIds intersect the actor's own. Never roleId.
+    //   - System roles (`system: true`) are client-immutable; migration-seeded,
+    //     clone-to-customize.
+    // Ordering: isOrgMember() (one exists()) is checked before isSuperAdmin()
+    // (exists()+get() on admin_settings/user_roles) so the common teacher path
+    // stays cheap and the super-admin lookup runs only for non-members.
 
     match /organizations/{orgId} {
       allow read: if isOrgMember(orgId) || isSuperAdmin();
-      // Only super admins can create, archive (delete), flip AI/plan, or
-      // change `status` (soft-archive). Domain admins can edit identity-ish
-      // fields for their own org. `users`/`buildings` are derived counts
-      // maintained server-side — never settable from the client at the
-      // domain-admin tier.
+      // Super admins: create/delete, AI/plan, status. Domain admins: identity
+      // fields for their own org only. users/buildings are server-derived counts,
+      // never client-settable at the domain-admin tier.
       allow create, delete: if isSuperAdmin();
       allow update: if isSuperAdmin() ||
         (isDomainAdmin(orgId) &&
@@ -328,13 +275,10 @@ service cloud.firestore {
 
       match /domains/{domainId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        // Domain admin or super admin only. Create must carry canonical
-        // orgId + matching doc id, and clients cannot seed `status:'verified'`
-        // or inflate `users` — verification is DNS-based server-side, and
-        // `users` is a derived count. `keys().hasOnly([...])` mirrors the
-        // shape enforced on buildings/roles/members so clients can't stash
-        // arbitrary fields on create. Update is whitelisted to the fields
-        // admins actually configure.
+        // Domain/super admin only. Create pins canonical orgId + doc id, forces
+        // status:'pending' and users:0 (verification is server-side DNS; users is
+        // derived), and hasOnly([...]) blocks stray fields. Update is whitelisted
+        // to the configurable fields.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.orgId == orgId &&
           request.resource.data.id == domainId &&
@@ -356,13 +300,9 @@ service cloud.firestore {
 
       match /roles/{roleId} {
         allow read: if isOrgMember(orgId) || isSuperAdmin();
-        // System roles are seeded by the migration script with `{ merge: true }`
-        // and are otherwise immutable from clients — every client mutation is
-        // refused if `system == true`, with one narrow exception: super admins
-        // may patch `perms` on system roles so they can tune capability
-        // defaults from the admin console (see the `update` branch below).
-        // Client-created roles must carry canonical path identity, be
-        // explicitly non-system, and stay within the supported schema so
+        // System roles are migration-seeded and client-immutable, except super
+        // admins may patch `perms` (see update branch). Client-created roles must
+        // pin path identity, be system:false, and stay within the schema so
         // clients can't attach unexpected fields.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.id == roleId &&
@@ -371,11 +311,9 @@ service cloud.firestore {
           request.resource.data.keys().hasOnly([
             'id', 'name', 'blurb', 'color', 'system', 'perms'
           ]);
-        // Update whitelist keeps identity (id) and seed flag (system) pinned
-        // and blocks extensions beyond the known fields. Super admins may
-        // additionally edit `perms` on system roles (still identity-pinned and
-        // `system:true` preserved) so they can tune capability defaults from
-        // the admin console; domain admins remain locked out of system docs.
+        // Update pins id + system and blocks unknown fields. Super admins may
+        // also edit `perms` on system roles (system:true preserved); domain
+        // admins stay locked out of system docs.
         allow update: if
           (isSuperAdmin() &&
            request.resource.data.system == resource.data.system &&
@@ -407,33 +345,16 @@ service cloud.firestore {
                        request.auth.token.email.lower() == emailLower) ||
                     isOrgMember(orgId) ||
                     isSuperAdmin();
-        // Domain+ admins manage members with a field whitelist so identity
-        // fields (email, orgId, uid, addedBy, addedBySource) stay pinned to
-        // what the invitation/sign-in flow set. `uid` is intentionally not
-        // in the update whitelist: Phase 4's first-sign-in link-uid write
-        // must happen through a Cloud Function (Admin SDK bypasses these
-        // rules) so no client actor can reassign a member's uid and hijack
-        // the linked account. Building admins can only update `status` on
-        // members whose buildingIds intersect their own — see the update
-        // branch below for the `hasAny()` scoping note.
-        // Create enforces shape: doc id == lowercased email (both the path
-        // segment and payload field must be lowercase so isOrgMember() — which
-        // always looks up `members/{token.email.lower()}` — can find the
-        // record), required fields present, and only the invite-shape keys
-        // are allowed.
-        //
-        // Email case handling (F15): every membership read keys off
-        // `request.auth.token.email.lower()` (always lowercase), so a member
-        // doc whose stored email/id is mixed-case is orphaned and matching
-        // legitimate members get permission-denied. We therefore reject any
-        // mixed-case write at the source:
-        //   - `request.resource.data.email == request.resource.data.email.lower()`
-        //     pins the stored email field to lowercase, and
-        //   - `request.resource.data.email == emailLower` ties it to the
-        //     (lowercased) doc id `emailLower`.
-        // Together these guarantee the doc id is lowercase too, so the earlier
-        // standalone `emailLower == emailLower.lower()` guard is redundant and
-        // has been dropped.
+        // Domain+ admins manage members via a field whitelist so identity fields
+        // (email, orgId, uid, addedBy, addedBySource) stay pinned. `uid` is NOT
+        // update-whitelisted: the first-sign-in uid link must go through a CF
+        // (Admin SDK) so no client can reassign a uid and hijack the account.
+        // Building admins may update only `status` on members whose buildingIds
+        // intersect their own (see update branch). Create pins doc id ==
+        // lowercased email (so isOrgMember()'s members/{email.lower()} lookup
+        // resolves), requires the core fields, and hasOnly() the invite-shape
+        // keys. F15: request.resource.data.email is forced to lower() and ==
+        // emailLower, so the stored email and doc id are both guaranteed lowercase.
         allow create: if (isSuperAdmin() || isDomainAdmin(orgId)) &&
           request.resource.data.email == request.resource.data.email.lower() &&
           request.resource.data.email == emailLower &&
@@ -451,37 +372,25 @@ service cloud.firestore {
            request.resource.data.diff(resource.data).affectedKeys().hasOnly([
              'roleId', 'buildingIds', 'status', 'name', 'invitedAt', 'lastActive'
            ]) &&
-           // Anti-escalation: a domain admin must NOT be able to mint a super
-           // admin. roleId == 'super_admin' is a live isSuperAdmin() grant via
-           // isMemberSuperAdmin(), and this branch otherwise lets a domain admin
-           // write any roleId — including onto their own member doc — which would
-           // be a self-escalation path. Block writing 'super_admin' unless the
-           // doc already had it (so edits to an existing super-admin's other
-           // fields still pass). Only a super admin (first disjunct) can grant it.
+           // Anti-escalation: roleId=='super_admin' is a live isSuperAdmin() grant
+           // (isMemberSuperAdmin()), so a domain admin must not write it (incl.
+           // onto their own doc) unless the doc already had it. Only a super admin
+           // (first disjunct) can grant it.
            (request.resource.data.get('roleId', '') != 'super_admin' ||
             resource.data.get('roleId', '') == 'super_admin')) ||
-          // Building admin can flip `status` on a member whose buildingIds
-          // overlap their own. The overlap is alias-aware via
-          // buildingListsOverlap(), so a target member and acting admin storing
-          // buildingIds in mismatched canonical/legacy formats (e.g. 'high' vs
-          // 'orono-high-school') still match — closing the prior false-DENIAL
-          // gap without needing `.map()`. An empty list on either side yields no
-          // overlap, so a newly invited member with `buildingIds: []` is *not*
-          // editable by a building admin — the domain admin must assign a
-          // building first. This is intentional: building admins shouldn't act
-          // on members who haven't been scoped into their building yet.
-          // See config/buildings.ts for the canonical alias table.
+          // Building admin may flip `status` on a member whose buildingIds overlap
+          // their own, alias-aware via buildingListsOverlap() (so 'high' vs
+          // 'orono-high-school' still match, no .map() needed). An empty list on
+          // either side = no overlap, so an unscoped member (buildingIds: []) is
+          // not editable until a domain admin assigns a building. See
+          // config/buildings.ts.
           (isBuildingAdmin(orgId) &&
            buildingListsOverlap(resource.data.get('buildingIds', []), orgMember(orgId).get('buildingIds', [])) &&
            request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status'])) ||
-          // Self-write: the signed-in user may stamp their own `lastActive`
-          // on their own member doc. Bound strictly — email/orgId must match
-          // the existing record and only `lastActive` can change, so this
-          // cannot escalate role/buildingIds/status or touch another user.
-          // Powers the "Last active" column in the Organization admin panel;
-          // the alternative (a server trigger off Firebase Auth sign-in
-          // events) costs a Cloud Function for a write the client can safely
-          // make itself under this rule.
+          // Self-write: a user may stamp `lastActive` on their own member doc.
+          // Strictly bound — email/orgId must match and only `lastActive` may
+          // change, so it can't escalate role/buildingIds/status or touch another
+          // user. Powers the admin panel's "Last active" column without a CF.
           (request.auth != null &&
            request.auth.token.email != null &&
            request.auth.token.email.lower() == emailLower &&
@@ -521,15 +430,10 @@ service cloud.firestore {
         allow read, write: if isSuperAdmin() || isDomainAdmin(orgId);
       }
 
-      // Cached analytics snapshot, written nightly by the
-      // `recomputeAdminAnalytics` scheduled function (Admin SDK, bypasses
-      // rules) and read by the `adminAnalytics` HTTP function. Surfaced here
-      // so the client can read it directly in future iterations without going
-      // through the HTTP handler; today the HTTP handler is still the only
-      // reader, but a client-direct read path would be a strict cost win.
-      // Read is gated to org admins (any tier) since the snapshot carries
-      // per-member emails and engagement data. All writes are blocked — no
-      // client should ever write here; the scheduler is the sole writer.
+      // Cached analytics snapshot, written nightly by recomputeAdminAnalytics
+      // (Admin SDK, bypasses rules). Read gated to org admins (any tier) — it
+      // carries per-member emails + engagement data. All client writes blocked;
+      // the scheduler is the sole writer.
       match /analytics/{document} {
         allow read: if isSuperAdmin() ||
                     isDomainAdmin(orgId) ||
@@ -548,25 +452,18 @@ service cloud.firestore {
       allow write: if false; // Only create via Firebase Console or Admin SDK
     }
 
-    // Dashboards - users can only access their own dashboards in their subcollection.
-    // studentRole tokens (minted by studentLoginV1) are denied outright: students
-    // do not own a teacher-style dashboard, and the client app redirects them
-    // to /my-assignments. This rule is the actual security boundary — without
-    // it, a studentRole user calling Firestore directly could still create a
-    // dashboard doc under their own uid.
+    // Dashboards — owner-only. studentRole tokens (studentLoginV1) are denied
+    // outright: students don't own a teacher dashboard (the app redirects them to
+    // /my-assignments), and this rule is the real boundary against a studentRole
+    // user creating a dashboard doc under their own uid via direct Firestore.
     match /users/{userId}/dashboards/{dashboardId} {
       allow read, write: if request.auth != null && request.auth.uid == userId
                          && !isStudentRoleUser() && notDeactivated();
 
-      // Phase 2 PR 2.6: DrawingWidget object content moves off the dashboard
-      // document into a page-nested subcollection so a single Firestore write
-      // is one object (not the whole canvas). Page-level metadata lives on
-      // the parent /pages/{pageId} doc (background template, future per-page
-      // settings); the inner /objects/{objectId} collection carries the
-      // DrawableObject list. The parent dashboard rule already establishes
-      // owner-only access; these nested rules keep the same boundary so the
-      // subcollection inherits dashboard semantics without a separate
-      // top-level match.
+      // DrawingWidget objects live in a page-nested subcollection so one write is
+      // one object, not the whole canvas. /pages/{pageId} holds page metadata,
+      // /objects/{objectId} the DrawableObject list. These nested rules repeat the
+      // parent's owner-only boundary so the subcollection inherits it.
       match /drawings/{widgetId}/pages/{pageId} {
         allow read, write: if request.auth != null && request.auth.uid == userId
                            && !isStudentRoleUser() && notDeactivated();
@@ -582,15 +479,10 @@ service cloud.firestore {
     match /users/{userId}/rosters/{rosterId} {
       allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
 
-      // Phase 3 — non-PII PIN index sidecar. Bridges PIN-joining
-      // students into the SSO uid space via `pinLoginV1`. The cloud
-      // function `commitRosterPinIndexV1` writes these via the admin
-      // SDK (rules-bypass), and `pinLoginV1` reads them via the admin
-      // SDK as well. Clients have NO write path here — the data is
-      // load-bearing for cap enforcement and a hostile teacher-uid
-      // claim would otherwise let them rewrite their own pseudonym
-      // mapping. Admin reads are allowed for support / debugging;
-      // students never touch this collection directly.
+      // Non-PII PIN index sidecar bridging PIN-joining students into the SSO uid
+      // space. commitRosterPinIndexV1 writes and pinLoginV1 reads via Admin SDK;
+      // clients have NO write path (load-bearing for cap enforcement). Owner/admin
+      // read only, for support/debugging.
       match /pin_index/{indexKey} {
         allow read: if request.auth != null &&
           (request.auth.uid == userId || isAdmin());
@@ -598,19 +490,11 @@ service cloud.firestore {
       }
     }
 
-    // PLC Overview layout — per-user customization of the PLC Dashboard
-    // bento grid. Pure view preferences, so no PLC membership check is
-    // needed (a non-member's layout doc here would be inert because the
-    // tiles can't read PLC content without passing the PLC rule gates).
-    // Schema lock-down keeps the doc shape closed for future readers.
-    //
-    // Per-tile interior validation (kind / size enums) is intentionally
-    // delegated to the client parser in `usePlcOverviewLayout.ts` rather
-    // than CEL: Firestore rules don't expose `.every()` over lists, and
-    // the blast radius of garbage tile entries is bounded to the user's
-    // own dashboard (the rule scope is owner-only). The tiles-list size
-    // cap below prevents a single doc from being weaponized as unbounded
-    // storage.
+    // PLC Overview layout — per-user PLC dashboard bento-grid prefs. No PLC
+    // membership check needed (a non-member's doc is inert — tiles still pass the
+    // PLC rule gates to read content). Per-tile enum validation is delegated to
+    // usePlcOverviewLayout.ts (CEL has no .every()); blast radius is owner-only
+    // and the tiles size cap below bounds doc size.
     match /users/{userId}/plc_layouts/{plcId} {
       allow read, delete: if request.auth != null && request.auth.uid == userId
                           && notDeactivated();
@@ -623,13 +507,9 @@ service cloud.firestore {
                    && request.resource.data.updatedAt is int;
     }
 
-    // Per-user private unread cursor for a PLC's activity feed (Decision 2.2,
-    // §3.4). One doc per (user, plc): `{ lastSeenAt }`. "Since you were here"
-    // is the set of activity events with `createdAt > lastSeenAt`; the sidebar
-    // badge counts them. Strictly owner-only — no teammate ever reads or writes
-    // another member's cursor. Schema is locked to the single `lastSeenAt`
-    // field, which dual-accepts `int || timestamp` during the serverTimestamp
-    // rollout (§3.2).
+    // Per-user unread cursor for a PLC activity feed: one doc per (user, plc),
+    // `{ lastSeenAt }`. Strictly owner-only. Schema locked to `lastSeenAt`, which
+    // dual-accepts int || timestamp during the serverTimestamp rollout.
     match /users/{userId}/plc_state/{plcId} {
       allow read, delete: if request.auth != null && request.auth.uid == userId
                           && notDeactivated();
@@ -717,13 +597,9 @@ service cloud.firestore {
     }
 
     // Private server-managed credentials (e.g. encrypted Google OAuth
-    // refresh_token written by `exchangeGoogleAuthCode` and read by
-    // `refreshGoogleAccessToken`). DENY ALL client access — the Admin SDK
-    // from Cloud Functions bypasses rules and is the only path that
-    // should read or write here. Default-deny would cover this too, but
-    // an explicit rule documents the intent and protects against any
-    // future permissive `users/{userId}/{document=**}` rule accidentally
-    // exposing the refresh_token.
+    // refresh_token via exchangeGoogleAuthCode / refreshGoogleAccessToken).
+    // DENY ALL client access — Admin SDK only. Explicit (vs default-deny) to
+    // document intent and guard against a future permissive users/** rule.
     match /users/{userId}/private/{document=**} {
       allow read, write: if false;
     }
@@ -758,14 +634,10 @@ service cloud.firestore {
       allow read, write: if isAdmin();
     }
 
-    // Admin audit log - admin-only read; create-only writes (immutable).
-    // Written by GlobalPermissionsManager when admins change model config
-    // (or other sensitive settings). Without this rule the default-deny
-    // policy silently rejects every write and audit logging is a no-op.
-    // `create` (not `write`) is intentional: audit entries must be append-only
-    // so an admin cannot edit or delete their own trail. `timestamp` is set
-    // server-side via serverTimestamp() at the call site (more tamper-resistant
-    // than a client-supplied epoch), so no `is int` validation is added here.
+    // Admin audit log — admin-only read; create-only (append-only so an admin
+    // can't edit/delete their own trail). Written by GlobalPermissionsManager on
+    // sensitive settings changes. timestamp is set server-side via
+    // serverTimestamp(), so no is-int validation here.
     match /admin_audit_log/{logId} {
       allow read, create: if isAdmin();
     }
@@ -785,22 +657,13 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    // Admin-created short links resolved by the client at /r/:code.
-    // - Public `get`: anyone (incl. anonymous) can follow a known shortlink.
-    // - Admin-only `list`: prevents anonymous enumeration of every short
-    //   code + destination, which `allow read: if true` would otherwise
-    //   permit via a collection-level scan.
-    // - Admin-only create/edit/delete: only admins manage links.
-    // - Narrow anonymous update: the resolver bumps `clicks` by exactly 1
-    //   and stamps `lastClickedAt`. Restricting the diff prevents resetting
-    //   or inflating the counter — without these clauses an attacker could
-    //   set `clicks` to any value while still passing `affectedKeys`.
-    // - `lastClickedAt` is additionally clamped to a ±5 minute drift
-    //   window around server time. Without that bound an attacker could
-    //   stamp a far-future timestamp (e.g. year 2286) and poison any
-    //   "recently clicked" ordering or last-active analytics built on the
-    //   field. 5 minutes is generous enough to absorb realistic client
-    //   clock skew while still bounding the field tightly.
+    // Admin-created short links resolved at /r/:code.
+    // - get: public (anyone can follow a known shortlink).
+    // - list: admin-only (blocks anonymous enumeration of all codes + targets).
+    // - create/edit/delete: admin-only.
+    // - update: narrow anonymous path — the resolver may only bump `clicks` by
+    //   exactly 1 and stamp `lastClickedAt`, clamped to ±5min of server time
+    //   (prevents counter inflation/reset and far-future timestamp poisoning).
     match /short_links/{code} {
       allow get: if true;
       allow list: if isAdmin();
@@ -815,25 +678,13 @@ service cloud.firestore {
       allow delete: if isAdmin();
     }
 
-    // Classroom Add-on course links — maps a Google Classroom courseId to the
-    // ClassLink class (section) sourcedId, so the add-on can resolve students
-    // against the existing OneRoster roster + name pipeline. Keyed by the
-    // Google courseId; the doc records the claiming teacher. The student-login
-    // CF reads it via the Admin SDK (bypasses rules).
-    //
-    // READ is open to any authed user (the teacher discovery iframe reads the
-    // link to resolve class targeting). WRITES (create/update AND delete) are
-    // SERVER-ONLY: the `linkClassroomCourse` / `unlinkClassroomCourse` CFs first
-    // verify — with the teacher's own `classroom.courses.readonly` token — that
-    // the caller genuinely teaches the Google course, then write/delete via the
-    // Admin SDK. Rules cannot verify Google-course teaching, so a client `create`
-    // (checking only teacherUid == auth.uid) let ANY authed user squat ANY
-    // courseId: the student-login CF mints every student's class-gate `classIds`
-    // from whatever class this doc names, so a squatter could mis-route a victim
-    // course's students AND permanently lock the real teacher out (first-write-
-    // wins; an update requires the existing teacherUid). Blocking client writes
-    // closes that hole; the unlink CF provides the server-verified correction
-    // path (a wrong/stale link can't be fixed by a client delete).
+    // Classroom Add-on course links — maps a Google Classroom courseId to a
+    // ClassLink section sourcedId so the add-on resolves students via OneRoster.
+    // READ open to any authed user (the discovery iframe needs it). WRITES are
+    // server-only: linkClassroomCourse / unlinkClassroomCourse verify (with the
+    // teacher's classroom.courses.readonly token) that the caller teaches the
+    // course, then write via Admin SDK. Rules can't verify that, so a client
+    // create would let anyone squat any courseId and mis-route/lock out students.
     match /classroom_course_links/{courseId} {
       allow read: if request.auth != null;
       allow write: if false;
@@ -987,38 +838,21 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    // Shared boards — backing store for live-shared dashboards.
-    // Three import modes are layered on top of this collection:
-    //   - "Make a Copy"  : reader pulls a snapshot, no doc-side state changes
-    //   - "View-Only"    : reader joins as { role: 'viewer' }, host pushes updates
-    //   - "Synced"       : reader joins as { role: 'collaborator' }, both push updates
-    //
-    // Field surface:
-    //   originalAuthor: string (uid)         — host, set at create
-    //   sharedAt: number                     — timestamp
-    //   participants: { [uid]: { role, joinedAt, displayName? } }
-    //   intendedMode?: 'copy' | 'synced' | 'view-only' — host's chosen mode
-    //   updatedAt?: number / updatedBy?: string  — last writer (echo prevention)
-    //   ...plus all Dashboard fields (name, background, widgets, globalStyle, settings)
-    //
-    // Update rules:
-    //   - Host can update anything (content + participants).
-    //   - A participant with role=='collaborator' (Synced) can update content
-    //     fields but cannot rewrite the participants map or transfer ownership.
-    //   - A participant with role=='viewer' cannot update.
-    //   - Any authed user can append themselves to participants (join), but
-    //     cannot mutate other participants' entries or change other fields in
-    //     the same write.
-    //   - intendedMode is immutable after create — the recipient flow trusts
-    //     it to skip the picker, so any update path that allows it to drift
-    //     would let a participant spoof the host's choice.
+    // Shared boards — backing store for live-shared dashboards. Import modes:
+    //   - copy      : reader pulls a snapshot, no doc-side state
+    //   - view-only : reader joins as { role: 'viewer' }, host pushes
+    //   - synced    : reader joins as { role: 'collaborator' }, both push
+    // Fields: originalAuthor (uid host), sharedAt, participants
+    // { [uid]: { role, joinedAt, displayName? } }, intendedMode, updatedAt/By,
+    // plus all Dashboard fields. Update rules: host = anything; collaborator =
+    // content but not participants/ownership; viewer = none; any authed user may
+    // append only themselves to participants; intendedMode is immutable after
+    // create (the recipient flow trusts it to skip the picker).
     match /shared_boards/{shareId} {
-      // Substitute shares carry building/sub-email routing metadata and Drive
-      // grant ids that should not leak outside the org — restrict reads to
-      // the host, admins, and authenticated callers in the @orono.k12.mn.us
-      // domain (the same gate the /subs UI enforces client-side). Other
-      // share modes (synced, view-only, copy) remain readable by any
-      // authenticated user since they're discovered by share URL, not query.
+      // Substitute shares carry org-internal routing/Drive-grant metadata, so
+      // reads are restricted to host, admins, and @orono.k12.mn.us callers (the
+      // gate the /subs UI enforces). Other modes stay readable by any authed user
+      // (discovered by share URL, not query).
       allow read: if request.auth != null && (
         resource.data.get('intendedMode', null) != 'substitute'
         || resource.data.get('originalAuthor', null) == request.auth.uid
@@ -1026,23 +860,13 @@ service cloud.firestore {
         || request.auth.token.get('email', '').lower().matches('.*@orono[.]k12[.]mn[.]us$')
       );
 
-      // Host writes their own share, and if they tag it with a `plcId`,
-      // they must be a current member of that PLC. Defense-in-depth on top
-      // of the client-side PLC picker — a hostile client could otherwise
-      // surface their share on any PLC's tab.
-      //
-      // Substitute-share addendum (`intendedMode == 'substitute'`):
-      // - `buildingId` MUST be a non-empty string. The /subs directory
-      //   query joins on it; a missing/wrong value silently hides the share.
-      // - `expiresAt` MUST be a number strictly in the future AND at most
-      //   14 days out. The UI enforces the 14-day cap; mirroring it in
-      //   rules prevents a hostile client from creating a share that lives
-      //   for years (and keeps Drive grants live for that whole window).
-      //   1209600000ms == 14 * 24 * 60 * 60 * 1000.
-      // - `initialState` MUST be a list. Subs trust it for the "Reset board"
-      //   action; non-list values break that codepath.
-      // PLC scoping is intentionally NOT allowed for substitute shares —
-      // they don't belong on PLC Shared Boards tabs.
+      // Host writes their own share; a `plcId` tag requires current membership of
+      // that PLC (defense-in-depth on the client picker). Substitute addendum
+      // (intendedMode == 'substitute'): buildingId non-empty string (the /subs
+      // query joins on it); expiresAt a number in the future and ≤14 days out
+      // (1209600000ms — caps share + Drive-grant lifetime); initialState a list
+      // (subs trust it for "Reset board"); subEmails capped ≤20 (see DoS note
+      // below). PLC scoping is not allowed for substitute shares.
       allow create: if request.auth != null &&
         request.resource.data.originalAuthor == request.auth.uid &&
         (
@@ -1055,10 +879,8 @@ service cloud.firestore {
             && request.resource.data.expiresAt > request.time.toMillis()
             && request.resource.data.expiresAt <= request.time.toMillis() + 1209600000
             && request.resource.data.initialState is list
-            // Cap subEmails (same DoS guard as shared_collections create):
-            // DashboardContext iterates this list to issue Drive roster grants
-            // with no bound, so an unbounded list could exhaust the host's
-            // Drive API quota. Optional field — absence allowed; <= 20 when set.
+            // subEmails DoS cap: DashboardContext issues one Drive grant per entry
+            // with no bound. Optional; <=20 when set. (Same guard on update below.)
             && (!('subEmails' in request.resource.data)
                 || (request.resource.data.subEmails is list
                     && request.resource.data.subEmails.size() <= 20))
@@ -1071,28 +893,14 @@ service cloud.firestore {
           ).data.memberUids
         );
 
-      // Host or admin: full update power (content + participants), but
-      // intendedMode is locked to its create-time value AND any change to
-      // `plcId` (set or retarget) requires the writer to be a current
-      // member of the target PLC. Allowed plcId transitions: unchanged,
-      // un-scoping (→ null), or scoping to a PLC the writer belongs to.
-      // Admins bypass the membership check, matching the existing
-      // ownership-bypass elsewhere in this block.
-      //
-      // Substitute-share addendum: for `intendedMode == 'substitute'`, all
-      // lifecycle fields (`buildingId`, `initialState`, `expiresAt`,
-      // `subEmails`, `driveGrants`) are pinned to their create-time
-      // values. The sub view trusts these to be the frozen snapshot — if
-      // a host could retarget a share's building after creation, a sub
-      // who already opened the board would suddenly see a board they
-      // weren't expecting; if `initialState` could drift, the "Reset
-      // board" action would land on a different baseline than the one
-      // the sub started from; if `expiresAt` could be extended, the
-      // substitute share's frozen/time-boxed contract would be broken
-      // (and Drive grants would outlive their intended window); if
-      // `subEmails` or `driveGrants` could be rewritten, the cleanup
-      // job's accounting of "who got access to what" would silently
-      // drift. All pins are admin-overridable for emergency corrections.
+      // Host or admin: full update (content + participants), but intendedMode is
+      // locked to its create value and any plcId change (set/retarget) requires
+      // current membership of the target PLC (admins bypass). Allowed plcId
+      // transitions: unchanged, → null, or to a PLC the writer belongs to.
+      // Substitute addendum: all lifecycle fields (buildingId, initialState,
+      // expiresAt, subEmails, driveGrants) are pinned to create-time values so the
+      // sub's frozen, time-boxed snapshot can't drift (Drive grants can't outlive
+      // their window; cleanup accounting stays accurate). Admin-overridable.
       allow update: if request.auth != null &&
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin()) &&
         request.resource.data.get('intendedMode', null) == resource.data.get('intendedMode', null) &&
@@ -1115,26 +923,16 @@ service cloud.firestore {
                /databases/$(database)/documents/plcs/$(request.resource.data.plcId)
              ).data.memberUids
         ) &&
-        // Cap subEmails on EVERY owner update (not just substitute, which pins
-        // it above): a copy/PLC share otherwise lets an owner write an
-        // unbounded subEmails list via update, bloating the doc and arming any
-        // future server-side reader. Matches the create-time cap. Substitute
-        // shares already pin subEmails to its create value, so this is a no-op
-        // for them.
+        // subEmails cap on EVERY owner update (copy/PLC shares too, not just
+        // substitute which pins it above) — bounds doc size. Matches create cap.
         (!('subEmails' in request.resource.data)
           || (request.resource.data.subEmails is list
               && request.resource.data.subEmails.size() <= 20));
 
-      // Collaborator (Synced participant): may update content but must not
-      // change participants map, originalAuthor, originalAuthorName,
-      // sharedAt, intendedMode, or plcId. originalAuthorName in particular
-      // is the host display name shown in the import-picker / banner UI
-      // for every participant, so a collaborator who could rewrite it
-      // would be able to spoof the host's identity to other peers.
-      // plcId pins the share's PLC scope — a collaborator (a teammate
-      // who joined a non-PLC share) shouldn't be able to silently retarget
-      // someone else's share at an arbitrary PLC, and conversely shouldn't
-      // be able to strip the PLC scope from a PLC-shared board.
+      // Collaborator (Synced): may update content but not participants,
+      // originalAuthor, originalAuthorName (host display name — spoofable
+      // identity), sharedAt, intendedMode, or plcId (pins PLC scope so a
+      // collaborator can't retarget/strip another's share).
       allow update: if request.auth != null &&
         request.auth.uid in resource.data.get('participants', {}) &&
         resource.data.participants[request.auth.uid].get('role', '') == 'collaborator' &&
@@ -1146,11 +944,8 @@ service cloud.firestore {
         request.resource.data.get('plcId', null) == resource.data.get('plcId', null);
 
       // Self-join: any authed user may add ONLY their own uid to participants
-      // without changing any other field. Used by importers picking Synced
-      // or View-Only mode. Explicitly NOT allowed on substitute shares —
-      // subs view via /subs without importing, so any self-join on those
-      // docs would just pollute the participants map and surface as a
-      // phantom collaborator to the host.
+      // (Synced/View-Only importers). Not allowed on substitute shares — subs
+      // view via /subs without importing, so a self-join would be a phantom.
       allow update: if request.auth != null &&
         resource.data.get('intendedMode', null) != 'substitute' &&
         !(request.auth.uid in resource.data.get('participants', {})) &&
@@ -1160,10 +955,7 @@ service cloud.firestore {
         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['participants']);
 
       // Self-leave: any participant may remove ONLY their own uid from
-      // participants without changing any other field. Substitute shares
-      // never accept participants in the first place (see self-join rule),
-      // so this rule is effectively a no-op for them — the predicate
-      // `request.auth.uid in participants` would fail.
+      // participants. No-op for substitute shares (they never accept participants).
       allow update: if request.auth != null &&
         request.auth.uid in resource.data.get('participants', {}) &&
         !(request.auth.uid in request.resource.data.get('participants', {})) &&
@@ -1175,18 +967,14 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
-    // Collection-level shares — parent doc holds metadata, subcollection
-    // /shared_collections/{shareId}/boards/{boardId} holds frozen Board
-    // snapshots. Mirrors /shared_boards substitute gating (inline pattern)
-    // and the 14-day expiresAt cap.
+    // Collection-level shares — parent holds metadata, /boards/{boardId}
+    // subcollection holds frozen Board snapshots. Mirrors /shared_boards
+    // substitute gating + 14-day expiresAt cap.
     match /shared_collections/{shareId} {
-      // READ: any authed user for non-substitute shares. Substitute shares
-      // are gated by host, admin, or @orono.k12.mn.us email (same as
-      // /shared_boards), AND must not be past their expiresAt — the
-      // client-side `loadSharedCollection` filters expired shares, but a
-      // hostile client (direct REST/curl) would otherwise read stale
-      // snapshots indefinitely. Host and admin can still read past expiry
-      // for cleanup / debugging.
+      // READ: any authed user for non-substitute. Substitute shares gated by
+      // host/admin/@orono.k12.mn.us email AND not past expiresAt (a hostile
+      // direct-REST client would otherwise read stale snapshots forever). Host
+      // and admin can read past expiry for cleanup.
       allow read: if request.auth != null && (
         resource.data.get('intendedMode', null) != 'substitute'
         || resource.data.get('hostUid', null) == request.auth.uid
@@ -1197,19 +985,12 @@ service cloud.firestore {
         )
       );
 
-      // CREATE: host writes their own share. Substitute shares add a
-      // 14-day TTL cap (1209600000ms == 14 * 24 * 60 * 60 * 1000) AND
-      // require a non-empty buildingId — both mirror the /shared_boards
-      // substitute create rule. boardIds must be a non-empty list of
-      // at most 500 entries; collection.name must be a non-empty string;
-      // intendedMode must be in the legal set.
-      //
-      // Optional substitute fields `subEmails` and `driveGrants` (Drive
-      // roster grants, mirroring /shared_boards) are permitted at create
-      // time and PINNED thereafter by the UPDATE rule below (substitute
-      // Collection shares are fully immutable post-create), so a host can
-      // never silently retarget or rewrite them after a sub has opened a
-      // board — the same guarantee the per-field pins give on /shared_boards.
+      // CREATE: host writes their own share. boardIds = non-empty list ≤500;
+      // collection.name non-empty; intendedMode in the legal set. Substitute adds
+      // a 14-day TTL cap (1209600000ms) + non-empty buildingId (mirrors
+      // /shared_boards). Optional subEmails/driveGrants are allowed at create and
+      // PINNED by the update rule below (substitute Collection shares are fully
+      // immutable post-create).
       allow create: if request.auth != null
         && request.resource.data.hostUid == request.auth.uid
         && request.resource.data.boardIds is list
@@ -1226,26 +1007,18 @@ service cloud.firestore {
             && request.resource.data.expiresAt is number
             && request.resource.data.expiresAt > request.time.toMillis()
             && request.resource.data.expiresAt <= request.time.toMillis() + 1209600000
-            // Cap subEmails so a hostile client can't queue thousands of Drive
-            // roster grants (DashboardContext iterates this list with no bound),
-            // exhausting the host's Drive API quota per share. Optional field —
-            // absence is allowed; when present it must be a list of <= 20.
+            // subEmails DoS cap (one Drive grant per entry, unbounded). Optional;
+            // a list of <=20 when present.
             && (!('subEmails' in request.resource.data)
                 || (request.resource.data.subEmails is list
                     && request.resource.data.subEmails.size() <= 20))
           )
         );
 
-      // UPDATE: host-only, and ONLY allowed on copy shares (substitute
-      // shares are immutable post-creation — this fully pins every
-      // substitute field, including `expiresAt`, `buildingId`, `subEmails`
-      // and `driveGrants`, matching the per-field pins on /shared_boards
-      // but more strictly: no substitute update is permitted at all).
-      // NOTE: admins are ALSO blocked from updating substitute shares — the
-      // `intendedMode == 'copy'` guard applies regardless of isAdmin(), so a
-      // substitute Collection share is fully immutable post-create for
-      // everyone. Emergency corrections must be made via the Firebase console
-      // / Admin SDK (which bypass security rules), not through this rule.
+      // UPDATE: host-only, copy shares ONLY — substitute shares are fully
+      // immutable post-create (the intendedMode=='copy' guard applies even to
+      // admins, so every substitute field incl. expiresAt/buildingId/subEmails/
+      // driveGrants is pinned). Emergency fixes go via console/Admin SDK.
       allow update: if request.auth != null
         && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin())
         && resource.data.get('intendedMode', null) == 'copy';
@@ -1253,10 +1026,9 @@ service cloud.firestore {
       allow delete: if request.auth != null
         && (resource.data.get('hostUid', null) == request.auth.uid || isAdmin());
 
-      // Per-Board snapshots. Read mirrors parent semantics (including the
-      // expiresAt cutoff for substitute shares — see parent rule). Write
-      // only by parent's host (the share-creation writeBatch puts the
-      // parent doc first, then the boards, so the get() lookup resolves).
+      // Per-Board snapshots. Read mirrors parent semantics (incl. substitute
+      // expiresAt cutoff). Write only by the parent's host (the create batch
+      // writes the parent first, so the get() resolves).
       match /boards/{boardId} {
         allow read: if request.auth != null && (
           get(/databases/$(database)/documents/shared_collections/$(shareId)).data.get('intendedMode', null) != 'substitute'
@@ -1273,11 +1045,9 @@ service cloud.firestore {
       }
     }
 
-    // Preset substitute emails — per-building list of generic sub accounts
-    // (e.g. ohssub@orono.k12.mn.us) that teachers can quickly add when
-    // creating a Substitute (View-Only) share. Admin-managed. Authenticated
-    // users (teachers) read to populate the share modal's preset chip list.
-    // Doc id is the canonical building id (config/buildings.ts).
+    // Preset substitute emails — per-building list of generic sub accounts,
+    // admin-managed, read by teachers for the share modal's preset chips. Doc id
+    // = canonical building id (config/buildings.ts).
     match /preset_sub_emails/{buildingId} {
       allow read: if request.auth != null;
       allow write: if isAdmin();
@@ -1303,10 +1073,9 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
-    // Shared notebooks - a SMART Notebook published for staff sharing. Carries
-    // the author's page/asset download URLs (token-bearing, so cross-user
-    // readable) plus title/sections; a recipient pastes the link to import a
-    // copy. Same owner-write / authenticated-read pattern as shared_quizzes.
+    // Shared notebooks — a SMART Notebook published for staff sharing (carries
+    // token-bearing asset URLs + title/sections; recipient pastes link to copy).
+    // Same owner-write / authed-read pattern as shared_quizzes.
     match /shared_notebooks/{shareId} {
       allow get: if request.auth != null;
       allow create: if request.auth != null &&
@@ -1315,34 +1084,24 @@ service cloud.firestore {
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin());
     }
 
-    // Shared Activity Wall galleries — view-only published copy of an
-    // Activity Wall session's submissions. The teacher creates the share
-    // doc; viewers land at /activity-wall/gallery/{shareId} and read the
-    // doc to discover the underlying sessionId + gallery toggles
-    // (allowComments / allowCommentResponses / allowLikes). Reads are
-    // permitted for any signed-in caller (including anonymous gallery
-    // viewers) so an unauthenticated student can open the link.
+    // Shared Activity Wall galleries — view-only published copy of a session's
+    // submissions. Viewers land at /activity-wall/gallery/{shareId} and read the
+    // doc for the sessionId + toggles (allowComments/allowCommentResponses/
+    // allowLikes). Readable by any signed-in caller (incl. anonymous students).
     match /shared_activity_walls/{shareId} {
       allow read: if request.auth != null;
 
-      // Identity fields (id, sessionId, originalAuthor, createdAt) plus the
-      // sessionId-ownership check below force the share doc to be created by
-      // the teacher who owns the underlying Activity Wall session — a
-      // teacher cannot publish a gallery pointing at another teacher's
-      // submissions. `keys().hasOnly([...])` schema-locks the doc so a
-      // malicious client cannot smuggle in extra fields the rest of the
-      // stack might trust. `revoked` is permitted (but not required) at
-      // create time so a teacher who wants to publish-then-revoke in one
-      // round-trip is not blocked.
+      // Identity fields + the sessionId-ownership check force the doc to be
+      // created by the teacher who owns the underlying session (can't publish
+      // another teacher's submissions). hasOnly([...]) schema-locks the doc.
+      // `revoked` is allowed (not required) at create for publish-then-revoke.
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         request.resource.data.originalAuthor == request.auth.uid &&
         request.resource.data.id == shareId &&
         request.resource.data.sessionId is string &&
-        // NOTE: Firestore Rules has no `startsWith()` on strings — `matches()`
-        // (RE2) is the only built-in prefix primitive. Firebase Auth UIDs are
-        // documented as alphanumerics with no regex-special chars, so embedding
-        // the UID into the pattern is safe here.
+        // No startsWith() in rules — matches() (RE2) is the only prefix primitive.
+        // Auth UIDs are alphanumeric (no regex-special chars), so embedding is safe.
         request.resource.data.sessionId.matches(request.auth.uid + '_.*') &&
         request.resource.data.keys().hasOnly([
           'id', 'sessionId', 'originalAuthor', 'title', 'prompt', 'mode',
@@ -1360,11 +1119,9 @@ service cloud.firestore {
         (request.resource.data.expiresAt == null || request.resource.data.expiresAt is int) &&
         (!('revoked' in request.resource.data) || request.resource.data.revoked is bool);
 
-      // Identity fields are frozen post-create so a buggy/malicious client
-      // cannot retarget a published share at a different session or hijack
-      // attribution. Toggles (allow*, expiresAt, revoked) remain mutable
-      // for the teacher's revoke-without-delete and toggle-after-publish
-      // flows.
+      // Identity fields frozen post-create (can't retarget the session or hijack
+      // attribution); toggles (allow*, expiresAt, revoked) stay mutable for
+      // revoke-without-delete and toggle-after-publish.
       allow update: if request.auth != null &&
         (resource.data.get('originalAuthor', null) == request.auth.uid || isAdmin()) &&
         request.resource.data.id == resource.data.id &&
@@ -1439,37 +1196,23 @@ service cloud.firestore {
       }
     }
 
-    // Synced quiz groups — canonical, mutable record of a quiz shared
-    // across PLC peers. The group id is an unguessable v4 UUID, so reads
-    // are gated only on auth (matches the `shared_assignments` posture).
-    //
-    // Content writes (questions / title / version bump) are allowed only
-    // for existing participants — every peer's editor runs a transaction
-    // that increments `version` monotonically, so a non-participant can't
-    // overwrite content. The participants map itself is treated as
-    // immutable from the client side: joins/leaves go through the
-    // `joinSyncedQuizGroup` / `leaveSyncedQuizGroup` Cloud Functions
-    // (admin SDK) so we don't have to reason about partial-self mutations
-    // in CEL.
-    //
-    // Create is allowed by any authed user as long as `participants` carries
-    // ONLY the caller's uid — this lets `shareAssignment` stand up the
-    // group inline without round-tripping through a function. Subsequent
-    // member additions still require the function path.
+    // Synced quiz groups — canonical mutable record of a quiz shared across PLC
+    // peers. Group id is an unguessable v4 UUID, so reads are auth-only. Content
+    // writes (questions/title/version) require existing participation; version
+    // increments monotonically so a non-participant can't overwrite. The
+    // participants map is client-immutable — joins/leaves go through the
+    // join/leaveSyncedQuizGroup CFs. Create is open to any authed user iff
+    // participants carries only the caller's uid (lets shareAssignment stand up
+    // the group inline); later additions require the function path.
     match /synced_quizzes/{groupId} {
       allow get: if request.auth != null;
-      // Listing is closed: any authenticated user knowing only the
-      // collection name could otherwise enumerate every synced quiz
-      // (questions included), defeating the unguessable-id assumption
-      // that gates `get`. Clients always know the specific groupId via
-      // either their own `quiz_metadata` doc or a pasted share URL, so
-      // `get` is sufficient.
+      // list closed: it would let any authed user enumerate every synced quiz
+      // (defeating the unguessable-id gate on get). Clients always know the
+      // groupId via their quiz_metadata or a share URL, so get suffices.
       allow list: if false;
 
-      // Allowed top-level fields on a synced-quiz doc. Pin via
-      // `keys().hasOnly(...)` so a malicious client can't smuggle
-      // arbitrary extra fields onto the doc that downstream
-      // consumers might trust.
+      // hasOnly(...) pins the top-level field surface so a client can't smuggle
+      // extra fields downstream consumers might trust.
       allow create: if request.auth != null
         && request.resource.data.keys().hasOnly([
              'id', 'version', 'title', 'questions',
@@ -1488,11 +1231,9 @@ service cloud.firestore {
         && (!('plcId' in request.resource.data) || request.resource.data.plcId is string)
         && (!('behavior' in request.resource.data) || request.resource.data.behavior is map);
 
-      // Content updates: caller must be a participant; participants map and
-      // doc id are immutable from the client; version must strictly
-      // increase by 1 (loser of a concurrent transaction retries with the
-      // newer base version). The hasOnly clause locks the field surface
-      // so an update can't introduce new top-level fields either.
+      // Content updates: caller must be a participant; participants + id are
+      // client-immutable; version must increase by exactly 1 (concurrent loser
+      // retries on the newer base); hasOnly locks the field surface.
       allow update: if request.auth != null
         && request.auth.uid in resource.data.participants
         && request.resource.data.keys().hasOnly([
@@ -1509,19 +1250,15 @@ service cloud.firestore {
         && request.resource.data.get('plcId', null) == resource.data.get('plcId', null)
         && (!('behavior' in request.resource.data) || request.resource.data.behavior is map);
 
-      // No client-side delete. If a group becomes orphaned (empty
-      // participants), it stays — pasting an old share URL should still
-      // resolve the bootstrap snapshot rather than 404.
+      // No client delete. An orphaned (empty-participants) group stays so an old
+      // share URL still resolves the bootstrap snapshot rather than 404.
       allow delete: if false;
 
-      // ---- Bounded version history (PRD §5.1 / §3.10, Decision 5.1) ----
-      //
-      // A pre-edit snapshot of canonical content, written fire-and-forget by
-      // the publish path AFTER the canonical commit so versioning never
-      // blocks a publish. Participants read; participant-create-only with a
-      // schema lock + self-attributed `savedBy`. No client update/delete —
-      // pruning beyond the local ~10 cap is server-side GC via the Admin SDK,
-      // so the history can never be silently rewritten from a client.
+      // ---- Bounded version history (PRD §5.1/§3.10) ----
+      // Pre-edit snapshot of canonical content, written fire-and-forget after the
+      // canonical commit so it never blocks a publish. Participant read;
+      // participant-create-only with a schema lock + self-attributed `savedBy`. No
+      // client update/delete — pruning past the ~10 cap is Admin-SDK GC.
       match /versions/{versionId} {
         // Participant read (mirrors the parent group's participant gate).
         allow read: if request.auth != null
@@ -1561,11 +1298,9 @@ service cloud.firestore {
 
     match /synced_video_activities/{groupId} {
       allow get: if request.auth != null;
-      // Listing is closed for the same reason as `synced_quizzes`: any
-      // authenticated user knowing only the collection name could otherwise
-      // enumerate every synced activity (questions included). Clients always
-      // know the specific groupId via either their own
-      // `video_activity_metadata` or a pasted share URL.
+      // list closed (see synced_quizzes): would let any authed user enumerate
+      // every synced activity. Clients know the groupId via their
+      // video_activity_metadata or a share URL.
       allow list: if false;
 
       allow create: if request.auth != null
@@ -1584,10 +1319,8 @@ service cloud.firestore {
         && (!('plcId' in request.resource.data) || request.resource.data.plcId is string)
         && (!('behavior' in request.resource.data) || request.resource.data.behavior is map);
 
-      // Content updates: caller must be a participant; participants map and
-      // doc id are immutable from the client; version must strictly increase
-      // by 1. Loser of a concurrent transaction retries with the new base
-      // version. Mirrors `synced_quizzes` line-for-line.
+      // Content updates: participant-only; participants + id client-immutable;
+      // version increases by exactly 1. Mirrors synced_quizzes line-for-line.
       allow update: if request.auth != null
         && request.auth.uid in resource.data.participants
         && request.resource.data.keys().hasOnly([
@@ -1604,12 +1337,10 @@ service cloud.firestore {
 
       allow delete: if false;
 
-      // ---- Bounded version history (PRD §5.1 / §3.10, Decision 5.1) ----
-      //
-      // Mirrors the `synced_quizzes/{groupId}/versions` block exactly, scoped
-      // to Video Activity. Participant read; participant-create-only with a
-      // schema lock + self-attributed `savedBy`; no client update/delete (GC
-      // is server-side).
+      // ---- Bounded version history (PRD §5.1/§3.10) ----
+      // Mirrors synced_quizzes/{groupId}/versions, scoped to Video Activity.
+      // Participant read; participant-create-only (schema lock + self `savedBy`);
+      // no client update/delete (server-side GC).
       match /versions/{versionId} {
         allow read: if request.auth != null
           && request.auth.uid in
@@ -1629,15 +1360,11 @@ service cloud.firestore {
     }
 
     // ---- PLC (Professional Learning Community) helpers + rules ----
-    //
-    // PLCs are top-level so cross-teacher reads work — every member needs to
-    // read the doc, not just the lead. The lead has full write authority;
-    // non-leads can only self-add (accepting an invite) or self-remove (leaving).
-    //
-    // Invitations use a deterministic doc id `<plcId>_<emailLower>` so the
-    // accept-flow rule can verify an outstanding invite without enumerating.
-    // Resending an invite to the same email overwrites the previous record,
-    // which is the desired behavior (re-arms a declined invite).
+    // PLCs are top-level so every member (not just the lead) can read the doc.
+    // The lead has full write authority; non-leads can only self-add (accept an
+    // invite) or self-remove (leave). Invitations use a deterministic doc id
+    // `<plcId>_<emailLower>` so the accept rule verifies an invite without
+    // enumerating; re-inviting the same email overwrites (re-arms a declined one).
     function plcInviteDocId(plcId, emailLower) {
       return plcId + '_' + emailLower;
     }
@@ -1649,24 +1376,13 @@ service cloud.firestore {
       return plcData.get('members', {}).get(uid, {}).get('role', '');
     }
 
-    // True when the caller may WRITE PLC content (Decision 3.2 — viewer role,
-    // §3.2 / §4 rules discipline). A content editor is an active member whose
-    // role in the canonical `members` map is anything OTHER than 'viewer'
-    // (lead / coLead / member). Reads the canonical map by `get()`-ing the PLC
-    // root once. Legacy (map-less) PLCs that predate the members map (Decision
-    // 1.2) treat ANY uid present in the denormalized `memberUids` index as an
-    // editor — the `viewer` role only ever exists inside the map, so a PLC
-    // without a map simply has no viewers, and gating it on the map alone would
-    // wrongly lock every un-migrated member out of content writes during the
-    // rollout. When the map IS present, a uid keyed there governs: a viewer
-    // entry returns false (read-only), every other role returns true.
-    //
-    // Content subcollections (assessments, meetings, quizzes, video_activities,
-    // assignments, notes, todos, docs, comments) thread this into their
-    // create/update/delete branches so a viewer is denied content writes while
-    // reads stay open. Viewer-writable surfaces — a member's OWN presence doc
-    // and their OWN `/users/{uid}/plc_state` unread cursor — deliberately do
-    // NOT call this (a viewer must still heartbeat presence + track unread).
+    // True when the caller may WRITE PLC content (viewer role, Decision 3.2). An
+    // editor is a member whose role in the `members` map is not 'viewer'. Legacy
+    // (map-less) PLCs treat any uid in the denormalized memberUids as an editor
+    // (viewer only exists in the map, so a map-less PLC has no viewers — gating on
+    // the map alone would lock un-migrated members out during rollout). Content
+    // subcollections thread this into their write branches (reads stay open).
+    // Viewer-writable surfaces (own presence doc, own plc_state cursor) skip it.
     function plcCanEditContent(plcId) {
       let plcData = get(/databases/$(database)/documents/plcs/$(plcId)).data;
       let role = plcRoleOf(plcData, request.auth.uid);
@@ -1679,11 +1395,9 @@ service cloud.firestore {
         : request.auth.uid in plcData.memberUids;
     }
 
-    // True when the caller is a membership manager of the PLC — the sitting
-    // `lead` OR a `coLead` (Decision 1.2). Reads the canonical `members` map
-    // first; falls back to the denormalized `leadUid` so legacy (un-migrated)
-    // PLCs that predate the map still authorize their lead. Co-leads only gain
-    // management rights once the PLC carries a populated `members` map.
+    // True when the caller is a membership manager — the sitting lead OR a coLead
+    // (Decision 1.2). Falls back to the denormalized leadUid so legacy (map-less)
+    // PLCs still authorize their lead; coLeads exist only once the map is present.
     function isPlcMembershipManager(plcData) {
       let role = plcRoleOf(plcData, request.auth.uid);
       return request.auth.uid == plcData.get('leadUid', '')
@@ -1691,31 +1405,21 @@ service cloud.firestore {
         || role == 'coLead';
     }
 
-    // Count of members in the proposed `members` map whose role is 'lead'.
-    // The exactly-one-lead invariant (Decision 1.2) means a role change must
-    // never mint a second lead — only `transferLead` moves the crown. We can't
-    // iterate a map in CEL, so this leans on the denormalized `leadUid` mirror:
-    // a valid post-update map has exactly the `leadUid` member at role 'lead'.
-    // Callers pair this with a `leadUid`-immutability check.
+    // Exactly-one-lead invariant (Decision 1.2): a role change must never mint a
+    // second lead (only transferLead moves the crown). CEL can't iterate a map, so
+    // this leans on the leadUid mirror — the leadUid member is 'lead' both sides.
+    // Pair with a leadUid-immutability check.
     function plcLeadRoleUnchanged(plcData, newData) {
       return plcRoleOf(newData, newData.get('leadUid', '')) == 'lead'
         && plcRoleOf(plcData, plcData.get('leadUid', '')) == 'lead';
     }
 
-    // Guards the broad sitting-lead update branch against minting a SECOND lead
-    // (the exactly-one-lead invariant, Decision 1.2). The broad branch is the
-    // ONLY write path that can rewrite arbitrary `members` entries; without a
-    // members constraint the lead could set a teammate's role to 'lead' and
-    // persist a two-lead map (the corruption `migratePlcs.ts` has to repair).
-    //
-    // CEL can't iterate a map's values, so — mirroring the `roleChangeUid`
-    // pointer convention used by `isChangingMemberRole` — the only members
-    // mutation the broad branch permits is a single-member REMOVAL named by the
-    // transient `removeMemberUid` pointer. That removed member's entry flips to
-    // status 'removed' (role left as-is, since they're being dropped); no other
-    // member entry may change, so no second lead can be introduced. Returns true
-    // when `members` is untouched (rename / tenancy-backfill writes), so those
-    // legitimate broad writes still pass.
+    // Guards the broad sitting-lead update branch against minting a second lead
+    // (Decision 1.2). That branch is the only path that can rewrite arbitrary
+    // members entries, so its only permitted members mutation is a single-member
+    // REMOVAL named by the transient `removeMemberUid` pointer (entry flips to
+    // status 'removed'; no other entry changes). Returns true when members is
+    // untouched, so rename / tenancy-backfill writes still pass.
     function plcBroadMembersOk() {
       let touchesMembers =
         'members' in request.resource.data.diff(resource.data).affectedKeys();
@@ -1739,24 +1443,20 @@ service cloud.firestore {
            );
     }
 
-    // True iff the pending update is the caller self-adding to memberUids
-    // (i.e. accepting an invitation). Verified against the existence of a
-    // matching *pending* deterministic invitation doc, AND constrained so
-    // the only membership change is appending the caller — preventing a
-    // malicious invitee from rewriting the whole memberUids array.
+    // True iff the update is the caller self-adding to memberUids (accepting an
+    // invite). Verified against a matching *pending* invitation doc, and
+    // constrained so the only change is appending the caller (an invitee can't
+    // rewrite the whole array).
     function isAcceptingPlcInvite(plcId) {
       let emailLower = request.auth.token.get('email', '').lower();
       let oldMembers = resource.data.memberUids;
       let newMembers = request.resource.data.memberUids;
       let oldEmails = resource.data.memberEmails;
       let newEmails = request.resource.data.memberEmails;
-      // The canonical `members` map (Decision 1.2) moves in lockstep with the
-      // denormalized indexes: accepting an invite appends the caller's own
-      // member entry (role 'member', status 'active') and touches no other
-      // member. `members` is OPTIONAL in the diff so legacy (un-migrated) PLCs
-      // that only carry the arrays still accept invites cleanly; when present,
-      // the diff may add ONLY the caller's own uid key, and that entry must be
-      // an active, non-privileged self record (no minting lead/coLead).
+      // members map moves in lockstep with the denormalized indexes: accepting
+      // appends only the caller's own entry (role 'member', status 'active').
+      // OPTIONAL in the diff (legacy array-only PLCs still accept); when present,
+      // may add only the caller's uid as an active self record.
       let membersUntouchedOrSelfAppended =
         !('members' in request.resource.data.diff(resource.data).affectedKeys())
         || (
@@ -1785,92 +1485,59 @@ service cloud.firestore {
         && get(/databases/$(database)/documents/plc_invitations/$(plcInviteDocId(plcId, emailLower))).data.status == 'pending';
     }
 
-    // True when `updatedAt` on the pending write is either a server timestamp
-    // or a legacy numeric millis value (dual-accept during the serverTimestamp
-    // rollout, Decision 3.2 / §3.2). Branches that bump `updatedAt` call this
-    // so a future tightening to timestamp-only is a one-line change here.
+    // updatedAt dual-accept (timestamp || legacy int millis) during the
+    // serverTimestamp rollout (Decision 3.2). Centralized so tightening to
+    // timestamp-only is a one-line change.
     function plcUpdatedAtOk() {
       let v = request.resource.data.get('updatedAt', 0);
       return v is timestamp || v is int;
     }
 
-    // Dual-accept for a named time field on a PLC subcollection doc
-    // (notes/todos/docs `createdAt` / `lastEditedAt` / `updatedAt`). During the
-    // serverTimestamp() rollout (Decision 1.3) writes carry a Firestore
-    // `timestamp`, while legacy docs (and any client that hasn't shipped the
-    // change) carry a plain `int` millis value — accept both. No new field is
-    // added to the schema; only the accepted TYPE of an existing field widens.
+    // Dual-accept (timestamp || int millis) for a named time field on a PLC
+    // subcollection doc (createdAt / lastEditedAt / updatedAt) during the
+    // serverTimestamp rollout. Only widens the accepted type, no new field.
     function plcSubTimeFieldOk(field) {
       let v = request.resource.data.get(field, 0);
       return v is timestamp || v is int;
     }
 
-    // True when the optional soft-delete tombstone (`deletedAt`, Decision 3.1)
-    // on a PLC subcollection doc is well-formed: absent (live doc / legacy),
-    // explicitly null (live / restored), a Firestore `timestamp`
-    // (serverTimestamp() at soft-delete time), or a legacy `int` millis value
-    // (dual-accept during the serverTimestamp rollout, §3.2). Notes, todos,
-    // docs, quizzes, video_activities and comments all carry this field; the
-    // helper keeps the accepted shape consistent across them. Hard-deletion of
-    // tombstoned docs (deletedAt older than 30 days) is performed server-side by
-    // the Wave-4 `gcPlcOrphans` scheduled function via the Admin SDK — these
-    // rules only govern the soft-delete/restore flips, never the GC sweep.
+    // Soft-delete tombstone (`deletedAt`, Decision 3.1) well-formed: absent, null,
+    // timestamp, or legacy int millis. Carried by notes/todos/docs/quizzes/
+    // video_activities/comments. Hard-deletion (>30d) is server-side via
+    // gcPlcOrphans; these rules govern only the soft-delete/restore flips.
     function plcSubDeletedAtOk() {
       let v = request.resource.data.get('deletedAt', null);
       return v == null || v is timestamp || v is int;
     }
 
-    // True when an OPTIONAL, NULLABLE time field on a PLC subcollection doc is
-    // well-formed: absent (legacy / not yet scheduled), explicitly null
-    // (cleared), a Firestore `timestamp` (serverTimestamp() write), or a legacy
-    // `int` millis value (dual-accept during the serverTimestamp rollout, §3.2).
-    // Used for the Common Assessment scheduling fields (`opensAt` / `dueAt`,
-    // §3.6) which differ from the always-present `createdAt`/`updatedAt`
-    // (covered by plcSubTimeFieldOk) in that they may be omitted or null.
+    // Optional NULLABLE time field well-formed: absent, null, timestamp, or legacy
+    // int millis. Used for Common Assessment scheduling (opensAt / dueAt, §3.6),
+    // which unlike createdAt/updatedAt may be omitted or null.
     function plcSubNullableTimeFieldOk(field) {
       let v = request.resource.data.get(field, null);
       return v == null || v is timestamp || v is int;
     }
 
-    // True when a tenancy field (`orgId` / `buildingId`, Decision 1.1) is
-    // immutable-after-set: it may be backfilled once (null/absent → value),
-    // re-written idempotently (value → same value), or left untouched, but a
-    // non-null value can never be changed to a DIFFERENT value. This stops a
-    // member from re-homing a PLC into another org's discovery directory after
-    // the migration stamps `orgId`. (Type is validated on create.)
+    // Tenancy field (orgId / buildingId, Decision 1.1) immutable-after-set: may be
+    // backfilled once (null → value) or rewritten to the same value, never to a
+    // different one — stops re-homing a PLC into another org's directory.
     function plcTenancyImmutableAfterSet(field) {
       let old = resource.data.get(field, null);
       let knew = request.resource.data.get(field, null);
       return old == null || knew == old;
     }
 
-    // True iff the pending update is any current member setting (or
-    // clearing) `sharedSheetUrl` and nothing else. `sharedSheetUrl` is
-    // populated by the first PLC member who creates a Share-with-PLC
-    // assignment — auto-created sheets can't require lead rights, because
-    // a teammate may kick off the first PLC assignment before the lead
-    // does. Constrained so this branch can't be used to smuggle other
-    // field changes (memberUids, leadUid, name, etc.).
-    //
-    // Allowed transitions:
-    //   - null/absent → string  (first member sets the URL)
-    //   - string → null         (clear, e.g. after a 404 stale-sheet)
-    //
-    // Rejected: string → different string. That would let one member
-    // overwrite another's already-cached PLC sheet URL and orphan the
-    // original sheet for everyone else. A no-op re-set to the SAME string is
-    // also rejected: it produces no `sharedSheetUrl` diff, so the
-    // hasAny(['sharedSheetUrl']) guard treats it as an mtime-only ping (the
-    // value is already correct, so the retry is a harmless no-op). The
-    // client-side
-    // `setPlcSharedSheetUrl` is also transactional, but we enforce the
-    // invariant in rules too as defense-in-depth.
+    // True iff the update is any current member setting/clearing `sharedSheetUrl`
+    // and nothing else (any member, not lead-only — a teammate may create the
+    // first PLC assignment before the lead). Allowed transitions: null → string
+    // (first set), string → null (clear). Rejected: string → different string
+    // (would orphan another's cached sheet); a same-value re-set produces no diff
+    // and is treated as an mtime-only no-op. Defense-in-depth on the transactional
+    // client setPlcSharedSheetUrl.
     function isSettingPlcSharedSheetUrl() {
       return (request.auth.uid in resource.data.memberUids)
-        // hasOnly + hasAny: the diff must be exactly the sharedSheetUrl
-        // (and the customary updatedAt bump). hasAny ensures this branch
-        // can't be exercised for an updatedAt-only ping that would let a
-        // member reset the doc's mtime without actually setting the URL.
+        // hasOnly + hasAny: diff is exactly sharedSheetUrl (+ updatedAt); hasAny
+        // blocks an updatedAt-only ping that resets mtime without setting the URL.
         && request.resource.data.diff(resource.data).affectedKeys()
              .hasOnly(['sharedSheetUrl', 'updatedAt'])
         && request.resource.data.diff(resource.data).affectedKeys()
@@ -1887,12 +1554,9 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is any current member toggling the
-    // dashboard `features` map (and nothing else). Per spec, every PLC
-    // member can toggle which optional sections render in the PLC Dashboard
-    // — this is shared configuration, not lead-only. Constrained to the
-    // `features` field plus the customary `updatedAt` bump so this branch
-    // can't be used to smuggle membership/leadership/sheet-URL changes.
+    // True iff the update is any current member toggling the dashboard `features`
+    // map and nothing else — shared config, not lead-only. Closed to features +
+    // updatedAt so it can't smuggle membership/leadership/sheet-URL changes.
     function isUpdatingPlcFeatures() {
       return (request.auth.uid in resource.data.memberUids)
         && request.resource.data.diff(resource.data).affectedKeys()
@@ -1903,17 +1567,11 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is any current member toggling the opt-in
-    // weekly-digest flag (`digestOptIn`, Decision 2.3) and nothing else. The
-    // digest is opt-in shared configuration — every member can flip it, exactly
-    // like `features` — so it's NOT lead-only. Mirrors `isUpdatingPlcFeatures`:
-    // the diff is closed to `digestOptIn` plus the customary `updatedAt` bump
-    // (hasOnly), the flip MUST actually touch `digestOptIn` (hasAny, so this
-    // branch can't be exercised for an updatedAt-only ping), and the value must
-    // be a boolean — so this branch can't smuggle membership / leadership /
-    // sheet-URL / feature changes. The email itself is sent server-side by the
-    // `plcWeeklyDigest` scheduled function, gated additionally by the global
-    // `plc-digest.enabled` kill switch (default OFF).
+    // True iff the update is any current member toggling the opt-in weekly-digest
+    // flag (`digestOptIn`, Decision 2.3) and nothing else (member-flippable like
+    // features, not lead-only). Closed to digestOptIn + updatedAt, must be bool.
+    // The email is sent server-side by plcWeeklyDigest, gated by the global
+    // plc-digest.enabled kill switch (default OFF).
     function isUpdatingPlcDigestOptIn() {
       return (request.auth.uid in resource.data.memberUids)
         && request.resource.data.diff(resource.data).affectedKeys()
@@ -1924,22 +1582,17 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is the caller self-removing from
-    // memberUids (i.e. leaving the PLC). The lead can't use this path —
-    // they must transfer leadership first or delete the PLC outright.
-    // Constrained so the only membership change is dropping the caller —
-    // preventing a leaving member from also evicting other members.
+    // True iff the update is the caller self-removing from memberUids (leaving).
+    // The lead can't use this path (transfer or delete first). Constrained so the
+    // only change is dropping the caller (can't evict others while leaving).
     function isLeavingPlc() {
       let oldMembers = resource.data.memberUids;
       let newMembers = request.resource.data.memberUids;
       let oldEmails = resource.data.memberEmails;
       let newEmails = request.resource.data.memberEmails;
-      // The canonical `members` map (Decision 1.2) moves in lockstep with the
-      // denormalized indexes — when present in the diff, the ONLY entry that
-      // may change is the leaver's own, and it must flip to status 'removed'.
-      // This keeps the leave branch from being used to rewrite a teammate's
-      // role/status while self-removing. `members` is OPTIONAL in the diff so
-      // legacy (un-migrated) PLCs that only carry the arrays still leave.
+      // members map moves in lockstep: when in the diff, only the leaver's own
+      // entry may change (flip to status 'removed'), so the branch can't rewrite a
+      // teammate while self-removing. OPTIONAL (legacy array-only PLCs still leave).
       let membersUntouchedOrSelfRemoved =
         !('members' in request.resource.data.diff(resource.data).affectedKeys())
         || (
@@ -1963,28 +1616,17 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is a membership manager (the sitting `lead`
-    // OR a `coLead` — Decision 1.2) transferring leadership to another current
-    // member. `transferLead` is the only way to move the crown, preserving the
-    // exactly-one-lead invariant. Constrained so:
-    //   - only a lead/co-lead may invoke it (via isPlcMembershipManager),
-    //   - the new leadUid must be an existing member (no promoting an
-    //     outsider), and must differ from the old lead,
-    //   - the leadUid mirror moves in lockstep with the `members` map: the
-    //     INCOMING lead is role 'lead' and the OUTGOING lead is demoted to a
-    //     non-lead role — so the map never carries two leads,
-    //   - the diff touches only leadUid + members + updatedAt (and the
-    //     denormalized memberUids/memberEmails, which a transfer leaves
-    //     unchanged but the client re-writes), never name/sheet-url/org, and
-    //   - the membership SET is unchanged (a transfer reassigns a role, it
-    //     does not add or drop members).
+    // True iff a membership manager (lead OR coLead, Decision 1.2) transfers
+    // leadership to another current member — the only way to move the crown.
+    // Constrained: invoker is lead/coLead; new leadUid is an existing member ≠ old
+    // lead; map lockstep (incoming → 'lead', outgoing demoted, never two leads);
+    // diff closed to leadUid/members/memberUids/memberEmails/updatedAt; membership
+    // set unchanged (reassigns a role, doesn't add/drop).
     function isTransferringPlcLead() {
       let oldLead = resource.data.leadUid;
       let newLead = request.resource.data.leadUid;
-      // Lockstep map<->leadUid checks only apply once the PLC carries a
-      // populated members map; legacy (map-less) PLCs transfer via leadUid
-      // alone (and only the sitting lead can drive that — co-leads only exist
-      // in the map, so isPlcMembershipManager already requires the map there).
+      // Lockstep checks apply only once a populated members map exists; legacy
+      // map-less PLCs transfer via leadUid alone (only the sitting lead can).
       let mapPresent =
         'members' in request.resource.data
         && request.auth.uid in request.resource.data.members;
@@ -1994,9 +1636,8 @@ service cloud.firestore {
              request.resource.data.members[newLead].role == 'lead'
              && request.resource.data.members[oldLead].role != 'lead'
            );
-      // A transfer may change ONLY the two lead entries in the members map — a
-      // manager can't silently re-role other members in the same write (that
-      // must go through isChangingMemberRole, one entry at a time).
+      // A transfer may change ONLY the two lead entries — re-roling others must
+      // go through isChangingMemberRole, one at a time.
       let membersDiffOk =
         !mapPresent
         || request.resource.data.members
@@ -2021,27 +1662,14 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is a membership manager (lead OR coLead —
-    // Decision 1.2) changing exactly ONE member's role within the non-lead
-    // set {coLead, member, viewer}, and nothing else. This is `setMemberRole`.
-    //
-    // Firestore rules cannot read a map value at a dynamically-discovered key
-    // (a `Set` from `affectedKeys()` is not indexable), so the target uid is
-    // supplied explicitly in the (schema-locked) `roleChangeUid` field. The
-    // rule then validates the named member's new role directly. `roleChangeUid`
-    // is a transient pointer; it is NOT membership data and is excluded from
-    // every other branch's field-set (so it can't be smuggled elsewhere).
-    //
-    // Guards the exactly-one-lead invariant:
-    //   - only a lead/co-lead may invoke it,
-    //   - leadUid is immutable (role changes never move the crown — that's
-    //     `transferLead`), and the lead member stays role 'lead' before & after,
-    //   - the diff touches only `members` + `roleChangeUid` + updatedAt,
-    //   - exactly the named member's entry changes; the target is NOT the
-    //     sitting lead (you can't demote the sole lead — transfer first),
-    //   - the new role is one of coLead/member/viewer (never 'lead', so this
-    //     branch can't mint a second lead), and
-    //   - the named member already exists (role changes don't add/drop people).
+    // True iff a membership manager (lead OR coLead) changes exactly ONE member's
+    // role within {coLead, member, viewer} and nothing else (setMemberRole). CEL
+    // can't index a map at a dynamic key, so the target uid is the schema-locked
+    // transient `roleChangeUid` pointer (excluded from every other branch).
+    // Guards exactly-one-lead: invoker is lead/coLead; leadUid immutable and the
+    // lead stays 'lead'; diff closed to members + roleChangeUid + updatedAt; only
+    // the named entry changes; target ≠ sitting lead; new role never 'lead'; the
+    // member already exists.
     function isChangingMemberRole() {
       let target = request.resource.data.get('roleChangeUid', '');
       let changedKeys =
@@ -2073,34 +1701,14 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // True iff the pending update is an in-org SITE ADMIN performing recovery on
-    // an abandoned PLC (Decision 3.4, §3.4) — reassigning leadership WITHOUT
-    // being a member of the PLC. This is the admin-recovery escape hatch for a
-    // PLC whose lead has left the district / can't transfer the crown.
-    //
-    // Scoped tightly:
-    //   - the caller is a site admin (`isAdmin()` — a doc under /admins),
-    //   - the PLC carries an `orgId` and the admin belongs to that SAME org
-    //     (`isOrgMember(resource.data.orgId)`) — an admin can never reach into
-    //     another org's PLC,
-    //   - the new leadUid is an EXISTING member of the PLC (no promoting an
-    //     outsider) and differs from the old lead,
-    //   - the leadUid mirror moves in lockstep with the `members` map — the
-    //     INCOMING lead becomes role 'lead' and the OUTGOING lead is demoted to
-    //     a non-lead role — IDENTICAL to the `isTransferringPlcLead` invariant,
-    //     so the map never carries two leads,
-    //   - the membership SET is unchanged (recovery reassigns a role; it does
-    //     not add/drop members), and
-    //   - the diff is closed to ['leadUid','members','memberUids','memberEmails',
-    //     'updatedAt'] — never name/sheet-url/org/features — so this branch
-    //     can't smuggle other field changes.
-    //
-    // Mutually exclusive with every other branch: the broad/transfer/role/
-    // accept/leave branches all require the caller to be a member (leadUid /
-    // memberUids / isPlcMembershipManager / in-memberUids gates), which a
-    // recovering admin is NOT — so only this branch authorizes a non-member
-    // admin write, and an actual member never satisfies the `!isMember` posture
-    // these branches implicitly carry.
+    // True iff an in-org SITE ADMIN recovers an abandoned PLC (Decision 3.4) —
+    // reassigning leadership WITHOUT being a member (the escape hatch when a lead
+    // leaves the district). Scoped: caller isAdmin(); PLC has an orgId and the
+    // admin is in that SAME org (never another org's PLC); new leadUid is an
+    // existing member ≠ old lead; map lockstep (incoming → 'lead', outgoing
+    // demoted, never two leads); membership set unchanged; diff closed to
+    // leadUid/members/memberUids/memberEmails/updatedAt. Mutually exclusive with
+    // the member-only branches (which all require membership the admin lacks).
     function isAdminManagingPlc() {
       let oldLead = resource.data.get('leadUid', '');
       let newLead = request.resource.data.get('leadUid', '');
@@ -2144,15 +1752,11 @@ service cloud.firestore {
         && plcUpdatedAtOk();
     }
 
-    // Slim, PII-FREE discovery mirror of each PLC root, server-written by the
-    // `mirrorPlcIndex` function (Decision 1.1 hardening). Powers the "PLCs in
-    // my building" directory WITHOUT exposing teacher emails/displayNames — it
-    // carries only name / orgId / buildingId / OPAQUE memberUids + count. Read
-    // by same-org peers (discovery), the PLC's own members, and admins; writes
-    // are SERVER-ONLY (the Admin SDK bypasses rules) so a client can never
-    // forge or tamper with a discovery entry. The full member PII stays gated
-    // to PLC members on the root doc (whose org-peer read branch was removed in
-    // favor of this mirror).
+    // Slim, PII-free discovery mirror of each PLC root, server-written by
+    // mirrorPlcIndex (Decision 1.1). Powers the "PLCs in my building" directory
+    // without exposing teacher emails/names — only name/orgId/buildingId/opaque
+    // memberUids + count. Read by same-org peers, members, and admins; writes are
+    // server-only so a client can't forge a discovery entry.
     match /plcIndex/{plcId} {
       allow read: if request.auth != null
         && (
@@ -2168,16 +1772,11 @@ service cloud.firestore {
     }
 
     match /plcs/{plcId} {
-      // Members + admins only. The root doc carries member PII (the `members`
-      // map's emails/displayNames and the `memberEmails` mirror), so it is
-      // NOT exposed to same-org peers: org discovery ("PLCs in my building",
-      // Decision 1.1) reads the slim, PII-free `/plcIndex/{plcId}` mirror
-      // (server-written by `mirrorPlcIndex`) instead of this root doc. The
-      // membership gate reads BOTH the canonical `members` map (Decision 1.2 —
-      // a uid keyed in `members` is a member) AND the denormalized `memberUids`
-      // index, so a PLC carrying either shape still authorizes its members
-      // during the rollout. Admins read so the admin PLC-resource push UI can
-      // enumerate PLCs to target.
+      // Members + admins only. The root doc carries member PII (emails/names), so
+      // it's NOT exposed to same-org peers — discovery reads the PII-free
+      // /plcIndex mirror instead. The gate reads BOTH the canonical members map
+      // and the denormalized memberUids index (either shape authorizes during
+      // rollout). Admins read for the PLC-resource push UI.
       allow read: if request.auth != null
         && (
           request.auth.uid in resource.data.get('members', {})
@@ -2185,13 +1784,10 @@ service cloud.firestore {
           || isAdmin()
         );
 
-      // The creating teacher is the lead and the only initial member. The
-      // canonical `members` map (Decision 1.2) must carry exactly that one uid
-      // at role 'lead' (active), and the denormalized indexes mirror it:
-      // memberUids == [uid] and leadUid == uid. Optional tenancy fields
-      // (`orgId` / `buildingId`, Decision 1.1) may be null or a string.
-      // createdAt/updatedAt accept a server `timestamp` OR a legacy `int`
-      // during the serverTimestamp rollout (dual-accept, §3.2).
+      // The creating teacher is the lead and only initial member: members map
+      // carries exactly that uid at role 'lead' (active), mirrored by
+      // memberUids == [uid] and leadUid == uid. Optional tenancy (orgId/
+      // buildingId) null or string; createdAt/updatedAt dual-accept timestamp||int.
       allow create: if request.auth != null
         && request.auth.uid == request.resource.data.leadUid
         && request.resource.data.memberUids == [request.auth.uid]
@@ -2220,35 +1816,20 @@ service cloud.firestore {
            );
 
       // Lead can rename, remove a member (named via `removeMemberUid`), or
-      // backfill tenancy — but cannot vacate leadership via this path (leadUid
-      // is immutable here, and the lead must stay in memberUids), and cannot
-      // mint a SECOND lead: `plcBroadMembersOk()` limits any `members` mutation
-      // on this branch to a single named removal, so role PROMOTIONS must go
-      // through `isChangingMemberRole` / `isTransferringPlcLead` (which guard
-      // the exactly-one-lead invariant). This blocks the lead from sneaking out
-      // through the broad lead-update branch and bypassing the
-      // "transfer leadership before leaving" intent of isLeavingPlc. The
-      // tenancy fields (`orgId`/`buildingId`) are immutable-after-set on this
-      // branch: once a non-null value is written it can't be changed (only
-      // null→value is allowed, e.g. the migration backfill), so a member can't
-      // re-home a PLC into another org's directory. All branches below are
-      // MUTUALLY EXCLUSIVE — each authorizes a disjoint write shape:
-      //   - broad sitting-lead update (rename / tenancy backfill / single-member
-      //     removal) — caller is the leadUid, leadUid immutable here;
-      //   - isAcceptingPlcInvite — a non-member self-adds via a pending invite;
+      // backfill tenancy — but can't vacate leadership here (leadUid immutable,
+      // lead stays in memberUids) and can't mint a second lead (plcBroadMembersOk
+      // limits members mutations to a single named removal; promotions go through
+      // isChangingMemberRole / isTransferringPlcLead). Tenancy (orgId/buildingId)
+      // is immutable-after-set (only null→value), so a member can't re-home the
+      // PLC. The update branches are MUTUALLY EXCLUSIVE, each a disjoint shape:
+      //   - broad sitting-lead update (rename / tenancy / single removal);
+      //   - isAcceptingPlcInvite — non-member self-adds via a pending invite;
       //   - isLeavingPlc — a non-lead member self-removes;
-      //   - isTransferringPlcLead — a lead/co-lead MEMBER moves the crown;
-      //   - isChangingMemberRole — a lead/co-lead MEMBER sets one member's role;
-      //   - isSettingPlcSharedSheetUrl — any member sets/clears the sheet URL;
-      //   - isUpdatingPlcFeatures — any member toggles the features map;
-      //   - isUpdatingPlcDigestOptIn — any member toggles the weekly-digest flag;
-      //   - isAdminManagingPlc — an in-org SITE ADMIN (NON-member) reassigns the
-      //     crown for recovery (Decision 3.4). This is the only branch that
-      //     authorizes a non-member write, and it requires `isAdmin()` +
-      //     same-org membership, which no ordinary member branch grants — so it
-      //     never overlaps the member branches.
-      // Non-leads can only self-add via accepted invite, self-remove, transfer
-      // (lead/co-lead), or change a single member's role (lead/co-lead).
+      //   - isTransferringPlcLead / isChangingMemberRole — lead/coLead MEMBER;
+      //   - isSettingPlcSharedSheetUrl / isUpdatingPlcFeatures /
+      //     isUpdatingPlcDigestOptIn — any member, narrow field;
+      //   - isAdminManagingPlc — in-org SITE ADMIN (non-member) recovery, the only
+      //     non-member branch (isAdmin() + same-org, never overlaps the rest).
       allow update: if request.auth != null && (
         (
           request.auth.uid == resource.data.leadUid
@@ -2257,9 +1838,8 @@ service cloud.firestore {
           && plcUpdatedAtOk()
           && plcTenancyImmutableAfterSet('orgId')
           && plcTenancyImmutableAfterSet('buildingId')
-          // Block minting a second lead on the only path that can rewrite
-          // arbitrary `members` entries (exactly-one-lead invariant, Dec 1.2):
-          // members changes here are limited to a single named removal.
+          // Block minting a second lead — members changes here are a single named
+          // removal only (exactly-one-lead invariant, Decision 1.2).
           && plcBroadMembersOk()
         )
         || isAcceptingPlcInvite(plcId)
@@ -2272,10 +1852,9 @@ service cloud.firestore {
         || isAdminManagingPlc()
       );
 
-      // The lead can dissolve the PLC. An in-org SITE ADMIN can also dissolve an
-      // abandoned PLC for recovery (Decision 3.4, §3.4) — gated to a PLC that
-      // carries an `orgId` matching an org the admin belongs to, so an admin can
-      // never reach into another org's PLC.
+      // The lead can dissolve the PLC; an in-org SITE ADMIN can also dissolve an
+      // abandoned PLC for recovery (Decision 3.4), gated to a PLC whose orgId
+      // matches an org the admin belongs to.
       allow delete: if request.auth != null
         && (
           request.auth.uid == resource.data.leadUid
@@ -2286,11 +1865,10 @@ service cloud.firestore {
           )
         );
 
-      // Index of PLC-mode assignments authored by any member. Each row is
-      // a small snapshot (title, ownerUid, sheetUrl, createdAt) written by
-      // the author when their personal `quiz_assignments` doc opts into
-      // PLC mode. Subcollection rather than a top-level collection so
-      // membership-gated reads are a one-line rule.
+      // Index of PLC-mode assignments authored by any member — a small snapshot
+      // (title, ownerUid, sheetUrl, createdAt) written by the author when their
+      // quiz_assignments doc opts into PLC mode. Subcollection so member-gated
+      // reads stay one-line.
       match /assignment_index/{assignmentId} {
         // Any current member can read the index — the dashboard renders
         // the same list for everyone in the PLC.
@@ -2299,33 +1877,14 @@ service cloud.firestore {
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Only the assignment author writes their own entries; doc id is
-        // forced to the source assignment id for easy join-back. The
-        // author must be a current PLC member — non-members can't fabricate
-        // entries pointing at someone else's assignment. Status mirroring
-        // (later phases) goes through the same `update` branch.
-        //
-        // Schema lock-down (`keys().hasOnly([...])`) keeps the doc shape
-        // closed so future readers can rely on the field set without
-        // defensive parsing of unexpected payloads.
-        //
-        // `sheetUrl` is pinned to the trusted Google Sheets domain — the
-        // dashboard renders this as a clickable link, so an unconstrained
-        // string would let a malicious member point teammates at a
-        // phishing URL through the dashboard. We can't pin to a single
-        // canonical PLC sheet because each assignment now gets its own
-        // unique sheet (per-assignment sheets, #1448), so the rule enforces
-        // the trusted host/path prefix instead. The client also validates
-        // `http(s)` before rendering — both layers stay (see PLC_ROADMAP).
-        //
-        // Create and update are split because the `update` branch must
-        // also check the *existing* `resource.data.ownerUid`. Without that
-        // extra check, a different PLC member could overwrite someone
-        // else's entry by simply setting `request.resource.data.ownerUid`
-        // to their own UID. The split also lets `update` enforce
-        // immutability on `id`, `ownerUid`, and `createdAt` so future
-        // status-mirroring writes (later phases) can't quietly retarget
-        // an entry to a different assignment or rewrite history.
+        // Author-only writes; doc id pinned to the source assignment id for
+        // join-back. Author must be a current PLC member (non-members can't
+        // fabricate entries for someone else's assignment). hasOnly([...]) locks
+        // the shape. sheetUrl is pinned to the trusted Google Sheets host/path
+        // (rendered as a clickable link, so an arbitrary string is a phishing
+        // vector; per-assignment sheets mean no single canonical URL). create/
+        // update are split so update can check the *existing* ownerUid (else a
+        // member could take over another's entry) and pin id/ownerUid/createdAt.
         allow create: if request.auth != null
           && request.auth.uid == request.resource.data.ownerUid
           && request.auth.uid in get(
@@ -2347,11 +1906,8 @@ service cloud.firestore {
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids
-          // Identity fields are immutable across the lifetime of the
-          // entry. Mutable fields are `status` (mirrored on pause /
-          // deactivate / reopen by the source assignment's owner) plus
-          // legacy mutable fields. The doc shape stays closed via
-          // `keys().hasOnly([...])`.
+          // Identity fields immutable; mutable: status (mirrored on pause/
+          // deactivate/reopen) + legacy fields. Shape closed via hasOnly([...]).
           && request.resource.data.id == resource.data.id
           && request.resource.data.ownerUid == resource.data.ownerUid
           && request.resource.data.createdAt == resource.data.createdAt
@@ -2364,26 +1920,17 @@ service cloud.firestore {
           && request.resource.data.status in ['active', 'paused', 'inactive']
           && request.resource.data.sheetUrl.matches('^https://docs[.]google[.]com/spreadsheets/.*$');
 
-        // Authors can clean up their own entries (e.g. if they delete the
-        // source assignment). No lead-override here — leads who want to
-        // sweep stale entries can ask the owner.
+        // Authors clean up their own entries. No lead-override — leads ask the
+        // owner to sweep stale entries.
         allow delete: if request.auth != null
           && request.auth.uid == resource.data.ownerUid;
       }
 
-      // PLC cross-teacher results aggregate. Replaces the
-      // Google-Sheet-backed `readPlcSheet` aggregation. Each (quiz, teacher)
-      // pair has exactly one contribution doc — auto-published by
-      // QuizResults when the owning teacher views her results. The PlcTab
-      // subscribes to this subcollection rather than reading the shared
-      // sheet, so a teacher's data shows up in the aggregate as soon as
-      // her client publishes, without an explicit "export" step.
-      //
-      // Doc id is `{quizId}_{teacherUid}` — the publishing teacher's
-      // *local* quizId (different across members for synced quizzes).
-      // Cross-teacher grouping happens via the `syncGroupId` field, not
-      // the key. Schema is locked with `keys().hasOnly([...])` so future
-      // readers can rely on the field set without defensive parsing.
+      // PLC cross-teacher results aggregate (replaces the Sheet-backed
+      // readPlcSheet). One contribution doc per (quiz, teacher), auto-published by
+      // QuizResults. Doc id `{quizId}_{teacherUid}` uses the publisher's *local*
+      // quizId; cross-teacher grouping is via syncGroupId, not the key. Shape
+      // locked via hasOnly([...]).
       match /contributions/{contribId} {
         function isPlcMember() {
           return request.auth != null
@@ -2392,22 +1939,15 @@ service cloud.firestore {
                ).data.memberUids;
         }
 
-        // OWNER-ONLY READ (FERPA boundary — PRD §3.6 step 2 / §9 PII risk).
-        // A contribution's `responses[]` embed `studentDisplayName` — raw,
-        // student-identifying PII. Only the owning teacher may read her own
-        // raw contribution. Every member-facing reader (Shared Data, Meeting
-        // Mode, Home) consumes the anonymized server-written `/aggregates`
-        // sibling instead (member-readable, PII-free). Tightened from the
-        // earlier `isPlcMember()` once all readers migrated to /aggregates
-        // (Wave 3) so a co-member can no longer read another teacher's raw
-        // student names. The owner's own named roster stays reachable via this
-        // self-read; cross-teacher rollups go through /aggregates.
+        // OWNER-ONLY READ (FERPA boundary — PRD §3.6/§9). responses[] embed raw
+        // studentDisplayName PII, so only the owning teacher reads her own raw
+        // contribution; every member-facing reader uses the PII-free /aggregates
+        // sibling. Tightened from isPlcMember() once readers migrated (Wave 3).
         allow read: if isPlcMember()
           && request.auth.uid == resource.data.teacherUid;
 
-        // Only the contributing teacher writes her own doc. Doc id is
-        // pinned to `{quizId}_{teacherUid}` so a member can't masquerade
-        // as another teacher by writing a doc with someone else's uid.
+        // Only the contributing teacher writes her own doc; id pinned to
+        // `{quizId}_{teacherUid}` so a member can't masquerade as another.
         allow create: if isPlcMember()
           && request.auth.uid == request.resource.data.teacherUid
           && contribId == request.resource.data.quizId + '_' + request.auth.uid
@@ -2426,12 +1966,9 @@ service cloud.firestore {
           && request.resource.data.responses is list
           && request.resource.data.updatedAt is number;
 
-        // Identity fields are immutable post-create. `quizId`,
-        // `syncGroupId`, and `teacherUid` are the keys the aggregate
-        // groups on — letting a teacher silently retarget her existing
-        // contribution to a different quiz would corrupt every viewer's
-        // aggregate. Mutable: questionsSnapshot, responses, teacherName,
-        // updatedAt.
+        // Identity immutable post-create: quizId/syncGroupId/teacherUid are the
+        // aggregate's grouping keys (retargeting would corrupt every viewer's
+        // rollup). Mutable: questionsSnapshot, responses, teacherName, updatedAt.
         allow update: if isPlcMember()
           && request.auth.uid == resource.data.teacherUid
           && request.auth.uid == request.resource.data.teacherUid
@@ -2449,30 +1986,20 @@ service cloud.firestore {
           && request.resource.data.responses is list
           && request.resource.data.updatedAt is number;
 
-        // A teacher can withdraw her own contribution (e.g. if she
-        // deletes the source assignment). Membership-gated to keep the
-        // policy consistent with read/create/update — every write to
-        // this subcollection requires the caller to currently be in the
-        // PLC. The doc-id pin (`{quizId}_{teacherUid}`) is asserted for
-        // defense-in-depth so a doc whose id doesn't match the canonical
-        // pattern (e.g. a migration-script write or an admin-tool entry)
-        // can't be deleted by a teacher whose uid happens to appear in
-        // `teacherUid`. Removed-member cleanup is the responsibility of
-        // the PLC removal flow, not the removed member's client.
+        // A teacher withdraws her own contribution, membership-gated (consistent
+        // with read/create/update). The id pin (`{quizId}_{teacherUid}`) is
+        // defense-in-depth so a non-canonical doc (migration/admin write) can't be
+        // deleted by a teacher whose uid happens to be in teacherUid.
         allow delete: if isPlcMember()
           && request.auth.uid == resource.data.teacherUid
           && contribId == resource.data.quizId + '_' + resource.data.teacherUid;
       }
 
-      // Anonymized per-assessment aggregates (Decisions 6.0 + 3.3). These are
-      // the member-readable, PII-free rollups of every teacher's contributions.
-      // Writes are SERVER-ONLY: the aggregation pipeline (`aggregatePlcAssessment`,
-      // Wave 3) and the one-shot `migratePlcs` skeleton seed write via the
-      // Admin SDK, which bypasses these rules. Clients may read (gated on PLC
-      // membership via BOTH the canonical `members` map and the denormalized
-      // `memberUids` index, mirroring the root-doc gate) but may NEVER create,
-      // update, or delete — so a member can't forge or tamper with an
-      // aggregate, and the raw-contribution PII boundary stays intact.
+      // Anonymized per-assessment aggregates (Decisions 6.0+3.3) — member-readable,
+      // PII-free rollups of every teacher's contributions. Writes are server-only
+      // (aggregatePlcAssessment + migratePlcs via Admin SDK). Members read (gated
+      // on members map OR memberUids); never create/update/delete, so the
+      // raw-contribution PII boundary holds.
       match /aggregates/{aggregateId} {
         function plcRootData() {
           return get(/databases/$(database)/documents/plcs/$(plcId)).data;
@@ -2486,33 +2013,22 @@ service cloud.firestore {
         allow create, update, delete: if false;
       }
 
-      // PLC Common Assessments (Decision 4.0c, §3.6). The team's first-class
-      // designated common assessment — a quiz or video-activity whose pooled
-      // results aggregate to ONE canonical id (`{plcId}/aggregates/{assessmentId}`),
-      // killing the old heuristic title-matching. PLC-owned: any current member
-      // can author, edit, or soft-delete an assessment (matching the
-      // quizzes/video_activities/assignments "shared-once-belongs-to-the-PLC"
-      // posture). Identity (`id`), authorship (`createdBy`, `createdAt`), the
-      // content `kind`, and the `syncGroupId` content pointer are all immutable
-      // post-create so a teammate's stale-mirror write can never retarget an
-      // assessment at a different sync group, flip quiz↔video-activity, or
-      // rewrite who created it (the aggregation pipeline groups raw
-      // contributions onto this `syncGroupId`).
-      //
-      // Schema lock-down (`keys().hasOnly([...])`) keeps the doc shape closed.
-      // The optional scheduling fields (`unitLabel`, `opensAt`, `dueAt`) and the
-      // `deletedAt` soft-delete tombstone (Decision 3.1) are validated when
-      // present; time fields dual-accept `int || timestamp` / null during the
-      // serverTimestamp rollout (§3.2).
+      // PLC Common Assessments (Decision 4.0c, §3.6) — a quiz/video-activity whose
+      // pooled results aggregate to one canonical id, replacing title-matching.
+      // PLC-owned: any non-viewer member authors/edits/soft-deletes. Identity (id),
+      // authorship (createdBy/createdAt), kind, and the syncGroupId pointer are
+      // immutable post-create (a stale mirror can't retarget the sync group or
+      // flip the kind). Shape locked via hasOnly([...]); optional scheduling
+      // (unitLabel/opensAt/dueAt) + deletedAt tombstone validated when present,
+      // time fields dual-accept int||timestamp||null.
       match /assessments/{assessmentId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Create: any non-viewer member, doc id pinned, createdBy must equal the
-        // caller. A viewer (Decision 3.2) is denied content writes via
-        // plcCanEditContent (reads stay open above).
+        // Create: any non-viewer member (plcCanEditContent — viewers denied), doc
+        // id pinned, createdBy == caller.
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2525,9 +2041,8 @@ service cloud.firestore {
           && request.resource.data.title is string
           && request.resource.data.kind in ['quiz', 'video-activity']
           && request.resource.data.syncGroupId is string
-          // Guard against an empty `syncGroupId` smuggling a broken stub past
-          // the rule — the aggregation pipeline keys on it. Defense-in-depth
-          // (the client also rejects empty strings).
+          // Non-empty syncGroupId (the aggregation pipeline keys on it);
+          // defense-in-depth, the client also rejects empty.
           && request.resource.data.syncGroupId.size() > 0
           && request.resource.data.status in [
                'planning', 'active', 'reviewing', 'closed'
@@ -2542,11 +2057,9 @@ service cloud.firestore {
           && plcSubTimeFieldOk('createdAt')
           && plcSubTimeFieldOk('updatedAt');
 
-        // Update: any non-viewer member can mutate the working fields (title,
-        // unitLabel, opensAt, dueAt, status, updatedAt) or soft-delete/restore
-        // via `deletedAt`. Identity (`id`), authorship (`createdBy`,
-        // `createdAt`), the content `kind`, and the `syncGroupId` pointer are
-        // immutable. A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Update: non-viewer member mutates working fields (title/unitLabel/
+        // opensAt/dueAt/status/updatedAt) or soft-deletes via deletedAt. Identity,
+        // createdBy/createdAt, kind, syncGroupId immutable; viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2572,13 +2085,9 @@ service cloud.firestore {
           && plcSubDeletedAtOk()
           && plcSubTimeFieldOk('updatedAt');
 
-        // Any non-viewer member can hard-delete an assessment (PLC-owned model —
-        // matches the quizzes/video_activities/assignments delete posture).
-        // Members typically soft-delete via `deletedAt`; a hard delete is the
-        // explicit "remove entirely" path. The orphaned
-        // `aggregates/{assessmentId}` doc (server-written) is swept by the
-        // Wave-4 `gcPlcOrphans` function. A viewer (Decision 3.2) is denied via
-        // plcCanEditContent.
+        // Non-viewer member can hard-delete (PLC-owned model). Soft-delete via
+        // deletedAt is typical; the orphaned aggregates/{assessmentId} doc is
+        // swept by gcPlcOrphans. Viewers denied via plcCanEditContent.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
@@ -2635,10 +2144,8 @@ service cloud.firestore {
           && plcSubTimeFieldOk('heldAt')
           && plcSubTimeFieldOk('updatedAt');
 
-        // Update: any non-viewer member can mutate the working fields or
-        // soft-delete / restore via `deletedAt`. Identity (`id`), authorship
-        // (`createdBy`), `heldAt`, and `facilitatorUid` are immutable. A viewer
-        // (Decision 3.2) is denied via plcCanEditContent.
+        // Update: non-viewer member mutates working fields or soft-deletes via
+        // deletedAt. id/createdBy/heldAt/facilitatorUid immutable; viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2666,40 +2173,26 @@ service cloud.firestore {
           && plcSubDeletedAtOk()
           && plcSubTimeFieldOk('updatedAt');
 
-        // Any non-viewer member can hard-delete a meeting record (PLC-owned
-        // model). Members typically soft-delete via `deletedAt`; tombstone GC is
-        // the Wave-4 `gcPlcOrphans` function's job. A viewer (Decision 3.2) is
-        // denied via plcCanEditContent.
+        // Non-viewer member can hard-delete (PLC-owned); soft-delete via deletedAt
+        // is typical, tombstone GC is gcPlcOrphans. Viewers denied.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
 
-      // PLC Quiz Library (Phase 2). Lightweight headers pointing at
-      // canonical `/synced_quizzes/{groupId}` docs — questions live there,
-      // not here. Any current PLC member can share a new quiz, edit any
-      // shared quiz's mirrored header (title/questionCount), or unshare.
-      // The orphan policy is "PLC copy stays" — deleting your personal
-      // copy of the source quiz does NOT cascade-delete the PLC entry.
-      //
-      // Schema lock-down (`keys().hasOnly([...])`) keeps the doc shape
-      // closed. Identity fields (`id`, `syncGroupId`, `sharedBy`,
-      // `sharedByEmail`, `sharedByName`, `sharedAt`) are immutable post-
-      // create so a different member can't quietly retarget the entry to
-      // a different sync group or rewrite attribution.
+      // PLC Quiz Library (Phase 2). Lightweight headers pointing at canonical
+      // /synced_quizzes/{groupId} docs (questions live there). Any member shares /
+      // mirror-edits (title/questionCount) / unshares; orphan policy "PLC copy
+      // stays". Shape locked via hasOnly([...]); identity + attribution
+      // (id/syncGroupId/sharedBy*/sharedAt) immutable post-create.
       match /quizzes/{plcQuizId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Create: any member, doc id pinned, sharedBy must equal caller.
-        // No content (questions) on this doc — those live in the synced
-        // group, which has its own rule layer.
-        // Schema widened in Wave 2 (§3.10): the optional `deletedAt` soft-delete
-        // tombstone (Decision 3.1). Optional so legacy entries keep validating;
-        // `keys().hasOnly([...])` still closes the doc shape.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: any non-viewer member (plcCanEditContent), doc id pinned,
+        // sharedBy == caller. Questions live in the synced group. Optional
+        // deletedAt tombstone (Decision 3.1); shape locked via hasOnly([...]).
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2713,9 +2206,7 @@ service cloud.firestore {
           && request.resource.data.questionCount is int
           && request.resource.data.questionCount >= 0
           && request.resource.data.syncGroupId is string
-          // Guard against an empty `syncGroupId` smuggling a broken stub
-          // entry past the rule. The Cloud Function rejects empty strings
-          // server-side too; pinning at the rule layer is defense-in-depth.
+          // Non-empty syncGroupId (defense-in-depth; the CF also rejects empty).
           && request.resource.data.syncGroupId.size() > 0
           && request.resource.data.sharedByEmail is string
           && request.resource.data.sharedByName is string
@@ -2723,11 +2214,9 @@ service cloud.firestore {
           && request.resource.data.updatedAt is int
           && plcSubDeletedAtOk();
 
-        // Update: any non-viewer member can mirror title/questionCount/updatedAt
-        // (e.g. after a peer publishes an edit) or soft-delete/restore via
-        // `deletedAt`. Identity + attribution fields are immutable so
-        // stale-mirror writes can't quietly retarget the entry or rewrite who
-        // shared it. A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Update: non-viewer member mirrors title/questionCount/updatedAt or
+        // soft-deletes via deletedAt. Identity + attribution immutable; viewers
+        // denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2747,35 +2236,24 @@ service cloud.firestore {
           && request.resource.data.updatedAt is int
           && plcSubDeletedAtOk();
 
-        // Any non-viewer member can unshare. Matches the "PLC-owned" model — a
-        // quiz shared with the PLC belongs to the PLC, not the original sharer.
-        // A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Non-viewer member can unshare (PLC-owned model); viewers denied.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
 
-      // PLC Video Activity Library (Phase 4). Mirrors the Phase 2 quiz
-      // library above — lightweight headers pointing at canonical
-      // `/synced_video_activities/{groupId}` docs. Any current member can
-      // share / edit-mirror / unshare. Orphan policy: deleting your
-      // personal copy does NOT cascade-delete the PLC entry.
-      //
-      // Extra field over the quiz block: `youtubeUrl` (mirrored from
-      // source; used for tile thumbnail rendering). All other identity +
-      // attribution invariants are identical.
+      // PLC Video Activity Library (Phase 4). Mirrors the quiz library —
+      // headers pointing at /synced_video_activities/{groupId}. Any member
+      // shares/mirror-edits/unshares; orphan policy "PLC copy stays". Extra field
+      // vs quizzes: youtubeUrl (tile thumbnail); other invariants identical.
       match /video_activities/{plcVideoActivityId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Create: any member, doc id pinned, sharedBy must equal caller.
-        // Questions live in the synced group, not on this doc.
-        // Schema widened in Wave 2 (§3.10): the optional `deletedAt` soft-delete
-        // tombstone (Decision 3.1). Optional so legacy entries keep validating;
-        // `keys().hasOnly([...])` still closes the doc shape.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: non-viewer member (plcCanEditContent), doc id pinned, sharedBy ==
+        // caller. Questions live in the synced group. Optional deletedAt tombstone;
+        // shape locked via hasOnly([...]).
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2790,9 +2268,7 @@ service cloud.firestore {
           && request.resource.data.questionCount is int
           && request.resource.data.questionCount >= 0
           && request.resource.data.syncGroupId is string
-          // Guard against an empty `syncGroupId` smuggling a broken stub.
-          // The Cloud Function rejects empty strings server-side too;
-          // pinning at the rule layer is defense-in-depth.
+          // Non-empty syncGroupId (defense-in-depth; the CF also rejects empty).
           && request.resource.data.syncGroupId.size() > 0
           && request.resource.data.sharedByEmail is string
           && request.resource.data.sharedByName is string
@@ -2800,11 +2276,9 @@ service cloud.firestore {
           && request.resource.data.updatedAt is int
           && plcSubDeletedAtOk();
 
-        // Update: any non-viewer member can mirror title/questionCount/
-        // youtubeUrl/updatedAt or soft-delete/restore via `deletedAt`. Identity
-        // + attribution fields are immutable so stale-mirror writes can't
-        // retarget the entry or rewrite who shared it. A viewer (Decision 3.2)
-        // is denied via plcCanEditContent.
+        // Update: non-viewer member mirrors title/questionCount/youtubeUrl/
+        // updatedAt or soft-deletes via deletedAt. Identity + attribution
+        // immutable; viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2825,39 +2299,26 @@ service cloud.firestore {
           && request.resource.data.updatedAt is int
           && plcSubDeletedAtOk();
 
-        // Any non-viewer member can unshare. Matches the PLC-owned model — once
-        // shared, the entry belongs to the PLC, not the original sharer. A
-        // viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Non-viewer member can unshare (PLC-owned model); viewers denied.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
 
-      // PLC-authored Assignments (Phase 3). Templates that any member can
-      // pick up onto their own board. Each template points at a canonical
-      // `synced_quizzes/{groupId}` doc (importers pull content from there
-      // since the source quiz lives only in the author's Drive).
-      //
-      // Posture mirrors the PLC Quiz Library above — any current member
-      // can author, mirror updates, or unshare. Identity + attribution
-      // fields are immutable post-create so a teammate can't quietly
-      // retarget an entry or rewrite who shared it.
-      //
-      // Orphan policy: deleting a template does NOT cascade to teammates'
-      // already-imported personal assignments — those are independent
-      // assignment + session docs after import.
+      // PLC-authored Assignments (Phase 3). Templates any member can pick up onto
+      // their board, pointing at a canonical synced_quizzes/{groupId} (content
+      // lives there). Posture mirrors the Quiz Library — any member authors /
+      // mirror-updates / unshares; identity + attribution immutable. Orphan
+      // policy: deleting a template doesn't cascade to already-imported personal
+      // assignments.
       match /assignments/{plcAssignmentId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Create: any member, doc id pinned, sharedBy must equal caller.
-        // Session config is opaque to the rule — `sessionOptions` is a map
-        // and its keys vary by session mode. We pin shape via top-level
-        // `keys().hasOnly([...])` and lean on the importer's own client
-        // validation for individual option fields.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: non-viewer member (plcCanEditContent), doc id pinned, sharedBy ==
+        // caller. sessionOptions is an opaque map (keys vary by mode); shape pinned
+        // via hasOnly([...]), per-field validation is client-side.
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2882,11 +2343,8 @@ service cloud.firestore {
           && request.resource.data.sharedAt is int
           && request.resource.data.updatedAt is int;
 
-        // Update: any non-viewer member can mirror title/sessionOptions/
-        // updatedAt (e.g. if the author later edits the template). Identity +
-        // attribution fields are immutable so stale-mirror writes can't
-        // quietly retarget the entry or rewrite who shared it. A viewer
-        // (Decision 3.2) is denied via plcCanEditContent.
+        // Update: non-viewer member mirrors title/sessionOptions/updatedAt.
+        // Identity + attribution immutable; viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2909,32 +2367,24 @@ service cloud.firestore {
                 || request.resource.data.attemptLimit is int)
           && request.resource.data.updatedAt is int;
 
-        // Any non-viewer member can unshare a template. Already-imported
-        // personal assignments on teammates' boards keep running (independent
-        // docs). A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Non-viewer member can unshare; already-imported personal assignments
+        // keep running (independent docs). Viewers denied.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
 
-      // PLC shared notes (Phase 5). Lightweight collaborative notebook —
-      // any current member can CRUD any note. LWW on edits via the
-      // `lastEditedBy` / `lastEditedAt` snapshot on each write. Schema
-      // is locked so future readers can rely on the field set.
+      // PLC shared notes (Phase 5). Collaborative notebook — any member CRUDs any
+      // note; LWW via lastEditedBy/lastEditedAt. Shape locked via hasOnly([...]).
       match /notes/{noteId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Schema widened in Wave 2 (§3.8): structured meeting notes add the
-        // optional `kind` ('freeform' | 'meeting') + `meetingId` link, the
-        // optimistic-concurrency `version` counter (Decision 2.4), and the
-        // `deletedAt` soft-delete tombstone (Decision 3.1). All four are
-        // OPTIONAL so legacy notes (and clients that haven't shipped the new
-        // fields) keep validating; `keys().hasOnly([...])` still closes the
-        // doc shape against unknown fields.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: non-viewer member (plcCanEditContent). Optional fields: kind
+        // ('freeform'|'meeting'), meetingId, version (Decision 2.4), deletedAt
+        // tombstone — all OPTIONAL so legacy notes validate; hasOnly([...]) closes
+        // the shape.
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -2967,20 +2417,11 @@ service cloud.firestore {
           && plcSubTimeFieldOk('createdAt')
           && plcSubTimeFieldOk('lastEditedAt');
 
-        // Update: any current member can edit any note. createdBy /
-        // createdAt / id are immutable — they describe who first authored
-        // the note and shouldn't be rewritten by later editors. The
-        // editor must stamp themselves into `lastEditedBy` so the audit
-        // trail is honest.
-        //
-        // Optimistic concurrency (Decision 2.4): the incoming `version` must be
-        // exactly `oldVersion + 1` (a stale writer who fetched an older copy
-        // bumps to a number that no longer equals old+1, so the write is
-        // rejected and the client raises the conflict toast — mirroring the
-        // `synced_quizzes` version posture). During rollout, an update where
-        // BOTH the stored and incoming docs omit `version` is also accepted so
-        // un-migrated notes keep saving until every client writes the field.
-        // A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Update: any non-viewer member edits any note; id/createdBy/createdAt
+        // immutable, editor stamps lastEditedBy. Optimistic concurrency (Decision
+        // 2.4): incoming version must be old+1 (stale writer is rejected → conflict
+        // toast); during rollout both-absent version is also accepted. Viewers
+        // denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -3019,9 +2460,8 @@ service cloud.firestore {
                )
              );
 
-        // Any non-viewer member can delete (matches the "shared notebook" model
-        // — notes are PLC-owned, not creator-owned). A viewer (Decision 3.2) is
-        // denied via plcCanEditContent.
+        // Non-viewer member can delete (PLC-owned, not creator-owned); viewers
+        // denied.
         allow delete: if request.auth != null
           && plcCanEditContent(plcId);
       }
@@ -3034,11 +2474,8 @@ service cloud.firestore {
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Schema widened in Wave 2 (§3.10): docs add the optional `deletedAt`
-        // soft-delete tombstone (Decision 3.1). Optional so legacy docs keep
-        // validating; `keys().hasOnly([...])` still closes the doc shape.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: non-viewer member (plcCanEditContent). Optional deletedAt
+        // tombstone; shape locked via hasOnly([...]).
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -3076,23 +2513,17 @@ service cloud.firestore {
           && plcCanEditContent(plcId);
       }
 
-      // PLC shared to-do list (Phase 5). One doc per todo so concurrent
-      // toggles don't serialize on a single parent doc. Any current
-      // member can CRUD any todo.
+      // PLC shared to-do list (Phase 5). One doc per todo (concurrent toggles
+      // don't serialize). Any member CRUDs any todo.
       match /todos/{todoId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
                /databases/$(database)/documents/plcs/$(plcId)
              ).data.memberUids;
 
-        // Schema widened in Wave 2 (§3.9): to-dos add the optional
-        // `assigneeUid` (member this is assigned to), `dueAt` (due date),
-        // `meetingId` (provenance from a meeting action item — Decision 3.9),
-        // and `deletedAt` soft-delete tombstone (Decision 3.1). All four are
-        // OPTIONAL so legacy to-dos keep validating; `keys().hasOnly([...])`
-        // still closes the doc shape.
-        // A viewer (Decision 3.2) is denied content writes via plcCanEditContent
-        // (reads stay open above).
+        // Create: non-viewer member (plcCanEditContent). Optional: assigneeUid,
+        // dueAt, meetingId (Decision 3.9), deletedAt tombstone — all OPTIONAL so
+        // legacy to-dos validate; hasOnly([...]) closes the shape.
         allow create: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -3121,11 +2552,9 @@ service cloud.firestore {
           && plcSubDeletedAtOk()
           && plcSubTimeFieldOk('createdAt');
 
-        // Update: createdBy / createdAt / id are immutable. `done`, `text`,
-        // `assigneeUid`, `dueAt`, `meetingId`, and `deletedAt` are mutable so
-        // any non-viewer teammate can mark a todo complete, tweak the wording,
-        // (re)assign it, set a due date, link it to a meeting, or soft-delete/
-        // restore it. A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Update: id/createdBy/createdAt immutable; done/text/assigneeUid/dueAt/
+        // meetingId/deletedAt mutable (any non-viewer can complete, edit, assign,
+        // schedule, link, or soft-delete). Viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -3159,18 +2588,11 @@ service cloud.firestore {
           && plcCanEditContent(plcId);
       }
 
-      // PLC presence (Decision 2.1, §3.3). Coarse per-section "who's here":
-      // each member maintains their OWN doc (id == their uid), heartbeating
-      // `lastActiveAt` on a ~45s cadence while the dashboard is open. Any
-      // member may read every presence doc (that's the whole point of the
-      // "who's here" strip); a member may only write the doc keyed to their
-      // own uid (`presenceUid == request.auth.uid`), so nobody can spoof a
-      // teammate's presence. Schema is locked via `keys().hasOnly([...])`;
-      // `lastActiveAt` dual-accepts `int || timestamp` during the
-      // serverTimestamp rollout (§3.2). Stale-presence garbage collection
-      // (docs older than ~5 min) is DEFERRED to the Wave-4 `gcPlcOrphans`
-      // scheduled function (Admin SDK) — these rules govern only the
-      // member-owned heartbeat writes, never the GC sweep.
+      // PLC presence (Decision 2.1, §3.3). Per-section "who's here": each member
+      // heartbeats their OWN doc (id == uid) ~45s. Any member reads all presence
+      // docs; a member writes only their own (presenceUid == auth.uid), so nobody
+      // spoofs a teammate. Shape locked via hasOnly([...]); lastActiveAt
+      // dual-accepts int||timestamp. Stale-doc GC is gcPlcOrphans, not these rules.
       match /presence/{presenceUid} {
         allow read: if request.auth != null
           && request.auth.uid in get(
@@ -3198,17 +2620,11 @@ service cloud.firestore {
           && request.auth.uid == presenceUid;
       }
 
-      // PLC activity log (Decision 2.2, §3.4). Append-only feed of materialized
-      // events written fire-and-forget from the mutation paths. Any current
-      // member may read (the "since you were here" digest + sidebar badge);
-      // any current member may CREATE an event, but ONLY one whose `actorUid`
-      // equals their own uid (no forging another teammate's actions). Clients
-      // may NEVER update or delete an event — the log is immutable from the
-      // client; bounded trimming (events older than ~90 days) is DEFERRED to
-      // the Wave-4 `gcPlcOrphans` scheduled function (Admin SDK), which bypasses
-      // these rules. Schema is locked via `keys().hasOnly([...])`; `type` is
-      // pinned to the closed `PlcActivityType` union; the optional `targetType`
-      // / `targetId` / `targetTitle` fields are validated when present.
+      // PLC activity log (Decision 2.2, §3.4). Append-only event feed written
+      // fire-and-forget. Any member reads; any member creates an event but only
+      // one whose actorUid == their uid (no forging). Clients never update/delete
+      // (immutable; ~90d trimming is gcPlcOrphans). Shape locked via hasOnly([...]);
+      // type pinned to the PlcActivityType union; optional target* validated.
       match /activity/{eventId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
@@ -3251,17 +2667,11 @@ service cloud.firestore {
         allow update, delete: if false;
       }
 
-      // PLC comments + @mentions (Decision 2.6, §3.5). Scoped comments that
-      // start on Shared Data result cards (`targetType: 'dataCard'`) and extend
-      // to assessments/notes. Any current member may read all comments. Create:
-      // any member, but `authorUid` must equal the caller (no impersonation),
-      // doc id pinned to `commentId`, schema locked. Update is limited to the
-      // mutable surface — the AUTHOR may edit `body`/`editedAt` and/or soft-
-      // delete via `deletedAt`; ANY member may flip `deletedAt` (tidy-up soft-
-      // delete posture). Identity fields (`id`, `targetType`, `targetId`,
-      // `authorUid`, `authorName`, `createdAt`, `mentions`) are immutable on
-      // update. `mentions` is a list of member uids. Hard-deletion of tombstoned
-      // comments is DEFERRED to the Wave-4 `gcPlcOrphans` function.
+      // PLC comments + @mentions (Decision 2.6, §3.5). Scoped to dataCard /
+      // assessment / note targets. Any member reads. Create: any member, authorUid
+      // == caller, id pinned, schema locked. Update: author may edit body/editedAt
+      // and/or soft-delete; any member may flip deletedAt; identity/attribution/
+      // targeting/mentions immutable. Hard-delete is gcPlcOrphans.
       match /comments/{commentId} {
         allow read: if request.auth != null
           && request.auth.uid in get(
@@ -3293,11 +2703,9 @@ service cloud.firestore {
           && plcSubDeletedAtOk()
           && plcSubTimeFieldOk('createdAt');
 
-        // Update: identity + attribution + targeting + mentions are immutable.
-        // The author may edit body/editedAt and/or soft-delete; any non-viewer
-        // member may soft-delete (flip `deletedAt`). The edit gate +
-        // immutability pins together mean a non-author can only ever change
-        // `deletedAt`. A viewer (Decision 3.2) is denied via plcCanEditContent.
+        // Update: identity/attribution/targeting/mentions immutable. Author edits
+        // body/editedAt and/or soft-deletes; any non-viewer may flip deletedAt (a
+        // non-author can only ever change deletedAt). Viewers denied.
         allow update: if request.auth != null
           && plcCanEditContent(plcId)
           && request.resource.data.keys().hasOnly([
@@ -3337,9 +2745,8 @@ service cloud.firestore {
     }
 
     match /plc_invitations/{inviteId} {
-      // Invitee can see their own pending/terminal invites; lead sees the
-      // ones they sent. Both are needed for the sidebar UI to render
-      // "Pending invites" and "Outstanding invitations" panels.
+      // Invitee sees their own invites; the inviter sees the ones they sent (for
+      // the sidebar "Pending invites" / "Outstanding invitations" panels).
       allow read: if request.auth != null
         && request.auth.token.get('email', '') != ''
         && (
@@ -3367,12 +2774,9 @@ service cloud.firestore {
              'invitedByName', 'invitedAt', 'status', 'orgId'
            ]);
 
-      // Invitee can patch only status + respondedAt to mark accepted/declined.
-      // Status must transition *from* 'pending' *to* a terminal state — this
-      // blocks resurrecting a terminal invite back to 'pending' or setting
-      // it to an arbitrary string.
-      // Note: the invitee never deletes the invite — the lead can revoke it,
-      // and accepted invites are kept for audit (the sidebar filters to pending).
+      // Invitee patches only status + respondedAt to accept/decline. Status must
+      // go pending → terminal (no resurrecting to pending or arbitrary strings).
+      // The invitee never deletes; the lead revokes, accepted invites kept for audit.
       allow update: if request.auth != null
         && request.auth.token.get('email', '') != ''
         && resource.data.inviteeEmailLower == request.auth.token.email.lower()
@@ -3380,10 +2784,8 @@ service cloud.firestore {
         && request.resource.data.status in ['accepted', 'declined']
         && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'respondedAt']);
 
-      // Lead can revoke (delete) outstanding invites. The inviter can also
-      // always delete their own invites — same semantic, plus it lets the
-      // lead clean up any orphans should the parent PLC ever go missing
-      // (the get() below would otherwise fail on a deleted parent).
+      // Lead/co-lead can revoke (delete) invites; the inviter can always delete
+      // their own (also cleans up orphans if the parent PLC is gone).
       allow delete: if request.auth != null
         && (
           request.auth.uid == resource.data.invitedByUid
@@ -3424,33 +2826,13 @@ service cloud.firestore {
     // owns the document and stores their uid on the `teacherUid` field.
     // Multiple concurrent sessions per teacher are allowed.
     match /quiz_sessions/{sessionId} {
-      // Reads are intentionally permissive: any authenticated caller can
-      // `get` and `list` session documents. PR #1390 split this into
-      // `get`/`list` and kept a `resource.data`-based studentRole class gate
-      // on `get`, on the theory that `get` rules have `resource.data`
-      // available at evaluation time. Empirically that still denied teacher
-      // single-doc subscriptions after a paused→active transition, breaking
-      // the Start flow; removing the `resource.data` reference unblocks it
-      // without widening enumeration beyond what the list rule already
-      // allows.
-      //
-      // studentRole (ClassLink-via-Google SSO) class gating is now enforced
-      // exclusively on the response write rules below, which dereference
-      // the parent session's `classId` via a runtime `get()` — a per-write
-      // fetch, not a predicate the analyzer has to reason about ahead of
-      // time. Students can see session metadata by id but cannot submit a
-      // response to a session outside their classIds claim.
-      //
-      // Restricting enumeration further would require a Cloud Function
-      // proxy; for now we accept that any authenticated user can read
-      // session documents (matches the pre-SSO behavior).
-      //
-      // Privacy impact: any authenticated user who knows a sessionId (a
-      // v4 UUID — unguessable in practice) can read `code`, `classId`,
-      // `publicQuestions` (answer-key-stripped by schema — see types.ts
-      // `QuizPublicQuestion`), and `revealedAnswers` (populated only when
-      // the teacher has intentionally broadcast a reveal). No PII fields
-      // live on the session doc itself.
+      // Reads are intentionally permissive: any authed caller can get/list session
+      // docs. studentRole class gating is enforced on the response WRITE rules
+      // below (runtime get() of the parent classId), not on read — students see
+      // session metadata by id but can't submit outside their classIds. Tighter
+      // enumeration would need a CF proxy. Privacy: a sessionId is an unguessable
+      // v4 UUID; the doc exposes only code/classId/publicQuestions (answer-key
+      // stripped) /revealedAnswers — no PII.
       allow read: if request.auth != null;
       // Only the teacher (session owner) can create/update/delete the session document.
       // Ownership is carried on the `teacherUid` field (no longer the doc id).
@@ -3460,26 +2842,12 @@ service cloud.firestore {
         resource.data.teacherUid == request.auth.uid;
 
       match /responses/{responseKey} {
-        // Quiz response records store only a PIN — no student name or email.
-        //
-        // Doc-keying note: {responseKey} is no longer guaranteed to equal the
-        // student's auth uid. For studentRole (SSO) joiners it still does;
-        // for anonymous PIN joiners it is `pin-{classPeriod}-{pin}` so the
-        // attempt limit survives device/storage resets. Ownership checks
-        // therefore compare against the `studentUid` field on the doc, not
-        // against the wildcard key.
-        //
-        // Teacher ownership is looked up from the parent session doc because
-        // the sessionId is no longer the teacher's uid. This adds one get()
-        // per response write (~50ms, $0 at class scale).
-        //
-        // Read-count optimization (LO4): all of the session field helpers
-        // below derive from the SAME parent session doc. Instead of each
-        // helper issuing its own get() on quiz_sessions/$(sessionId), they all
-        // read off a single sessionData() snapshot. This mirrors the
-        // orgMember() precedent above (one get().data, fields via .get()).
-        // Authorization behavior is unchanged — only the document-read count
-        // per request is reduced.
+        // Quiz response records store only a PIN — no name/email. {responseKey}
+        // equals the student uid for SSO joiners, or `pin-{classPeriod}-{pin}` for
+        // anonymous joiners (so the attempt cap survives storage resets), so
+        // ownership compares the `studentUid` field, not the key. Teacher ownership
+        // is read from the parent session doc. LO4: all session-field helpers below
+        // read off ONE sessionData() snapshot (fewer reads, same authorization).
         function sessionData() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data;
         }
@@ -3497,77 +2865,46 @@ service cloud.firestore {
         function sessionMode() {
           return sessionData().get('mode', 'submissions');
         }
-        // Server-side attempt cap. The client also enforces this in the
-        // join + submit transactions; the rule is the last line of defense
-        // against a race, a buggy client, or a hostile caller. Returns
-        // null when the session has no cap (legacy or explicitly unlimited).
+        // Server-side attempt cap (last line of defense vs a race/buggy/hostile
+        // client; the client also enforces it). null = no cap.
         function sessionAttemptLimit() {
           return sessionData().get('attemptLimit', null);
         }
 
-        // Student branch allows `resource == null` so the student-app join
-        // flow can call getDoc() to probe whether a response already exists
-        // before deciding to create or resume — without it the rules engine
-        // throws a Null value error on `resource.data.studentUid`. The
-        // class-gate check is kept as a hard prerequisite so a studentRole
-        // user can't probe responses in a session they're not enrolled in
-        // (anonymous PIN users pass the gate by definition, matching the
-        // legacy "any authenticated joiner can probe" behavior).
+        // Student branch allows resource == null so the join flow can probe via
+        // getDoc() before create/resume (else a Null-value throw on studentUid).
+        // The class gate stays a hard prerequisite so a studentRole user can't
+        // probe a session they're not enrolled in (anon PIN passes by definition).
         allow read: if request.auth != null && (
           request.auth.uid == sessionTeacherUid() ||
           isAdmin() ||
           (passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            (resource == null || request.auth.uid == resource.data.studentUid))
         );
-        // Create is only ever invoked when the doc doesn't yet exist
-        // (Firestore semantics), so the deterministic response key naturally
-        // enforces one-doc-per-roster-student. Field-based ownership: the
-        // writer's auth.uid must match the `studentUid` they're writing.
-        //
-        // Key-format constraint: with deterministic keys any authenticated
-        // roster-mate who knows PIN+period could otherwise grief-create a
-        // victim's doc under an arbitrary key. We tighten this by requiring:
-        //   - studentRole (SSO) writers use `responseKey == auth.uid` (the
-        //     same key scheme the client computes for them).
-        //   - Anonymous (PIN) writers use a key matching the shape
-        //     `pin-{encodedPeriod}-{encodedPin}` with `[a-z0-9_]` segments.
-        //     This mirrors `encodeResponseKeySegment()` on the client.
-        // Classmate-on-classmate grief with both parties on the same
-        // PIN+period is not fully preventable here (shared-secret design);
-        // the cross-auth-type paths are now closed.
+        // Create runs only when the doc is absent, so the deterministic key gives
+        // one-doc-per-roster-student. Field ownership: auth.uid == studentUid. Key
+        // format: SSO writers use responseKey == auth.uid; anon PIN writers use
+        // `pin-{encodedPeriod}-{encodedPin}` ([a-z0-9_] segments, mirroring
+        // encodeResponseKeySegment). Same-PIN+period classmate grief isn't fully
+        // preventable (shared secret); cross-auth-type paths are closed.
         allow create: if request.auth != null &&
           request.resource.data.studentUid == request.auth.uid &&
-          // If `lastWriteAt` is supplied, it must be server-stamped
-          // (`serverTimestamp()` from the SDK resolves to `request.time`
-          // at rule evaluation). Optional to keep the rule tolerant of
-          // legacy joins / test fixtures that don't carry the field;
-          // the worst case is the doc never appears in the idle
-          // auto-submit sweep (teacher-visible, manually cleanable) —
-          // not data loss.
+          // If supplied, lastWriteAt must be server-stamped (== request.time).
+          // Optional (legacy joins/fixtures); worst case it's missed by the idle
+          // auto-submit sweep, not data loss.
           (request.resource.data.get('lastWriteAt', null) == null ||
            request.resource.data.lastWriteAt == request.time) &&
           // Students cannot forge a score on creation
           request.resource.data.score == null &&
           // Students cannot forge prior completions
           request.resource.data.get('completedAttempts', 0) == 0 &&
-          // Students cannot forge a `preSyncVersion` other than 0 — the
-          // field is initialized to 0 by the client at create time so
-          // `syncAssignmentToLatest` can run a server-side
-          // `where('preSyncVersion', '==', 0)` query that catches the
-          // row. A malicious student submitting `preSyncVersion: 999`
-          // would silently dodge that query and never get tagged.
-          // Tags are written by the teacher on sync, never by the
-          // student.
+          // preSyncVersion must be 0 at create so syncAssignmentToLatest's
+          // where('preSyncVersion','==',0) query catches the row; a forged value
+          // (e.g. 999) would dodge sync tagging. Tags are teacher-written.
           request.resource.data.get('preSyncVersion', 0) == 0 &&
-          // Block forgery of teacher-only / cron-only fields at create
-          // time. A malicious join payload could otherwise include
-          // `autoSubmitted: true` (cron signal), `unlocked: true`
-          // (teacher signal — would trip the rejoin resume-unlocked
-          // branch), `unlockedAt`, or forged `grading.*` (teacher
-          // grading data). Explicitly deny these rather than maintain
-          // an exhaustive allowlist — the UPDATE rule already has a
-          // hasOnly whitelist that's the source of truth for the
-          // student's mutable surface.
+          // Block forging teacher/cron-only fields at create (autoSubmitted,
+          // unlocked, unlockedAt, grading.*). Explicit denials; the UPDATE rule's
+          // hasOnly whitelist is the source of truth for the student's surface.
           request.resource.data.get('autoSubmitted', null) == null &&
           request.resource.data.get('unlocked', null) == null &&
           request.resource.data.get('unlockedAt', null) == null &&
@@ -3582,22 +2919,12 @@ service cloud.firestore {
         allow update: if request.auth != null && (
           // Teacher and admins can update any field
           request.auth.uid == sessionTeacherUid() || isAdmin() ||
-          // Students may only update their own response to submit answers
-          // or to re-join under the attempt cap. Ownership is enforced
-          // against the `studentUid` field, not the doc key (which may be
-          // pin-derived for anonymous joiners).
-          //
-          // Mutable fields: answers, status, submittedAt, tabSwitchWarnings,
-          // completedAttempts, classPeriod, score (score is reset to null on
-          // rejoin; students still can't forge a real score — see below).
-          // pin and join metadata are immutable.
-          //
-          // Monotonic fields (prevent rollback tampering): tabSwitchWarnings
-          // and completedAttempts may only stay the same or increase.
-          //
-          // Score guard: students may only ever write null to `score` — this
-          // blocks a forged high score while still allowing the rejoin reset
-          // flow to clear a previously null value to null.
+          // Students update only their own response (ownership via studentUid, not
+          // the key) to submit answers or rejoin under the cap. Mutable: answers,
+          // status, submittedAt, tabSwitchWarnings, completedAttempts, classPeriod,
+          // score (reset to null on rejoin). pin/join metadata immutable.
+          // Monotonic (no rollback): tabSwitchWarnings, completedAttempts.
+          // Score guard: students may only ever write null to score.
           (request.auth.uid == resource.data.studentUid &&
            passesStudentClassGateCompat(sessionClassIds(), sessionClassId()) &&
            request.resource.data.studentUid == resource.data.studentUid &&
@@ -3683,24 +3010,14 @@ service cloud.firestore {
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['resultsLockedOut']) ||
             (resource.data.get('resultsLockedOut', false) == false ||
              request.resource.data.get('resultsLockedOut', false) == true)) &&
-           // Attempt-cap enforcement. completedAttempts may not exceed the
-           // session's attemptLimit. attemptLimit == null means unlimited.
-           // Without this rule a hostile client could call completeQuiz N
-           // times and increment the counter past the cap.
+           // Attempt-cap: completedAttempts ≤ attemptLimit (null = unlimited),
+           // else a hostile client could increment past the cap.
            (sessionAttemptLimit() == null ||
             request.resource.data.get('completedAttempts', 0) <= sessionAttemptLimit()) &&
-           // Status-transition gate: students cannot re-complete an
-           // already-completed response. Submitting transitions
-           // 'joined'/'in-progress' → 'completed'; rejoining-under-cap
-           // transitions 'completed' → 'joined' (still allowed by this
-           // rule because the new status is not 'completed'). The case
-           // this blocks is 'completed' → 'completed', which only happens
-           // via a race or bug.
-           //
-           // Only fires when the update actually touches `status`. Writes
-           // that leave status alone (tab-warning increments during the
-           // quiz, results-protection writes after publish) need to be
-           // allowed even when the doc is already in the 'completed' state.
+           // Status-transition gate: blocks 'completed' → 'completed' (re-complete
+           // via race/bug). Submitting goes joined/in-progress → completed; rejoin
+           // goes completed → joined. Only fires when the update touches status, so
+           // status-untouched writes pass even on an already-completed doc.
            (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['status']) ||
             resource.data.get('status', '') != 'completed' ||
             request.resource.data.get('status', '') != 'completed'))
@@ -3708,15 +3025,10 @@ service cloud.firestore {
         allow delete: if request.auth != null &&
           (request.auth.uid == sessionTeacherUid() || isAdmin());
 
-        // Append-only snapshot log of overwritten answers. Each entry
-        // captures a prior `answers[i]` value the moment before it gets
-        // replaced in the parent response doc — see `submitAnswer` in
-        // `useQuizSession.ts`. Used to recover student text lost to a
-        // race (stray blank draft after a hydration miss) or to a
-        // student retyping over their own work after a lockout. Writes
-        // are throttled per-question on the client; the rule still
-        // pins the doc shape so a hostile authenticated user can't
-        // dump arbitrary data into the subcollection.
+        // Append-only snapshot log of overwritten answers — captures a prior
+        // answers[i] before it's replaced (see submitAnswer in useQuizSession.ts),
+        // to recover text lost to a race or post-lockout retype. Throttled on the
+        // client; the rule pins the doc shape against arbitrary dumps.
         match /history/{historyId} {
           function parentStudentUid() {
             return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)/responses/$(responseKey)).data.studentUid;
@@ -3727,9 +3039,8 @@ service cloud.firestore {
             request.auth.uid == sessionTeacherUid() ||
             request.auth.uid == parentStudentUid()
           );
-          // Create: only the owning student of the parent response.
-          // Field shape is strict so a malicious caller can't smuggle
-          // fields; `snapshotAt == request.time` forces server stamping.
+          // Create: only the owning student of the parent response; strict shape;
+          // snapshotAt == request.time forces server stamping.
           allow create: if request.auth != null &&
             request.auth.uid == parentStudentUid() &&
             request.resource.data.keys().hasOnly(
@@ -3747,15 +3058,10 @@ service cloud.firestore {
         }
       }
 
-      // Archived responses — copies of student responses that the teacher
-      // removed (which used to be a hard delete). Live response is gone
-      // so the deterministic key is free for a fresh rejoin; the archive
-      // preserves partial answers so the teacher can recover them and so
-      // the dev (and admins) can fetch attempts that never reached
-      // submit. Students never read archived responses — privacy from
-      // classmates and from themselves (no use case where they would
-      // need to). Idle auto-submit does NOT archive — those land back
-      // in /responses with `autoSubmitted: true`.
+      // Archived responses — copies of teacher-removed responses (was a hard
+      // delete). Frees the deterministic key for a fresh rejoin while preserving
+      // partial answers for teacher recovery. Students never read archives. Idle
+      // auto-submit doesn't archive (those stay in /responses, autoSubmitted:true).
       match /archived_responses/{responseKey} {
         function sessionTeacherUidArch() {
           return get(/databases/$(database)/documents/quiz_sessions/$(sessionId)).data.teacherUid;
@@ -3763,14 +3069,9 @@ service cloud.firestore {
         allow read: if request.auth != null && (
           request.auth.uid == sessionTeacherUidArch() || isAdmin()
         );
-        // The session teacher OR an admin can archive a response. The
-        // delete rule on the parent /responses doc has always allowed
-        // both — without symmetric allowance here, an admin removing a
-        // student would have the archive create rejected and the whole
-        // batch (including the delete) rolls back. archivedBy must be
-        // the writer's own auth.uid (no proxy writes), and the
-        // archiveReason is constrained to a small set so a future log
-        // query can bucket by reason.
+        // Teacher or admin can archive (symmetric with the parent delete rule,
+        // else an admin's archive+delete batch rolls back). archivedBy ==
+        // auth.uid (no proxy writes); archiveReason constrained to a small set.
         allow create: if request.auth != null &&
           (request.auth.uid == sessionTeacherUidArch() || isAdmin()) &&
           request.resource.data.archivedBy == request.auth.uid &&
@@ -3782,15 +3083,10 @@ service cloud.firestore {
         allow update, delete: if isAdmin();
       }
 
-      // View tracking for view-only Share links. Each pageview by a student
-      // (anonymous or studentRole) appends an immutable doc with just a
-      // server timestamp; the teacher's "Shared" archive aggregates the
-      // count via getCountFromServer(). Refresh-inflation is accepted —
-      // the metric is "URL opens", not "unique viewers".
-      //
-      // The create rule requires the parent session to exist AND be in
-      // view-only mode, so an authenticated user can't spam view docs
-      // under arbitrary or non-view-only session IDs to inflate metrics.
+      // View tracking for view-only Share links — each pageview appends an
+      // immutable {viewedAt} doc; the teacher's archive counts via
+      // getCountFromServer() ("URL opens", refresh-inflation accepted). Create
+      // requires the parent session to exist AND be view-only (no metric spam).
       match /views/{viewId} {
         allow read: if request.auth != null && (
           isAdmin() ||
@@ -3805,54 +3101,34 @@ service cloud.firestore {
       }
     }
 
-    // Quiz Attempt Ledger — top-level, cross-launch attempt counter per
-    // (ASSIGNMENT, student), NOT per quiz template. See `QuizAttemptLedger` in
-    // types.ts and `QUIZ_ATTEMPT_LEDGER_COLLECTION` in `useQuizSession.ts` for
-    // the rationale. The doc id is `${assignmentId}__${studentUid}` (the
-    // assignmentId is the session id); the `quizId` field is retained as
-    // metadata. The `studentUid` field on the doc must equal the student's auth
-    // uid (the rules can't decompose the doc id back into its halves).
-    //
-    // Ledger writes happen only inside the `completeQuiz` transaction
-    // alongside the response status flip, so the rules' append-only
-    // invariant on `completedAttempts` is the last line of defense
-    // against a hostile or buggy client trying to roll the counter
-    // back. The teacher's `removeStudent` action deletes the ledger
-    // (atomic with the response delete) — see Phase 2 in the
-    // attempt-cap fix branch.
+    // Quiz Attempt Ledger — top-level cross-launch attempt counter per
+    // (ASSIGNMENT, student), not per quiz template. Doc id
+    // `${assignmentId}__${studentUid}`; studentUid field must equal the caller's
+    // auth uid (rules can't split the id). Writes happen inside completeQuiz, so
+    // the append-only completedAttempts invariant is the last line of defense
+    // against rollback; removeStudent deletes the ledger atomically.
     match /quiz_attempt_ledger/{ledgerId} {
-      // `resource == null` short-circuit lets the student-app join flow
-      // call getDoc() to probe whether a ledger entry exists before
-      // deciding to create it on first completion — without it, the
-      // rules engine throws a Null-value error on
-      // `resource.data.teacherUid` and the read is denied. Mirrors the
-      // response read rule pattern. The student's pseudonym uid is an
-      // opaque HMAC (computed in `studentLoginV1`), so probing another
-      // student's path is not realistically possible without already
-      // knowing that student's uid.
+      // resource == null short-circuit lets the join flow probe via getDoc()
+      // before first-completion create (else a Null-value throw on teacherUid).
+      // The student pseudonym uid is an opaque HMAC, so probing another's path
+      // isn't realistic without already knowing that uid.
       allow read: if request.auth != null && (
         resource == null ||
         isAdmin() ||
         request.auth.uid == resource.data.teacherUid ||
         request.auth.uid == resource.data.studentUid
       );
-      // Student creates their own ledger entry on first completion.
-      // Constraints mirror the response create rule shape:
-      //   - studentUid field must equal the caller's auth uid
-      //   - completedAttempts must initialize to exactly 1 (not 0 — a
-      //     ledger entry only exists once the first completion has
-      //     occurred, and not >1 — a fresh entry shouldn't be able to
-      //     forge prior history)
-      //   - identity fields must be present and well-typed
+      // Student creates their own ledger entry on first completion: studentUid ==
+      // auth uid; completedAttempts == exactly 1 (entry exists only after the first
+      // completion, and can't forge prior history); identity fields well-typed.
       allow create: if request.auth != null &&
         request.resource.data.studentUid == request.auth.uid &&
         request.resource.data.completedAttempts == 1 &&
         request.resource.data.quizId is string &&
         request.resource.data.teacherUid is string &&
         request.resource.data.lastAttemptAt is number;
-      // Update is split into a STUDENT branch (monotonic increment via
-      // their own completeQuiz transaction) and a TEACHER branch (reset
-      // to 0). Identity fields are immutable on both.
+      // Update split: STUDENT branch (increment by 1) and TEACHER branch (decrease/
+      // reset). Identity fields immutable on both.
       allow update: if request.auth != null && (
         // Student branch — increment by exactly 1.
         (request.auth.uid == resource.data.studentUid &&
@@ -3862,13 +3138,9 @@ service cloud.firestore {
          request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
          request.resource.data.lastAttemptAt is number)
         ||
-        // Teacher reset/refund branch — decrease completedAttempts.
-        // Used by `removeStudent` (effectively resets to 0 via batch
-        // delete, kept here for compatibility) and `unlockStudentAttempt`
-        // (refunds one attempt so the student isn't immediately re-blocked
-        // by the cap on resume). The teacher may only DECREASE the
-        // counter, never inflate it — this preserves the cap as an
-        // anti-cheating defense while permitting deliberate refunds.
+        // Teacher reset/refund branch — may only DECREASE completedAttempts
+        // (removeStudent reset, unlockStudentAttempt refund); never inflate, so the
+        // cap stays an anti-cheating defense.
         (request.auth.uid == resource.data.teacherUid &&
          request.resource.data.studentUid == resource.data.studentUid &&
          request.resource.data.quizId == resource.data.quizId &&
@@ -3879,20 +3151,11 @@ service cloud.firestore {
         ||
         isAdmin()
       );
-      // Owning teacher (or admin) may delete the entry — used by the
-      // teacher monitor's "Reset student" / "Remove student" actions. The
-      // student cannot delete (they'd be able to wipe their own cap).
-      //
-      // The `resource == null` short-circuit makes deleting a NON-EXISTENT
-      // ledger a harmless no-op. Without it the rule dereferences
-      // `resource.data.teacherUid` on a null resource and DENIES — which
-      // breaks `removeStudent`'s atomic archive+delete batch for any response
-      // that never wrote a ledger (anonymous PIN joiners, idle auto-submitted
-      // blanks, joined-only stubs, legacy pre-ledger responses), surfacing as
-      // a "Missing or insufficient permissions" toast. The read rule above
-      // already uses this same pattern; the delete rule must match it.
-      // Defense-in-depth alongside the client existence probe in
-      // `removeStudent`.
+      // Teacher or admin may delete (monitor "Reset"/"Remove student"); students
+      // can't (they'd wipe their own cap). resource == null makes deleting a
+      // non-existent ledger a no-op — without it removeStudent's atomic
+      // archive+delete batch breaks for responses that never wrote a ledger
+      // (anon PIN, idle blanks, stubs, legacy).
       allow delete: if request.auth != null && (
         resource == null ||
         request.auth.uid == resource.data.teacherUid || isAdmin()
@@ -3925,10 +3188,8 @@ service cloud.firestore {
          request.resource.data.completedAttempts == resource.data.completedAttempts + 1 &&
          request.resource.data.lastAttemptAt is number)
         ||
-        // Teacher reset/refund branch — see quiz_attempt_ledger above.
-        // The teacher may only DECREASE completedAttempts; this supports
-        // both the legacy `removeStudent` reset-to-0 and the new
-        // `unlockStudentAttempt` refund-by-one flow.
+        // Teacher reset/refund branch (see quiz_attempt_ledger): may only DECREASE
+        // completedAttempts (removeStudent reset + unlockStudentAttempt refund).
         (request.auth.uid == resource.data.teacherUid &&
          request.resource.data.studentUid == resource.data.studentUid &&
          request.resource.data.activityId == resource.data.activityId &&
@@ -3939,36 +3200,24 @@ service cloud.firestore {
         ||
         isAdmin()
       );
-      // `resource == null` short-circuit mirrors quiz_attempt_ledger above:
-      // deleting a non-existent ledger is a safe no-op, and without it the
-      // rule null-derefs `resource.data.teacherUid` and denies. VA has no
-      // ledger-deleting remove path today, but the guard keeps the two
-      // ledgers' delete rules symmetric and forecloses the same footgun.
+      // resource == null no-op mirrors quiz_attempt_ledger (avoids a null-deref
+      // deny). VA has no ledger-deleting remove path today, but keeps the two
+      // ledgers symmetric.
       allow delete: if request.auth != null && (
         resource == null ||
         request.auth.uid == resource.data.teacherUid || isAdmin()
       );
     }
 
-    // Announcements - admins write; reads are tenant-scoped.
-    //
-    // Multi-tenant isolation (defense-in-depth with the client listener gate):
-    //   - Legacy docs (no `orgId`) stay readable by ANY authenticated user.
-    //     This preserves the pre-isolation behavior so existing Orono
-    //     announcements (which predate the field, until the backfill stamps
-    //     'orono') keep showing for everyone, exactly as today.
-    //   - A doc WITH an `orgId` is readable only by a member of that org
-    //     (via `isOrgMember`) — or any admin, since the admin manager UI
-    //     subscribes to the full collection to manage every announcement.
-    // The write rule is unchanged: only admins create/update/delete.
+    // Announcements — admins write; reads are tenant-scoped. Legacy docs (no
+    // orgId) stay readable by any authed user (preserves pre-isolation behavior);
+    // a doc WITH an orgId is readable only by that org's members (isOrgMember) or
+    // any admin (the manager UI subscribes to the whole collection).
     match /announcements/{announcementId} {
       allow read: if request.auth != null
         && (
-          // No orgId field — OR an explicit `orgId: null` (which has the field
-          // present) — is legacy/global, readable by any authed user. Allowing
-          // the explicit-null case too prevents a doc written with orgId:null
-          // from falling through to isOrgMember(null) and becoming invisible to
-          // everyone except admins.
+          // Missing orgId OR explicit orgId:null = legacy/global, any authed user.
+          // (The null case avoids isOrgMember(null) hiding the doc from everyone.)
           !('orgId' in resource.data)
           || resource.data.orgId == null
           || isOrgMember(resource.data.orgId)
@@ -3995,13 +3244,9 @@ service cloud.firestore {
     // per resource — no per-PLC fan-out.
     match /plc_resources/{resourceId} {
       allow read: if request.auth != null;
-      // Schema is locked with keys().hasOnly([...]) so a malicious/buggy
-      // admin client can't persist arbitrary fields. `request.resource.data`
-      // is the post-write merged doc, so partial updates are validated in
-      // full too. The auth gate is `createdByAdminUid == request.auth.uid`;
-      // `createdByAdminEmail` is a display snapshot validated as a string
-      // (not pinned to token.email, which the client stores from
-      // `user.email` and may differ in case/availability).
+      // Shape locked via hasOnly([...]) (post-write merged doc, so partial updates
+      // validate in full). Gate: createdByAdminUid == auth.uid; createdByAdminEmail
+      // is a display snapshot validated as a string (not pinned to token.email).
       allow create, update: if isAdmin()
         && request.resource.data.id == resourceId
         && request.resource.data.keys().hasOnly([
@@ -4034,15 +3279,11 @@ service cloud.firestore {
       allow write: if isAdmin();
     }
 
-    // Custom Widgets - admins can read/write all; non-admins can read published+enabled+accessible widgets
-    // NOTE: resource.data.buildings is a UI-targeting field only (filters which
-    // buildings display the widget in their Dock). It is NOT an access-control
-    // boundary enforced here — enforcing it would require an expensive get() call
-    // to look up building membership and is not necessary given that all
-    // custom_widgets content is already scoped to authenticated users within the
-    // same district deployment. If per-building access control is needed in the
-    // future, add building membership to custom auth claims and check
-    // request.auth.token.buildings here.
+    // Custom Widgets — admins read/write all; non-admins read published+enabled+
+    // accessible widgets. NOTE: resource.data.buildings is UI-targeting only (Dock
+    // display filter), NOT an access boundary (enforcing it needs a get(); content
+    // is already authed-scoped within the district). Future per-building control:
+    // add buildings to custom claims and check request.auth.token.buildings.
     match /custom_widgets/{widgetId} {
       allow read: if isAdmin() ||
         (request.auth != null &&
@@ -4078,22 +3319,16 @@ service cloud.firestore {
 
     // Video Activity Sessions — Teacher creates, anonymous students can read and submit responses
     match /video_activity_sessions/{sessionId} {
-      // Reads are intentionally permissive for any authenticated caller.
-      // See quiz_sessions for the rationale: a `resource.data`-based
-      // studentRole class gate on `get` still denied teacher single-doc
-      // subscriptions after a status transition; the class gate is now
-      // enforced on the response write rules below, which dereference the
-      // parent session's `classId` via a runtime `get()`.
+      // Reads permissive for any authed caller (see quiz_sessions): studentRole
+      // class gating is enforced on the response WRITE rules below (runtime get()
+      // of the parent classId), not on read.
       allow read: if request.auth != null;
       // Only authenticated (non-anonymous) users can create sessions (teachers)
       allow create: if request.auth != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
-      // Teacher owners may update their own session — including renames,
-      // status changes, sync-pull content updates, PLC linkage attach, score-
-      // publish field writes, and PR3 sharing fields. Identity fields stay
-      // immutable. The looser allowlist matches the Quiz session pattern:
-      // simple ownership check + immutable identity, no per-field hasOnly
-      // (sync, PLC, publish flows would otherwise need ever-growing
-      // allowlists). The student-side response rule below remains tight.
+      // Teacher owners update their own session (renames, status, sync-pull, PLC
+      // attach, score-publish, sharing fields); identity immutable. Looser
+      // allowlist like Quiz sessions (ownership + immutable identity, no per-field
+      // hasOnly). The student response rule below stays tight.
       allow update: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         resource.data.teacherUid == request.auth.uid &&
@@ -4101,17 +3336,13 @@ service cloud.firestore {
         request.resource.data.activityId == resource.data.activityId &&
         request.resource.data.teacherUid == resource.data.teacherUid &&
         request.resource.data.createdAt == resource.data.createdAt;
-      // Owning teacher (or admin) may delete — used by the Video Activity
-      // "Delete permanently" action in the Assignment archive to clean up the
-      // session along with the per-teacher assignment doc. Mirrors GL sessions.
+      // Owning teacher (or admin) may delete (VA "Delete permanently" cleanup).
+      // Mirrors GL sessions.
       allow delete: if request.auth != null &&
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
-      // Doc id (`responseDocId`) is one of:
-      //   - `auth.uid`                   (SSO `studentRole` joiners — stable per user)
-      //   - `pin-{period}-{pin}`         (anonymous PIN joiners — period-scoped)
-      // Mirrors the Quiz response keying contract; see `computeResponseKey`
-      // and `encodeResponseKeySegment` in `useQuizSession.ts`.
+      // Doc id (responseDocId): auth.uid (SSO) or pin-{period}-{pin} (anon).
+      // Mirrors the Quiz keying contract (computeResponseKey / encodeResponseKeySegment).
       match /responses/{responseDocId} {
         function vaSessionClassId() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('classId', '');
@@ -4126,39 +3357,26 @@ service cloud.firestore {
         function vaSessionMode() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('mode', 'submissions');
         }
-        // Server-side attempt cap. attemptLimit lives nested under
-        // sessionOptions on VideoActivitySession. Pre-PR1 sessions have no
-        // sessionOptions field at all; we tolerate that with the default
-        // empty map. Returns null when the session has no cap.
+        // Server-side attempt cap (nested under sessionOptions; pre-PR1 sessions
+        // lack it, defaulted to {}). null = no cap.
         function vaSessionAttemptLimit() {
           return get(/databases/$(database)/documents/video_activity_sessions/$(sessionId)).data.get('sessionOptions', {}).get('attemptLimit', null);
         }
 
-        // Student branch allows `resource == null` so the student-app join
-        // flow can call getDoc() to probe whether a response already exists
-        // before deciding to create. Without this guard, a read of a
-        // non-existent `pin-*` doc would throw a Null-value error on
-        // `resource.data.studentUid` and deny the write. Mirrors the Quiz
-        // response read rule.
+        // Student branch allows resource == null so the join flow can probe via
+        // getDoc() before create (else a Null-value throw on studentUid). Mirrors
+        // the Quiz response read.
         allow read: if request.auth != null && (
           isAdmin() ||
           request.auth.uid == vaSessionTeacherUid() ||
           (passesStudentClassGateCompat(vaSessionClassIds(), vaSessionClassId()) &&
            (resource == null || request.auth.uid == resource.data.studentUid))
         );
-        // Students create their own response. The `studentUid` field must
-        // equal the caller's auth uid (prevents impersonation). Doc-id
-        // shape is enforced split-by-auth-mode:
-        //   - SSO (studentRole)  → responseDocId must equal auth.uid
-        //   - Anonymous (PIN)    → responseDocId must match
-        //                          ^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$
-        //                          (mirrors
-        //                          `encodeResponseKeySegment` on the
-        //                          client). This closes the cross-auth
-        //                          path where any authenticated caller
-        //                          could grief-create arbitrary `pin-*`
-        //                          docs.
-        // studentRole users must also be enrolled in the session's class.
+        // Students create their own response: studentUid == auth uid (no
+        // impersonation). Doc-id by auth mode: SSO → responseDocId == auth.uid;
+        // anon PIN → ^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$ (mirrors
+        // encodeResponseKeySegment, closes the cross-auth grief path). studentRole
+        // users must be enrolled in the session's class.
         allow create: if request.auth != null &&
           request.resource.data.studentUid == request.auth.uid &&
           request.resource.data.score == null &&
@@ -4172,21 +3390,11 @@ service cloud.firestore {
           (isStudentRoleUser()
             ? responseDocId == request.auth.uid
             : responseDocId.matches('^pin-[a-z0-9_]{1,64}-[a-z0-9_]{1,64}$'));
-        // Update is split into a TEACHER branch (PR3 publish-scores writes
-        // `score`/`isCorrect`/`scoreVisibility` onto each response) and a
-        // STUDENT branch (the existing answer-submit path). The teacher
-        // branch is permissive — the parent session's `teacherUid` gate
-        // is sufficient ownership; admins also pass for the
-        // `delete-assignment` and emergency repair flows. Mirrors the
-        // Quiz response update pattern.
-        //
-        // Branch mutual exclusivity is by intent, not accident: the teacher
-        // branch only checks `request.auth.uid == vaSessionTeacherUid()`,
-        // never `resource.data`, so a student calling update() will fail
-        // the teacher disjunct (their uid won't match the session's
-        // teacherUid) and fall through to the student branch's full
-        // append-only invariants. If `vaSessionTeacherUid()` ever needs to
-        // dereference the response itself (it shouldn't), revisit.
+        // Update split: TEACHER branch (PR3 publish-scores: score/isCorrect/
+        // scoreVisibility; gated by parent teacherUid, admins also pass) and
+        // STUDENT branch (answer-submit, append-only invariants). Mutually
+        // exclusive by intent — the teacher branch checks only
+        // vaSessionTeacherUid(), so a student falls through to the student branch.
         allow update: if request.auth != null && (
           // Teacher branch.
           (request.auth.uid == vaSessionTeacherUid() || isAdmin()) ||
@@ -4199,14 +3407,8 @@ service cloud.firestore {
             request.resource.data.get('name', null) == resource.data.get('name', null) &&
             request.resource.data.get('joinedAt', null) == resource.data.get('joinedAt', null) &&
             request.resource.data.score == resource.data.score &&
-            // `affectedKeys()` (not `changedKeys()`) — the former covers
-            // added/removed/changed; the latter only covers keys present on
-            // both sides with different values, so a brand-new arbitrary
-            // field smuggled in by the write would slip past the whitelist.
-            // The `score == resource.data.score` immutability above blocks
-            // score-smuggling specifically, but any other injected field
-            // (current or future protection fields, metadata, etc.) would
-            // be wide open without this guard.
+            // affectedKeys() (not changedKeys()) covers added/removed too, so a
+            // smuggled new field can't slip past the whitelist.
             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
               'answers',
               'completedAt',
@@ -4215,19 +3417,13 @@ service cloud.firestore {
               'classPeriod',
               'unlocked'
             ]) &&
-            // Students may only ever CLEAR the unlock flag — never set
-            // it. The teacher sets `unlocked: true`; `completeActivity`
-            // clears it back to false on submission of a resumed attempt.
+            // Students may only ever CLEAR unlocked (teacher sets true;
+            // completeActivity clears it on resumed-attempt submit).
             (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['unlocked']) ||
              request.resource.data.get('unlocked', false) == false) &&
             request.resource.data.answers is list &&
-            // Append-only on answers, EXCEPT during a rejoin-reset for a
-            // new attempt under the cap. The reset path writes
-            // `completedAt: null` on a doc whose prior `completedAt` was
-            // non-null, signaling a fresh attempt; in that single case
-            // answers may be cleared to []. Otherwise the legacy
-            // append-only invariant holds (prevents a mid-attempt
-            // student from rolling back their answers).
+            // Append-only on answers, except a rejoin-reset (prior completedAt
+            // non-null → null) may clear answers to []. Otherwise no rollback.
             ((resource.data.get('completedAt', null) != null &&
               request.resource.data.get('completedAt', null) == null &&
               request.resource.data.answers.size() == 0) ||
@@ -4241,12 +3437,8 @@ service cloud.firestore {
             // client-side join + completeActivity transactions.
             (vaSessionAttemptLimit() == null ||
              request.resource.data.get('completedAttempts', 0) <= vaSessionAttemptLimit()) &&
-            // completedAt transition gate: students cannot write a new
-            // non-null completedAt when the prior completedAt was already
-            // non-null. Legit completion goes null → non-null;
-            // rejoin-under-cap goes non-null → null. The case this
-            // blocks is non-null → non-null, which only happens via a
-            // race or bug.
+            // completedAt gate: blocks non-null → non-null (race/bug). Completion
+            // is null → non-null; rejoin is non-null → null.
             (resource.data.get('completedAt', null) == null ||
              request.resource.data.get('completedAt', null) == null)
           )
@@ -4281,12 +3473,9 @@ service cloud.firestore {
 
     // MiniApp Assignment Sessions — Teacher creates, anonymous students can read
     match /mini_app_sessions/{sessionId} {
-      // Reads are intentionally permissive for any authenticated caller.
-      // See quiz_sessions for the rationale: a `resource.data`-based
-      // studentRole class gate on `get` still denied teacher single-doc
-      // subscriptions; the class gate is now enforced on the submission
-      // write rules below, which dereference the parent session's
-      // `classIds` via a runtime `get()`.
+      // Reads permissive for any authed caller (see quiz_sessions): studentRole
+      // class gating is enforced on the submission WRITE rules below (runtime
+      // get() of the parent classIds), not on read.
       allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions they own
       allow create: if request.auth != null &&
@@ -4301,11 +3490,9 @@ service cloud.firestore {
         request.resource.data.status in ['active', 'ended'];
       allow delete: if false;
 
-      // MiniApp student submissions. Replaces the legacy Apps Script →
-      // Google Sheets pipeline. Doc ID is either an opaque per-assignment
-      // pseudonym (studentRole launches) or the anonymous Firebase Auth UID
-      // (legacy shared-link launches). Payload is deliberately opaque —
-      // no PII is persisted.
+      // MiniApp student submissions (replaces the legacy Sheets pipeline). Doc id
+      // is an opaque per-assignment pseudonym (studentRole) or the anonymous auth
+      // uid (legacy shared-link). Payload is deliberately opaque — no PII.
       match /submissions/{submissionId} {
         function maSessionData() {
           return get(/databases/$(database)/documents/mini_app_sessions/$(sessionId)).data;
@@ -4314,43 +3501,23 @@ service cloud.firestore {
           return maSessionData().get('classIds', []);
         }
 
-        // Session owner (teacher) and admins can read all submissions.
-        // A student may read their own submission doc (used for the
-        // completion-badge check in /my-assignments). Identity on a doc is
-        // carried by the `studentUid` field (= the submitter's auth uid at
-        // write time), so the same check applies to both studentRole
-        // launches (where docId is an opaque pseudonym) and anonymous
-        // launches (where docId happens to equal auth.uid).
+        // Teacher + admins read all submissions; a student reads their own (the
+        // /my-assignments completion badge). Identity is the studentUid field
+        // (works for both pseudonym and auth-uid doc ids).
         allow read: if request.auth != null && (
           isAdmin() ||
           maSessionData().teacherUid == request.auth.uid ||
           resource.data.studentUid == request.auth.uid
         );
 
-        // Any authenticated user (anonymous or studentRole) may create or
-        // update their own submission while the session is active.
-        // - Every submission must carry a `studentUid` field equal to the
-        //   caller's auth.uid so the doc is attributable and the student
-        //   can read it back via the rule above.
-        // - Anonymous launches must additionally use their auth uid as the
-        //   doc ID so the docId == studentUid invariant keeps them from
-        //   spraying extra docs under different keys.
-        // - studentRole launches use an opaque per-assignment pseudonym as
-        //   the docId. The HMAC secret server-side prevents forging another
-        //   student's pseudonym, and the class gate blocks cross-class
-        //   writes. The studentUid field still pins the submitter for read
-        //   authorization and accountability.
-        // Payload shape is validated to prevent junk writes bloating the
-        // subcollection.
-        //
-        // Two write paths are allowed:
-        //   1. Full submission (submissionsEnabled must be true) — payload
-        //      can be any valid map up to 50 keys.
-        //   2. Completion marker (any active session regardless of
-        //      submissionsEnabled) — payload must be exactly {completed: true}.
-        //      This lets students mark view-only (no submissions) assignments
-        //      as done so the completion badge appears in /my-assignments
-        //      without requiring submissionsEnabled.
+        // Any authed user (anon or studentRole) creates/updates their own
+        // submission while the session is active. studentUid must == auth.uid
+        // (attributable + readable back). Anon launches must also use auth.uid as
+        // the doc id (no doc-spraying); studentRole launches use an opaque
+        // pseudonym (HMAC-unforgeable, class-gated). Two write paths: (1) full
+        // submission (submissionsEnabled true) payload ≤50 keys; (2) completion
+        // marker (any active session) payload exactly {completed: true} — lets
+        // view-only assignments show the /my-assignments badge.
         allow create, update: if request.auth != null &&
           maSessionData().status == 'active' &&
           passesStudentClassGateList(maSessionClassIds()) &&
@@ -4393,10 +3560,9 @@ service cloud.firestore {
       }
     }
 
-    // AI Usage Tracking — read-only for users; all writes go through Cloud Functions (Admin SDK)
-    // The Cloud Function uses db.runTransaction() via the Admin SDK, which bypasses these rules.
-    // Client-side write access is intentionally removed to prevent users from resetting their
-    // daily quota by writing a document with count = 0 via the Firestore client SDK.
+    // AI Usage Tracking — read-only for users; all writes go through Cloud
+    // Functions (Admin SDK), so a user can't reset their daily quota by writing
+    // count = 0 from the client.
     match /ai_usage/{usageId} {
       // Document ID is formatted as {uid}_{YYYY-MM-DD}
       // Security rule replacement for startsWith: usageId >= prefix && usageId < prefix + '\uf8ff'
@@ -4409,25 +3575,18 @@ service cloud.firestore {
 
     // Guided Learning Sessions — Teacher creates, authenticated (incl. anonymous) students read and submit
     match /guided_learning_sessions/{sessionId} {
-      // Reads are intentionally permissive for any authenticated caller.
-      // See quiz_sessions for the rationale: a `resource.data`-based
-      // studentRole class gate on `get` still denied teacher single-doc
-      // subscriptions; the class gate is now enforced on the response
-      // write rules below, which dereference the parent session's
-      // `classId` via a runtime `get()`.
+      // Reads permissive for any authed caller (see quiz_sessions): studentRole
+      // class gating is enforced on the response WRITE rules below (runtime get()
+      // of the parent classId), not on read.
       allow read: if request.auth != null;
       // Only authenticated (non-anonymous) teachers can create sessions; they must own it
       allow create: if request.auth != null &&
         request.auth.token.firebase.sign_in_provider != 'anonymous' &&
         request.resource.data.teacherUid == request.auth.uid;
-      // The owning teacher (or admin) may update the session — used by
-      // `publishAssignmentScores` to mirror `scoreVisibility` +
-      // `revealedAnswers` onto the session doc so the student listener can
-      // gate its review screen without subscribing to teacher-owned docs.
-      // Mirrors the Quiz session rule (`quiz_sessions/{sessionId}` allow
-      // update). Only the owning teacher (or admin) may delete — used by
-      // the Wave 2-GL "Delete permanently" action in the Assignment archive
-      // to clean up the session along with the per-teacher assignment doc.
+      // Owning teacher (or admin) may update (publishAssignmentScores mirrors
+      // scoreVisibility + revealedAnswers onto the session so the student listener
+      // can gate review without teacher-owned docs; mirrors Quiz sessions) and
+      // delete (GL "Delete permanently" cleanup).
       allow update, delete: if request.auth != null &&
         (resource.data.teacherUid == request.auth.uid || isAdmin());
 
@@ -4441,10 +3600,9 @@ service cloud.firestore {
         function glSessionTeacherUid() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.teacherUid;
         }
-        // Defense in depth — block response writes on view-only sessions.
-        // GuidedLearningSession.mode already names the play-mode
-        // (structured/guided/explore), so the assignment mode ships under
-        // `assignmentMode` here. The other three widgets store it as `mode`.
+        // Block response writes on view-only sessions. GL stores assignment mode
+        // under `assignmentMode` (its `mode` is play-mode: structured/guided/
+        // explore); other widgets use `mode`.
         function glSessionMode() {
           return get(/databases/$(database)/documents/guided_learning_sessions/$(sessionId)).data.get('assignmentMode', 'submissions');
         }
@@ -4465,21 +3623,12 @@ service cloud.firestore {
           passesStudentClassGateCompat(glSessionClassIds(), glSessionClassId()) &&
           // Block submissions on view-only sessions (mode is frozen at creation)
           glSessionMode() == 'submissions';
-        // Two disjoint branches:
-        //
-        //   TEACHER branch — the owning teacher (or admin) writes `score` and
-        //   per-answer `isCorrect` when they call `publishAssignmentScores`,
-        //   and clears those on unpublish. The session's `teacherUid` is the
-        //   sole ownership gate; we deliberately don't constrain
-        //   `request.resource.data` further so future publish-flow fields
-        //   don't require a rules edit. Mirrors the Quiz / VA response
-        //   update pattern.
-        //
-        //   STUDENT branch — append answers / set completedAt on their own
-        //   response, with `score` locked immutable from the client. Branch
-        //   mutual exclusivity is by intent: a student calling update() will
-        //   fail the teacher disjunct (uid != teacherUid) and fall through
-        //   to the student branch's full append-only invariants.
+        // Two disjoint branches: TEACHER (owning teacher/admin writes score +
+        // per-answer isCorrect on publishAssignmentScores, clears on unpublish;
+        // teacherUid is the sole gate, unconstrained payload so publish fields
+        // don't need rules edits) and STUDENT (append answers / set completedAt,
+        // score client-immutable). Mutually exclusive — a student fails the
+        // teacher disjunct and falls through to the student invariants.
         allow update: if request.auth != null && (
           // Teacher branch.
           (request.auth.uid == glSessionTeacherUid() || isAdmin()) ||
@@ -4503,11 +3652,8 @@ service cloud.firestore {
         );
       }
 
-      // View tracking for view-only Share links (see quiz_sessions/views).
-      // Create requires the parent session to exist AND be in view-only mode.
-      // GL stores assignment mode under `assignmentMode` (not `mode`) — the
-      // session's `mode` field is reserved for play-mode (structured / guided
-      // / explore). See types.ts and the response create rule above.
+      // View tracking for view-only Share links (see quiz_sessions/views). GL
+      // stores assignment mode under `assignmentMode` (its `mode` is play-mode).
       match /views/{viewId} {
         allow read: if request.auth != null && (
           isAdmin() ||
@@ -4525,12 +3671,9 @@ service cloud.firestore {
     // Activity Wall Sessions — Teacher owns it (UID prefix in sessionId), students submit entries
     // sessionId is formatted as {teacherUid}_{activityId}
     match /activity_wall_sessions/{sessionId} {
-      // Reads are intentionally permissive for any authenticated caller.
-      // See quiz_sessions for the rationale: a `resource.data`-based
-      // studentRole class gate on `get` still denied teacher single-doc
-      // subscriptions; the class gate is now enforced on the submission
-      // write rules below, which dereference the parent session's
-      // `classId` via a runtime `get()`.
+      // Reads permissive for any authed caller (see quiz_sessions): studentRole
+      // class gating is enforced on the submission WRITE rules below (runtime
+      // get() of the parent classId), not on read.
       allow read: if request.auth != null;
       // Only authenticated non-anonymous teachers/admins can create or update the session document itself.
       allow create, update: if request.auth != null &&
@@ -4548,14 +3691,9 @@ service cloud.firestore {
           return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('classIds', []);
         }
 
-        // Any authenticated user (including anonymous) can create a submission.
-        // Photo submissions may include Firebase storage metadata for later Drive archiving.
-        // studentRole (GIS) users must be enrolled in the session's class. Uses
-        // the Phase-5A compat gate (classIds list ?? legacy classId) so a
-        // session migrated to multi-class targeting still gates correctly —
-        // matching every other session type (quiz/VA/GL/miniapp). The legacy
-        // single-classId path is preserved for pre-5A sessions that only carry
-        // `classId`.
+        // Any authed user (incl. anon) can create a submission (photo subs may
+        // carry storage metadata for Drive archiving). studentRole users must be
+        // enrolled; uses the Phase-5A compat gate (classIds ?? legacy classId).
         allow create: if request.auth != null &&
           exists(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)) &&
           passesStudentClassGateCompat(awSessionClassIds(), awSessionClassId()) &&
@@ -4571,11 +3709,9 @@ service cloud.firestore {
           !('driveFileId' in request.resource.data) &&
           !('archiveError' in request.resource.data) &&
           !('archivedAt' in request.resource.data);
-        // Only teacher and admins can read or delete submissions —
-        // EXCEPT when the parent session has been published as a view-only
-        // gallery (`publiclyShared == true`), in which case any
-        // authenticated caller (including anonymous gallery viewers) can
-        // read the approved submissions. Delete remains teacher/admin-only.
+        // Teacher/admins read+delete submissions, EXCEPT a published view-only
+        // gallery (publiclyShared == true) is readable by any authed caller (incl.
+        // anon gallery viewers). Delete stays teacher/admin-only.
         allow read: if request.auth != null &&
                             (isAdmin() ||
                              sessionId.matches(request.auth.uid + '_.*') ||
@@ -4613,13 +3749,10 @@ service cloud.firestore {
       allow delete: if false;
 
       match /votes/{participantUid} {
-        // Reads the parent session doc once (let-bound) and reuses it for both
-        // the active-gate and the optionIndex range check, rather than calling
-        // a get()-wrapping helper twice. The allow rule's preceding exists()
-        // guard is a separate access, but Firestore caches reads to the same
-        // path within a single rule evaluation, so it is not double-billed.
-        // Only invoked after the allow rule confirmed the doc exists and
-        // optionIndex is an int, so the get() + comparison are safe.
+        // Reads the parent session once (let-bound), reused for the active-gate
+        // and optionIndex range check. Same-path reads are cached per evaluation,
+        // so the preceding exists() isn't double-billed. Invoked only after the
+        // allow rule confirmed the doc exists and optionIndex is an int.
         function voteTargetsActiveInRangeOption() {
           let session = get(/databases/$(database)/documents/poll_sessions/$(sessionId)).data;
           return session.get('active', false) == true &&
@@ -4627,10 +3760,9 @@ service cloud.firestore {
             request.resource.data.optionIndex < session.get('optionCount', 0);
         }
 
-        // Any authed user (incl. anonymous) may create/update ONLY the vote
-        // doc whose id equals their own uid. Exactly {optionIndex, votedAt};
-        // optionIndex an int within [0, optionCount); only while the session
-        // is active. Re-voting overwrites (one vote per device).
+        // Any authed user (incl. anon) may create/update ONLY the vote doc whose
+        // id == their uid. Exactly {optionIndex, votedAt}; optionIndex int in
+        // [0, optionCount); only while active. Re-voting overwrites (one/device).
         allow create, update: if request.auth != null &&
           request.auth.uid == participantUid &&
           exists(/databases/$(database)/documents/poll_sessions/$(sessionId)) &&
@@ -4669,11 +3801,8 @@ service cloud.firestore {
     }
 
     // === Library folders (Wave 3) ===
-    // Per-teacher folder tree for each library-style widget (Quiz, Video
-    // Activity, Guided Learning, MiniApp). Folders never cross widgets —
-    // each widget has its own collection. Owner-only read/write, matching
-    // the *_assignments pattern above. Wave 3-A ships the rules + schema;
-    // Wave 3-B wires the UI.
+    // Per-teacher folder tree per library widget (Quiz/VA/GL/MiniApp); folders
+    // never cross widgets. Owner-only read/write, like *_assignments above.
     match /users/{userId}/collections/{collectionId} {
       allow read, write: if request.auth != null && request.auth.uid == userId && notDeactivated();
     }


### PR DESCRIPTION
Promotes the comments-only `firestore.rules` slim (#2089) to production.

- **205335 bytes, 56.8 KB headroom** under the 256 KiB cap (was ~1 KB).
- **Zero rule-logic change** — 2431 non-comment code lines byte-identical (proven by comment-stripped diff); `firebase deploy --only firestore:rules --dry-run` compiles clean.
- Deploying this re-uploads a behaviorally-identical compiled ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)