### PR TITLE
D4: use @/ alias for i18n locale imports

### DIFF
--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -2,10 +2,10 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-import en from '../locales/en.json';
-import es from '../locales/es.json';
-import de from '../locales/de.json';
-import fr from '../locales/fr.json';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+import de from '@/locales/de.json';
+import fr from '@/locales/fr.json';
 
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English', nativeLabel: 'English' },


### PR DESCRIPTION
## Nightly Consistency Routine — D4 Import Path Convention

**Dimension:** D4 — Import Path Convention (Cross-Directory)

**Canonical form:** Use the `@/` alias for all cross-directory imports (e.g. `import en from '@/locales/en.json'`), never a relative path that escapes the importing file's own directory.

**Instances unified:** `i18n/index.ts` — 4 imports (`en`, `es`, `de`, `fr` locale JSON files) converted from `'../locales/*.json'` to `'@/locales/*.json'`. `i18n/` and `locales/` are sibling root-level directories, so the original imports were a textbook cross-directory relative import — the exact anti-pattern this dimension targets. This is a stray instance missed by all 30 prior nightly D4 sweeps (i18n/ was never previously called out as a swept directory).

**Enforcement:** None added this run — this was a single isolated file outside any recurring bug-class directory (unlike `components/plc/**`, which already has an ESLint `no-restricted-imports` rule from a prior run). Not a recurring pattern, so a new lint rule isn't warranted.

**Behavior-preservation evidence:**
- Pure import-path syntax change; no runtime logic touched. The `@/` alias resolves to the repo root in both `vite.config.ts` and `tsconfig.json`, so `@/locales/en.json` and `../locales/en.json` (from `i18n/index.ts`) resolve to the identical file (`/locales/en.json`).
- `pnpm run validate` (type-check, lint, format-check, root test suite, functions test suite, test-count guard) — all green (6784 root tests + 703 functions tests passing).
- `pnpm run build` (Vite build + SSR prerender build) — green, no errors.

**Risk tag:** `mechanical` (pure equivalence — import path syntax only, same resolved module).

🤖 Generated by the nightly `unifier` consistency routine (`docs/routines/unifier.md`, run 31).


---
_Generated by [Claude Code](https://claude.ai/code/session_018EcQ4MQGkg42ALKn4ixTnx)_