### PR TITLE
fix(D3): retrofit SettingsLabel group-heading pattern for 3 orphaned labels

### DIFF
--- a/components/layout/dock/MagicLayoutModal.tsx
+++ b/components/layout/dock/MagicLayoutModal.tsx
@@ -102,8 +102,14 @@ export const MagicLayoutModal: React.FC<MagicLayoutModalProps> = ({
         )}
 
         <div className="mb-6">
-          <SettingsLabel>Try these</SettingsLabel>
-          <div className="flex flex-wrap gap-2">
+          <SettingsLabel as="span" id="magic-layout-suggestions-label">
+            Try these
+          </SettingsLabel>
+          <div
+            role="group"
+            aria-labelledby="magic-layout-suggestions-label"
+            className="flex flex-wrap gap-2"
+          >
             {[
               'Small group rotations with a timer',
               'Morning meeting with weather and calendar',

--- a/components/widgets/InstructionalRoutines/LibraryManager.tsx
+++ b/components/widgets/InstructionalRoutines/LibraryManager.tsx
@@ -372,8 +372,14 @@ export const LibraryManager: React.FC<LibraryManagerProps> = ({
           </div>
         </div>
 
-        <div className="space-y-3 pt-4 border-t">
-          <SettingsLabel>Default Steps</SettingsLabel>
+        <div
+          className="space-y-3 pt-4 border-t"
+          role="group"
+          aria-labelledby="routine-default-steps-label"
+        >
+          <SettingsLabel as="span" id="routine-default-steps-label">
+            Default Steps
+          </SettingsLabel>
           {routine.steps.map((step, i) => (
             <div
               key={i}

--- a/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
+++ b/components/widgets/MiniApp/components/SaveAsWidgetModal.tsx
@@ -85,7 +85,7 @@ export const SaveAsWidgetModal: React.FC<SaveAsWidgetModalProps> = ({
               })}
             </div>
             <div className="min-w-0">
-              <SettingsLabel>Preview</SettingsLabel>
+              <SettingsLabel as="span">Preview</SettingsLabel>
               <p className="text-sm font-bold text-slate-700 truncate">
                 {trimmed.length > 0 ? trimmed : 'Untitled widget'}
               </p>


### PR DESCRIPTION
## Nightly Unifier — Run 30 — D3 Settings Panel Label Primitives

**Canonical form (newly established, outside this routine, in `components/common/SettingsLabel.tsx` via a separate human-reviewed PR):** `<SettingsLabel as="span" id="...">Group Heading</SettingsLabel>` paired with `role="group" aria-labelledby="..."` on the container of sibling controls, for label text that heads a *group* of controls rather than pairing 1:1 with a single form control (where the default `as="label"` + `htmlFor` remains correct).

This resolves a previously-documented architecture gap: a prior nightly run (D3, run 26, PR #2144) converted 3 hand-rolled headings to `<SettingsLabel>` but left them on the default `as="label"`, so each rendered an orphaned `<label>` with no associated control — flagged by automated PR review at the time. The `as="span"` capability now exists (already adopted in `MiniAppLibraryModal.tsx`/`PdfLibraryModal.tsx`/`StickerLibraryModal.tsx`/`WorkSymbolsConfigurationModal.tsx` by that separate PR) — this PR retrofits the 3 known orphaned instances to match.

**Instances fixed:**
1. `components/layout/dock/MagicLayoutModal.tsx` — "Try these" heading above a `flex flex-wrap gap-2` of suggestion-chip buttons → `as="span"` + `id="magic-layout-suggestions-label"`, chip container gets `role="group" aria-labelledby`.
2. `components/widgets/InstructionalRoutines/LibraryManager.tsx` — "Default Steps" heading above a steps list → `as="span"` + `id="routine-default-steps-label"`, list container gets `role="group" aria-labelledby`.
3. `components/widgets/MiniApp/components/SaveAsWidgetModal.tsx` — "Preview" heading above a single display-text block (not a control group) → `as="span"` only, no `role="group"` wrapper (there's nothing to group — a single caption, not multiple controls).

**Behavior-preservation evidence:**
- `as="span"` renders the identical `text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2` class string as a `<span>` instead of `<label>` — zero visual change.
- `role="group"`/`aria-labelledby` are ARIA-only attributes, no visual effect.
- No logic, props, or JSX structure otherwise touched — this is a pure accessibility-semantics fix (removes the orphaned-`<label>` a11y issue) with no visual delta.

**Deferred/skipped (per this run's scope):**
- `LunchCount/SubmitReportModal.tsx` — already fixed in a separate still-open PR (#2164); not duplicated here.
- The large "lighter-weight tier" NEEDS-REVIEW cluster (MinTierSelect, NeedDoPutThen, NoteConfigurationPanel, TimeTool, NumberLine, assignment-config family, ChecklistConfigurationPanel) — untouched, still needs a human product decision on visual-weight change.

**Verification:**
- `pnpm run validate` (post-rebase onto latest `dev-paul`): type-check, lint (0 warnings), format-check clean; 559/559 root test files (6729/6729 tests), 37/37 functions files (703/703 tests), test-count guard passed.
- `pnpm run build`: app + SSR prerender both succeeded.

**Risk tag:** mechanical (visual-neutral primitive swap + ARIA-only attributes).

🤖 Part of the automated nightly consistency ("unifier") routine — see `docs/routines/unifier.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYBRf9bFnk3e5i55QsEzcG)_