### PR TITLE
fix(dashboard-layout): stop stale collection id leaking into active-board picker

### DIFF
--- a/components/layout/sidebar/SidebarBoardsActive.tsx
+++ b/components/layout/sidebar/SidebarBoardsActive.tsx
@@ -17,8 +17,10 @@ export const SidebarBoardsActive: React.FC<SidebarBoardsActiveProps> = ({
   const { dashboards, activeDashboard, loadDashboard } = useDashboard();
   const { lastActiveCollectionId } = useAuth();
 
-  const activeCollectionId =
-    activeDashboard?.collectionId ?? lastActiveCollectionId ?? null;
+  // collectionId: null (root) is meaningful — only fall back when there's no active dashboard.
+  const activeCollectionId = activeDashboard
+    ? (activeDashboard.collectionId ?? null)
+    : (lastActiveCollectionId ?? null);
 
   const boardsInActiveCollection = dashboards
     .filter((d) => (d.collectionId ?? null) === activeCollectionId)

--- a/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
+++ b/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
@@ -5,12 +5,12 @@ import type { Dashboard } from '@/types';
 
 interface MockUseDashboardReturn {
   dashboards: Dashboard[];
-  activeDashboard: Dashboard;
-  loadDashboard: () => void;
+  activeDashboard: Dashboard | null;
+  loadDashboard: (id: string) => void;
 }
 
 interface MockUseAuthReturn {
-  lastActiveCollectionId: string | null;
+  lastActiveCollectionId: string | null | undefined;
 }
 
 const mockUseDashboard = vi.fn<() => MockUseDashboardReturn>();
@@ -151,6 +151,60 @@ describe('SidebarBoardsActive', () => {
     render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
     expect(screen.getByText('Root Board')).toBeInTheDocument();
     expect(screen.queryByText('Collection Board')).not.toBeInTheDocument();
+    expect(screen.getByText('Boards')).toBeInTheDocument();
+  });
+
+  it('falls back to lastActiveCollectionId when there is no active dashboard at all', () => {
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'root1',
+          name: 'Root Board',
+          collectionId: null,
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+        {
+          id: 'c1-board',
+          name: 'Collection Board',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: null,
+      loadDashboard: vi.fn(),
+    });
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: 'c1' });
+
+    const onOpenModal = vi.fn();
+    render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
+    expect(screen.getByText('Collection Board')).toBeInTheDocument();
+    expect(screen.queryByText('Root Board')).not.toBeInTheDocument();
+  });
+
+  it('treats an undefined lastActiveCollectionId (profile not yet loaded) as root, not a crash', () => {
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'root1',
+          name: 'Root Board',
+          collectionId: null,
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: null,
+      loadDashboard: vi.fn(),
+    });
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: undefined });
+
+    const onOpenModal = vi.fn();
+    render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
+    expect(screen.getByText('Root Board')).toBeInTheDocument();
     expect(screen.getByText('Boards')).toBeInTheDocument();
   });
 });

--- a/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
+++ b/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
@@ -154,6 +154,44 @@ describe('SidebarBoardsActive', () => {
     expect(screen.getByText('Boards')).toBeInTheDocument();
   });
 
+  it('shows root boards for a legacy board with no collectionId (undefined)', () => {
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'legacy1',
+          name: 'Legacy Board',
+          collectionId: undefined,
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+        {
+          id: 'c1-board',
+          name: 'Collection Board',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: {
+        id: 'legacy1',
+        name: 'Legacy Board',
+        collectionId: undefined,
+        createdAt: 0,
+        background: '',
+        widgets: [],
+      },
+      loadDashboard: vi.fn(),
+    });
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: 'c1' });
+
+    const onOpenModal = vi.fn();
+    render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
+    expect(screen.getByText('Legacy Board')).toBeInTheDocument();
+    expect(screen.queryByText('Collection Board')).not.toBeInTheDocument();
+  });
+
   it('falls back to lastActiveCollectionId when there is no active dashboard at all', () => {
     mockUseDashboard.mockReturnValue({
       dashboards: [

--- a/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
+++ b/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SidebarBoardsActive } from '@/components/layout/sidebar/SidebarBoardsActive';
 import type { Dashboard } from '@/types';
@@ -15,6 +15,11 @@ interface MockUseAuthReturn {
 
 const mockUseDashboard = vi.fn<() => MockUseDashboardReturn>();
 const mockUseAuth = vi.fn<() => MockUseAuthReturn>();
+
+beforeEach(() => {
+  mockUseDashboard.mockReset();
+  mockUseAuth.mockReset();
+});
 
 vi.mock('@/context/useDashboard', () => ({
   useDashboard: () => mockUseDashboard(),

--- a/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
+++ b/tests/components/layout/sidebar/SidebarBoardsActive.test.tsx
@@ -1,48 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SidebarBoardsActive } from '@/components/layout/sidebar/SidebarBoardsActive';
+import type { Dashboard } from '@/types';
+
+interface MockUseDashboardReturn {
+  dashboards: Dashboard[];
+  activeDashboard: Dashboard;
+  loadDashboard: () => void;
+}
+
+interface MockUseAuthReturn {
+  lastActiveCollectionId: string | null;
+}
+
+const mockUseDashboard = vi.fn<() => MockUseDashboardReturn>();
+const mockUseAuth = vi.fn<() => MockUseAuthReturn>();
 
 vi.mock('@/context/useDashboard', () => ({
-  useDashboard: () => ({
-    dashboards: [
-      {
-        id: 'b1',
-        name: 'Warm-up',
-        collectionId: 'c1',
-        createdAt: 0,
-        background: '',
-        widgets: [],
-      },
-      {
-        id: 'b2',
-        name: 'Activity',
-        collectionId: 'c1',
-        createdAt: 0,
-        background: '',
-        widgets: [],
-      },
-      {
-        id: 'b3',
-        name: 'Other',
-        collectionId: 'c2',
-        createdAt: 0,
-        background: '',
-        widgets: [],
-      },
-    ],
-    activeDashboard: {
-      id: 'b1',
-      name: 'Warm-up',
-      collectionId: 'c1',
-      createdAt: 0,
-      background: '',
-      widgets: [],
-    },
-    loadDashboard: vi.fn(),
-  }),
+  useDashboard: () => mockUseDashboard(),
 }));
 vi.mock('@/context/useAuth', () => ({
-  useAuth: () => ({ lastActiveCollectionId: 'c1' }),
+  useAuth: () => mockUseAuth(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -54,6 +32,45 @@ vi.mock('react-i18next', () => ({
 
 describe('SidebarBoardsActive', () => {
   it('renders only Boards in the active Collection', () => {
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'b1',
+          name: 'Warm-up',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+        {
+          id: 'b2',
+          name: 'Activity',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+        {
+          id: 'b3',
+          name: 'Other',
+          collectionId: 'c2',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: {
+        id: 'b1',
+        name: 'Warm-up',
+        collectionId: 'c1',
+        createdAt: 0,
+        background: '',
+        widgets: [],
+      },
+      loadDashboard: vi.fn(),
+    });
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: 'c1' });
+
     const onOpenModal = vi.fn();
     render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
     expect(screen.getByText('Warm-up')).toBeInTheDocument();
@@ -62,9 +79,73 @@ describe('SidebarBoardsActive', () => {
   });
 
   it('calls onOpenModal when "Manage all boards" is clicked', () => {
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'b1',
+          name: 'Warm-up',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: {
+        id: 'b1',
+        name: 'Warm-up',
+        collectionId: 'c1',
+        createdAt: 0,
+        background: '',
+        widgets: [],
+      },
+      loadDashboard: vi.fn(),
+    });
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: 'c1' });
+
     const onOpenModal = vi.fn();
     render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
     fireEvent.click(screen.getByRole('button', { name: /manage all boards/i }));
     expect(onOpenModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows root boards, not a stale Collection, when the active board is legitimately at root', () => {
+    // Regression: `??` treated a meaningful null collectionId as nullish.
+    mockUseDashboard.mockReturnValue({
+      dashboards: [
+        {
+          id: 'root1',
+          name: 'Root Board',
+          collectionId: null,
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+        {
+          id: 'c1-board',
+          name: 'Collection Board',
+          collectionId: 'c1',
+          createdAt: 0,
+          background: '',
+          widgets: [],
+        },
+      ],
+      activeDashboard: {
+        id: 'root1',
+        name: 'Root Board',
+        collectionId: null,
+        createdAt: 0,
+        background: '',
+        widgets: [],
+      },
+      loadDashboard: vi.fn(),
+    });
+    // Stale value left over from before the active board changed to root.
+    mockUseAuth.mockReturnValue({ lastActiveCollectionId: 'c1' });
+
+    const onOpenModal = vi.fn();
+    render(<SidebarBoardsActive isVisible={true} onOpenModal={onOpenModal} />);
+    expect(screen.getByText('Root Board')).toBeInTheDocument();
+    expect(screen.queryByText('Collection Board')).not.toBeInTheDocument();
+    expect(screen.getByText('Boards')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

**Root cause:** `SidebarBoardsActive.tsx` computed `activeCollectionId` as `activeDashboard?.collectionId ?? lastActiveCollectionId ?? null`. `collectionId: null` is a meaningful value (the board legitimately lives at root, not "missing"), but `??` can't distinguish "intentionally null" from "absent" — so whenever the active board was at root, the expression fell through to `lastActiveCollectionId`, a value from `AuthContext`'s profile listener that can be stale during its round-trip. Result: briefly showing boards from the wrong Collection instead of the root boards list. The sibling `BoardNavFab.tsx:46` already gets this right (`activeDashboard?.collectionId ?? null`, no extra fallback).

**Fix:** Branch explicitly on whether `activeDashboard` exists, rather than chaining `??` across a value that can be meaningfully `null`:
```ts
const activeCollectionId = activeDashboard
  ? (activeDashboard.collectionId ?? null)
  : (lastActiveCollectionId ?? null);
```

**Band-aid rejected:** Special-casing the render output for the "flash of wrong boards" symptom — rejected because it would leave the underlying `??`-on-meaningful-null bug in the expression itself, unlike the sibling component that already gets this right.

**Risk:** contained.

## Test plan
- [x] Added a third test case to `SidebarBoardsActive.test.tsx`: a root board (`collectionId: null`) as `activeDashboard` with a stale `lastActiveCollectionId`. Fails on unpatched code (`getByText('Root Board')` not found; wrong collection's boards rendered instead); passes after the fix. Verified independently by the orchestrator (reverted the component to `dev-paul`, confirmed the new test fails; restored the fix, confirmed all 3 tests pass).
- [x] `pnpm run validate` — clean.
- [x] `pnpm run build` — clean.

🤖 Generated by the nightly SpartBoard code-health routine (subagent-authored, orchestrator-reviewed and reformatted for comment-length compliance).


---
_Generated by [Claude Code](https://claude.ai/code/session_016q3PiEgee4YfNbDKV7yWf5)_