### PR TITLE
Address PR #2098 review comments (NonNullable, label htmlFor, AI-feature sync docs)

### DIFF
--- a/components/widgets/NumberLine/Settings.tsx
+++ b/components/widgets/NumberLine/Settings.tsx
@@ -200,10 +200,14 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div>
-            <label className="block text-xs font-semibold text-slate-500 mb-1">
+            <label
+              htmlFor={`nl-display-${widget.id}`}
+              className="block text-xs font-semibold text-slate-500 mb-1"
+            >
               Display Mode
             </label>
             <select
+              id={`nl-display-${widget.id}`}
               value={displayMode}
               onChange={(e) =>
                 updateConfig({

--- a/components/widgets/NumberLine/Settings.tsx
+++ b/components/widgets/NumberLine/Settings.tsx
@@ -84,10 +84,14 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
         <SettingsLabel icon={Settings}>Axis Configuration</SettingsLabel>
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-xs font-semibold text-slate-500 mb-1">
+            <label
+              htmlFor={`nl-min-${widget.id}`}
+              className="block text-xs font-semibold text-slate-500 mb-1"
+            >
               Min Value
             </label>
             <input
+              id={`nl-min-${widget.id}`}
               type="number"
               defaultValue={min}
               aria-label="Min Value"
@@ -119,10 +123,14 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div>
-            <label className="block text-xs font-semibold text-slate-500 mb-1">
+            <label
+              htmlFor={`nl-max-${widget.id}`}
+              className="block text-xs font-semibold text-slate-500 mb-1"
+            >
               Max Value
             </label>
             <input
+              id={`nl-max-${widget.id}`}
               type="number"
               defaultValue={max}
               aria-label="Max Value"
@@ -154,10 +162,14 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div>
-            <label className="block text-xs font-semibold text-slate-500 mb-1">
+            <label
+              htmlFor={`nl-step-${widget.id}`}
+              className="block text-xs font-semibold text-slate-500 mb-1"
+            >
               Step (Interval)
             </label>
             <input
+              id={`nl-step-${widget.id}`}
               type="number"
               min="0.01"
               step="any"

--- a/components/widgets/NumberLine/Settings.tsx
+++ b/components/widgets/NumberLine/Settings.tsx
@@ -94,7 +94,6 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               id={`nl-min-${widget.id}`}
               type="number"
               defaultValue={min}
-              aria-label="Min Value"
               onBlur={(e) => {
                 if (minCancelledRef.current) {
                   minCancelledRef.current = false;
@@ -133,7 +132,6 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               id={`nl-max-${widget.id}`}
               type="number"
               defaultValue={max}
-              aria-label="Max Value"
               onBlur={(e) => {
                 if (maxCancelledRef.current) {
                   maxCancelledRef.current = false;
@@ -174,7 +172,6 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
               min="0.01"
               step="any"
               defaultValue={step}
-              aria-label="Step (Interval)"
               onBlur={(e) => {
                 if (stepCancelledRef.current) {
                   stepCancelledRef.current = false;

--- a/tests/components/admin/Analytics/AiFeatureLabels.test.ts
+++ b/tests/components/admin/Analytics/AiFeatureLabels.test.ts
@@ -3,6 +3,14 @@ import { AI_FEATURE_LABELS } from '@/components/admin/Analytics/aiFeatureLabels'
 
 // Mirror of GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts — keep in sync.
 // ('guided-learning' is intentionally absent — it writes no ai_usage counter.)
+//
+// IMPORTANT: Adding a new AI feature requires updating THREE locations atomically.
+// Because frontend tests cannot import from functions/src/ (cross-package boundary),
+// this list is a manual copy and cannot be derived from the source of truth — so a
+// missed update here would otherwise pass silently while the chart shows a raw ID:
+//   1. GEMINI_SPECIFIC_FEATURES in functions/src/adminAnalyticsCompute.ts (source of truth)
+//   2. AI_FEATURE_LABELS in components/admin/Analytics/aiFeatureLabels.ts
+//   3. GEMINI_SPECIFIC_FEATURES in this test file
 const GEMINI_SPECIFIC_FEATURES = [
   'smart-poll',
   'embed-mini-app',

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -722,7 +722,7 @@ export class QuizDriveService {
       // First-occurrence dedup mirrors buildResultsSheetDataShared — correctSet must agree with the grader's first-occurrence semantics.
       const firstOccurrenceAnswers = new Map<
         string,
-        (typeof r.answers)[number]
+        NonNullable<typeof r.answers>[number]
       >();
       for (const a of r.answers ?? []) {
         if (!firstOccurrenceAnswers.has(a.questionId)) {


### PR DESCRIPTION
This PR applies fixes for the three unresolved review threads on #2098. It targets `dev-paul` so the changes flow into that PR's branch (the environment blocks pushing directly to `dev-paul`).

## Changes

1. **`utils/quizDriveService.ts`** — Apply the reviewer's `NonNullable<typeof r.answers>[number]` suggestion. While `QuizResponse.answers` is currently a required non-optional type (so the original compiled fine), `NonNullable` makes the defensive intent explicit and is resilient if the signature ever widens to optional.

2. **`tests/components/admin/Analytics/AiFeatureLabels.test.ts`** — Expand the existing "keep in sync" comment to explicitly document the three locations that must be updated atomically when adding a new AI feature (the cross-package boundary prevents importing the source of truth directly).

3. **`components/widgets/NumberLine/Settings.tsx`** — Link each visible `<label>` (Min/Max/Step) to its input via `htmlFor`/`id` (keyed by `widget.id` to avoid collisions), so clicking the label text focuses the input — completing the accessibility pass.

## Validation

- `pnpm run type-check` — passes
- `eslint` + `prettier` — clean on edited files
- Affected tests (`AiFeatureLabels.test.ts`, `NumberLine/Settings.test.tsx`) — 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018NkijkG22yZBsJVuJSRxWv)_