### PR TITLE
fix(plcWeeklyDigest): removed member leaks back in via legacy memberEmails mirror

### DIFF
--- a/functions/src/plcWeeklyDigest.test.ts
+++ b/functions/src/plcWeeklyDigest.test.ts
@@ -157,6 +157,32 @@ describe('collectRecipientEmails — de-dupe + lowercase, no fan-out', () => {
     expect(recipients).toEqual(['active@school.org']);
   });
 
+  it('does not leak a removed member via legacy memberEmails when memberUids is absent', () => {
+    // Regression: a legacy PLC may carry BOTH a canonical `members` map (which
+    // gates on status) AND a denormalized `memberEmails` mirror (no per-uid
+    // status).  When `memberUids` is absent, the memberEmails guard
+    // (`if (activeMemberUids && !activeMemberUids.has(uid)) continue`) never
+    // fires, so a uid marked `removed` in `members` still slips through via
+    // memberEmails and receives the digest — a privacy leak.
+    //
+    // Correct behavior: the removed member's email must never appear in the
+    // result, regardless of which source of truth (members map or memberEmails
+    // mirror) it comes from.
+    const recipients = collectRecipientEmails({
+      members: {
+        u1: { email: 'active@school.org', status: 'active' },
+        u2: { email: 'removed@school.org', status: 'removed' },
+      },
+      memberEmails: {
+        u1: 'active@school.org',
+        u2: 'removed@school.org',
+      },
+      // No memberUids — simulates a legacy PLC that pre-dates the active-only
+      // memberUids index.
+    });
+    expect(recipients).toEqual(['active@school.org']);
+  });
+
   it('drops a legacy memberEmails entry whose uid is not in (active-only) memberUids', () => {
     // Un-migrated PLC: no members map; memberEmails still lists a removed
     // teacher. memberUids is the active-only source of truth → filter by it.

--- a/functions/src/plcWeeklyDigest.ts
+++ b/functions/src/plcWeeklyDigest.ts
@@ -295,13 +295,24 @@ export function collectRecipientEmails(plc: {
     : null;
   // Prefer the canonical members map (carries email); fall back to the
   // denormalized memberEmails mirror for legacy PLCs.
+  //
+  // Track UIDs of removed members so the memberEmails pass below can exclude
+  // them even when `memberUids` is absent (legacy PLCs pre-dating the
+  // active-only uid index). Without this, a uid marked `removed` in `members`
+  // leaks back in via the unguarded memberEmails path.
+  const removedUids = new Set<string>();
   const members = plc.members;
   if (members && typeof members === 'object') {
-    for (const member of Object.values(members as Record<string, unknown>)) {
+    for (const [uid, member] of Object.entries(
+      members as Record<string, unknown>
+    )) {
       if (member && typeof member === 'object') {
         // Removed members keep an audit entry in the map (status 'removed')
         // but must NOT receive the digest — only active members are recipients.
-        if ((member as { status?: unknown }).status === 'removed') continue;
+        if ((member as { status?: unknown }).status === 'removed') {
+          removedUids.add(uid);
+          continue;
+        }
         add((member as { email?: unknown }).email);
       }
     }
@@ -314,6 +325,10 @@ export function collectRecipientEmails(plc: {
       // Skip emails whose uid is no longer an active member (defends the
       // legacy/un-migrated path; the members-map path above filters by status).
       if (activeMemberUids && !activeMemberUids.has(uid)) continue;
+      // Also skip UIDs that were explicitly marked 'removed' in the members
+      // map — prevents a removed member whose email lingers in the legacy
+      // memberEmails mirror from receiving the digest when memberUids is absent.
+      if (removedUids.has(uid)) continue;
       add(email);
     }
   }


### PR DESCRIPTION
## Summary

Bug found and fixed by the nightly code-health pass (2026-06-28).

### Bug — `plcWeeklyDigest`: removed PLC members still receive the weekly digest on legacy PLCs (commit `d002132`)

**Root cause:** `collectRecipientEmails` builds recipients from two sources in sequence: the canonical `members` map (with per-uid `status` fields) and the legacy denormalized `memberEmails` mirror (no status). The guard on the `memberEmails` pass was:

```typescript
if (activeMemberUids && !activeMemberUids.has(uid)) continue;
```

`activeMemberUids` is `null` when the PLC pre-dates the `memberUids` active-only index. `null && ...` is always falsy, so the guard never fires. A uid marked `status: 'removed'` in `members` (correctly skipped in the first pass) slips back in via the `memberEmails` mirror — a privacy leak: the removed teacher receives the weekly digest.

**Fix:** Track removed uids as a `Set<string>` while walking the `members` map. In the `memberEmails` pass, consult `removedUids` as a second guard — both checks are active regardless of whether `memberUids` exists.

**Test:** Regression test: legacy PLC with `members` (uid2 `status: 'removed'`) and `memberEmails` containing both uids, no `memberUids` index. Asserts only `active@school.org` appears in the output.

**Evidence of fail → pass:**
- Before fix: `Tests 699 passed | 1 failed` — `AssertionError: expected ['active@school.org', 'removed@school.org'] to deeply equal ['active@school.org']`
- After fix: `Tests 700 passed (700)`

## Test plan

- [ ] `pnpm run validate` (functions) green on this branch
- [ ] `plcWeeklyDigest.test.ts` — new regression test passes; removed member no longer in recipient list
- [ ] Manual review: legacy PLCs without `memberUids` should only send digest to active members

---
_Generated by [Claude Code](https://claude.ai/code/session_014C7NDGcGFymQbA8cHuc8Jo)_