### PR TITLE
fix(D4): convert Organization/views cross-directory imports to @/ alias

### DIFF
--- a/components/admin/Organization/views/AllOrganizationsView.tsx
+++ b/components/admin/Organization/views/AllOrganizationsView.tsx
@@ -13,7 +13,7 @@ import {
   LocalModal,
   Field,
   Select,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 
 const PLAN_LABEL: Record<Plan, string> = {
   basic: 'Basic Pack',

--- a/components/admin/Organization/views/BuildingsView.tsx
+++ b/components/admin/Organization/views/BuildingsView.tsx
@@ -13,7 +13,7 @@ import {
   Select,
   ViewHeader,
   LocalModal,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 
 const TYPE_META: Record<
   BuildingType,

--- a/components/admin/Organization/views/DomainsView.tsx
+++ b/components/admin/Organization/views/DomainsView.tsx
@@ -20,7 +20,7 @@ import {
   StatusPill,
   ViewHeader,
   LocalModal,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 
 const AUTH_LABEL: Record<AuthMethod, string> = {
   google: 'Google SSO',

--- a/components/admin/Organization/views/OverviewView.tsx
+++ b/components/admin/Organization/views/OverviewView.tsx
@@ -9,7 +9,7 @@ import {
   Btn,
   Badge,
   Confirm,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 import { Toggle } from '@/components/common/Toggle';
 
 const PLAN_META: Record<

--- a/components/admin/Organization/views/RolesView.tsx
+++ b/components/admin/Organization/views/RolesView.tsx
@@ -24,7 +24,7 @@ import {
   LocalModal,
   Textarea,
   Confirm,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 
 interface Props {
   roles: RoleRecord[];

--- a/components/admin/Organization/views/StudentPageView.tsx
+++ b/components/admin/Organization/views/StudentPageView.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { GraduationCap, Bell, UserRound, Utensils } from 'lucide-react';
 import type { StudentPageConfig } from '../types';
-import { Card, Field, Input, ViewHeader } from '../components/primitives';
+import {
+  Card,
+  Field,
+  Input,
+  ViewHeader,
+} from '@/components/admin/Organization/components/primitives';
 import { Toggle } from '@/components/common/Toggle';
 
 interface Props {

--- a/components/admin/Organization/views/TestClassesView.tsx
+++ b/components/admin/Organization/views/TestClassesView.tsx
@@ -12,7 +12,7 @@ import {
   Textarea,
   ViewHeader,
   LocalModal,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 
 interface Props {
   testClasses: TestClassRecord[];

--- a/components/admin/Organization/views/UsersView.tsx
+++ b/components/admin/Organization/views/UsersView.tsx
@@ -39,7 +39,7 @@ import {
   LocalModal,
   Textarea,
   Confirm,
-} from '../components/primitives';
+} from '@/components/admin/Organization/components/primitives';
 import { parseInvitesCsv, type InviteIntent } from '@/utils/csvImport';
 
 interface Props {


### PR DESCRIPTION
## Nightly Unifier — Run 30 — D4 Import Path Convention

**Canonical form:** cross-directory imports use the `@/` alias (`import { X } from '@/components/...'`), never a relative path that escapes the current directory into a sibling feature directory.

**Instances unified (8 files, all in one new-since-last-audit directory):**
- `components/admin/Organization/views/{AllOrganizationsView,BuildingsView,DomainsView,OverviewView,RolesView,StudentPageView,TestClassesView,UsersView}.tsx` — each imported the sibling `components/admin/Organization/components/primitives` module via `'../components/primitives'` → converted to `@/components/admin/Organization/components/primitives`.

This directory wasn't covered by any prior D4 sweep (Organization/ is a newer admin subtree). Found via a fresh repo-wide grep for relative imports escaping their own directory, cross-checked against the accepted gray zones (same-directory `./`, the `common/library/importer/ImportWizard.tsx` within-feature exception, single-level plc-subdir→plc-root imports).

**Orchestrator repair during review:** `StudentPageView.tsx`'s converted import line exceeded Prettier's print width and needed multi-line wrapping — `eslint --fix` applied to reformat it; content unchanged.

**Behavior-preservation evidence:** type-only/value-only import path swap, zero runtime behavior change — `tsc --noEmit` resolves all 8 cleanly against the same module.

**Verification:**
- `pnpm run validate` (post-rebase onto latest `dev-paul`, which now includes the run-28 `PlcHome.tsx` fix + the new `no-restricted-imports` ESLint rule for `components/plc/**` from PR #2155 — this change doesn't touch `plc/`, so unaffected): type-check, lint (0 warnings), format-check clean; 559/559 root test files (6729/6729 tests), 37/37 functions files (703/703 tests), test-count guard passed.
- `pnpm run build`: app + SSR prerender both succeeded.

**Enforcement:** none added this run — a single new directory's stragglers didn't justify a bespoke lint rule (unlike the recurring `plc/*` cross-subdirectory bug class already covered by PR #2155's rule). A fresh repo-wide grep found no other new anti-pattern instances beyond this directory.

**Risk tag:** mechanical (pure import-path equivalence).

🤖 Part of the automated nightly consistency ("unifier") routine — see `docs/routines/unifier.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UYBRf9bFnk3e5i55QsEzcG)_