### PR TITLE
fix(announcements): close multi-tenant data leak in the no-org listener query

### DIFF
--- a/components/announcements/AnnouncementOverlay.tsx
+++ b/components/announcements/AnnouncementOverlay.tsx
@@ -353,7 +353,7 @@ const AnnouncementWindow: React.FC<{
  * as floating windows above the dashboard.
  */
 export const AnnouncementOverlay: React.FC = () => {
-  const { user, selectedBuildings, userTier, orgId } = useAuth();
+  const { user, selectedBuildings, userTier, orgId, roleResolved } = useAuth();
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [dismissed, setDismissed] = useState<Set<string>>(() => {
     // Pre-populate from localStorage on mount
@@ -381,29 +381,42 @@ export const AnnouncementOverlay: React.FC = () => {
   //   Legacy docs without an orgId field won't appear on this path — those are
   //   backfilled separately via scripts/migrateAnnouncements.js (see report).
   //
-  // PATH B — orgId is null/undefined (user not yet in an org, or still loading):
-  //   Query: where('isActive', '==', true)  ← legacy behavior, unchanged.
-  //   This preserves behavior for org-less or loading users: legacy/no-orgId
-  //   docs remain visible, and the client-side org filter in useMemo provides
-  //   defense-in-depth.
+  // PATH B — orgId resolved to null (no org membership doc for this user,
+  // e.g. an internal-tier user who was never added as an org member — this
+  // is a PERMANENT state, not just a loading window; see `roleResolved` gate
+  // below):
+  //   Query: where('orgId', '==', null)
+  //   A plain where('isActive','==',true) scan (no orgId filter) was tried
+  //   here previously and is NOT SAFE: confirmed against the real Firestore
+  //   emulator, a security rule's per-document OR-branches (e.g.
+  //   isOrgMember(resource.data.orgId)) are NOT enforced as a per-doc filter
+  //   for a list query whose own where() clauses don't already pin that
+  //   field — Firestore silently returns every isActive doc, including other
+  //   orgs' docs that a direct getDoc() on the same rule correctly denies.
+  //   'orgId'=='null' is a real equality filter Firestore CAN prove safe, at
+  //   the cost of not surfacing legacy pre-isolation docs (missing the field
+  //   entirely) here either — the same accepted trade-off Path A already has
+  //   pending scripts/migrateAnnouncements.js.
   //
   // The effect re-subscribes whenever orgId changes so the scoped listener
   // opens as soon as the membership snapshot lands (orgId: null → 'orono').
   //
-  // Free-tier gate: a no-org ("free") teacher must NEVER open the global
-  // announcements listener — `userTier` is the already-exposed distribution
-  // tier ('internal' | 'org' | 'free'). The loading/unresolved state is treated
-  // as NOT subscribed (the gate only opens once the tier is positively known to
-  // be non-free), which fails closed. (We do NOT call setAnnouncements([]) here:
-  // a synchronous setState in an effect trips react-hooks/set-state-in-effect,
-  // and the render-time guard below already renders nothing for free users even
-  // if their tier flips mid-session.)
+  // Gating: a no-org ("free") teacher must NEVER open the announcements
+  // listener — `userTier` is the already-exposed distribution tier
+  // ('internal' | 'org' | 'free'). `roleResolved` (membership + student-role
+  // resolution settled) additionally holds the listener closed while orgId
+  // is still loading, so the still-loading window can never run the old
+  // unscoped query — both gates fail closed. (We do NOT call
+  // setAnnouncements([]) here: a synchronous setState in an effect trips
+  // react-hooks/set-state-in-effect, and the render-time guard below already
+  // renders nothing for free users even if their tier flips mid-session.)
   useEffect(() => {
     // We only subscribe if we have a user object.
     // isAuthBypass allows the UI to render, but Firestore still needs an auth
     // token unless the rules are set to allow public read (which they are not).
     if (!user) return;
     if (userTier === 'free') return;
+    if (!roleResolved) return;
 
     const announcementsRef = collection(db, 'announcements');
 
@@ -411,8 +424,8 @@ export const AnnouncementOverlay: React.FC = () => {
       orgId != null
         ? // PATH A: org-scoped — single-field index, no composite index required.
           query(announcementsRef, where('orgId', '==', orgId))
-        : // PATH B: legacy unscoped — isActive filter applied server-side.
-          query(announcementsRef, where('isActive', '==', true));
+        : // PATH B: see comment above — provably safe null-org scope.
+          query(announcementsRef, where('orgId', '==', null));
 
     const unsub = onSnapshot(
       q,
@@ -430,7 +443,7 @@ export const AnnouncementOverlay: React.FC = () => {
     return unsub;
     // orgId is intentionally included: when the membership snapshot delivers
     // orgId (null → 'orono'), the effect re-runs to open the org-scoped listener.
-  }, [user, userTier, orgId]);
+  }, [user, userTier, orgId, roleResolved]);
 
   // Periodic clock update for scheduled activation/dismissal checks
   useEffect(() => {

--- a/tests/components/announcements/AnnouncementOverlay.test.tsx
+++ b/tests/components/announcements/AnnouncementOverlay.test.tsx
@@ -58,7 +58,11 @@ const MOCK_USER = { uid: 'user-1', email: 'test@example.com' };
 
 function mockAuth(
   selectedBuildings: string[] = [],
-  opts: { userTier?: 'internal' | 'org' | 'free'; orgId?: string | null } = {}
+  opts: {
+    userTier?: 'internal' | 'org' | 'free';
+    orgId?: string | null;
+    roleResolved?: boolean;
+  } = {}
 ) {
   vi.mocked(useAuth).mockReturnValue({
     user: MOCK_USER,
@@ -68,6 +72,9 @@ function mockAuth(
     // Default to 'internal' so existing behavior-tests subscribe (Orono path).
     userTier: opts.userTier ?? 'internal',
     orgId: opts.orgId ?? null,
+    // Default true so existing tests (written before the roleResolved gate)
+    // keep exercising post-resolution behavior; opt into false to test the gate.
+    roleResolved: opts.roleResolved ?? true,
   } as ReturnType<typeof useAuth>);
 }
 
@@ -683,21 +690,37 @@ describe('AnnouncementOverlay', () => {
       expect(screen.queryByText('Inactive')).not.toBeInTheDocument();
     });
 
-    it('PATH B: builds where("isActive","==",true) when orgId is null', () => {
-      // Legacy / org-loading path: no org scoping, isActive still filtered
-      // server-side exactly as before.
+    it('PATH B: builds where("orgId","==",null) when orgId is null', () => {
+      // Regression (data leak): a bare where('isActive','==',true) scan has no
+      // orgId filter for Firestore to structurally enforce. Confirmed against
+      // the real Firestore emulator that this lets a foreign org's doc come
+      // back even though a direct getDoc() on that same doc is correctly
+      // denied by firestore.rules — list queries only get the isolation the
+      // rule promises when the query itself is scoped to the same field the
+      // rule branches on. where('orgId','==',null) is a real equality filter
+      // Firestore can prove safe.
       mockAuth([], { userTier: 'internal', orgId: null });
       render(<AnnouncementOverlay />);
-      expect(vi.mocked(where)).toHaveBeenCalledWith('isActive', '==', true);
+      expect(vi.mocked(where)).toHaveBeenCalledWith('orgId', '==', null);
     });
 
-    it('PATH B: does NOT use where("orgId",...) when orgId is null', () => {
+    it('PATH B: does NOT use where("isActive",...) as a server constraint when orgId is null', () => {
       mockAuth([], { userTier: 'internal', orgId: null });
       render(<AnnouncementOverlay />);
-      const orgIdCalls = vi
+      const isActiveCalls = vi
         .mocked(where)
-        .mock.calls.filter((args) => args[0] === 'orgId');
-      expect(orgIdCalls).toHaveLength(0);
+        .mock.calls.filter((args) => args[0] === 'isActive');
+      expect(isActiveCalls).toHaveLength(0);
+    });
+
+    it('does not subscribe while membership resolution is still pending (roleResolved=false)', () => {
+      // The listener must fail closed during the loading window rather than
+      // open the (formerly unsafe) unscoped query. Once roleResolved flips to
+      // true the effect re-runs and subscribes with the correct scoped query.
+      mockAuth([], { userTier: 'internal', orgId: null, roleResolved: false });
+      render(<AnnouncementOverlay />);
+      expect(firestoreCallback).toBeNull();
+      expect(vi.mocked(where)).not.toHaveBeenCalled();
     });
 
     it('re-subscribes with org-scoped query when orgId resolves from null to a string', () => {
@@ -706,13 +729,11 @@ describe('AnnouncementOverlay', () => {
       // listener and open a new org-scoped one.
       const { rerender } = render(<AnnouncementOverlay />);
 
-      // Initial render: orgId null → PATH B
+      // Initial render: orgId null → PATH B (orgId==null, not yet the real org)
       mockAuth([], { userTier: 'internal', orgId: null });
       rerender(<AnnouncementOverlay />);
-      // orgId-equality calls should still be zero
-      expect(
-        vi.mocked(where).mock.calls.filter((args) => args[0] === 'orgId')
-      ).toHaveLength(0);
+      expect(vi.mocked(where)).toHaveBeenCalledWith('orgId', '==', null);
+      expect(vi.mocked(where)).not.toHaveBeenCalledWith('orgId', '==', 'orono');
 
       vi.mocked(where).mockClear();
 

--- a/tests/rules/announcementsQuery.test.ts
+++ b/tests/rules/announcementsQuery.test.ts
@@ -38,7 +38,7 @@ const ORONO = 'orono';
 const OTHER = 'other-org';
 
 const MEMBER_UID = 'member-uid';
-const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
+const MEMBER_EMAIL = 'teacher@orono.k12.mn.us';
 
 const RULES_PATH = fileURLToPath(
   new URL('../../firestore.rules', import.meta.url)
@@ -102,6 +102,7 @@ describe('announcements list-query tenant isolation', () => {
     await assertFails(getDoc(doc(db, 'announcements/other-org-active')));
   });
 
+  // Intentional: this asserts the OLD unscoped query SUCCEEDS and returns a foreign-org doc — Firestore does not apply resource.data-dependent rule branches as a per-doc filter for list queries (see Firebase "Secure query" / rules-are-not-filters docs). If the rules are ever tightened to block this at the rules layer, this test will fail by design, signalling the fix's rationale changed — not a regression.
   it('LEAK (documents the Firestore quirk the fix works around): an unscoped isActive query returns a foreign-org doc the rule denies directly', async () => {
     const db = asMember();
     const q = query(

--- a/tests/rules/announcementsQuery.test.ts
+++ b/tests/rules/announcementsQuery.test.ts
@@ -1,0 +1,138 @@
+// Regression test for a multi-tenant data leak in AnnouncementOverlay.tsx's
+// "PATH B" listener query (used whenever orgId hasn't resolved to a non-null
+// org — including the PERMANENT state of an internal-tier user with no
+// `/organizations/{orgId}/members/{email}` doc, not just a brief loading
+// window).
+//
+// The old query — where('isActive','==',true), no orgId filter — was assumed
+// to be protected by the firestore.rules read rule's isOrgMember(resource.data
+// .orgId) branch. Confirmed against the REAL Firestore emulator that this is
+// false: a security rule's per-document branches are only enforced for a list
+// query when the query's own where() clauses structurally pin the field the
+// rule depends on. Without that, Firestore returns every isActive doc,
+// including another org's — even though a direct getDoc() on that same
+// document is correctly denied by the identical rule. See AnnouncementOverlay
+// .tsx's PATH B comment for the fix: where('orgId','==',null), a filter
+// Firestore CAN prove safe.
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+  RulesTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  setDoc,
+  getDoc,
+  getDocs,
+  collection,
+  query,
+  where,
+  doc,
+} from 'firebase/firestore';
+
+const PROJECT_ID = 'spartboard-rules-test-announcements';
+const ORONO = 'orono';
+const OTHER = 'other-org';
+
+const MEMBER_UID = 'member-uid';
+const MEMBER_EMAIL = 'paul.ivers@orono.k12.mn.us';
+
+const RULES_PATH = fileURLToPath(
+  new URL('../../firestore.rules', import.meta.url)
+);
+
+let testEnv: RulesTestEnvironment;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: readFileSync(RULES_PATH, 'utf8'),
+      host: process.env.FIRESTORE_EMULATOR_HOST?.split(':')[0] ?? '127.0.0.1',
+      port: Number(
+        process.env.FIRESTORE_EMULATOR_HOST?.split(':')[1] ?? '8080'
+      ),
+    },
+  });
+});
+
+afterAll(async () => {
+  await testEnv?.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    const db = ctx.firestore();
+    await setDoc(doc(db, `organizations/${ORONO}/members/${MEMBER_EMAIL}`), {
+      email: MEMBER_EMAIL,
+      orgId: ORONO,
+      roleId: 'teacher',
+      status: 'active',
+    });
+    // Legacy pre-isolation doc: no orgId field at all.
+    await setDoc(doc(db, 'announcements/legacy'), {
+      title: 'legacy',
+      isActive: true,
+    });
+    // Explicitly orgId:null doc — the shape the fixed query targets.
+    await setDoc(doc(db, 'announcements/explicit-null-org'), {
+      title: 'explicit null org',
+      isActive: true,
+      orgId: null,
+    });
+    // Another org's active announcement — must never reach an orono caller.
+    await setDoc(doc(db, 'announcements/other-org-active'), {
+      title: 'other org',
+      isActive: true,
+      orgId: OTHER,
+    });
+  });
+});
+
+const asMember = () =>
+  testEnv.authenticatedContext(MEMBER_UID, { email: MEMBER_EMAIL }).firestore();
+
+describe('announcements list-query tenant isolation', () => {
+  it('sanity: a direct getDoc on the foreign-org doc is correctly denied by the rule', async () => {
+    const db = asMember();
+    await assertFails(getDoc(doc(db, 'announcements/other-org-active')));
+  });
+
+  it('LEAK (documents the Firestore quirk the fix works around): an unscoped isActive query returns a foreign-org doc the rule denies directly', async () => {
+    const db = asMember();
+    const q = query(
+      collection(db, 'announcements'),
+      where('isActive', '==', true)
+    );
+    const snap = await assertSucceeds(getDocs(q));
+    const ids = snap.docs.map((d) => d.id).sort();
+    expect(ids).toContain('other-org-active');
+  });
+
+  it('FIX: where(orgId==null) — the query AnnouncementOverlay now uses — excludes the foreign-org doc', async () => {
+    const db = asMember();
+    const q = query(
+      collection(db, 'announcements'),
+      where('orgId', '==', null)
+    );
+    const snap = await assertSucceeds(getDocs(q));
+    const ids = snap.docs.map((d) => d.id).sort();
+    expect(ids).toEqual(['explicit-null-org']);
+  });
+
+  it('Path A: where(orgId==orono) run by an org member returns only that org and excludes the foreign doc', async () => {
+    const db = asMember();
+    const q = query(
+      collection(db, 'announcements'),
+      where('orgId', '==', ORONO)
+    );
+    const snap = await assertSucceeds(getDocs(q));
+    const ids = snap.docs.map((d) => d.id).sort();
+    expect(ids).toEqual([]);
+    expect(ids).not.toContain('other-org-active');
+  });
+});


### PR DESCRIPTION
## Root cause

`AnnouncementOverlay.tsx`'s "PATH B" listener query (used whenever `orgId` hasn't resolved to a specific org — a **permanent** state for internal-tier users who are never added as an org member, not just a loading window) ran `where('isActive','==',true)` with no `orgId` filter.

Confirmed against the real Firestore emulator: Firestore does **not** enforce a security rule's `resource.data`-dependent OR-branches (`isOrgMember(resource.data.orgId)`) as a per-document filter for a list query whose own `where()` clauses don't pin the same field. The rule correctly denies a direct `getDoc()` on a foreign org's announcement, but the unscoped list query silently returned it anyway. The client's own defense-in-depth filter only excludes foreign-org docs once `orgId` is non-null, so for this exact population (internal-tier, no org membership) the leaked doc rendered in the UI.

## Fix

- Changed PATH B's query to `where('orgId', '==', null)` — an equality filter Firestore can structurally prove safe (same "legacy field-absent docs invisible until backfill" trade-off PATH A already accepts).
- Added a `roleResolved` gate (already exposed by `useAuth()`) so the listener never opens the old unscoped query during the loading window either.

## Rejected band-aid

Tightening the rule alone (e.g. more OR branches) doesn't help — the emulator confirms the rule is already logically correct for direct reads. The enforcement gap is specific to Firestore's list-query safety analysis, so the fix has to live in the query shape, not the rule.

## Regression tests

- `tests/rules/announcementsQuery.test.ts` (new) — real Firestore-emulator proof: documents the leak (unscoped `isActive` query returns a foreign-org doc) and proves the fix (`orgId == null` excludes it), plus a sanity check that direct `getDoc` is already correctly denied.
- `tests/components/announcements/AnnouncementOverlay.test.tsx` — updated PATH B query assertions + new `roleResolved` gating test.

**Fail-before / pass-after** (independently re-verified by the orchestrator): swapped in the pre-fix component against the updated test file — 4/47 component tests fail exactly as claimed; restored, all 47 pass.

## Verification

- `pnpm run test:rules` — 47/47 files, 1112/1112 tests pass on the real emulator (orchestrator-independent run).
- `pnpm run validate` — type-check, lint (0 warnings), format, all tests, test-count guard — all pass (orchestrator-independent run).
- `pnpm run build:all` — app + functions build succeed (orchestrator-independent run).

## Risk: contained

Client-side query-shape change only; no `firestore.rules` change. All existing client consumers of the `announcements` collection were checked — this is the only listener affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEJTpeRWqRCPMhEfKbDNPZ)_