### PR TITLE
fix(D3): convert LunchCount SubmitReportModal notes label to SettingsLabel

### DIFF
--- a/components/widgets/LunchCount/SubmitReportModal.tsx
+++ b/components/widgets/LunchCount/SubmitReportModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { Button } from '@/components/common/Button';
 import { Modal } from '@/components/common/Modal';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { FileSpreadsheet, X, Send } from 'lucide-react';
 
 /**
@@ -191,12 +192,9 @@ export const SubmitReportModal: React.FC<SubmitReportModalProps> = ({
 
           {/* Notes */}
           <div className="space-y-2">
-            <label
-              htmlFor="report-notes"
-              className="text-xxs font-black text-slate-400 uppercase tracking-widest"
-            >
+            <SettingsLabel htmlFor="report-notes">
               Additional Notes
-            </label>
+            </SettingsLabel>
             <textarea
               id="report-notes"
               value={notes}


### PR DESCRIPTION
## Nightly Unifier — Run 29 — D3 Settings Panel Label Primitives

**Canonical form:** `<SettingsLabel htmlFor="...">Label</SettingsLabel>` from `components/common/SettingsLabel.tsx`, replacing hand-rolled `text-xxs font-black text-slate-400 uppercase tracking-widest` label markup.

**Instance unified:**
- `components/widgets/LunchCount/SubmitReportModal.tsx` — the "Additional Notes" `<label htmlFor="report-notes">` above the report-notes `<textarea>` hand-rolled the exact canonical anti-pattern → `<SettingsLabel htmlFor="report-notes">`.

This resolves a backlog item that had sat as NEEDS REVIEW since run 9 ("human decision needed on whether SubmitReportModal labels fall under D3 scope"). Splitting the file's byte-exact matches apart resolved the ambiguity: the "Date" / "Staff Name" / "Submission Label" spans in the same modal caption **static read-only display values**, not form controls — left untouched, out of D3 scope even though the class string matches. Only the "Additional Notes" label sits directly above a single, unambiguous form control (`<textarea id="report-notes">`), so it's a clean conversion with `htmlFor` pairing preserved.

**Behavior-preservation evidence:**
- `SettingsLabel` renders the identical class combination as a `<label>` — no visible text/markup change beyond the primitive swap.
- **Spacing (corrected after review):** the label-to-textarea gap grows from 8px to 16px. `SettingsLabel` adds `block mb-2` (8px) where the original hand-rolled `<label>` had neither `block` nor a margin, so the only spacing came from the parent `space-y-2` container's `margin-top: 0.5rem` on the textarea. I initially claimed these two margins *collapse* to a net 8px (same as before) — that's wrong. Empirically verified via a real Chromium (Playwright): `<textarea>`'s UA-stylesheet default is `display: inline-block`, and CSS margin collapsing only applies between adjacent block-level boxes, so the label's `mb-2` and the textarea's `mt-2` are **additive, not collapsing** — the actual gap is 16px. This is a minor, real visual change, not a preserved one. It's consistent with the established `SettingsLabel` convention used elsewhere in the repo (e.g. `RandomSettings.tsx:535`) and the existing "mb-1→mb-2 canonical alignment" precedent accepted in prior nightly-unifier PRs (#1783, #1870) — judged acceptable, not reverted.
- `pnpm run validate` (orchestrator-independent re-run of lint + tsc on the changed file, full suite already run by the authoring pass): 0 lint errors/warnings, 0 type errors.
- `pnpm run build`: passes (run during authoring; no build-relevant surface touched by this change).
- No component test exists for `SubmitReportModal.tsx` specifically; the adjacent `tests/i18n/widgetLunchCountLocales.test.ts` is unaffected (label text unchanged).

**Risk tag:** mechanical (component swap with identical rendered classes), with one acknowledged minor visual delta (8px→16px label spacing, see above).

**Deferred / backlog (not touched here, logged in `docs/routines/unifier.md`):**
- `components/common/RosterModeControl.tsx:19` — same byte-exact anti-pattern, but sits in a flex-row alongside a toggle-button group (existing D3-E5/E16 flex-row exclusion pattern) — left alone.
- `components/student/NextUpStudentApp.tsx:193` — student-facing kiosk form, out of D3 scope (already D3-E11).
- `components/widgets/LunchCount/SubmitReportModal.tsx` "Date"/"Staff Name"/"Submission Label" spans — read-only display captions, not form-control labels — left untouched.

🤖 Part of the automated nightly consistency ("unifier") routine — see `docs/routines/unifier.md`.