### PR TITLE
fix(layout): plug remaining isLocked gaps — mini toolbar settings gear + DraggableSticker Delete

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -2921,6 +2921,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
                   <div className="flex items-center gap-1 -mr-1">
                     <IconButton
                       onClick={() => {
+                        if (isLocked) return;
                         updateWidget(widget.id, {
                           flipped: !widget.flipped,
                         });

--- a/components/widgets/stickers/DraggableSticker.tsx
+++ b/components/widgets/stickers/DraggableSticker.tsx
@@ -29,6 +29,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
     bringToFront,
     moveWidgetLayer,
     deleteAllWidgets,
+    isActiveBoardReadOnly,
   } = useDashboard();
   const { showConfirm } = useDialog();
   const [isSelected, setIsSelected] = useState(false);
@@ -73,6 +74,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
         setIsSelected(false);
         setShowMenu(false);
       } else if (key === 'Delete' || key === 'Backspace') {
+        if ((widget.isLocked ?? false) || isActiveBoardReadOnly) return;
         removeWidget(widget.id);
       }
     };
@@ -86,7 +88,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
         handleCustomKeyboard
       );
     };
-  }, [widget.id, removeWidget]);
+  }, [widget.id, widget.isLocked, isActiveBoardReadOnly, removeWidget]);
 
   const handlePointerDown = (e: React.PointerEvent) => {
     // If clicking menu or handles, don't drag

--- a/components/widgets/stickers/DraggableSticker.tsx
+++ b/components/widgets/stickers/DraggableSticker.tsx
@@ -172,12 +172,15 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
       return;
     }
 
+    const isLocked = (widget.isLocked ?? false) || isActiveBoardReadOnly;
+
     if (
       (e.key === 'Delete' || e.key === 'Backspace') &&
       !e.shiftKey &&
       !e.altKey &&
       !e.ctrlKey
     ) {
+      if (isLocked) return;
       e.preventDefault();
       e.stopPropagation();
       removeWidget(widget.id);
@@ -186,6 +189,7 @@ export const DraggableSticker: React.FC<DraggableStickerProps> = ({
 
     // Alt + Delete or Alt + Backspace: Clear all widgets
     if ((e.key === 'Delete' || e.key === 'Backspace') && e.altKey) {
+      if (isLocked) return;
       e.preventDefault();
       e.stopPropagation();
       const confirmed = await showConfirm(t('widgetWindow.clearEntireBoard'), {

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -804,6 +804,14 @@ describe('DraggableWindow (Tests folder)', () => {
       expect(screen.getByLabelText(/^settings/i)).toBeDisabled();
     });
 
+    it('does not call updateWidget when the locked settings gear button is clicked (early-return guard)', () => {
+      // fireEvent.click bypasses the native disabled check — this test confirms
+      // the onClick early-return guard (`if (isLocked) return`) also blocks the call.
+      renderLocked();
+      fireEvent.click(screen.getByLabelText(/^settings/i));
+      expect(mockContext.updateWidget).not.toHaveBeenCalled();
+    });
+
     it('disables the annotate button when widget is locked', () => {
       renderLocked();
       expect(screen.getByLabelText(/^annotate/i)).toBeDisabled();


### PR DESCRIPTION
## Summary

Follow-up to #2110 addressing two lock-guard gaps identified during review after merge.

- **`DraggableWindow.tsx` mini toolbar settings gear** (~line 2923): had `disabled={isLocked}` but no `if (isLocked) return` early-return guard in `onClick`. The maximize-toolbar settings gear added in #2110 received both; this one was missed. Since `onClick` calls `updateWidget({ flipped: !widget.flipped })` (a Firestore write), a programmatic `dispatchEvent` or accessibility tool click would bypass `disabled` and mutate shared board state on a read-only board.

- **`DraggableSticker.tsx` `handleCustomKeyboard` Delete/Backspace** (~line 76): called `removeWidget(widget.id)` unconditionally — no `widget.isLocked` or `isActiveBoardReadOnly` check. Pressing Delete on a selected sticker on a read-only board deleted it. Guard added: `if ((widget.isLocked ?? false) || isActiveBoardReadOnly) return`.

- **New regression test**: `does not call updateWidget when the locked settings gear button is clicked (early-return guard)` added to the `Toolbar button lock guards` describe block.

## Root cause

Both gaps are the same class as #2110's original bug: `disabled` alone doesn't stop programmatic `.click()` / `dispatchEvent` calls. The mini toolbar settings gear was added to the `disabled` list in #2110 but the matching onClick guard was missed; DraggableSticker was a pre-existing gap in the same `widget-keyboard-action` event protocol.

## Test plan

- [ ] New settings gear early-return test passes
- [ ] `DraggableSticker` Delete guard: `(widget.isLocked ?? false) || isActiveBoardReadOnly` — same composite as `DraggableWindow.isLocked`

Supersedes #2116 (rebased onto current `dev-paul` after #2110 merge).

---
_Generated by [Claude Code](https://claude.ai/code/session_014uHLEm9dXsfMdjGLoDJmux)_