### PR TITLE
fix(useSyncedQuizGroups): dedupe syncGroupIds to prevent loading from hanging forever

### DIFF
--- a/hooks/useSyncedQuizGroups.ts
+++ b/hooks/useSyncedQuizGroups.ts
@@ -119,7 +119,10 @@ export function useSyncedQuizGroupsByIds(
   // contents in a fresh array reference. Inside the effect we re-derive
   // the id list from `idsKey` rather than closing over the prop so the
   // effect's dependency list reflects what it actually consumes.
-  const idsKey = (syncGroupIds ?? []).slice().sort().join(',');
+  // Dedupe first — a repeated id would otherwise inflate `total` below and hang `loading` at `true` forever.
+  const idsKey = Array.from(new Set(syncGroupIds ?? []))
+    .sort()
+    .join(',');
 
   // Adjust state during render when the id set changes — React's
   // sanctioned alternative to calling setState synchronously inside an

--- a/tests/hooks/useSyncedQuizGroups.test.ts
+++ b/tests/hooks/useSyncedQuizGroups.test.ts
@@ -10,11 +10,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import * as firestore from 'firebase/firestore';
 import {
   publishSyncedQuiz,
   pullSyncedQuizContent,
   createSyncedQuizGroup,
+  useSyncedQuizGroupsByIds,
 } from '@/hooks/useSyncedQuizGroups';
 import type { QuizBehaviorSettings } from '@/types';
 
@@ -235,5 +237,35 @@ describe('createSyncedQuizGroup — behavior field threading', () => {
     const [_ref, payload] = (firestore.setDoc as unknown as Mock).mock
       .calls[0] as [unknown, Record<string, unknown>];
     expect(payload).not.toHaveProperty('behavior');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useSyncedQuizGroupsByIds — loading must resolve even with duplicate ids
+// ---------------------------------------------------------------------------
+
+describe('useSyncedQuizGroupsByIds — duplicate id handling', () => {
+  beforeEach(() => {
+    // `doc()` is mocked (top-level beforeEach) to return the joined path string.
+    (firestore.onSnapshot as unknown as Mock).mockImplementation(
+      (
+        ref: string,
+        onNext: (snap: { exists: () => boolean; data: () => unknown }) => void
+      ) => {
+        const id = ref.split('/').pop();
+        onNext({ exists: () => true, data: () => ({ title: id }) });
+        return () => undefined;
+      }
+    );
+  });
+
+  it('resolves loading to false when the id list contains a duplicate', async () => {
+    const { result } = renderHook(() =>
+      useSyncedQuizGroupsByIds(['group-1', 'group-1', 'group-2'])
+    );
+
+    // Regression for the twin bug already fixed in useSyncedVideoActivityGroups.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.groups.size).toBe(2);
   });
 });


### PR DESCRIPTION
## Root cause
`hooks/useSyncedQuizGroups.ts`, `useSyncedQuizGroupsByIds`: the `idsKey` driving the per-doc `onSnapshot` listener effect was built with `(syncGroupIds ?? []).slice().sort().join(',')` — no deduplication. Inside the effect, `total = ids.length` (the un-deduped count) is compared against a `resolved: Set<string>` of doc ids that have delivered a snapshot.

If the caller passes a duplicate `syncGroupId` (e.g. a teacher with two personal quiz replicas that both point at the same PLC sync group — reachable via `PlcQuizLibraryBody.tsx`'s `syncedReplicaGroupIds`, built by mapping over `personalQuizzes` without dedup), `total` counts the duplicate but `resolved.size` can never exceed the number of *unique* ids — so `resolved.size === total` never becomes true and `loading` hangs at `true` forever. It also opens a redundant second `onSnapshot` listener on the same document (wasted Firestore read cost).

This is a "twin-hook drift" bug: the sibling hook `hooks/useSyncedVideoActivityGroups.ts` already carries the correct fix (`Array.from(new Set(syncGroupIds ?? []))...`) with an explicit comment documenting this exact failure mode — the fix was never ported to the quiz hook.

## Fix
Changed `idsKey` construction in `useSyncedQuizGroups.ts` to `Array.from(new Set(syncGroupIds ?? [])).sort().join(',')`, mirroring `useSyncedVideoActivityGroups.ts` exactly.

## Rejected band-aid
Could have special-cased `resolved.size >= total` instead of `===`, but that's a symptom patch — it doesn't fix the redundant duplicate-listener registration/read-cost waste, and it diverges further from the now-inconsistent VA sibling. The root-cause fix (dedupe at the source) is one line and keeps both hooks in lockstep.

## Regression test
`tests/hooks/useSyncedQuizGroups.test.ts`: renders the hook with `['group-1', 'group-1', 'group-2']`, mocks `onSnapshot` to resolve synchronously, asserts `loading` becomes `false` and `groups.size === 2`.
- **Fail before**: test fails — `loading` never resolves (`waitFor` timeout, `expected true to be false`).
- **Pass after**: 9/9 tests pass.

## Evidence
Independently reproduced by the orchestrator: checked out `dev-paul`'s `useSyncedQuizGroups.ts` with the new test — 1 failed / 8 passed. Restored the fix — 9/9 passed. `pnpm run validate` and `pnpm run build` both pass on this branch.

## Note
Both current call sites (`PlcQuizLibraryBody.tsx`, `QuizWidget/Widget.tsx`) only destructure `{ groups }`, not `{ loading }`, so the hang was latent/unobserved in production UI — but it's a real defect in the hook's documented public contract, and the fix removes a genuine wasted-listener resource cost regardless.

**Risk: contained**

🤖 Generated as part of the automated nightly code-health run.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSdrNnarDUKYMw6dFAhe4t)_