### PR TITLE
fix(privacy): add Random/Stations custom-name fields to PII scrub allowlist

### DIFF
--- a/utils/dashboardPII.test.ts
+++ b/utils/dashboardPII.test.ts
@@ -79,6 +79,40 @@ describe('dashboardPII', () => {
           style: 'digital',
         } as unknown as WidgetConfig,
       },
+      {
+        id: 'widget-4',
+        type: 'random',
+        x: 3,
+        y: 3,
+        w: 2,
+        h: 2,
+        z: 1,
+        flipped: false,
+        config: {
+          mode: 'shuffle',
+          // Jigsaw/manual-edit name lists — same "raw student name" shape as
+          // firstNames/lastNames/remainingStudents above, just added later.
+          lockedNames: ['Alice Smith'],
+          unassignedNames: ['Bob Jones'],
+          doneNames: ['Carol Lee'],
+        } as unknown as WidgetConfig,
+      },
+      {
+        id: 'widget-5',
+        type: 'stations',
+        x: 4,
+        y: 4,
+        w: 2,
+        h: 2,
+        z: 1,
+        flipped: false,
+        config: {
+          stations: [],
+          assignments: {},
+          rosterMode: 'custom',
+          customRoster: ['Dana White'],
+        } as unknown as WidgetConfig,
+      },
     ],
   };
 
@@ -95,6 +129,20 @@ describe('dashboardPII', () => {
       expect(scrubbed.widgets[0].config).toEqual({ mode: 'wheel' });
       expect(scrubbed.widgets[1].config).toEqual({ layout: 'grid' });
       expect(scrubbed.widgets[2].config).toEqual({ style: 'digital' });
+    });
+
+    it('removes Random jigsaw/manual-edit name lists (lockedNames, unassignedNames, doneNames)', () => {
+      const scrubbed = scrubDashboardPII(mockDashboardWithPii);
+      expect(scrubbed.widgets[3].config).toEqual({ mode: 'shuffle' });
+    });
+
+    it('removes Stations custom roster names', () => {
+      const scrubbed = scrubDashboardPII(mockDashboardWithPii);
+      expect(scrubbed.widgets[4].config).toEqual({
+        stations: [],
+        assignments: {},
+        rosterMode: 'custom',
+      });
     });
 
     it('does not mutate the original dashboard', () => {
@@ -124,6 +172,14 @@ describe('dashboardPII', () => {
         },
         'widget-2': {
           names: ['Alice Smith', 'Bob Jones'],
+        },
+        'widget-4': {
+          lockedNames: ['Alice Smith'],
+          unassignedNames: ['Bob Jones'],
+          doneNames: ['Carol Lee'],
+        },
+        'widget-5': {
+          customRoster: ['Dana White'],
         },
       });
       // widget-3 has no PII, so it should be omitted

--- a/utils/dashboardPII.ts
+++ b/utils/dashboardPII.ts
@@ -21,8 +21,12 @@ export const PII_WIDGET_FIELDS = [
   'lastNames', // RandomWidget, ChecklistWidget — newline-delimited name list
   'completedNames', // ChecklistWidget — names/IDs of students who completed items
   'remainingStudents', // RandomWidget — unpicked students in current session
+  'lockedNames', // RandomWidget — manually pinned names (Jigsaw/manual edit)
+  'unassignedNames', // RandomWidget — names parked in the Unassigned tray
+  'doneNames', // RandomWidget — names marked "done" in Shuffle mode
   'names', // SeatingChartWidget — custom roster name list
   'roster', // LunchCountConfig — student name array
+  'customRoster', // StationsConfig — custom-mode roster name list
 ] as const;
 
 export type PiiWidgetField = (typeof PII_WIDGET_FIELDS)[number];


### PR DESCRIPTION
## Root cause

`PII_WIDGET_FIELDS` in `utils/dashboardPII.ts` is the allowlist `scrubDashboardPII` uses to strip raw student names from a dashboard before every Firestore write (student PII must stay client-side / in the teacher's private Google Drive, never in Firestore — per the module's own documented contract). The list covered the original fields but was never updated when two newer custom-roster features were added:

- `RandomConfig.lockedNames` / `unassignedNames` / `doneNames` — raw student names used by Random's Jigsaw manual pin/unassign flow and Shuffle mode's "done" marking.
- `StationsConfig.customRoster` — the custom-mode roster name list.

Because these fields were absent from the allowlist, `scrubDashboardPII`/`extractDashboardPII` silently passed them straight through to Firestore instead of scrubbing them, defeating the module's privacy contract for any teacher using these features.

## Fix

Added `lockedNames`, `unassignedNames`, `doneNames`, `customRoster` to `PII_WIDGET_FIELDS`. Verified each field name is unique to its one config type (no collateral stripping elsewhere).

## Rejected band-aid

Also considered stripping the `assignments` field (used by `StationsConfig`/`LunchCountConfig`/`SeatingChartConfig`, and keyed by literal display name in Stations custom mode — arguably a worse PII surface). Rejected for this PR: `assignments` is reused across three widget types with different key semantics (SeatingChart already migrated to ID-keys via its own legacy-migration effect; LunchCount's semantics weren't verified this run), so blanket-stripping it by field name in this allowlist-based scrubber would silently destroy legitimate non-PII data on every save. Flagged as a separate backlog item requiring a widget-level fix in `components/widgets/Stations/**`.

## Regression test

`utils/dashboardPII.test.ts` — added mock widgets covering all four new fields in both `scrubDashboardPII` and `extractDashboardPII`.

**Fail-before / pass-after** (independently re-verified by the orchestrator): swapped in the pre-fix allowlist — 3/18 tests fail (the four fields survive the scrub / are missing from the extracted supplement); restored, 18/18 pass.

## Verification

- `pnpm run validate` — clean (orchestrator-independent run).
- `pnpm run build` — passes (orchestrator-independent run).

## Risk: contained

Four-line allowlist addition; no behavior change for any existing field.

## Not fixed (backlog)

- `components/widgets/Stations/Widget.tsx`: `assignments` keyed by literal student display name in both class-roster and custom modes — needs an ID-keying migration like SeatingChart already has.
- `LunchCountConfig.assignments` may have the same name-vs-ID-key ambiguity — not verified this run.
- `components/classroomAddon/TeacherDiscoveryRoute.tsx` dedup-fence gap (previously flagged, still unowned by any area glob).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEJTpeRWqRCPMhEfKbDNPZ)_