### PR TITLE
fix(import-wizard): guard against stale in-flight promises after close/reopen

### DIFF
--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -111,11 +111,18 @@ export function ImportWizard<TData>({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Bumped on every open/close transition so in-flight async handlers (parse,
+  // AI-assist, picker) can detect a stale session and skip applying their
+  // result — the wizard stays mounted across close/reopen, so promises
+  // started before a close can still resolve after a reopen.
+  const sessionRef = useRef(0);
+
   // Reset ephemeral state whenever the wizard opens.
   // Using adjust-state-while-rendering so we don't need useEffect.
   const [prevOpen, setPrevOpen] = useState(isOpen);
   if (prevOpen !== isOpen) {
     setPrevOpen(isOpen);
+    sessionRef.current += 1;
     if (isOpen) {
       setStep('source');
       setSheetUrl('');
@@ -145,10 +152,14 @@ export function ImportWizard<TData>({
     supportsCsv || supportsJson || supportsHtml || supportsFile;
 
   const runParse = async (payload: ImportSourcePayload): Promise<void> => {
+    const session = sessionRef.current;
     setLoading(true);
     setParseError(null);
     try {
       const result = await adapter.parse(payload);
+      // The wizard was closed and/or reopened while this parse was in
+      // flight — its result belongs to a cancelled session, discard it.
+      if (session !== sessionRef.current) return;
       setParsed(result.data);
       setWarnings(result.warnings);
       // If the adapter can extract a title from the parsed data (e.g. an
@@ -163,11 +174,12 @@ export function ImportWizard<TData>({
       }
       setStep('preview');
     } catch (err) {
+      if (session !== sessionRef.current) return;
       setParseError(
         err instanceof Error ? err.message : 'Failed to parse import source.'
       );
     } finally {
-      setLoading(false);
+      if (session === sessionRef.current) setLoading(false);
     }
   };
 
@@ -181,23 +193,26 @@ export function ImportWizard<TData>({
 
   const handlePickSheet = async (): Promise<void> => {
     if (!adapter.pickSheet) return;
+    const session = sessionRef.current;
     setParseError(null);
     setPicking(true);
     try {
       const picked = await adapter.pickSheet();
+      if (session !== sessionRef.current) return;
       // Null = the user dismissed the Picker — stay on the source step with no
       // error. Otherwise parse the picked sheet (it's now drive.file-readable).
       if (picked) {
         await runParse({ kind: 'sheet', url: picked.url });
       }
     } catch (err) {
+      if (session !== sessionRef.current) return;
       setParseError(
         err instanceof Error
           ? err.message
           : 'Failed to open the Google Drive picker.'
       );
     } finally {
-      setPicking(false);
+      if (session === sessionRef.current) setPicking(false);
     }
   };
 
@@ -208,6 +223,7 @@ export function ImportWizard<TData>({
     if (fileInputRef.current) fileInputRef.current.value = '';
     if (!file) return;
 
+    const session = sessionRef.current;
     const kind = inferKindFromFileName(file.name, adapter.supportedSources);
     if (kind === 'file') {
       await runParse({ kind: 'file', file });
@@ -215,8 +231,10 @@ export function ImportWizard<TData>({
     }
     try {
       const text = await file.text();
+      if (session !== sessionRef.current) return;
       await runParse({ kind, text, fileName: file.name });
     } catch (err) {
+      if (session !== sessionRef.current) return;
       setParseError(
         err instanceof Error ? err.message : 'Failed to read the selected file.'
       );
@@ -263,23 +281,26 @@ export function ImportWizard<TData>({
   const handleAiGenerate = async (): Promise<void> => {
     if (!adapter.aiAssist) return;
     if (!aiPrompt.trim()) return;
+    const session = sessionRef.current;
     setAiGenerating(true);
     setParseError(null);
     try {
       const data = await adapter.aiAssist.generate({ prompt: aiPrompt.trim() });
+      if (session !== sessionRef.current) return;
       setParsed(data);
       setWarnings([]);
       setAiOpen(false);
       setAiPrompt('');
       setStep('preview');
     } catch (err) {
+      if (session !== sessionRef.current) return;
       setParseError(
         err instanceof Error
           ? err.message
           : 'Failed to generate from AI. Please try again.'
       );
     } finally {
-      setAiGenerating(false);
+      if (session === sessionRef.current) setAiGenerating(false);
     }
   };
 
@@ -295,19 +316,24 @@ export function ImportWizard<TData>({
       setValidationErrors(v.errors.length > 0 ? v.errors : ['Invalid import.']);
       return;
     }
+    const session = sessionRef.current;
     setValidationErrors([]);
     setSaveError(null);
     setSaving(true);
     try {
       await adapter.save(parsed, trimmed);
+      // A stale save (from before a close/reopen) must not close or report
+      // "saved" against the freshly-reopened session.
+      if (session !== sessionRef.current) return;
       onSaved?.(trimmed);
       onClose();
     } catch (err) {
+      if (session !== sessionRef.current) return;
       setSaveError(
         err instanceof Error ? err.message : 'Failed to save import.'
       );
     } finally {
-      setSaving(false);
+      if (session === sessionRef.current) setSaving(false);
     }
   };
 

--- a/components/common/library/importer/ImportWizard.tsx
+++ b/components/common/library/importer/ImportWizard.tsx
@@ -111,14 +111,10 @@ export function ImportWizard<TData>({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Bumped on every open/close transition so in-flight async handlers (parse,
-  // AI-assist, picker) can detect a stale session and skip applying their
-  // result — the wizard stays mounted across close/reopen, so promises
-  // started before a close can still resolve after a reopen.
+  // Bumped on every open/close transition; in-flight handlers check it to drop results from a cancelled session.
   const sessionRef = useRef(0);
 
-  // Reset ephemeral state whenever the wizard opens.
-  // Using adjust-state-while-rendering so we don't need useEffect.
+  // Adjust-state-while-rendering: reset on open without useEffect.
   const [prevOpen, setPrevOpen] = useState(isOpen);
   if (prevOpen !== isOpen) {
     setPrevOpen(isOpen);
@@ -157,8 +153,7 @@ export function ImportWizard<TData>({
     setParseError(null);
     try {
       const result = await adapter.parse(payload);
-      // The wizard was closed and/or reopened while this parse was in
-      // flight — its result belongs to a cancelled session, discard it.
+      // Stale session — wizard closed/reopened while this parse was in flight.
       if (session !== sessionRef.current) return;
       setParsed(result.data);
       setWarnings(result.warnings);
@@ -322,8 +317,7 @@ export function ImportWizard<TData>({
     setSaving(true);
     try {
       await adapter.save(parsed, trimmed);
-      // A stale save (from before a close/reopen) must not close or report
-      // "saved" against the freshly-reopened session.
+      // Stale session — don't close or report "saved" against a freshly-reopened wizard.
       if (session !== sessionRef.current) return;
       onSaved?.(trimmed);
       onClose();

--- a/tests/components/ImportWizard.test.tsx
+++ b/tests/components/ImportWizard.test.tsx
@@ -484,6 +484,63 @@ describe('ImportWizard', () => {
     expect((titleInput as HTMLInputElement).value).toBe('User Typed Title');
   });
 
+  it('does not let a stale in-flight parse from before a close/reopen clobber the freshly-reset state', async () => {
+    // Deferred promise lets the test control exactly when adapter.parse resolves.
+    let resolveParse:
+      | ((v: { data: FakeData; warnings: string[] }) => void)
+      | null = null;
+    const parsePromise = new Promise<{ data: FakeData; warnings: string[] }>(
+      (resolve) => {
+        resolveParse = resolve;
+      }
+    );
+    const { adapter } = makeAdapter({
+      parseImpl: () => parsePromise,
+    });
+    const { rerender } = renderWizard(adapter);
+
+    // Kick off a parse that will not resolve until we say so.
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(urlField, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/stale' },
+    });
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+
+    // Close the wizard, then reopen it before the stale parse resolves —
+    // ImportWizard is always mounted by its callers (isOpen only toggles the
+    // Modal's own visibility), so this component instance's state survives.
+    rerender(
+      <ImportWizard<FakeData>
+        isOpen={false}
+        onClose={vi.fn()}
+        adapter={adapter}
+      />
+    );
+    rerender(
+      <ImportWizard<FakeData>
+        isOpen={true}
+        onClose={vi.fn()}
+        adapter={adapter}
+      />
+    );
+
+    // Reopening should have reset to a clean Source step.
+    expect(screen.getByLabelText('Google Sheet URL')).toBeInTheDocument();
+
+    // Now let the stale parse from before the close resolve.
+    await act(async () => {
+      resolveParse?.({ data: { rows: ['stale-row'] }, warnings: [] });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The stale result must not push the freshly-reopened wizard to Preview.
+    expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Google Sheet URL')).toBeInTheDocument();
+  });
+
   it('shows the template helper when adapter exposes templateHelper', () => {
     const { adapter } = makeAdapter({
       templateHelper: {

--- a/tests/components/ImportWizard.test.tsx
+++ b/tests/components/ImportWizard.test.tsx
@@ -541,6 +541,63 @@ describe('ImportWizard', () => {
     expect(screen.getByLabelText('Google Sheet URL')).toBeInTheDocument();
   });
 
+  it('does not fire onSaved/onClose when a stale save resolves after close/reopen', async () => {
+    let resolveSave: (() => void) | null = null;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    const { adapter } = makeAdapter({ saveImpl: () => savePromise });
+    const { rerender, onSaved, onClose } = renderWizard(adapter);
+
+    // Source → parse → Preview.
+    const urlField = screen.getByLabelText('Google Sheet URL');
+    fireEvent.change(urlField, {
+      target: { value: 'https://docs.google.com/spreadsheets/d/x' },
+    });
+    fireEvent.click(
+      urlField.parentElement?.querySelector('button') as HTMLButtonElement
+    );
+    await screen.findByTestId('preview');
+
+    // Preview → Confirm.
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    const titleInput = await screen.findByLabelText('Title');
+    fireEvent.change(titleInput, { target: { value: 'My Quiz' } });
+
+    // Start the save — this becomes the stale operation.
+    fireEvent.click(screen.getByRole('button', { name: /save to library/i }));
+
+    // Close and reopen before the save resolves.
+    rerender(
+      <ImportWizard<FakeData>
+        isOpen={false}
+        onClose={onClose}
+        adapter={adapter}
+        onSaved={onSaved}
+      />
+    );
+    rerender(
+      <ImportWizard<FakeData>
+        isOpen={true}
+        onClose={onClose}
+        adapter={adapter}
+        onSaved={onSaved}
+      />
+    );
+
+    // Let the stale save resolve.
+    await act(async () => {
+      resolveSave?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    // Freshly-reopened wizard should still be on Source.
+    expect(screen.getByLabelText('Google Sheet URL')).toBeInTheDocument();
+  });
+
   it('shows the template helper when adapter exposes templateHelper', () => {
     const { adapter } = makeAdapter({
       templateHelper: {


### PR DESCRIPTION
## Root cause

`components/common/library/importer/ImportWizard.tsx` is always mounted by every caller (`QuizWidget/Widget.tsx`, `MiniApp/Widget.tsx`, `VideoActivityWidget/components/Creator.tsx`) — callers only toggle the `isOpen` prop, never unmount the component. The wizard resets its ephemeral state on any `isOpen` transition, but its five async handlers (`runParse`, `handlePickSheet`, `handleFilePicked`, `handleAiGenerate`, `handleConfirmSave`) had no cancellation guard. Closing the wizard mid-operation and reopening it before the promise settled let the stale `.then` continuation run after the reset and overwrite the freshly-reset state with the cancelled operation's result — jumping straight to Preview with old data, or in the save case, firing `onSaved`/closing the freshly-reopened wizard.

This was a previously-flagged, unverified backlog lead from a prior nightly run; this run confirmed and fixed it.

## Fix

Added a `sessionRef` counter bumped on every `isOpen` transition. All five async handlers capture the session at entry and check it after each `await` before applying any `setState` — the general, root-cause fix, covering all five handlers that shared the identical race.

## Rejected band-aid

Unmounting/remounting the wizard via a `key` prop tied to `isOpen` at each of the three call sites was considered and rejected: it would touch three separate widget files instead of the shared primitive, wouldn't prevent the race for any future caller of `ImportWizard`, and would lose in-progress UI state (e.g. an AI-assist prompt draft) unnecessarily on every close.

## Regression test

`tests/components/ImportWizard.test.tsx` — new test using a deferred promise to simulate a stale in-flight parse surviving a close/reopen cycle.

**Fail-before / pass-after** (independently re-verified by the orchestrator): swapped in the pre-fix component — the new test fails (`expected document not to contain element, found <div data-testid="preview">`); restored, passes.

## Verification

- `pnpm run validate` — clean (orchestrator-independent run: type-check, lint, format, 558 files/6727 tests root + 37 files/703 tests functions, test-count guard).
- `pnpm run build` — passes (orchestrator-independent run).

## Risk: contained

Isolated to one shared component's internal state-guard logic; behavior for the non-race happy path is unchanged.

## Not fixed (backlog)

`handleCreateTemplate`/`handleCopyTemplateUrl` share the same architectural gap but only touch lower-risk state (`creatingTemplate`/`parseError`) — left for a future sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEJTpeRWqRCPMhEfKbDNPZ)_