### PR TITLE
refactor(imports): fix plc/resources cross-subdir relative import (D4)

### DIFF
--- a/components/plc/resources/PlcResourcesBody.tsx
+++ b/components/plc/resources/PlcResourcesBody.tsx
@@ -23,7 +23,7 @@ import { pullSyncedVideoActivityContent } from '@/hooks/useSyncedVideoActivityGr
 import { logError } from '@/utils/logError';
 import { getPlcMemberEmail } from '@/utils/plc';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
-import type { PlcSectionId } from '../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 
 interface PlcResourcesBodyProps {
   plc: Plc;


### PR DESCRIPTION
## Nightly Unifier — D4 Import Path Convention

**Canonical form:** cross-directory imports use the `@/` alias (e.g. `@/components/plc/sections`), never a relative path that escapes the importing file's own directory.

**Instance unified:** `components/plc/resources/PlcResourcesBody.tsx:26` — `import type { PlcSectionId } from '../sections'` resolved into the parent `components/plc/` directory, a different directory than `plc/resources/`. Converted to `import type { PlcSectionId } from '@/components/plc/sections'`. This is the same recurring plc/ cross-subdirectory anti-pattern fixed in prior nightly runs (PRs #2055, #2062).

**Enforcement:** none added this run (see follow-up note below) — this is a manual fix.

**Behavior-preservation evidence:** Pure import-path rewrite, same module, same export, no logic touched. `pnpm run validate` (type-check + lint + format-check + tests) green: root 556/556 test files, 6644/6644 tests; functions 37/37 files, 703/703 tests. `pnpm run build` succeeds (client + SSR bundles, prerender OK).

**Risk tag:** mechanical (pure equivalence — single import path string, no behavior change).

**Deferred to backlog (not fixed in this PR, to keep scope contained):**
- `components/plc/home/PlcHome.tsx:23` has the **identical** anti-pattern (`import type { PlcSectionId } from '../sections'`) — pre-existing, missed by earlier plc/ import-path sweeps. Flagged for the next D4 pass.
- Enforcement idea: an ESLint `no-restricted-imports` rule scoped to `components/plc/*/**` blocking relative imports that escape the subdirectory would catch this class of bug at author-time instead of relying on nightly sweeps — this pattern has now recurred across 5+ runs. Worth a small dedicated follow-up PR.

---
🤖 Nightly consistency run (unifier). See `docs/routines/unifier.md` for the full dimension canon and backlog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbaHuHWov8U3Dwu7s5pqmK)_