### PR TITLE
fix(widgets): resolve 3 review findings from #2098/#2125

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -892,6 +892,13 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
     // Keyboard Shortcuts for Focused Widget
     if (e.key === 'Escape' && !e.shiftKey && !e.altKey && !e.ctrlKey) {
+      // Kill the native event so DashboardView's global window keydown handler
+      // doesn't ALSO fire for this same Escape and dispatch a
+      // widget-keyboard-action, which would run handleCustomKeyboard's mirrored
+      // branch and issue a second, redundant updateWidget write. e.stopPropagation()
+      // below only stops React's synthetic tree; the native event still bubbles to
+      // window without this. (Matches the input-Escape branch above.)
+      e.nativeEvent.stopImmediatePropagation();
       // Locked widgets (per-widget lock OR read-only board): allow Esc to
       // dismiss transient UI (annotation overlay, confirm dialog) but DO
       // NOT mutate `widget.flipped` or `widget.minimized` — both would

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -892,13 +892,6 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
 
     // Keyboard Shortcuts for Focused Widget
     if (e.key === 'Escape' && !e.shiftKey && !e.altKey && !e.ctrlKey) {
-      // Kill the native event so DashboardView's global window keydown handler
-      // doesn't ALSO fire for this same Escape and dispatch a
-      // widget-keyboard-action, which would run handleCustomKeyboard's mirrored
-      // branch and issue a second, redundant updateWidget write. e.stopPropagation()
-      // below only stops React's synthetic tree; the native event still bubbles to
-      // window without this. (Matches the input-Escape branch above.)
-      e.nativeEvent.stopImmediatePropagation();
       // Locked widgets (per-widget lock OR read-only board): allow Esc to
       // dismiss transient UI (annotation overlay, confirm dialog) but DO
       // NOT mutate `widget.flipped` or `widget.minimized` — both would

--- a/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningEditor.tsx
@@ -225,6 +225,11 @@ function SettingChip<T extends string>({
             onKeyDown={(e) => {
               if (e.key === 'Escape') {
                 e.nativeEvent.stopImmediatePropagation();
+                // Also stop React's synthetic bubble: this popover renders in
+                // the widget settings panel wrapped by DraggableWindow's
+                // onKeyDown, whose flipped-close branch would otherwise fire and
+                // close the whole settings panel along with this popover.
+                e.stopPropagation();
                 setOpen(false);
               }
             }}
@@ -343,6 +348,11 @@ const WelcomeChip: React.FC<WelcomeChipProps> = ({
             onKeyDown={(e) => {
               if (e.key === 'Escape') {
                 e.nativeEvent.stopImmediatePropagation();
+                // Also stop React's synthetic bubble: this popover renders in
+                // the widget settings panel wrapped by DraggableWindow's
+                // onKeyDown, whose flipped-close branch would otherwise fire and
+                // close the whole settings panel along with this popover.
+                e.stopPropagation();
                 setOpen(false);
               }
             }}
@@ -1054,6 +1064,11 @@ const CaptureMenuButton: React.FC<{
             onKeyDown={(e) => {
               if (e.key === 'Escape') {
                 e.nativeEvent.stopImmediatePropagation();
+                // Also stop React's synthetic bubble: this popover renders in
+                // the widget settings panel wrapped by DraggableWindow's
+                // onKeyDown, whose flipped-close branch would otherwise fire and
+                // close the whole settings panel along with this popover.
+                e.stopPropagation();
                 setOpen(false);
               }
             }}

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -4963,6 +4963,11 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const bringToFront = useCallback((id: string) => {
     if (!activeIdRef.current) return;
+    // Read-only guard, consistent with every other mutating action here.
+    // Without it, clicking any widget on a read-only board (DraggableWindow
+    // calls bringToFront on pointer-down) writes a z-index change through
+    // setDashboards and marks lastLocalUpdateAt, triggering a Firestore sync.
+    if (isActiveBoardReadOnlyRef.current) return;
 
     setDashboards((prev) => {
       const active = prev.find((d) => d.id === activeIdRef.current);

--- a/hooks/useScreenRecord.ts
+++ b/hooks/useScreenRecord.ts
@@ -147,6 +147,11 @@ export const useScreenRecord = (options: ScreenRecordOptions = {}) => {
 
   // Cleanup on unmount
   useEffect(() => {
+    // Re-assert mounted on (re)mount. React 18 StrictMode runs mount → cleanup
+    // → remount in dev; without resetting here, the cleanup below leaves
+    // mountedRef.current === false permanently, so startRecording()'s
+    // post-getDisplayMedia guard aborts every recording in development.
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
       if (timerRef.current) clearInterval(timerRef.current);

--- a/tests/components/widgets/GuidedLearningEditor.escape.portal.test.tsx
+++ b/tests/components/widgets/GuidedLearningEditor.escape.portal.test.tsx
@@ -141,15 +141,11 @@ describe('GuidedLearningEditorContextPane — SettingChip Escape closes popover'
     const menu = document.querySelector('[role="menu"][data-widget-portal]');
     expect(menu).not.toBeNull();
 
-    act(() => {
-      (menu as Element).dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Escape',
-          bubbles: true,
-          cancelable: true,
-        })
-      );
-    });
+    // fireEvent routes through React's synthetic system, which traverses the
+    // fiber tree across the portal boundary — the path that actually exercises
+    // e.stopPropagation() (a raw dispatchEvent would not reliably reach the
+    // ancestor's React onKeyDown).
+    fireEvent.keyDown(menu as Element, { key: 'Escape' });
 
     // Popover closed, but the ancestor keydown must NOT have fired.
     expect(

--- a/tests/components/widgets/GuidedLearningEditor.escape.portal.test.tsx
+++ b/tests/components/widgets/GuidedLearningEditor.escape.portal.test.tsx
@@ -115,4 +115,46 @@ describe('GuidedLearningEditorContextPane — SettingChip Escape closes popover'
       document.querySelector('[role="menu"][data-widget-portal]')
     ).toBeNull();
   });
+
+  it('does not bubble the popover Escape to an ancestor onKeyDown (would close the settings panel)', () => {
+    // Reproduces the real DraggableWindow nesting: the editor renders inside the
+    // widget settings panel, whose wrapper has an onKeyDown that closes the panel
+    // on Escape. createPortal preserves React-tree bubbling, so without
+    // e.stopPropagation() in the popover handler the Escape reaches this ancestor
+    // and closes the whole panel along with the popover.
+    const ancestorEscape = vi.fn();
+    render(
+      <div
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') ancestorEscape();
+        }}
+      >
+        <GuidedLearningEditorContextPane state={makeState()} />
+      </div>
+    );
+
+    const pulseChip = screen.getByRole('button', { name: /pulse/i });
+    act(() => {
+      fireEvent.click(pulseChip);
+    });
+
+    const menu = document.querySelector('[role="menu"][data-widget-portal]');
+    expect(menu).not.toBeNull();
+
+    act(() => {
+      (menu as Element).dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+
+    // Popover closed, but the ancestor keydown must NOT have fired.
+    expect(
+      document.querySelector('[role="menu"][data-widget-portal]')
+    ).toBeNull();
+    expect(ancestorEscape).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Addresses unresolved reviewer comments across the two open feature PRs (#2098 and #2125). The environment blocks pushing directly to `dev-paul`, so these fixes are routed in via this branch (same pattern as #2099/#2123/#2125).

## Findings addressed

1. **`DashboardContext.bringToFront` missing read-only guard** — #2125 [`discussion_r3515411311`](https://github.com/OPS-PIvers/SpartBoard/pull/2125#discussion_r3515411311)
   `bringToFront` was the only mutating action without the `isActiveBoardReadOnlyRef.current` guard that every other action has. `DraggableWindow` calls it on pointer-down, so clicking **any** widget on a read-only board silently wrote a z-index change to Firestore. Added the guard.

2. **`useScreenRecord` StrictMode `mountedRef`** — #2098 [`discussion_r3515306238`](https://github.com/OPS-PIvers/SpartBoard/pull/2098#discussion_r3515306238)
   `mountedRef = useRef(true)` was set `false` in the `[]`-dep cleanup and never reset. React 18 StrictMode's mount→cleanup→remount left it `false` permanently, so `startRecording`'s post-`getDisplayMedia` guard aborted every recording in dev. Re-assert `mountedRef.current = true` in the effect's setup body.

3. **`GuidedLearningEditor` popovers close the settings panel** — #2098 [`discussion_r3516055066`](https://github.com/OPS-PIvers/SpartBoard/pull/2098#discussion_r3516055066)
   The SettingChip / WelcomeChip / CaptureMenuButton popovers called `stopImmediatePropagation()` but not `e.stopPropagation()`. `createPortal` preserves React-tree bubbling, so Escape reached `DraggableWindow`'s `onKeyDown` and closed the whole settings panel. Added `e.stopPropagation()` to all three, plus a regression test (using `fireEvent.keyDown`, verified to fail without the fix).

## Withdrawn from this PR

- **`DraggableWindow` Escape double-write** — #2098 [`discussion_r3512759275`](https://github.com/OPS-PIvers/SpartBoard/pull/2098#discussion_r3512759275). The `stopImmediatePropagation()` fix was reverted after an automated review confirmed it was too broad: React 18 delegates at `#root`, so killing the native event there silences other Escape handlers (GuidedLearningPlayer step-lightbox, DrawingWidget popovers, group-build exit) whenever a widget is focused. Both narrower alternatives collide with existing tested keyboard behavior. The double-write is low-severity (debounced, idempotent), so it's deferred to a dedicated change that reconciles `handleKeyDown`/`handleCustomKeyboard`.

## Declined

- **`useQuizSession` `total = correctMap.size`** — #2098 [`discussion_r3512759021`](https://github.com/OPS-PIvers/SpartBoard/pull/2098#discussion_r3512759021). The deduplication is intentional and correct: the matching UI renders each unique left-term once, so the number of unique prompts is the right denominator. Reverting would make an answer key with a duplicated left-term unwinnable. Full explanation on the thread.

## Test plan

- [x] `pnpm run type-check` → 0 errors
- [x] `pnpm exec eslint` on all touched files → clean
- [x] `pnpm exec prettier --check` → clean
- [x] `useScreenRecord.test.ts` → 9/9
- [x] `escapeInteraction` + `DashboardView` + `DraggableWindow` (both suites) + `GuidedLearningEditor.escape.portal` → 117/117
- [x] New GL regression test verified to fail without the fix, pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQMW3zRyvfXSrks9Dkb3Um