### PR TITLE
fix(analytics): add missing AI feature labels for 6 Gemini features

### DIFF
--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -860,13 +860,10 @@ const WidgetsPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
   );
 };
 
-const AI_FEATURE_LABELS: Record<string, string> = {
-  'smart-poll': 'Smart Poll',
-  'embed-mini-app': 'Mini App',
-  'video-activity-audio-transcription': 'Video Activity',
-  quiz: 'Quiz Generation',
-  ocr: 'OCR',
-};
+// Re-exported from a separate module to keep this file component-only and
+// satisfy the react-refresh/only-export-components lint rule.
+export { AI_FEATURE_LABELS } from './aiFeatureLabels';
+import { AI_FEATURE_LABELS } from './aiFeatureLabels';
 
 const AiPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
   const featureRows = useMemo(

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -860,9 +860,6 @@ const WidgetsPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
   );
 };
 
-// Re-exported from a separate module to keep this file component-only and
-// satisfy the react-refresh/only-export-components lint rule.
-export { AI_FEATURE_LABELS } from './aiFeatureLabels';
 import { AI_FEATURE_LABELS } from './aiFeatureLabels';
 
 const AiPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {

--- a/components/admin/Analytics/AnalyticsManager.tsx
+++ b/components/admin/Analytics/AnalyticsManager.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/config/buildings';
 import { TOOLS } from '@/config/tools';
 import { LinksPanel } from './LinksPanel';
+import { AI_FEATURE_LABELS } from './aiFeatureLabels';
 
 interface EngagementCounts {
   total: number;
@@ -859,8 +860,6 @@ const WidgetsPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
     </div>
   );
 };
-
-import { AI_FEATURE_LABELS } from './aiFeatureLabels';
 
 const AiPanel: React.FC<{ data: AnalyticsData }> = ({ data }) => {
   const featureRows = useMemo(

--- a/components/admin/Analytics/aiFeatureLabels.ts
+++ b/components/admin/Analytics/aiFeatureLabels.ts
@@ -1,0 +1,25 @@
+/**
+ * Human-readable labels for Gemini feature IDs tracked in the `ai_usage`
+ * Firestore collection.
+ *
+ * These IDs are defined in `GEMINI_SPECIFIC_FEATURES` in
+ * `functions/src/adminAnalyticsCompute.ts`. When a new feature is added there,
+ * add a corresponding entry here so admins see a friendly name in the AI
+ * Feature Breakdown chart instead of the raw programmer-ID string.
+ *
+ * The fallback in AiPanel is: `AI_FEATURE_LABELS[feature] ?? feature`
+ * (i.e., unlabelled features fall back to the raw key).
+ */
+export const AI_FEATURE_LABELS: Record<string, string> = {
+  'smart-poll': 'Smart Poll',
+  'embed-mini-app': 'Mini App',
+  'video-activity-audio-transcription': 'Video Activity',
+  quiz: 'Quiz Generation',
+  ocr: 'OCR',
+  'blooms-ai': "Bloom's AI",
+  'video-activity-recommend': 'Video Recommendations',
+  'dashboard-layout': 'Dashboard Layout AI',
+  'instructional-routine': 'Instructional Routines AI',
+  'widget-builder': 'Widget Builder AI',
+  'widget-explainer': 'Widget Explainer AI',
+};

--- a/components/admin/Analytics/aiFeatureLabels.ts
+++ b/components/admin/Analytics/aiFeatureLabels.ts
@@ -1,15 +1,4 @@
-/**
- * Human-readable labels for Gemini feature IDs tracked in the `ai_usage`
- * Firestore collection.
- *
- * These IDs are defined in `GEMINI_SPECIFIC_FEATURES` in
- * `functions/src/adminAnalyticsCompute.ts`. When a new feature is added there,
- * add a corresponding entry here so admins see a friendly name in the AI
- * Feature Breakdown chart instead of the raw programmer-ID string.
- *
- * The fallback in AiPanel is: `AI_FEATURE_LABELS[feature] ?? feature`
- * (i.e., unlabelled features fall back to the raw key).
- */
+// Keep in sync with GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts.
 export const AI_FEATURE_LABELS: Record<string, string> = {
   'smart-poll': 'Smart Poll',
   'embed-mini-app': 'Mini App',

--- a/functions/src/adminAnalyticsCompute.ts
+++ b/functions/src/adminAnalyticsCompute.ts
@@ -462,6 +462,10 @@ export async function computeAnalyticsForOrg(
   // NOT included (by design):
   //   generateGuidedLearning — admin-only, writes no ai_usage counter at all
   //   generateVideoActivity  — writes only the overall {uid}_{date} counter
+  //
+  // IMPORTANT: Keep in sync with the mirror in
+  // tests/components/admin/Analytics/AiFeatureLabels.test.ts — that test's
+  // exhaustiveness check validates AI_FEATURE_LABELS against this list.
   const GEMINI_SPECIFIC_FEATURES = [
     'smart-poll',
     'embed-mini-app',

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -1,23 +1,8 @@
-/**
- * Regression test for AI_FEATURE_LABELS coverage.
- *
- * GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts defines
- * which feature IDs are tracked in the ai_usage collection. Each feature must
- * have a human-readable label in AI_FEATURE_LABELS so admins see friendly
- * names in the AI Feature Breakdown chart instead of raw programmer-ID strings.
- *
- * This test locks in the full expected set. If a new feature is added to
- * GEMINI_SPECIFIC_FEATURES without a corresponding label here the test will
- * fail, prompting the developer to add a label.
- */
 import { describe, it, expect } from 'vitest';
 import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/aiFeatureLabels';
 
-/**
- * Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts.
- * Keep this list in sync when features are added or removed there.
- * ('guided-learning' is intentionally absent — it writes no ai_usage counter.)
- */
+// Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts — keep in sync.
+// ('guided-learning' is intentionally absent — it writes no ai_usage counter.)
 const GEMINI_SPECIFIC_FEATURES = [
   'smart-poll',
   'embed-mini-app',

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Regression test for AI_FEATURE_LABELS coverage.
+ *
+ * GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts defines
+ * which feature IDs are tracked in the ai_usage collection. Each feature must
+ * have a human-readable label in AI_FEATURE_LABELS so admins see friendly
+ * names in the AI Feature Breakdown chart instead of raw programmer-ID strings.
+ *
+ * This test locks in the full expected set. If a new feature is added to
+ * GEMINI_SPECIFIC_FEATURES without a corresponding label here the test will
+ * fail, prompting the developer to add a label.
+ */
+import { describe, it, expect } from 'vitest';
+import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/AnalyticsManager';
+
+/**
+ * Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts.
+ * Keep this list in sync when features are added or removed there.
+ * Notably, 'guided-learning' was removed in PR #2067.
+ */
+const GEMINI_SPECIFIC_FEATURES = [
+  'smart-poll',
+  'embed-mini-app',
+  'video-activity-audio-transcription',
+  'quiz',
+  'ocr',
+  'blooms-ai',
+  'video-activity-recommend',
+  'dashboard-layout',
+  'instructional-routine',
+  'widget-builder',
+  'widget-explainer',
+] as const;
+
+describe('AI_FEATURE_LABELS', () => {
+  it('has a human-readable label for every tracked Gemini feature', () => {
+    const missing: string[] = [];
+
+    for (const featureId of GEMINI_SPECIFIC_FEATURES) {
+      const label = AI_FEATURE_LABELS[featureId];
+      if (!label || label === featureId) {
+        missing.push(featureId);
+      }
+    }
+
+    expect(
+      missing,
+      `Missing friendly labels for: ${missing.join(', ')}`
+    ).toHaveLength(0);
+  });
+
+  it('label values differ from their raw feature-ID keys', () => {
+    for (const featureId of GEMINI_SPECIFIC_FEATURES) {
+      const label = AI_FEATURE_LABELS[featureId];
+      expect(
+        label,
+        `Label for '${featureId}' should not equal the raw key`
+      ).not.toBe(featureId);
+    }
+  });
+
+  it('contains exactly the expected feature IDs (no stale entries)', () => {
+    const labelKeys = Object.keys(AI_FEATURE_LABELS).sort();
+    const expectedKeys = [...GEMINI_SPECIFIC_FEATURES].sort();
+    expect(labelKeys).toEqual(expectedKeys);
+  });
+});

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -11,7 +11,7 @@
  * fail, prompting the developer to add a label.
  */
 import { describe, it, expect } from 'vitest';
-import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/AnalyticsManager';
+import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/aiFeatureLabels';
 
 /**
  * Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts.

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -49,16 +49,6 @@ describe('AI_FEATURE_LABELS', () => {
     ).toHaveLength(0);
   });
 
-  it('label values differ from their raw feature-ID keys', () => {
-    for (const featureId of GEMINI_SPECIFIC_FEATURES) {
-      const label = AI_FEATURE_LABELS[featureId];
-      expect(
-        label,
-        `Label for '${featureId}' should not equal the raw key`
-      ).not.toBe(featureId);
-    }
-  });
-
   it('contains exactly the expected feature IDs (no stale entries)', () => {
     const labelKeys = Object.keys(AI_FEATURE_LABELS).sort();
     const expectedKeys = [...GEMINI_SPECIFIC_FEATURES].sort();

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -16,7 +16,7 @@ import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/aiFeatureLabels'
 /**
  * Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts.
  * Keep this list in sync when features are added or removed there.
- * Notably, 'guided-learning' was removed in PR #2067.
+ * ('guided-learning' is intentionally absent — it writes no ai_usage counter.)
  */
 const GEMINI_SPECIFIC_FEATURES = [
   'smart-poll',


### PR DESCRIPTION
## Root Cause

`components/admin/Analytics/AnalyticsManager.tsx` contained an `AI_FEATURE_LABELS` map with 5 entries matching the original set of tracked Gemini features. Over subsequent releases, 6 new features were added to `GEMINI_SPECIFIC_FEATURES` in `functions/src/adminAnalyticsCompute.ts` (which now has 11 entries). The `AiPanel` component used `AI_FEATURE_LABELS[feature] ?? feature` as a fallback — so the 6 unlabelled features silently fell through and displayed raw programmer-ID strings (`blooms-ai`, `video-activity-recommend`, `dashboard-layout`, `instructional-routine`, `widget-builder`, `widget-explainer`) in the AI Feature Breakdown chart visible to admins.

## Fix Summary

1. Extracted `AI_FEATURE_LABELS` to `components/admin/Analytics/aiFeatureLabels.ts` — required because the `react-refresh/only-export-components` ESLint rule disallows exporting non-component values from component files.
2. Added the 6 missing human-readable labels:
   - `'blooms-ai'` → `"Bloom's AI"`
   - `'video-activity-recommend'` → `"Video Recommendations"`
   - `'dashboard-layout'` → `"Dashboard Layout AI"`
   - `'instructional-routine'` → `"Instructional Routines AI"`
   - `'widget-builder'` → `"Widget Builder AI"`
   - `'widget-explainer'` → `"Widget Explainer AI"`
3. Added sync comments cross-referencing `GEMINI_SPECIFIC_FEATURES` in `adminAnalyticsCompute.ts`.

## Rejected Band-Aid

Replacing the `?? feature` fallback with `?? formatFeatureId(feature)` (e.g. replacing hyphens with spaces) would produce passable output (`blooms ai`) but miss the opportunity to provide accurate names like "Bloom's AI". The root cause is a missing label list, not a missing formatter.

## Regression Test

`tests/components/admin/Analytics/AiFeatureLabels.test.ts` — 2 `it()` blocks:
1. Every key in the expected feature ID list has a truthy label that differs from the raw key (catches both missing labels and identity-mapped labels in one pass).
2. The map is exhaustive against the current `GEMINI_SPECIFIC_FEATURES` list (catches stale entries).

**Before fix:** Tests would fail for the 6 missing features.  
**After fix:** Both tests pass.

## Risk

**Contained** — change adds a new file and updates one import in AnalyticsManager. No data model, Firestore, or routing changes. Admin-only panel.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MxYdKYysLuXL5x5mygD1V)_