### PR TITLE
fix(quiz): strict Matching grade compares unique prompts, not raw pair count

### DIFF
--- a/hooks/useQuizSession.ts
+++ b/hooks/useQuizSession.ts
@@ -447,8 +447,15 @@ export function gradeAnswer(
     }
     // Size = unique prompts; raw length inflates total when correctAnswer has duplicate left-terms.
     const total = correctMap.size;
-    // Strict correctness: every prompt matched AND no extra pairs submitted.
-    const strictCorrect = matched === total && givenPairs.length === total;
+    // Strict correctness: every prompt matched AND no extra *distinct* prompts
+    // submitted. Compare against `seenLefts.size` (unique submitted left-terms),
+    // not the raw `givenPairs.length` — the raw count includes accidental
+    // duplicate pairs (e.g. "a:1|b:2|a:1"), which would otherwise force
+    // strictCorrect=false and award 0 points in non-partial mode even though
+    // every unique prompt was answered correctly. `seenLefts` is the same set
+    // the matching loop deduplicates against, so this stays consistent with how
+    // `matched` is counted while still rejecting genuinely extra prompts.
+    const strictCorrect = matched === total && seenLefts.size === total;
     if (!partial) {
       return {
         isCorrect: strictCorrect,

--- a/tests/hooks/useQuizSession.gradeAnswer.test.ts
+++ b/tests/hooks/useQuizSession.gradeAnswer.test.ts
@@ -166,3 +166,44 @@ describe('gradeAnswer — Matching partial-credit isCorrect consistency', () => 
     expect(allRight.pointsEarned).toBe(0);
   });
 });
+
+describe('gradeAnswer — Matching non-partial strict correctness vs duplicate pairs', () => {
+  // Regression for the bug where `strictCorrect` compared the answer key size
+  // against the RAW submitted pair count (`givenPairs.length`) instead of the
+  // count of unique submitted prompts (`seenLefts.size`). A duplicate pair
+  // inflated `givenPairs.length` past `total`, forcing strictCorrect=false and
+  // awarding 0 points in non-partial mode even though every unique prompt was
+  // answered correctly.
+  const strictQ = (pts: number): QuizQuestion => ({
+    id: 'sm-regression',
+    timeLimit: 0,
+    text: 'Match',
+    type: 'Matching',
+    correctAnswer: 'dog:bark|cat:meow',
+    incorrectAnswers: [],
+    points: pts,
+    allowPartialCredit: false,
+  });
+
+  it('all unique prompts correct but a duplicate pair submitted: isCorrect=true, full credit', () => {
+    // Previously returned isCorrect:false, pointsEarned:0 because
+    // givenPairs.length (3) !== total (2).
+    const result = gradeAnswer(strictQ(2), 'dog:bark|cat:meow|dog:bark');
+    expect(result.isCorrect).toBe(true);
+    expect(result.pointsEarned).toBe(2);
+    expect(result.pointsMax).toBe(2);
+  });
+
+  it('exact all-correct (no duplicates): isCorrect=true, full credit', () => {
+    const result = gradeAnswer(strictQ(2), 'dog:bark|cat:meow');
+    expect(result.isCorrect).toBe(true);
+    expect(result.pointsEarned).toBe(2);
+  });
+
+  it('extra DISTINCT prompt not in the answer key still rejects strict correctness', () => {
+    // seenLefts.size (3) !== total (2) — extra distinct prompts must still fail.
+    const result = gradeAnswer(strictQ(2), 'dog:bark|cat:meow|cow:moo');
+    expect(result.isCorrect).toBe(false);
+    expect(result.pointsEarned).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Routes a confirmed review-fix into **#2098** (the environment blocks pushing directly to `dev-paul`).

Addresses the `strictCorrect` bug flagged on [`hooks/useQuizSession.ts:451`](https://github.com/OPS-PIvers/SpartBoard/pull/2098#discussion_r3500605354) in PR #2098.

### The bug

In the **non-partial** `Matching` grading path, `strictCorrect` compared the answer-key size (`total = correctMap.size`, unique prompts) against the **raw** submitted pair count `givenPairs.length`, which is never deduplicated:

```ts
const strictCorrect = matched === total && givenPairs.length === total;
```

A student who submits a duplicate pair — e.g. `"dog:bark|cat:meow|dog:bark"` against the key `"dog:bark|cat:meow"` — gets `givenPairs.length === 3` while `total === 2`, forcing `strictCorrect = false` and **0 points** in non-partial mode even though every unique prompt was answered correctly.

### The fix

`seenLefts` already tracks the unique submitted left-terms the matching loop counts `matched` against, so it is the consistent count to compare with `total`:

```ts
const strictCorrect = matched === total && seenLefts.size === total;
```

This accepts accidental duplicate pairs while still rejecting submissions that include genuinely **extra distinct** prompts not in the answer key (`seenLefts.size > total`).

## Changes

- `hooks/useQuizSession.ts` — compare `seenLefts.size` instead of `givenPairs.length`; expanded the inline comment to document the rationale.
- `tests/hooks/useQuizSession.gradeAnswer.test.ts` — new `describe` block covering the non-partial path: duplicate-pair (full credit), exact match (full credit), and extra-distinct-prompt (rejected).

## Verification

- `vitest run tests/hooks/useQuizSession.gradeAnswer.test.ts` → 16/16 pass
- `pnpm run type-check` → 0 errors
- `eslint` + `prettier --check` on both files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgJLh8rgnv2GHEvovHocdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgJLh8rgnv2GHEvovHocdr)_