### PR TITLE
chore(imports): convert remaining context/ test file imports to @/ alias

### DIFF
--- a/context/DashboardContext.bringToFront.test.tsx
+++ b/context/DashboardContext.bringToFront.test.tsx
@@ -3,7 +3,7 @@ import { render, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DashboardProvider } from './DashboardContext';
 import { useDashboard } from './useDashboard';
-import { Dashboard, WidgetData } from '../types';
+import { Dashboard, WidgetData } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Mocks (mirrors tests/DashboardContext_removeWidgets.test.tsx)

--- a/context/DashboardContext.immediate.test.tsx
+++ b/context/DashboardContext.immediate.test.tsx
@@ -3,7 +3,7 @@ import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardProvider } from './DashboardContext';
 import { useDashboard } from './useDashboard';
-import { Dashboard, WidgetData } from '../types';
+import { Dashboard, WidgetData } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Mocks (mirrors DashboardContext.bringToFront.test.tsx)

--- a/context/dashboardCanvasStore.test.tsx
+++ b/context/dashboardCanvasStore.test.tsx
@@ -36,7 +36,7 @@ import {
   DashboardContext,
   type DashboardContextValue,
 } from './DashboardContextValue';
-import { Dashboard, WidgetData } from '../types';
+import { Dashboard, WidgetData } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Mocks (mirrors context/DashboardContext.bringToFront.test.tsx)

--- a/context/toolVisibility.test.tsx
+++ b/context/toolVisibility.test.tsx
@@ -32,7 +32,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DashboardProvider } from './DashboardContext';
 import { useDashboard } from './useDashboard';
 import { useToolVisibility } from './useToolVisibility';
-import { Dashboard, WidgetData, WidgetType, DockItem } from '../types';
+import { Dashboard, WidgetData, WidgetType, DockItem } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Mocks (mirrors context/dashboardCanvasStore.test.tsx)


### PR DESCRIPTION
## Nightly Unifier — D4 Import Path Convention

**Canonical form:** the `@/` alias for all cross-directory imports (e.g. `import { X } from '@/types'`).

**Instances unified (4 files, 1 import each):**
- `context/DashboardContext.bringToFront.test.tsx`
- `context/DashboardContext.immediate.test.tsx`
- `context/dashboardCanvasStore.test.tsx`
- `context/toolVisibility.test.tsx`

Each imported `Dashboard`/`WidgetData`/etc. via `'../types'` instead of `'@/types'`. These four files were the same ones touched by the run 23 D4 sweep (PR #2126), but that sweep only converted their `vi.mock('../context/...')` path strings — it missed the plain `import { ... } from '../types'` statement in the same files. Confirmed via repo-wide grep that no other `'../types'` (or other cross-directory relative) imports remain in `context/*.test.tsx`.

**Enforcement:** No new lint rule added this run (D4 has no dedicated ESLint rule yet — conversions rely on repo-wide grep sweeps per `docs/routines/unifier.md`). This is a pure staleness-catch on a previously-swept directory, not a new enforcement mechanism.

**Behavior/visual-preservation evidence:** Pure type-only import path change — `'../types'` and `'@/types'` resolve to the identical module (`types.ts` at repo root) from `context/`. No runtime behavior change possible. `type-check`, `lint --max-warnings 0`, `format:check`, and the full test suite all pass: **5985/5985** root tests + **703/703** functions tests.

**Risk tag:** mechanical (import path only, zero behavior change).

🤖 Nightly unifier routine — [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011uxqfoYcXThVdrcgzWndVF)_