### PR TITLE
fix(D1): convert ExpectationsWidget empty state to ScaledEmptyState

### DIFF
--- a/components/widgets/ExpectationsWidget/Widget.tsx
+++ b/components/widgets/ExpectationsWidget/Widget.tsx
@@ -430,6 +430,9 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
             icon={LayoutGrid}
             title="No Categories Enabled"
             subtitle="No expectation categories are enabled for this building."
+            iconClassName="text-slate-500"
+            titleClassName="text-slate-800"
+            subtitleClassName="text-slate-500"
           />
         }
       />

--- a/components/widgets/ExpectationsWidget/Widget.tsx
+++ b/components/widgets/ExpectationsWidget/Widget.tsx
@@ -14,11 +14,13 @@ import {
   ArrowLeft,
   MessagesSquare,
   CheckCircle2,
+  LayoutGrid,
 } from 'lucide-react';
 
 // --- Constants & Data ---
 
 import { WidgetLayout } from '../WidgetLayout';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import {
   VOLUME_OPTIONS,
   GROUP_OPTIONS,
@@ -424,15 +426,11 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
       <WidgetLayout
         padding="p-0"
         content={
-          <div
-            className="h-full w-full flex items-center justify-center text-slate-400 font-bold uppercase tracking-widest text-center"
-            style={{
-              fontSize: 'min(12px, 4cqmin)',
-              padding: 'min(24px, 5cqmin)',
-            }}
-          >
-            No expectation categories enabled for this building.
-          </div>
+          <ScaledEmptyState
+            icon={LayoutGrid}
+            title="No Categories Enabled"
+            subtitle="No expectation categories are enabled for this building."
+          />
         }
       />
     );

--- a/components/widgets/ExpectationsWidget/Widget.tsx
+++ b/components/widgets/ExpectationsWidget/Widget.tsx
@@ -430,9 +430,6 @@ export const ExpectationsWidget: React.FC<{ widget: WidgetData }> = ({
             icon={LayoutGrid}
             title="No Categories Enabled"
             subtitle="No expectation categories are enabled for this building."
-            iconClassName="text-slate-500"
-            titleClassName="text-slate-800"
-            subtitleClassName="text-slate-500"
           />
         }
       />


### PR DESCRIPTION
## Nightly Unifier — Run 30 — D1 Widget Empty States

**Canonical form:** `<ScaledEmptyState icon={X} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx`, never a hand-rolled centered div.

**Instance unified:**
- `components/widgets/ExpectationsWidget/Widget.tsx` (~line 421) — the "No expectation categories enabled for this building" state was a hand-rolled `h-full w-full flex items-center justify-center` div with `text-slate-400` text. This is the widget's full top-level content (returned directly from `WidgetLayout`'s `content` prop, replacing the entire widget when the admin building config disables all three categories) — not a nested sub-panel, so it's a safe full-bleed conversion. Converted to `<ScaledEmptyState icon={LayoutGrid} title="No Categories Enabled" subtitle="No expectation categories are enabled for this building." />`, reusing the widget's own dock icon (`LayoutGrid`, from `config/tools.ts`).

**Behavior-preservation evidence:**
- `expectations` is registered `skipScaling: true` in `WidgetRegistry.ts`, confirming `container-type: size` is established at the whole-widget level — `ScaledEmptyState`'s cqmin sizing resolves against the same boundary the old hand-rolled div implicitly relied on (no nested-panel scope mismatch, the documented D1 gotcha from prior runs).
- Logic branch (`!showVolume && !showGroup && !showInteraction`) untouched — only the rendered markup changed.
- Side effect: the original `text-slate-400` on a dark widget surface fell below the CLAUDE.md AA-contrast guidance for muted text on dark surfaces; `ScaledEmptyState`'s default tones resolve this.

**Backlog cleanup (no code changes, documentation only):** formalized 4 long-standing NEEDS-REVIEW items as proper Intentional Exceptions (proposed D1-E19 through D1-E22 — see companion doc PR): `QuizLiveMonitor.tsx` "No scores yet" (nested podium overlay), `GuidedLearningResults.tsx` "No responses yet" (already covered by the existing GuidedLearning results-screen exception), `PersonalSpotifyNowPlayingTab.tsx` (text-only, same family as the existing `EmptyHint` exception), `VideoActivityEditor.tsx` "No questions yet" (editor selection-placeholder, out of scope — same class as QuizManager/MiniAppManager editor exceptions).

**Verification:**
- `pnpm run validate` (post-rebase onto latest `dev-paul`): type-check, lint (0 warnings), format-check clean; 559/559 root test files (6729/6729 tests), 37/37 functions files (703/703 tests), test-count guard passed.
- `pnpm run build`: app + SSR prerender both succeeded.

**Risk tag:** mechanical (component swap preserving the same container-scaling boundary; two-line title/subtitle rewording is a minor copy adaptation to `ScaledEmptyState`'s convention, not a behavior change).

🤖 Part of the automated nightly consistency ("unifier") routine — see `docs/routines/unifier.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYBRf9bFnk3e5i55QsEzcG)_