### PR TITLE
fix(css-scaling): raise TalkingTool Scaffolding label cap to 10px floor

### DIFF
--- a/components/widgets/TalkingTool/Widget.tsx
+++ b/components/widgets/TalkingTool/Widget.tsx
@@ -55,7 +55,7 @@ export const TalkingToolWidget: React.FC<WidgetComponentProps> = ({
           <label
             className="font-black uppercase text-slate-400 tracking-widest block"
             style={{
-              fontSize: 'min(9px, 2.2cqmin)',
+              fontSize: 'min(10px, 2.2cqmin)',
               marginBottom: 'min(4px, 1cqmin)',
             }}
           >


### PR DESCRIPTION
## Summary

The TalkingTool widget's "Scaffolding" sidebar section-header label used `fontSize: 'min(9px, 2.2cqmin)'`. The CLAUDE.md content-scaling guidelines set **10px** as the minimum pixel cap for tertiary/metadata text, so a 9px cap left the label below that legibility floor at large widget sizes (relevant on projected classroom displays). TalkingTool is a `skipScaling: true` widget.

## Change

- `components/widgets/TalkingTool/Widget.tsx:58` — `min(9px, 2.2cqmin)` → `min(10px, 2.2cqmin)`

The `2.2cqmin` factor is unchanged, so small-size scaling behavior is identical; only the large-size clamp floor rises from 9px to the 10px minimum. Single-line, no layout or logic change.

## Verification

- `pnpm run type-check` — exit 0
- `pnpm exec eslint components/widgets/TalkingTool/Widget.tsx --max-warnings 0` — clean
- `pnpm exec prettier --check` — clean

Tracked as a LOW item in `docs/scheduled-tasks/css-scaling.md` (journal record lives on the `scheduled-tasks` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161R5shA5pcEAzunqFahT5p

---
_Generated by [Claude Code](https://claude.ai/code/session_0161R5shA5pcEAzunqFahT5p)_