### PR TITLE
chore(imports): convert remaining cross-directory relative imports to @/ alias

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -898,7 +898,7 @@ describe('DraggableWindow', () => {
 
   it('saves title and resets editing state when clicking outside after editing title', async () => {
     const user = userEvent.setup();
-    const { useClickOutside } = await import('../../hooks/useClickOutside');
+    const { useClickOutside } = await import('@/hooks/useClickOutside');
 
     // Pass test-widget as selected so toolbar shows
     renderComponent({}, <div>Content</div>, <div>Settings</div>, 'test-widget');

--- a/scripts/prerender-legal.tsx
+++ b/scripts/prerender-legal.tsx
@@ -19,9 +19,9 @@ import fs from 'fs';
 import path from 'path';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { PrivacyPolicyPage } from '../components/legal/PrivacyPolicyPage';
-import { TermsOfServicePage } from '../components/legal/TermsOfServicePage';
-import { SupportPage } from '../components/legal/SupportPage';
+import { PrivacyPolicyPage } from '@/components/legal/PrivacyPolicyPage';
+import { TermsOfServicePage } from '@/components/legal/TermsOfServicePage';
+import { SupportPage } from '@/components/legal/SupportPage';
 
 const PAGES: Array<{
   route: string;

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,4 +1,4 @@
-import { APP_NAME } from '../../config/constants';
+import { APP_NAME } from '@/config/constants';
 import { test, expect } from '@playwright/test';
 
 test.describe(APP_NAME, () => {

--- a/tests/e2e/sharing.spec.ts
+++ b/tests/e2e/sharing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { clipboardWriteTextInitScript } from '../testHelpers/e2eMocks';
+import { clipboardWriteTextInitScript } from '@/tests/testHelpers/e2eMocks';
 
 test.describe('Board Sharing', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { APP_NAME } from '../../config/constants';
+import { APP_NAME } from '@/config/constants';
 import { test, expect } from '@playwright/test';
 
 test('has title', async ({ page }) => {

--- a/utils/quizDriveService.ts
+++ b/utils/quizDriveService.ts
@@ -654,7 +654,7 @@ export class QuizDriveService {
         question: QuizQuestion,
         studentAnswer: string,
         response?: QuizResponse
-      ) => import('../types').GradeResult;
+      ) => import('@/types').GradeResult;
     }
   ): Promise<string> {
     // Quiz's grader threads per-response manual grades through for

--- a/vite.prerender.config.ts
+++ b/vite.prerender.config.ts
@@ -4,11 +4,17 @@
  * manualChunks, which Rollup rejects for SSR builds where react is
  * externalized — so the SSR compile uses this bare config instead.
  */
+import path from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
   build: {
     ssr: 'scripts/prerender-legal.tsx',
     outDir: 'dist-ssr',


### PR DESCRIPTION
## Nightly Unifier — D4: Import Path Convention (run 26)

**Canonical form:** `@/` alias for all cross-directory imports (repo root, no `src/`), e.g. `import { X } from '@/components/common/Toggle'`.

**Instances unified** (found via a fresh, repo-wide grep for cross-directory relative imports/`vi.mock` strings, not a diff-only scan):
- `components/common/DraggableWindow.test.tsx` — a runtime `await import('../../hooks/useClickOutside')` inside a test body (missed by prior sweeps, which only converted top-level `vi.mock(...)` strings in this file).
- `utils/quizDriveService.ts` — a type-only `import('../types').GradeResult` inline type reference.
- `tests/e2e/app.spec.ts`, `tests/e2e/smoke.spec.ts` — `'../../config/constants'` → `@/config/constants`.
- `tests/e2e/sharing.spec.ts` — `'../testHelpers/e2eMocks'` → `@/tests/testHelpers/e2eMocks`.
- `scripts/prerender-legal.tsx` — 3 imports of `components/legal/*` pages, plus `vite.prerender.config.ts` gained a `resolve.alias` entry for `@` so the SSR build can resolve it.

**Note on `tests/e2e/`:** the memory doc previously carried a note that Playwright e2e specs were "intentionally excluded (no `@/` alias)" — that turned out to be stale. Verified empirically that `pnpm exec playwright test --list` resolves the `@/`-aliased imports correctly (Playwright 1.58 reads `tsconfig.json`'s `paths`), so these three e2e files are legitimately in scope now and the stale exclusion note will be corrected in the nightly memory-doc PR.

**Enforcement:** none added this run (no lint rule currently forbids relative cross-directory imports) — noted as a standing backlog item; a `no-restricted-imports` ESLint rule would prevent regrowth but is a larger change than tonight's single-dimension scope.

**Behavior/visual preservation evidence:** pure module-resolution rewrite, zero runtime behavior change. Independently verified beyond `pnpm run validate` (556/556 + 6644/6644 root tests, 37/37 + 703/703 functions tests, 0 new `tsc` errors):
- `pnpm exec playwright test --list` on the 3 modified e2e spec files resolves and enumerates all 6 tests correctly.
- `vite build --config vite.prerender.config.ts && node dist-ssr/prerender-legal.js` runs end-to-end and prerenders `/privacy`, `/terms`, `/support` correctly with the new alias.
- Full `pnpm run build` (app bundle + SSR prerender) green.

**Risk tag:** mechanical (import-path rewrite only, verified with targeted runtime checks beyond the standard test suite given the build-config and Playwright-config changes involved).

Co-authored by an autonomous nightly consistency subagent, reviewed and integrated by the orchestrator.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JNd6Aq2frfxDyz6XnZVbyQ)_