### PR TITLE
fix(i18n): replace DE locale "Board" loanword with "Tafel" for consistency

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -1274,7 +1274,7 @@
       "title": "Tastenkürzel & Gesten",
       "keyboard": "Tastatur",
       "touchscreenGestures": "Touchscreen-Gesten",
-      "boardGestures": "Board-Hintergrund",
+      "boardGestures": "Tafel-Hintergrund",
       "widgetGestures": "Widget-Fenster",
       "footer": "Drücken Sie jederzeit <kbd>Strg/⌘</kbd> + <kbd>/</kbd>, um dieses Panel zu öffnen",
       "shortcuts": {
@@ -1324,7 +1324,7 @@
     },
     "stickers": {
       "collectionTitle": "Sticker-Sammlung",
-      "clearAll": "Alle Sticker vom Board löschen",
+      "clearAll": "Alle Sticker von der Tafel löschen",
       "wait": "Warten...",
       "dropOrPaste": "Bild ablegen oder einfügen",
       "toAddCustom": "um benutzerdefinierte Sticker hinzuzufügen",
@@ -1333,8 +1333,8 @@
       "myCollection": "Meine Sammlung",
       "dragOrClick": "Ziehen oder klicken zum Hinzufügen",
       "deleteSticker": "Sticker löschen",
-      "dragFromLibrary": "Sticker aus der Bibliothek auf das Board ziehen",
-      "stickerAdded": "Sticker zum Board hinzugefügt!",
+      "dragFromLibrary": "Sticker aus der Bibliothek auf die Tafel ziehen",
+      "stickerAdded": "Sticker zur Tafel hinzugefügt!",
       "filterAll": "Alle",
       "filterFavorites": "Favoriten",
       "filterMine": "Meine",
@@ -1405,7 +1405,7 @@
       "colorPalette": "Farbpalette",
       "glow": "Leuchten",
       "fonts": {
-        "inherit": "Vom Board",
+        "inherit": "Von der Tafel",
         "digital": "Digital",
         "modern": "Modern",
         "school": "Schule"
@@ -1547,7 +1547,7 @@
   },
   "shareCollection": {
     "title": "Sammlung teilen",
-    "subtitle": "{{count}} Board(s) aus dieser Sammlung werden geteilt.",
+    "subtitle": "{{count}} Tafel(n) aus dieser Sammlung werden geteilt.",
     "mode": "Freigabemodus",
     "copyMode": "Kopieren",
     "copyModeHint": "Der Empfänger importiert eine vollständige Kopie in sein Konto.",
@@ -1589,7 +1589,7 @@
     "heading": "Sammlungen",
     "boardCount": "{{count}} Tafel(n)",
     "boardPlaceholder": "Tafel …{{id}}",
-    "openBoard": "Dieses Board öffnen"
+    "openBoard": "Diese Tafel öffnen"
   },
   "collectionMenu": {
     "share": "Sammlung teilen…",
@@ -1648,7 +1648,7 @@
     "emptyResults": "Keine passenden Widgets."
   },
   "style": {
-    "readOnlyNotice": "Dieses Board ist schreibgeschützt. Stiländerungen werden nicht gespeichert."
+    "readOnlyNotice": "Diese Tafel ist schreibgeschützt. Stiländerungen werden nicht gespeichert."
   },
   "whatsNew": {
     "title": "Was ist neu",
@@ -1678,7 +1678,7 @@
       "dropImages": "Bilder hier ablegen oder zum Durchsuchen klicken",
       "supportedFiles": "PNG, JPG, GIF, WebP, SVG · Mehrere Dateien unterstützt",
       "collectionTitle": "Sticker-Sammlung",
-      "clearAll": "Alle Sticker vom Board löschen",
+      "clearAll": "Alle Sticker von der Tafel löschen",
       "wait": "Warten...",
       "dropOrPaste": "Bild ablegen oder einfügen",
       "toAddCustom": "um benutzerdefinierte Sticker hinzuzufügen",
@@ -1687,8 +1687,8 @@
       "myCollection": "Meine Sammlung",
       "dragOrClick": "Ziehen oder klicken zum Hinzufügen",
       "deleteSticker": "Sticker löschen",
-      "dragFromLibrary": "Sticker aus der Bibliothek auf das Board ziehen",
-      "stickerAdded": "Sticker zum Board hinzugefügt!"
+      "dragFromLibrary": "Sticker aus der Bibliothek auf die Tafel ziehen",
+      "stickerAdded": "Sticker zur Tafel hinzugefügt!"
     },
     "plc": {
       "recovery": {
@@ -1719,7 +1719,7 @@
     "loading": "PLG wird geladen…",
     "notFoundTitle": "PLG nicht gefunden",
     "notFoundBody": "Diese PLG existiert nicht oder Sie sind kein Mitglied mehr.",
-    "backToBoard": "Zurück zu meinem Board",
+    "backToBoard": "Zurück zu meiner Tafel",
     "hubTitle": "Meine PLGs",
     "hubSubtitle": "Öffnen Sie eine professionelle Lerngemeinschaft, um mit Ihrem Team zusammenzuarbeiten.",
     "hubEmptyTitle": "Noch keine PLGs",

--- a/tests/i18n/deBoardTafelTerminologyLocales.test.ts
+++ b/tests/i18n/deBoardTafelTerminologyLocales.test.ts
@@ -1,0 +1,110 @@
+// DE locale used the English loanword "Board" in 12 keys instead of the project's established "Tafel"; also guards against future re-introduction.
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+
+type LocaleFile = typeof en;
+
+/** Dotted path walker — returns the leaf string or undefined. */
+function getLeaf(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
+/** Recursively collects [path, value] pairs for every string leaf. */
+function collectStrings(
+  obj: unknown,
+  path: string,
+  out: Array<[string, string]>
+): void {
+  if (obj == null || typeof obj !== 'object') return;
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const p = path ? `${path}.${key}` : key;
+    if (typeof value === 'string') {
+      out.push([p, value]);
+    } else if (value && typeof value === 'object') {
+      collectStrings(value, p, out);
+    }
+  }
+}
+
+const AFFECTED_KEYS: Array<{ path: string; expectedDe: string }> = [
+  {
+    path: 'widgets.cheatSheet.boardGestures',
+    expectedDe: 'Tafel-Hintergrund',
+  },
+  {
+    path: 'widgets.stickers.clearAll',
+    expectedDe: 'Alle Sticker von der Tafel löschen',
+  },
+  {
+    path: 'widgets.stickers.dragFromLibrary',
+    expectedDe: 'Sticker aus der Bibliothek auf die Tafel ziehen',
+  },
+  {
+    path: 'widgets.stickers.stickerAdded',
+    expectedDe: 'Sticker zur Tafel hinzugefügt!',
+  },
+  { path: 'widgets.clock.fonts.inherit', expectedDe: 'Von der Tafel' },
+  {
+    path: 'shareCollection.subtitle',
+    expectedDe: '{{count}} Tafel(n) aus dieser Sammlung werden geteilt.',
+  },
+  { path: 'subCollections.openBoard', expectedDe: 'Diese Tafel öffnen' },
+  {
+    path: 'style.readOnlyNotice',
+    expectedDe:
+      'Diese Tafel ist schreibgeschützt. Stiländerungen werden nicht gespeichert.',
+  },
+  {
+    path: 'admin.stickers.clearAll',
+    expectedDe: 'Alle Sticker von der Tafel löschen',
+  },
+  {
+    path: 'admin.stickers.dragFromLibrary',
+    expectedDe: 'Sticker aus der Bibliothek auf die Tafel ziehen',
+  },
+  {
+    path: 'admin.stickers.stickerAdded',
+    expectedDe: 'Sticker zur Tafel hinzugefügt!',
+  },
+  { path: 'plcRoute.backToBoard', expectedDe: 'Zurück zu meiner Tafel' },
+];
+
+describe('EN locale — affected keys baseline', () => {
+  it.each(AFFECTED_KEYS)('en.$path exists', ({ path }) => {
+    expect(getLeaf(en, path), `en.${path} is missing`).toBeDefined();
+  });
+});
+
+describe('DE locale — "Board" terminology replaced with "Tafel"', () => {
+  it.each(AFFECTED_KEYS)(
+    'de.$path is the Tafel-based translation, not the Board drift',
+    ({ path, expectedDe }) => {
+      const value = getLeaf(de as unknown as LocaleFile, path);
+      expect(value, `de.${path} is missing`).toBeDefined();
+      expect(
+        value,
+        `de.${path} should be "${expectedDe}" (project convention is "Tafel", not the English ` +
+          `loanword "Board") but got "${value}"`
+      ).toBe(expectedDe);
+    }
+  );
+
+  it('has no remaining standalone "Board"/"Boards" usages anywhere in the locale', () => {
+    const all: Array<[string, string]> = [];
+    collectStrings(de, '', all);
+    const offenders = all.filter(([, value]) => /\bBoards?\b/.test(value));
+    expect(
+      offenders,
+      `Found ${offenders.length} DE locale value(s) using the English loanword "Board" ` +
+        `instead of the established "Tafel" translation: ` +
+        `${offenders.map(([p, v]) => `${p}="${v}"`).join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/i18n/deBoardTafelTerminologyLocales.test.ts
+++ b/tests/i18n/deBoardTafelTerminologyLocales.test.ts
@@ -4,8 +4,6 @@ import { describe, it, expect } from 'vitest';
 import en from '@/locales/en.json';
 import de from '@/locales/de.json';
 
-type LocaleFile = typeof en;
-
 /** Dotted path walker — returns the leaf string or undefined. */
 function getLeaf(root: unknown, path: string): string | undefined {
   let node: unknown = root;
@@ -86,7 +84,7 @@ describe('DE locale — "Board" terminology replaced with "Tafel"', () => {
   it.each(AFFECTED_KEYS)(
     'de.$path is the Tafel-based translation, not the Board drift',
     ({ path, expectedDe }) => {
-      const value = getLeaf(de as unknown as LocaleFile, path);
+      const value = getLeaf(de, path);
       expect(value, `de.${path} is missing`).toBeDefined();
       expect(
         value,
@@ -99,7 +97,7 @@ describe('DE locale — "Board" terminology replaced with "Tafel"', () => {
   it('has no remaining standalone "Board"/"Boards" usages anywhere in the locale', () => {
     const all: Array<[string, string]> = [];
     collectStrings(de, '', all);
-    const offenders = all.filter(([, value]) => /\bBoards?\b/.test(value));
+    const offenders = all.filter(([, value]) => /\bboards?\b/i.test(value));
     expect(
       offenders,
       `Found ${offenders.length} DE locale value(s) using the English loanword "Board" ` +


### PR DESCRIPTION
## Summary

**Root cause:** The German locale (`locales/de.json`) established "Tafel"/"Tafeln" as the sole translation for the whiteboard/dashboard concept early on (80+ existing usages), and ES/FR consistently use their own native words for the same concept everywhere. Twelve keys across `widgets.cheatSheet`, `widgets.stickers`, `widgets.clock.fonts`, `shareCollection`, `subCollections`, `style`, `admin.stickers`, and `plcRoute` instead used the English loanword "Board" (e.g. "Alle Sticker vom Board löschen" instead of "Alle Sticker von der Tafel löschen"). These are genuine translations, not verbatim-EN copies, so neither i18next's `defaultValue` fallback nor the existing verbatim-EN tests caught them — a narrower "wrong word choice within a real translation" bug class. Grammar/gender agreement was fixed too (Tafel is feminine: "von der Tafel", not the masculine/neuter forms "Board" took).

**Band-aid rejected:** Patching the string literals with no regression test — rejected because a bare fix with no guard would let this drift class silently regress again, exactly as it did across 12 separate spots from different feature branches.

**Risk:** contained.

## Test plan
- [x] Added `tests/i18n/deBoardTafelTerminologyLocales.test.ts`: asserts each of the 12 keys' exact fixed value, plus a full recursive sweep of `de.json` guarding against future re-introduction of the standalone word "Board"/"Boards". 13/25 tests fail on unpatched `de.json`; 25/25 pass after the fix. Verified independently by the orchestrator (reverted `de.json` to `dev-paul`, confirmed 13 failures; restored the fix, confirmed 25/25 pass).
- [x] `pnpm run validate` — clean.
- [x] `pnpm run build` — clean.

🤖 Generated by the nightly SpartBoard code-health routine (subagent-authored, orchestrator-reviewed and reformatted for comment-length compliance).


---
_Generated by [Claude Code](https://claude.ai/code/session_016q3PiEgee4YfNbDKV7yWf5)_