### PR TITLE
fix(quiz): matching question denominator inflated by duplicate left-terms in answer key

### DIFF
--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -425,10 +425,7 @@ export function gradeAnswer(
   if (question.type === 'Matching') {
     const correctPairs = correct.split('|').map(normalizeAnswer);
     const givenPairs = given.split('|').map(normalizeAnswer);
-    // Build a left→right map from the answer key. Counting by full pair
-    // membership in a Set lets a student score full credit by repeating one
-    // correct pair (e.g. correct "a:1|b:2", given "a:1|a:1" → 2/2). Keying by
-    // left term ensures each prompt is graded at most once.
+    // Build a left→right map; last entry wins for any duplicate left-term.
     const splitPair = (p: string): [string, string] => {
       const sep = p.indexOf(':');
       return sep < 0 ? [p, ''] : [p.slice(0, sep), p.slice(sep + 1)];
@@ -448,7 +445,8 @@ export function gradeAnswer(
         matched++;
       }
     }
-    const total = correctPairs.length;
+    // Size = unique prompts; raw length inflates total when correctAnswer has duplicate left-terms.
+    const total = correctMap.size;
     // Strict correctness: every prompt matched AND no extra pairs submitted.
     const strictCorrect = matched === total && givenPairs.length === total;
     if (!partial) {

--- a/tests/hooks/useQuizSession.test.ts
+++ b/tests/hooks/useQuizSession.test.ts
@@ -204,6 +204,38 @@ describe('gradeAnswer', () => {
       expect(partial.pointsEarned).toBeCloseTo(1, 5);
     });
 
+    it('Matching: duplicate left-term in answer key does not make question ungradeable', () => {
+      // Regression: if the stored correctAnswer has a duplicate left-term
+      // (e.g. authored as "a:1|a:2|b:3" — last write wins in the correctMap,
+      // leaving a→2, b→3), `total` must reflect the number of *unique* prompts
+      // (2), not the raw pair count (3).  With the old code (total=3) a student
+      // who correctly supplies both unique prompts "a:2|b:3" scores matched=2
+      // but total=3, earning only 2/3 partial credit and never achieving
+      // isCorrect=true — a question that is mathematically impossible to ace.
+      const q: QuizQuestion = {
+        id: 'pm-dup-key',
+        timeLimit: 0,
+        text: 'Match',
+        type: 'Matching',
+        // duplicate left-term 'a': last entry (a:2) wins in correctMap
+        correctAnswer: 'a:1|a:2|b:3',
+        incorrectAnswers: [],
+        points: 2,
+        allowPartialCredit: true,
+      };
+      // Student answers the two *unique* prompts correctly per the map (a→2, b→3)
+      const grade = gradeAnswer(q, 'a:2|b:3');
+      // Should earn full credit for matching all unique prompts
+      expect(grade.isCorrect).toBe(true);
+      expect(grade.pointsEarned).toBe(2);
+
+      // Strict (non-partial) variant
+      const strictQ: QuizQuestion = { ...q, allowPartialCredit: false };
+      const strict = gradeAnswer(strictQ, 'a:2|b:3');
+      expect(strict.isCorrect).toBe(true);
+      expect(strict.pointsEarned).toBe(2);
+    });
+
     it('Matching: full-credit bonus path still produces isCorrect=true with partial enabled', () => {
       const q: QuizQuestion = {
         id: 'pm3',


### PR DESCRIPTION
## Summary

- **Bug:** `gradeAnswer` for `Matching` questions used `correctPairs.length` as the denominator, but when `correctAnswer` contains a duplicate left-term (e.g. `"a:1|a:2|b:3"`), the `correctMap` only holds one entry per left-term while the raw pair count is higher. This made it mathematically impossible to earn full credit on such questions.
- **Fix:** Replace `const total = correctPairs.length` with `const total = correctMap.size` in `hooks/useQuizSession.ts:456`. The denominator now reflects the number of unique prompts the map can actually grade.
- **Test:** New regression test `'Matching: duplicate left-term in answer key does not make question ungradeable'` fails on `dev-paul`, passes after the fix. All 105 existing tests continue to pass.

## Files changed

- `hooks/useQuizSession.ts` — one-line fix + comment update
- `tests/hooks/useQuizSession.test.ts` — regression test

## Test plan

- [ ] `pnpm run test` — 105 tests pass in `useQuizSession.test.ts`
- [ ] Assign a matching quiz question with a duplicate left-term answer key; student answering all unique prompts correctly receives full credit

🤖 Nightly debugger run 22 — 2026-06-29

---
_Generated by [Claude Code](https://claude.ai/code/session_014uHLEm9dXsfMdjGLoDJmux)_