### PR TITLE
refactor(ui-unification): convert RandomGroups empty state to ScaledEmptyState

### DIFF
--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -5,6 +5,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { RandomGroup, SharedGroup } from '@/types';
 import { StudentChip } from './StudentChip';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 
 interface RandomGroupsProps {
   displayResult: string | string[] | string[][] | RandomGroup[] | null;
@@ -620,21 +621,13 @@ export const RandomGroups: React.FC<RandomGroupsProps> = ({
         );
       })}
       {showEmptyState && (
-        <div
-          className="col-span-full row-span-full flex flex-col items-center justify-center text-slate-300 italic font-bold"
-          style={{ gap: 'clamp(8px, 2.5cqmin, 18px)' }}
-        >
-          <Users
-            className="opacity-20"
-            style={{
-              width: 'clamp(32px, 10cqmin, 72px)',
-              height: 'clamp(32px, 10cqmin, 72px)',
-            }}
-          />
-          <span style={{ fontSize: 'clamp(12px, 3.5cqmin, 22px)' }}>
-            Click Randomize to Group
-          </span>
-        </div>
+        <ScaledEmptyState
+          icon={Users}
+          title="Click Randomize to Group"
+          className="col-span-full row-span-full"
+          iconClassName="text-slate-300 opacity-20"
+          titleClassName="text-slate-300 italic"
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Nightly Unifier — D1: Widget Empty States (run 26)

**Canonical form:** `<ScaledEmptyState icon={IconName} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx` — never hand-roll a centered div with an icon + text for a widget's "no data" state.

**Instance unified:** `components/widgets/random/RandomGroups.tsx` (~line 622) — the "Click Randomize to Group" placeholder (shown when `showEmptyState` is true) was a hand-rolled `flex flex-col items-center justify-center` div with a `Users` icon and italic caption. Converted to `ScaledEmptyState`, using `iconClassName`/`titleClassName` overrides to preserve the original icon opacity/color and caption italic/color. This was found via a fresh repo-wide grep across `components/widgets/**` (not diff-only), which is the methodology that has caught most of this dimension's real fixes in recent runs.

**Visual delta (expected, matches established precedent):** `ScaledEmptyState`'s title is always rendered `font-black uppercase tracking-widest` regardless of `titleClassName`. The original caption was mixed-case/`font-bold`. This casing/weight change is the intended, already-established canonical shift for this dimension (same change every prior D1 conversion has made, e.g. `RandomWidget.tsx`'s sibling "No Names Provided"/"Everyone Absent Today" states in PR #1770) — not a new visual risk.

**Behavior/visual preservation evidence:** `pnpm run validate` green (type-check, lint, format-check, 556/556 test files + 6644/6644 tests root, 37/37 files + 703/703 tests functions, test-count guard). `pnpm run build` green.

**Also resolved (no code change, doc-only backlog cleanup, folded into the nightly memory-doc PR):** the two run-25 NEEDS REVIEW items (`QuizLiveMonitor.tsx` "No scores yet", `GuidedLearningResults.tsx` "No responses yet...") were re-examined and classified as intentional exceptions — both are captions inside already-stylized/always-rendered monitor panels, analogous to existing exceptions, not missing-data empty states.

**Risk tag:** mechanical (pure component swap with explicit style overrides preserving the original visual treatment aside from the pre-established title-casing convention).

Co-authored by an autonomous nightly consistency subagent, reviewed and integrated by the orchestrator.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNd6Aq2frfxDyz6XnZVbyQ)_