### PR TITLE
chore(imports): convert config/ cross-directory relative imports to @/ alias

### DIFF
--- a/config/buildings.ts
+++ b/config/buildings.ts
@@ -1,5 +1,5 @@
-import { GradeLevel, LunchCountConfig } from '../types';
-import type { BuildingRecord, BuildingType } from '../types/organization';
+import { GradeLevel, LunchCountConfig } from '@/types';
+import type { BuildingRecord, BuildingType } from '@/types/organization';
 
 /**
  * Represents a school building with its associated grade levels.

--- a/config/expectationsData.ts
+++ b/config/expectationsData.ts
@@ -1,4 +1,4 @@
-import { ExpectationsConfig } from '../types';
+import { ExpectationsConfig } from '@/types';
 
 export const VOLUME_OPTIONS = [
   {

--- a/config/instructionalRoutines.ts
+++ b/config/instructionalRoutines.ts
@@ -1,4 +1,4 @@
-import { GradeLevel, RoutineStructure, RoutineAudience } from '../types';
+import { GradeLevel, RoutineStructure, RoutineAudience } from '@/types';
 
 export type { RoutineStructure, RoutineAudience };
 

--- a/config/tools.ts
+++ b/config/tools.ts
@@ -47,10 +47,10 @@ import {
   Triangle,
   Workflow,
 } from 'lucide-react';
-import { ToolMetadata } from '../types';
+import { ToolMetadata } from '@/types';
 
-import { RecordIcon } from '../components/layout/dock/RecordIcon';
-import { First5Icon } from '../components/widgets/First5/First5Icon';
+import { RecordIcon } from '@/components/layout/dock/RecordIcon';
+import { First5Icon } from '@/components/widgets/First5/First5Icon';
 
 /**
  * TOOLS is the Dock-facing catalog of user-selectable widgets. It is

--- a/config/widgetGradeLevels.ts
+++ b/config/widgetGradeLevels.ts
@@ -4,7 +4,7 @@ import {
   GradeFilter,
   InternalToolType,
   FeaturePermission,
-} from '../types';
+} from '@/types';
 
 export const ALL_GRADE_LEVELS: GradeLevel[] = ['k-2', '3-5', '6-8', '9-12'];
 


### PR DESCRIPTION
## Nightly Unifier — D4 Import Path Convention

**Canonical form:** `@/` alias for all cross-directory imports (repo root alias), per `docs/routines/unifier.md` D4 canon. Relative `'../foo'` is acceptable only for true same-directory imports or documented within-feature gray-zone exceptions (D4-E2).

**Instances unified (5 files, 7 import statements — the entire `config/` directory's D4 debt):**
- `config/tools.ts`: `'../types'` → `@/types`; `'../components/layout/dock/RecordIcon'` → `@/components/layout/dock/RecordIcon`; `'../components/widgets/First5/First5Icon'` → `@/components/widgets/First5/First5Icon`
- `config/widgetGradeLevels.ts`: `'../types'` → `@/types`
- `config/instructionalRoutines.ts`: `'../types'` → `@/types`
- `config/expectationsData.ts`: `'../types'` → `@/types`
- `config/buildings.ts`: `'../types'` → `@/types`; `'../types/organization'` → `@/types/organization`

This was found and deferred during run 23 (PR #2126) to avoid same-night scope creep — it's tonight's D4 target. This sweep covers the complete `config/` directory; no relative cross-directory imports remain there (`grep -rn "from '\.\./" config/` returns no matches).

**Enforcement:** No new lint rule added tonight — same alias-convention sweep pattern applied directory-by-directory across ~19 prior nightly runs (hooks/, utils/, context/, tests/, plc/, common/library/, admin/, settingsModal/sections/, etc). A `no-restricted-imports` ESLint rule to hard-block cross-directory relative imports has been discussed in prior run notes as a longer-term follow-up but is out of scope for this mechanical sweep.

**Behavior-preservation evidence:** Pure module-path rewrites — `@/` resolves to the exact same files as the relative paths (confirmed against `vite.config.ts` `resolve.alias` and `tsconfig.json` `compilerOptions.paths`), zero logic changes. `pnpm run validate` green on the rebased branch: type-check (root + functions), eslint, prettier, and full test suite — **5969/5969** root tests + **703/703** functions tests pass, identical counts to the `dev-paul` baseline run immediately before this change.

**Risk tag:** `mechanical` (pure equivalence — import path only, no production logic touched).

---
🤖 Generated by the nightly SpartBoard "unifier" consistency routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaEzgkDvuJZVmUyVHGJ6ER)_