### PR TITLE
fix(NumberLine): Escape now cancels edits in min/max/step inputs without saving

### DIFF
--- a/components/widgets/NumberLine/Settings.test.tsx
+++ b/components/widgets/NumberLine/Settings.test.tsx
@@ -104,6 +104,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Min Value input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const input = screen.getByLabelText('Min Value') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '99' } });
@@ -165,6 +166,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Max Value input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const input = screen.getByLabelText('Max Value') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '999' } });
@@ -225,6 +227,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Step input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const input = screen.getByLabelText('Step (Interval)') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '5' } });

--- a/components/widgets/NumberLine/Settings.test.tsx
+++ b/components/widgets/NumberLine/Settings.test.tsx
@@ -1,24 +1,4 @@
-/**
- * Regression tests for the Escape-cancel bug in NumberLineSettings.
- *
- * Root cause: The min, max, and step inputs used `defaultValue` (uncontrolled)
- * with `onBlur` to save. There was no Escape handler, so pressing Escape in the
- * browser triggered a native blur, which fired `onBlur` and saved the
- * typed-but-intended-to-cancel value. This is the same stale-onBlur pattern
- * fixed in DraggableWindow (#1965), RandomGroups (#1974), FolderTree (#1975),
- * and PollWidget (#2064).
- *
- * Fix: Each input now has an Escape branch in `onKeyDown` that sets a per-field
- * `cancelledRef` to `true` and resets the DOM value before calling
- * `e.currentTarget.blur()`. The `onBlur` handler checks the ref and returns
- * early (skipping `updateConfig`) when it's set, then resets the ref so
- * subsequent normal saves work.
- *
- * jsdom note: `e.currentTarget.blur()` inside a keyDown handler is a no-op in
- * jsdom — it does NOT dispatch a blur event. Tests therefore fire
- * `fireEvent.blur()` manually inside the same `act()` to replicate the
- * synchronous browser sequence (keyDown → blur).
- */
+// jsdom: e.currentTarget.blur() in keyDown is a no-op — tests fire fireEvent.blur() manually to replicate the synchronous browser keyDown→blur sequence.
 import React from 'react';
 import { act, render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/components/widgets/NumberLine/Settings.test.tsx
+++ b/components/widgets/NumberLine/Settings.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Regression tests for the Escape-cancel bug in NumberLineSettings.
+ *
+ * Root cause: The min, max, and step inputs used `defaultValue` (uncontrolled)
+ * with `onBlur` to save. There was no Escape handler, so pressing Escape in the
+ * browser triggered a native blur, which fired `onBlur` and saved the
+ * typed-but-intended-to-cancel value. This is the same stale-onBlur pattern
+ * fixed in DraggableWindow (#1965), RandomGroups (#1974), FolderTree (#1975),
+ * and PollWidget (#2064).
+ *
+ * Fix: Each input now has an Escape branch in `onKeyDown` that sets a per-field
+ * `cancelledRef` to `true` and resets the DOM value before calling
+ * `e.currentTarget.blur()`. The `onBlur` handler checks the ref and returns
+ * early (skipping `updateConfig`) when it's set, then resets the ref so
+ * subsequent normal saves work.
+ *
+ * jsdom note: `e.currentTarget.blur()` inside a keyDown handler is a no-op in
+ * jsdom — it does NOT dispatch a blur event. Tests therefore fire
+ * `fireEvent.blur()` manually inside the same `act()` to replicate the
+ * synchronous browser sequence (keyDown → blur).
+ */
+import React from 'react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NumberLineSettings } from './Settings';
+import { useDashboard } from '@/context/useDashboard';
+import { WidgetData } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+
+// TypographySettings / SurfaceColorSettings pull in additional context — stub
+// them out so we only need to mock useDashboard.
+vi.mock('@/components/common/TypographySettings', () => ({
+  TypographySettings: () => null,
+}));
+
+vi.mock('@/components/common/SurfaceColorSettings', () => ({
+  SurfaceColorSettings: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockUpdateWidget = vi.fn();
+
+const baseWidget: WidgetData = {
+  id: 'nl-test-1',
+  type: 'numberLine',
+  x: 0,
+  y: 0,
+  w: 700,
+  h: 300,
+  z: 1,
+  flipped: true,
+  config: {
+    min: -10,
+    max: 10,
+    step: 1,
+    displayMode: 'integers',
+    showArrows: true,
+    markers: [],
+    jumps: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('NumberLineSettings — Escape-cancel regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+    });
+  });
+
+  // ── Min Value ──────────────────────────────────────────────────────────────
+
+  it('does NOT call updateWidget when Escape is pressed on the Min Value input', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Min Value');
+
+    // Teacher types a new value but then cancels with Escape.
+    fireEvent.change(input, { target: { value: '99' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      // jsdom does not fire blur from e.currentTarget.blur(); trigger manually.
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+  });
+
+  it('resets the Min Value input to the original value after Escape', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Min Value');
+
+    fireEvent.change(input, { target: { value: '99' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    // The DOM value should revert to the original min (-10).
+    expect(input.value).toBe('-10');
+  });
+
+  it('DOES call updateWidget on normal blur of Min Value (Escape cancel does not poison future saves)', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Min Value');
+
+    // First: cancel an edit with Escape.
+    fireEvent.change(input, { target: { value: '99' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+
+    // Then: make a real edit and blur normally — save must go through.
+    fireEvent.change(input, { target: { value: '-5' } });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).toHaveBeenCalledOnce();
+    expect(mockUpdateWidget).toHaveBeenCalledWith(
+      'nl-test-1',
+      expect.objectContaining({
+        config: expect.objectContaining({ min: -5 }) as unknown,
+      })
+    );
+  });
+
+  // ── Max Value ──────────────────────────────────────────────────────────────
+
+  it('does NOT call updateWidget when Escape is pressed on the Max Value input', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Max Value');
+
+    fireEvent.change(input, { target: { value: '999' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+  });
+
+  it('resets the Max Value input to the original value after Escape', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Max Value');
+
+    fireEvent.change(input, { target: { value: '999' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    expect(input.value).toBe('10');
+  });
+
+  it('DOES call updateWidget on normal blur of Max Value after a prior Escape', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Max Value');
+
+    // Cancel first.
+    fireEvent.change(input, { target: { value: '999' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+
+    // Real save next.
+    fireEvent.change(input, { target: { value: '20' } });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).toHaveBeenCalledOnce();
+    expect(mockUpdateWidget).toHaveBeenCalledWith(
+      'nl-test-1',
+      expect.objectContaining({
+        config: expect.objectContaining({ max: 20 }) as unknown,
+      })
+    );
+  });
+
+  // ── Step (Interval) ────────────────────────────────────────────────────────
+
+  it('does NOT call updateWidget when Escape is pressed on the Step input', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Step (Interval)');
+
+    fireEvent.change(input, { target: { value: '5' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+  });
+
+  it('resets the Step input to the original value after Escape', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Step (Interval)');
+
+    fireEvent.change(input, { target: { value: '5' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+
+    expect(input.value).toBe('1');
+  });
+
+  it('DOES call updateWidget on normal blur of Step after a prior Escape', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Step (Interval)');
+
+    // Cancel first.
+    fireEvent.change(input, { target: { value: '5' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      fireEvent.blur(input);
+    });
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+
+    // Real save next.
+    fireEvent.change(input, { target: { value: '2' } });
+    act(() => {
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).toHaveBeenCalledOnce();
+    expect(mockUpdateWidget).toHaveBeenCalledWith(
+      'nl-test-1',
+      expect.objectContaining({
+        config: expect.objectContaining({ step: 2 }) as unknown,
+      })
+    );
+  });
+
+  // ── Enter still saves ──────────────────────────────────────────────────────
+
+  it('saves Min Value on Enter (Enter path unaffected by fix)', () => {
+    render(<NumberLineSettings widget={baseWidget} />);
+
+    const input = screen.getByLabelText('Min Value');
+
+    fireEvent.change(input, { target: { value: '-3' } });
+
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.blur(input);
+    });
+
+    expect(mockUpdateWidget).toHaveBeenCalledOnce();
+    expect(mockUpdateWidget).toHaveBeenCalledWith(
+      'nl-test-1',
+      expect.objectContaining({
+        config: expect.objectContaining({ min: -3 }) as unknown,
+      })
+    );
+  });
+});

--- a/components/widgets/NumberLine/Settings.test.tsx
+++ b/components/widgets/NumberLine/Settings.test.tsx
@@ -104,7 +104,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Min Value input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
-    const input = screen.getByLabelText('Min Value');
+    const input = screen.getByLabelText('Min Value') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '99' } });
 
@@ -165,7 +165,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Max Value input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
-    const input = screen.getByLabelText('Max Value');
+    const input = screen.getByLabelText('Max Value') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '999' } });
 
@@ -225,7 +225,7 @@ describe('NumberLineSettings — Escape-cancel regression', () => {
   it('resets the Step input to the original value after Escape', () => {
     render(<NumberLineSettings widget={baseWidget} />);
 
-    const input = screen.getByLabelText('Step (Interval)');
+    const input = screen.getByLabelText('Step (Interval)') as HTMLInputElement;
 
     fireEvent.change(input, { target: { value: '5' } });
 

--- a/components/widgets/NumberLine/Settings.tsx
+++ b/components/widgets/NumberLine/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { SurfaceColorSettings } from '@/components/common/SurfaceColorSettings';
 import { TypographySettings } from '@/components/common/TypographySettings';
@@ -34,6 +34,11 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
   const updateConfig = (updates: Partial<NumberLineConfig>) => {
     updateWidget(widget.id, { config: { ...config, ...updates } });
   };
+
+  // Escape-cancel refs for uncontrolled number inputs
+  const minCancelledRef = useRef(false);
+  const maxCancelledRef = useRef(false);
+  const stepCancelledRef = useRef(false);
 
   // Add Jump State
   const [newJumpStart, setNewJumpStart] = useState<number>(0);
@@ -85,7 +90,12 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             <input
               type="number"
               defaultValue={min}
+              aria-label="Min Value"
               onBlur={(e) => {
+                if (minCancelledRef.current) {
+                  minCancelledRef.current = false;
+                  return;
+                }
                 const parsed = parseFloat(e.target.value);
                 if (!Number.isNaN(parsed)) {
                   const clamped = Math.max(
@@ -99,6 +109,10 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
                   e.currentTarget.blur();
+                } else if (e.key === 'Escape') {
+                  minCancelledRef.current = true;
+                  e.currentTarget.value = String(min);
+                  e.currentTarget.blur();
                 }
               }}
               className="w-full px-3 py-2 border border-slate-200 rounded-lg"
@@ -111,7 +125,12 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             <input
               type="number"
               defaultValue={max}
+              aria-label="Max Value"
               onBlur={(e) => {
+                if (maxCancelledRef.current) {
+                  maxCancelledRef.current = false;
+                  return;
+                }
                 const parsed = parseFloat(e.target.value);
                 if (!Number.isNaN(parsed)) {
                   const clamped = Math.max(
@@ -124,6 +143,10 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
+                  e.currentTarget.blur();
+                } else if (e.key === 'Escape') {
+                  maxCancelledRef.current = true;
+                  e.currentTarget.value = String(max);
                   e.currentTarget.blur();
                 }
               }}
@@ -139,7 +162,12 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               min="0.01"
               step="any"
               defaultValue={step}
+              aria-label="Step (Interval)"
               onBlur={(e) => {
+                if (stepCancelledRef.current) {
+                  stepCancelledRef.current = false;
+                  return;
+                }
                 const parsed = parseFloat(e.target.value);
                 if (!Number.isNaN(parsed)) {
                   const safeBaseStep = Math.max(0.01, parsed);
@@ -152,6 +180,10 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {
+                  e.currentTarget.blur();
+                } else if (e.key === 'Escape') {
+                  stepCancelledRef.current = true;
+                  e.currentTarget.value = String(step);
                   e.currentTarget.blur();
                 }
               }}


### PR DESCRIPTION
## Root Cause

`components/widgets/NumberLine/Settings.tsx` had three uncontrolled `<input type="number">` elements (Min Value, Max Value, Step) with `onBlur` save callbacks but no Escape cancel handler. In real browsers, pressing Escape while an input has focus triggers a native `blur` event synchronously. That blur fired `onBlur`, which called `updateConfig` with whatever the teacher had typed — silently persisting the cancelled value to Firestore.

This is the same stale-onBlur pattern previously fixed in DraggableWindow (#1965), RandomGroups (#1974), FolderTree/FolderSidebar (#1975), and PollWidget (#2064).

## Fix Summary

- Added `minCancelledRef`, `maxCancelledRef`, `stepCancelledRef` (`useRef(false)`) — one per input, assigned synchronously in render body.
- Added an `Escape` branch to each input's `onKeyDown` handler: sets the ref to `true`, resets `e.currentTarget.value` to the original prop value, then calls `e.currentTarget.blur()`.
- Each `onBlur` handler now checks its ref on entry — if `true`, resets the ref to `false` and returns early (skipping `updateConfig`). Normal blur/Enter saves are unaffected.
- Added `aria-label` attributes to all three inputs for accessibility and testability.

## Rejected Band-Aid

Wrapping the Escape key handler in a `useEffect` or debounce would hide the race but not fix it — the browser's synchronous blur fires before any async cleanup can run. The ref flag must be set synchronously before the blur, which is what this fix does.

## Regression Test

`components/widgets/NumberLine/Settings.test.tsx` — 10 new tests covering all three inputs:
- Escape does NOT call `updateWidget`
- DOM value reverts to original after Escape
- Normal blur after a previous Escape still saves correctly (ref reset confirmed)

**Before fix:** Test fails — `getByLabelText('Min Value')` throws because the original code had no `aria-label`; even if patched past that, `updateWidget` is called on Escape+blur.  
**After fix:** All 10 tests pass.

> Note: `tsc` strict mode and `eslint-typescript` disagree on the return type of `screen.getByLabelText()` (`HTMLElement` vs inferred `HTMLInputElement`). Three `// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion` comments resolve the conflict at the `.value`-accessing declarations. Both `pnpm run type-check` and `pnpm exec eslint ... --max-warnings 0` pass cleanly.

## Risk

**Contained** — change is limited to three `onKeyDown` handlers and three `onBlur` guards in a single settings component. No state shape changes, no Firestore schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MxYdKYysLuXL5x5mygD1V)_