### PR TITLE
refactor(activityWall): unify empty-responses state with ScaledEmptyState (D1)

### DIFF
--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -60,6 +60,7 @@ import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useActivityWallLibrary } from '@/hooks/useActivityWallLibrary';
 import { Modal } from '@/components/common/Modal';
 import { ActivityWallShareModal } from '@/components/widgets/ActivityWall/ShareModal';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 const encodeActivityData = (
   activity: ActivityWallActivity,
@@ -1875,21 +1876,14 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
               style={{ padding: 'min(8px, 2cqmin)' }}
             >
               {visibleSubmissions.length === 0 ? (
-                <div
-                  className="h-full flex flex-col items-center justify-center text-slate-500 text-center"
-                  style={{ gap: 'min(6px, 1.5cqmin)' }}
-                >
-                  <MessageSquare
-                    style={{
-                      width: 'min(24px, 7cqmin)',
-                      height: 'min(24px, 7cqmin)',
-                    }}
-                    className="opacity-40"
-                  />
-                  <span style={{ fontSize: 'min(11px, 3.8cqmin)' }}>
-                    Responses will appear here after participants submit.
-                  </span>
-                </div>
+                <ScaledEmptyState
+                  icon={MessageSquare}
+                  title="No Responses Yet"
+                  subtitle="Responses will appear here after participants submit."
+                  iconClassName="text-slate-400"
+                  titleClassName="text-slate-600"
+                  subtitleClassName="text-slate-500"
+                />
               ) : activeActivity.mode === 'text' ? (
                 <div
                   className="flex flex-col"


### PR DESCRIPTION
## Nightly Unifier — D1 Widget Empty States

**Canonical form:** `<ScaledEmptyState icon={IconName} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx` for any widget front-face "no data" state — never a hand-rolled centered div with icon + text.

**Instance unified:** `components/widgets/ActivityWall/Widget.tsx` (~line 1877) — the submissions panel's "Responses will appear here after participants submit." state was a hand-rolled `div` with an opacity-40 `MessageSquare` icon and a single plain sentence, nested inside the shared `bg-slate-50` submissions card (that outer card is reused by the non-empty rendering path and was left untouched — only the inner icon+text was converted). Replaced with `ScaledEmptyState`, with `iconClassName`/`titleClassName`/`subtitleClassName` overridden to slate-600/500 tones (`ScaledEmptyState`'s defaults are tuned for dark widget chrome; this panel sits on a light card, so the documented override props were used — see the component's own doc comment).

**Note on visual change (please eyeball before merging):** `ScaledEmptyState` requires a `title` prop, which renders as a bold, uppercase, letter-spaced line. The original hand-rolled state had no separate title — just one plain sentence. This conversion adds a short title ("No Responses Yet") above the original sentence (now the subtitle). This is a minor, intentional content addition for consistency with every other widget empty state in the app (glanceability/visual-hierarchy design principle), not a defect, but it is not byte-for-byte visually identical to the original — hence the risk tag below.

**Left untouched (still catalogued as VISUAL-RISK — do not convert without designer sign-off):**
- `ActivityWall/Widget.tsx` ~line 1546 ("No activities yet") — the hand-rolled div itself *is* the card chrome (`bg-slate-50 rounded-xl border`, matching non-empty list-item styling); converting would require stripping/re-adding card structure via `ScaledEmptyState`'s `className`, a real structural mismatch.
- `SmartNotebook/components/Library.tsx` ~line 173 — icon sits inside its own nested `bg-white rounded-3xl border shadow-sm` card, same structural mismatch.

**New backlog candidates found (not converted, flagged for a future run):**
- `MusicWidget/PersonalSpotifyNowPlayingTab.tsx` ~line 65 — text-only, no icon (same rationale as existing D1-E9/E10 exceptions).
- `VideoActivityWidget/components/VideoActivityEditor.tsx` ~line 393 — editor/authoring modal placeholder, likely out of D1 scope entirely (analogous to QuizManager/MiniAppManager editor exceptions), flagged for explicit categorization.

**Behavior-preservation evidence:** `pnpm run validate` green — root 556/556 test files, 6644/6644 tests; functions 37/37 files, 703/703 tests; type-check/lint/format-check clean. `pnpm run build` succeeds.

**Risk tag:** visual-risk (adds a title line per the note above — needs a quick eyes-on check, not a pure no-op).

---
🤖 Nightly consistency run (unifier). See `docs/routines/unifier.md` for the full dimension canon and backlog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbaHuHWov8U3Dwu7s5pqmK)_