### PR TITLE
fix(functions): mirrorPlcIndex falls back to members map for lead-email when memberEmails absent

### DIFF
--- a/functions/src/mirrorPlcIndex.test.ts
+++ b/functions/src/mirrorPlcIndex.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // mirrorPlcIndex.ts has four module-level side effects that must be mocked
 // before the import so Vitest's transform can resolve them:
@@ -45,7 +45,12 @@ vi.mock('firebase-functions/logger', () => ({
   debug: vi.fn(),
 }));
 
-import { buildPlcIndexMirror, discoveryOrgId } from './mirrorPlcIndex';
+import * as admin from 'firebase-admin';
+import {
+  buildPlcIndexMirror,
+  discoveryOrgId,
+  mirrorPlcIndex,
+} from './mirrorPlcIndex';
 
 describe('buildPlcIndexMirror — slim, PII-free discovery mirror', () => {
   it('projects name / orgId / buildingId / memberUids + count (NO member PII)', () => {
@@ -132,5 +137,171 @@ describe('discoveryOrgId — anti-forgery gate on the discovery mirror', () => {
   it('returns null for an un-tenanted PLC (no claimed orgId)', () => {
     expect(discoveryOrgId(null, false)).toBeNull();
     expect(discoveryOrgId(null, true)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mirrorPlcIndex handler — forgery-guard lead-email resolution
+//
+// The forgery guard verifies that the PLC's LEAD is actually a member of the
+// claimed orgId before writing it to the discovery mirror. It resolves the
+// lead's email from (a) the denormalized `memberEmails` map or (b) the
+// canonical `members` map. A regression where only (a) is checked causes
+// post-migration PLCs — which may have `members` but no `memberEmails` — to
+// have their orgId silently dropped to null in the discovery mirror, making
+// them invisible to same-org peers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal stub Firestore for the handler: captures `plcIndex/{id}.set()` calls
+ * and answers `organizations/{orgId}/members/{email}.get()` queries.
+ */
+function makeHandlerDb(opts: {
+  leadIsMember: boolean;
+  captured: { path: string; data: Record<string, unknown> }[];
+}) {
+  const docRef = (
+    path: string
+  ): {
+    get: () => Promise<{ exists: boolean }>;
+    set: (data: Record<string, unknown>) => Promise<void>;
+    delete: () => Promise<void>;
+  } => ({
+    get: () => Promise.resolve({ exists: opts.leadIsMember }),
+    set: (data) => {
+      opts.captured.push({ path, data });
+      return Promise.resolve();
+    },
+    delete: () => Promise.resolve(),
+  });
+
+  return {
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        const base = `${name}/${id}`;
+        return {
+          ...docRef(base),
+          collection: (sub: string) => ({
+            doc: (subId: string) => docRef(`${base}/${sub}/${subId}`),
+          }),
+        };
+      },
+    }),
+    doc: (path: string) => docRef(path),
+  } as unknown as admin.firestore.Firestore;
+}
+
+/** Minimal Firestore event that drives the mirrorPlcIndex handler. */
+function makeEvent(
+  plcId: string,
+  afterData: Record<string, unknown> | null
+): Parameters<typeof mirrorPlcIndex>[0] {
+  return {
+    params: { plcId },
+    data: {
+      before: { exists: false, data: () => undefined },
+      after: {
+        exists: afterData !== null,
+        data: () => afterData ?? undefined,
+      },
+    },
+  } as unknown as Parameters<typeof mirrorPlcIndex>[0];
+}
+
+describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery guard', () => {
+  let captured: { path: string; data: Record<string, unknown> }[];
+
+  beforeEach(() => {
+    captured = [];
+    // Wire the firebase-admin mock so admin.firestore() returns our stub.
+    vi.mocked(admin.firestore).mockReturnValue(
+      makeHandlerDb({ leadIsMember: true, captured }) as unknown as ReturnType<
+        typeof admin.firestore
+      >
+    );
+  });
+
+  it('preserves orgId in the mirror when the lead email comes from memberEmails (baseline)', async () => {
+    // Classic pre-migration PLC: memberEmails contains the uid→email map;
+    // no canonical members map. Baseline confirms the happy path still works.
+    const event = makeEvent('plc-1', {
+      name: 'Math PLC',
+      orgId: 'orono',
+      leadUid: 'u1',
+      memberUids: ['u1'],
+      memberEmails: { u1: 'lead@orono.k12.mn.us' },
+    });
+
+    await mirrorPlcIndex(event);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].data.orgId).toBe('orono');
+  });
+
+  it(
+    'preserves orgId in the mirror when the lead email comes only from the ' +
+      'canonical members map (memberEmails absent — regression)',
+    async () => {
+      // Post-migration PLC: canonical `members` map holds the lead email but
+      // `memberEmails` was never populated (or was omitted on a Wave-1 create).
+      // Before the fix, the handler only read `memberEmails`, found nothing,
+      // and wrote orgId: null — making the PLC invisible in org discovery.
+      const event = makeEvent('plc-2', {
+        name: 'Science PLC',
+        orgId: 'orono',
+        leadUid: 'u1',
+        memberUids: ['u1'],
+        // No memberEmails field — only the canonical members map.
+        members: {
+          u1: {
+            uid: 'u1',
+            email: 'lead@orono.k12.mn.us',
+            displayName: 'Lead Teacher',
+            role: 'lead',
+            status: 'active',
+          },
+        },
+      });
+
+      await mirrorPlcIndex(event);
+
+      expect(captured).toHaveLength(1);
+      // orgId must be preserved — the lead IS a verified org member and the
+      // email came from the members map (the fallback path). Before the fix
+      // this would be null, silently hiding the PLC from org peers.
+      expect(captured[0].data.orgId).toBe('orono');
+    }
+  );
+
+  it('still drops a forged orgId to null when the lead email resolves but the member check fails', async () => {
+    // Wire a db where the lead is NOT found in the org's members collection.
+    vi.mocked(admin.firestore).mockReturnValue(
+      makeHandlerDb({
+        leadIsMember: false,
+        captured,
+      }) as unknown as ReturnType<typeof admin.firestore>
+    );
+
+    const event = makeEvent('plc-3', {
+      name: 'Forged PLC',
+      orgId: 'wrong-org',
+      leadUid: 'u1',
+      memberUids: ['u1'],
+      members: {
+        u1: {
+          uid: 'u1',
+          email: 'lead@myschool.org',
+          role: 'lead',
+          status: 'active',
+        },
+      },
+    });
+
+    await mirrorPlcIndex(event);
+
+    expect(captured).toHaveLength(1);
+    // The lead's email resolved (from members map), but the org membership
+    // check failed → forgery guard must still null out the orgId.
+    expect(captured[0].data.orgId).toBeNull();
   });
 });

--- a/functions/src/mirrorPlcIndex.test.ts
+++ b/functions/src/mirrorPlcIndex.test.ts
@@ -159,6 +159,7 @@ describe('discoveryOrgId — anti-forgery gate on the discovery mirror', () => {
 function makeHandlerDb(opts: {
   leadIsMember: boolean;
   captured: { path: string; data: Record<string, unknown> }[];
+  queriedPaths?: string[];
 }) {
   const docRef = (
     path: string
@@ -167,7 +168,10 @@ function makeHandlerDb(opts: {
     set: (data: Record<string, unknown>) => Promise<void>;
     delete: () => Promise<void>;
   } => ({
-    get: () => Promise.resolve({ exists: opts.leadIsMember }),
+    get: () => {
+      opts.queriedPaths?.push(path);
+      return Promise.resolve({ exists: opts.leadIsMember });
+    },
     set: (data) => {
       opts.captured.push({ path, data });
       return Promise.resolve();
@@ -210,12 +214,14 @@ function makeEvent(
 
 describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery guard', () => {
   let captured: { path: string; data: Record<string, unknown> }[];
+  let queriedPaths: string[];
 
   beforeEach(() => {
     captured = [];
+    queriedPaths = [];
     // Wire the firebase-admin mock so admin.firestore() returns our stub.
     vi.mocked(admin.firestore).mockReturnValue(
-      makeHandlerDb({ leadIsMember: true, captured }) as unknown as ReturnType<
+      makeHandlerDb({ leadIsMember: true, captured, queriedPaths }) as unknown as ReturnType<
         typeof admin.firestore
       >
     );
@@ -235,7 +241,9 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
     await mirrorPlcIndex(event);
 
     expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe('plcIndex/plc-1');
     expect(captured[0].data.orgId).toBe('orono');
+    expect(queriedPaths).toContain('organizations/orono/members/lead@orono.k12.mn.us');
   });
 
   it(
@@ -266,10 +274,12 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
       await mirrorPlcIndex(event);
 
       expect(captured).toHaveLength(1);
+      expect(captured[0].path).toBe('plcIndex/plc-2');
       // orgId must be preserved — the lead IS a verified org member and the
       // email came from the members map (the fallback path). Before the fix
       // this would be null, silently hiding the PLC from org peers.
       expect(captured[0].data.orgId).toBe('orono');
+      expect(queriedPaths).toContain('organizations/orono/members/lead@orono.k12.mn.us');
     }
   );
 
@@ -279,6 +289,7 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
       makeHandlerDb({
         leadIsMember: false,
         captured,
+        queriedPaths,
       }) as unknown as ReturnType<typeof admin.firestore>
     );
 
@@ -300,8 +311,10 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
     await mirrorPlcIndex(event);
 
     expect(captured).toHaveLength(1);
+    expect(captured[0].path).toBe('plcIndex/plc-3');
     // The lead's email resolved (from members map), but the org membership
     // check failed → forgery guard must still null out the orgId.
     expect(captured[0].data.orgId).toBeNull();
+    expect(queriedPaths).toContain('organizations/wrong-org/members/lead@myschool.org');
   });
 });

--- a/functions/src/mirrorPlcIndex.test.ts
+++ b/functions/src/mirrorPlcIndex.test.ts
@@ -221,9 +221,11 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
     queriedPaths = [];
     // Wire the firebase-admin mock so admin.firestore() returns our stub.
     vi.mocked(admin.firestore).mockReturnValue(
-      makeHandlerDb({ leadIsMember: true, captured, queriedPaths }) as unknown as ReturnType<
-        typeof admin.firestore
-      >
+      makeHandlerDb({
+        leadIsMember: true,
+        captured,
+        queriedPaths,
+      }) as unknown as ReturnType<typeof admin.firestore>
     );
   });
 
@@ -243,7 +245,9 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
     expect(captured).toHaveLength(1);
     expect(captured[0].path).toBe('plcIndex/plc-1');
     expect(captured[0].data.orgId).toBe('orono');
-    expect(queriedPaths).toContain('organizations/orono/members/lead@orono.k12.mn.us');
+    expect(queriedPaths).toContain(
+      'organizations/orono/members/lead@orono.k12.mn.us'
+    );
   });
 
   it(
@@ -279,7 +283,9 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
       // email came from the members map (the fallback path). Before the fix
       // this would be null, silently hiding the PLC from org peers.
       expect(captured[0].data.orgId).toBe('orono');
-      expect(queriedPaths).toContain('organizations/orono/members/lead@orono.k12.mn.us');
+      expect(queriedPaths).toContain(
+        'organizations/orono/members/lead@orono.k12.mn.us'
+      );
     }
   );
 
@@ -315,6 +321,8 @@ describe('mirrorPlcIndex handler — lead-email resolution for orgId forgery gua
     // The lead's email resolved (from members map), but the org membership
     // check failed → forgery guard must still null out the orgId.
     expect(captured[0].data.orgId).toBeNull();
-    expect(queriedPaths).toContain('organizations/wrong-org/members/lead@myschool.org');
+    expect(queriedPaths).toContain(
+      'organizations/wrong-org/members/lead@myschool.org'
+    );
   });
 });

--- a/functions/src/mirrorPlcIndex.ts
+++ b/functions/src/mirrorPlcIndex.ts
@@ -129,8 +129,24 @@ export const mirrorPlcIndex = onDocumentWritten(
         unknown
       >;
       const rawLeadEmail = leadUid ? memberEmails[leadUid] : null;
+      // Fall back to the canonical `members` map when the denormalized
+      // `memberEmails` mirror is absent (e.g. a Wave-1 PLC that was never
+      // back-filled). Both fields carry the same email for active members;
+      // `members[uid].email` is the on-disk source of truth post-migration.
+      const rawLeadEmailFromMap =
+        leadUid && rootData.members && typeof rootData.members === 'object'
+          ? (
+              (rootData.members as Record<string, unknown>)[leadUid] as
+                | { email?: unknown }
+                | undefined
+            )?.email
+          : undefined;
       const leadEmail =
-        typeof rawLeadEmail === 'string' ? rawLeadEmail.toLowerCase() : null;
+        typeof rawLeadEmail === 'string'
+          ? rawLeadEmail.toLowerCase()
+          : typeof rawLeadEmailFromMap === 'string'
+            ? rawLeadEmailFromMap.toLowerCase()
+            : null;
       if (leadEmail) {
         const memberSnap = await db
           .doc(`organizations/${mirror.orgId}/members/${leadEmail}`)

--- a/functions/src/mirrorPlcIndex.ts
+++ b/functions/src/mirrorPlcIndex.ts
@@ -135,11 +135,7 @@ export const mirrorPlcIndex = onDocumentWritten(
       // `members[uid].email` is the on-disk source of truth post-migration.
       const rawLeadEmailFromMap =
         leadUid && rootData.members && typeof rootData.members === 'object'
-          ? (
-              (rootData.members as Record<string, unknown>)[leadUid] as
-                | { email?: unknown }
-                | undefined
-            )?.email
+          ? (rootData.members as Record<string, Record<string, unknown>>)[leadUid]?.email
           : undefined;
       const leadEmail =
         typeof rawLeadEmail === 'string'

--- a/functions/src/mirrorPlcIndex.ts
+++ b/functions/src/mirrorPlcIndex.ts
@@ -135,7 +135,9 @@ export const mirrorPlcIndex = onDocumentWritten(
       // `members[uid].email` is the on-disk source of truth post-migration.
       const rawLeadEmailFromMap =
         leadUid && rootData.members && typeof rootData.members === 'object'
-          ? (rootData.members as Record<string, Record<string, unknown>>)[leadUid]?.email
+          ? (rootData.members as Record<string, Record<string, unknown>>)[
+              leadUid
+            ]?.email
           : undefined;
       const leadEmail =
         typeof rawLeadEmail === 'string'


### PR DESCRIPTION
## Summary

- **Bug:** `mirrorPlcIndex` Cloud Function only read `memberEmails[leadUid]` for the orgId forgery-guard lead-email lookup. Any PLC without the `memberEmails` denormalized field (Wave-1 PLCs, newly-created PLCs) returned `null` for `leadEmail`, skipping the org membership check and writing `orgId: null` to the discovery mirror. Affected PLCs become invisible in same-org peer discovery.
- **Fix:** After failing to find the email in `memberEmails`, fall back to `(members[leadUid] as { email? }).email` — the canonical on-disk source of truth.
- **Test:** 3 new handler integration tests: baseline (memberEmails present → orgId preserved), regression (only members map → orgId preserved), forgery guard (email resolves but membership fails → orgId null). Total: 702 tests pass.

## Files changed

- `functions/src/mirrorPlcIndex.ts` — fallback email resolution
- `functions/src/mirrorPlcIndex.test.ts` — 3 new handler tests

## Test plan

- [ ] `pnpm -C functions run test` — 702 tests pass
- [ ] Wave-1 PLC (only `members` map populated) appears correctly in org discovery directory

🤖 Nightly debugger run 22 — 2026-06-29

---
_Generated by [Claude Code](https://claude.ai/code/session_014uHLEm9dXsfMdjGLoDJmux)_