### PR TITLE
fix(D4): unify plc cross-subdirectory import + enforce with ESLint rule

### DIFF
--- a/components/plc/home/PlcHome.tsx
+++ b/components/plc/home/PlcHome.tsx
@@ -20,7 +20,7 @@
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Plc } from '@/types';
-import type { PlcSectionId } from '../sections';
+import type { PlcSectionId } from '@/components/plc/sections';
 import { usePlcActivity } from '@/context/usePlcContext';
 import { usePlcUnread } from '@/hooks/usePlcUnread';
 import { AttentionCard } from './cards/AttentionCard';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -151,5 +151,36 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-assignment': 'off',
     },
   },
+  {
+    // D4 (Import Path Convention) enforcement: a file under a
+    // components/plc/<subdir>/ directory must not reach across into a
+    // SIBLING plc subdirectory (or the shared `plc/sections` module) via a
+    // relative import — use the `@/components/plc/<dir>/...` alias instead.
+    // This exact bug class recurred across many nightly unifier runs (see
+    // docs/routines/unifier.md D4 section — runs 6, 7, 17, 18, 26, 28).
+    // Root-level `components/plc/*.tsx` files (e.g. importing
+    // '../PlcAssignmentImportModal' from `plc/bodies/` or `plc/tabs/`) are
+    // an intentionally-preserved gray zone (D4-E2) and are NOT matched by
+    // this pattern, since it only fires when the segment immediately after
+    // the last '../' is itself a plc subdirectory name (or `sections`, the
+    // module at the center of the recurring bug).
+    files: ['components/plc/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              regex:
+                '^(\\.\\./)+(activity|assignments|authoring|bodies|comments|docs|home|meeting|presence|resources|search|sections|settings|sharedData|sync|tabs|versions|viewer)(/.*)?$',
+              caseSensitive: true,
+              message:
+                "Cross-subdirectory plc import — use '@/components/plc/<dir>/...' instead of a relative path that escapes this subdirectory (see D4 in docs/routines/unifier.md).",
+            },
+          ],
+        },
+      ],
+    },
+  },
   prettierConfig
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -172,7 +172,7 @@ export default tseslint.config(
           patterns: [
             {
               regex:
-                '^(\\.\\./)+(activity|assignments|authoring|bodies|comments|docs|home|meeting|presence|resources|search|sections|settings|sharedData|sync|tabs|versions|viewer)(/.*)?$',
+                '^(\\.\\./)+(activity|assignments|authoring|bodies|comments|docs|home|meeting|members|presence|resources|search|sections|settings|sharedBoards|sharedData|sync|tabs|versions|viewer)(/.*)?$',
               caseSensitive: true,
               message:
                 "Cross-subdirectory plc import — use '@/components/plc/<dir>/...' instead of a relative path that escapes this subdirectory (see D4 in docs/routines/unifier.md).",


### PR DESCRIPTION
## Nightly Unifier — Run 28 — D4 Import Path Convention

**Canonical form:** cross-directory imports use the `@/` alias (`import { X } from '@/components/plc/sections'`), never a relative path that escapes the current directory into a sibling feature directory.

**Instance unified:**
- `components/plc/home/PlcHome.tsx:23` — `import type { PlcSectionId } from '../sections'` → `import type { PlcSectionId } from '@/components/plc/sections'`.

This is the recurring `components/plc/*/` cross-subdirectory relative-import bug class that has now hit nightly unifier runs 6, 7, 17, 18, 26, and this run (28) — it was left open as a deferred "NEEDS FIX" backlog item across the last two runs specifically to be picked up next, and this run confirms it was still unfixed at the current `dev-paul` tip.

**Enforcement added (the real fix, not just a manual sweep):** a new `no-restricted-imports` block in `eslint.config.js`, scoped to `files: ['components/plc/**/*.{ts,tsx}']`, that flags any relative import escaping into a sibling plc subdirectory (or the `plc/sections` module — the actual conduit for this recurring bug). It deliberately does **not** match the documented plc-root gray zone (e.g. `'../PlcAssignmentImportModal'` imported from `plc/bodies/` or `plc/tabs/`), which prior nightly runs have repeatedly confirmed as an intentional exception.

**Behavior-preservation evidence:**
- Type-only import swap — zero runtime behavior change.
- `pnpm exec eslint components/plc --max-warnings 0`: 0 errors/warnings (re-verified independently).
- Full `pnpm run validate`: type-check ✅ (root + functions), lint ✅ 0 errors/0 warnings, format:check ✅, tests 6726/6726 (root) + 703/703 (functions).
- `pnpm run build`: client bundle + SSR prerender both succeeded.
- New ESLint rule verified two ways: (1) planted a copy of the exact bug pattern in a scratch file — rule caught it; (2) full repo `pnpm run lint` stays clean — no false positives on any existing code, including the preserved D4-E2 gray zone.

**Risk tag:** mechanical (pure equivalence — a type-only import path change plus a new lint rule with no runtime surface).

**Deferred / backlog:** none for this dimension — a fresh grep across all `components/plc/*/` found no other stragglers of this pattern, and non-plc `'../'` cross-directory hits are all pre-existing accepted gray-zone imports (D4-E2).

🤖 Part of the automated nightly consistency ("unifier") routine — see `docs/routines/unifier.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc7fgcdeAckcAcUrvgjdg6)_