### PR TITLE
fix(TalkingToolWidget): resync active tab when admin's live categories change

### DIFF
--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -135,6 +135,65 @@ describe('TalkingToolWidget', () => {
     ).toBeInTheDocument();
   });
 
+  it('resyncs the active tab when the admin removes the currently selected category', () => {
+    vi.mocked(useAuth).mockReturnValue(mockAuthContext());
+
+    const { rerender } = render(<TalkingToolWidget widget={mockWidget} />);
+
+    // Select the "Share What You Think" tab
+    fireEvent.click(screen.getByText('Share What You Think'));
+    expect(
+      screen.getByText('Share What You Think', { selector: 'h3' })
+    ).toBeInTheDocument();
+
+    // Admin live-updates feature permissions, dropping the "share" category
+    vi.mocked(useAuth).mockReturnValue(
+      mockAuthContext({
+        featurePermissions: [
+          {
+            widgetType: 'talking-tool',
+            accessLevel: 'public',
+            betaUsers: [],
+            enabled: true,
+            config: {
+              categories: [
+                {
+                  id: 'listen',
+                  label: 'Listen Closely',
+                  color: '#008ab6',
+                  icon: 'Ear',
+                  stems: [{ id: 'l1', text: 'What do you mean by ________?' }],
+                },
+                {
+                  id: 'support',
+                  label: 'Support What You Say',
+                  color: '#5aafd1',
+                  icon: 'BookOpen',
+                  stems: [{ id: 'su1', text: 'In the text, ________.' }],
+                },
+              ],
+            },
+          },
+        ] as FeaturePermission[],
+      })
+    );
+    rerender(<TalkingToolWidget widget={mockWidget} />);
+
+    // Content falls back to the first remaining category
+    expect(
+      screen.getByText('Listen Closely', { selector: 'h3' })
+    ).toBeInTheDocument();
+
+    // The sidebar button for that same category must be the one highlighted as active
+    const listenButton = screen
+      .getByText('Listen Closely', {
+        selector: 'span',
+      })
+      .closest('button');
+    expect(listenButton).not.toBeNull();
+    expect(listenButton?.style.backgroundColor).toBe('rgb(0, 138, 182)');
+  });
+
   it('renders custom categories from global config', () => {
     vi.mocked(useAuth).mockReturnValue(
       mockAuthContext({

--- a/components/widgets/TalkingTool/Widget.test.tsx
+++ b/components/widgets/TalkingTool/Widget.test.tsx
@@ -192,6 +192,7 @@ describe('TalkingToolWidget', () => {
       .closest('button');
     expect(listenButton).not.toBeNull();
     expect(listenButton?.style.backgroundColor).toBe('rgb(0, 138, 182)');
+    expect(listenButton).toHaveAttribute('aria-pressed', 'true');
   });
 
   it('renders custom categories from global config', () => {

--- a/components/widgets/TalkingTool/Widget.tsx
+++ b/components/widgets/TalkingTool/Widget.tsx
@@ -33,6 +33,15 @@ export const TalkingToolWidget: React.FC<WidgetComponentProps> = ({
     : DEFAULT_TALKING_TOOL_CATEGORIES;
 
   const [activeTab, setActiveTab] = useState<string>(categories[0]?.id ?? '');
+  // Resync activeTab during render if the admin-configured category set changed underneath it
+  const categoryKey = categories.map((c) => c.id).join('|');
+  const [lastCategoryKey, setLastCategoryKey] = useState(categoryKey);
+  if (categoryKey !== lastCategoryKey) {
+    setLastCategoryKey(categoryKey);
+    if (!categories.some((c) => c.id === activeTab)) {
+      setActiveTab(categories[0]?.id ?? '');
+    }
+  }
 
   const activeCat = categories.find((c) => c.id === activeTab) ?? categories[0];
 

--- a/components/widgets/TalkingTool/Widget.tsx
+++ b/components/widgets/TalkingTool/Widget.tsx
@@ -96,6 +96,7 @@ export const TalkingToolWidget: React.FC<WidgetComponentProps> = ({
             return (
               <button
                 key={cat.id}
+                aria-pressed={isActive}
                 onClick={() => setActiveTab(cat.id)}
                 className={`w-full flex flex-col items-center justify-center transition-all border ${
                   isActive


### PR DESCRIPTION
## Root cause
`TalkingToolWidget`'s `activeTab` was initialized once via `useState(categories[0]?.id ?? '')` and never resynced. `categories` comes from `featurePermissions`, which is a live Firestore `onSnapshot` subscription in `AuthContext` — an admin editing the Talking Tool's categories in Feature Permissions while the widget is mounted on a teacher's dashboard is a real, reachable path, not hypothetical.

When the currently-selected category is removed from the new set, `activeCat = categories.find(...) ?? categories[0]` correctly falls back the *displayed content* to `categories[0]`, but `activeTab` itself still holds the stale (now nonexistent) id. In the sidebar, `isActive = activeTab === cat.id` is then false for every button, so no tab appears highlighted even though the content shown belongs to the first category — a silent highlight/content mismatch.

## Fix
Added a render-time resync using the "adjust state while rendering" pattern (per this repo's `useEffect`-is-an-escape-hatch-only convention): track a `categoryKey` (joined category ids) alongside the previous key in state; when it changes during render and `activeTab` no longer exists in the new category set, immediately call `setActiveTab(categories[0]?.id ?? '')`.

## Rejected band-aid
Removing the `?? categories[0]` fallback (or forcing a full remount via `key`) would mask the symptom (blank/crash state, or losing the user's in-flight widget state on every unrelated categories update) instead of fixing the actual state-derivation bug. A `useEffect` watching `categories` would also work but violates this repo's explicit "useEffect is an escape hatch, not a default" rule for derived state — the render-body pattern is the sanctioned alternative already used elsewhere in the codebase.

## Regression test
`components/widgets/TalkingTool/Widget.test.tsx`: selects a category, then simulates a live feature-permissions update that drops it, and asserts the sidebar's highlighted button matches the displayed content.
- **Fail before**: `expected '' to be 'rgb(0, 138, 182)'` (no button highlighted)
- **Pass after**: 4/4 tests pass

## Evidence
Independently reproduced by the orchestrator: checked out `dev-paul`'s `Widget.tsx` with the new test — 1 failed / 3 passed. Restored the fix — 4/4 passed. `pnpm run validate` and `pnpm run build` both pass on this branch.

## Other leads investigated, not fixed (see backlog)
- `Stations/Widget.tsx` and `LunchCount/Widget.tsx` key `assignments` by literal display name (same PII/collision class as the already-migrated `SeatingChart`). Confirmed real, but a proper fix requires a widget-level ID-keying migration across multiple files — too large to root-cause fix safely in one run. Left as a backlog item rather than shipping a half-fix.
- TimeTool's "+" button ceiling/disabled-prop design issue — explicitly not touched (known regression trap per project history, needs deliberate design work).

**Risk: contained**

🤖 Generated as part of the automated nightly code-health run.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSdrNnarDUKYMw6dFAhe4t)_