### PR TITLE
test(useRosters): fix race condition in PII-migration test synchronization

### DIFF
--- a/tests/hooks/useRosters.test.ts
+++ b/tests/hooks/useRosters.test.ts
@@ -719,7 +719,7 @@ describe('useRosters — PII migration', () => {
       .mockImplementation(
         () =>
           new Promise((resolve) =>
-            setTimeout(() => resolve({ id: 'migrated-file' }), 5)
+            setTimeout(() => resolve({ id: 'migrated-file' }), 0)
           )
       );
     currentDriveService = makeDriveService({ uploadFile });

--- a/tests/hooks/useRosters.test.ts
+++ b/tests/hooks/useRosters.test.ts
@@ -713,7 +713,15 @@ describe('useRosters — deleteRoster & setActiveRoster', () => {
 describe('useRosters — PII migration', () => {
   it('moves students[] out of Firestore into Drive and removes the field', async () => {
     localStorage.removeItem(migrationKey(TEACHER_UID)); // force migration
-    const uploadFile = vi.fn().mockResolvedValue({ id: 'migrated-file' });
+    // Resolve on a later macrotask (like a real Drive call) so the test can't assume updateDoc already fired.
+    const uploadFile = vi
+      .fn()
+      .mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve({ id: 'migrated-file' }), 5)
+          )
+      );
     currentDriveService = makeDriveService({ uploadFile });
 
     const { result } = renderHook(() => useRosters(mockUser));
@@ -725,7 +733,9 @@ describe('useRosters — PII migration', () => {
       }),
     ]);
 
-    await waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1));
+    // Poll the write itself — the upload call alone doesn't prove updateDoc has run yet.
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalledTimes(1));
+    expect(uploadFile).toHaveBeenCalledTimes(1);
     // Firestore doc patched: driveFileId set, count kept, students deleted.
     expect(mockUpdateDoc).toHaveBeenCalledWith(
       'users/teacher-1/rosters/r1',
@@ -740,7 +750,10 @@ describe('useRosters — PII migration', () => {
     await waitFor(() =>
       expect(localStorage.getItem(migrationKey(TEACHER_UID))).toBe('1')
     );
-    expect(result.current.rosters[0].students[0].id).toBe('s1');
+    // Poll — rosters state settles after the flag write, not necessarily in the same tick.
+    await waitFor(() =>
+      expect(result.current.rosters[0]?.students[0]?.id).toBe('s1')
+    );
   });
 
   it('does not re-run migration once the per-user flag is set', async () => {

--- a/tests/hooks/useRosters.test.ts
+++ b/tests/hooks/useRosters.test.ts
@@ -734,7 +734,10 @@ describe('useRosters — PII migration', () => {
     ]);
 
     // Poll the write itself — the upload call alone doesn't prove updateDoc has run yet.
-    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalledTimes(1));
+    // Poll on the weaker "called" condition, then assert the exact count synchronously —
+    // an exact-count poll condition times out instead of failing clearly if the count ever overshoots.
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1);
     expect(uploadFile).toHaveBeenCalledTimes(1);
     // Firestore doc patched: driveFileId set, count kept, students deleted.
     expect(mockUpdateDoc).toHaveBeenCalledWith(


### PR DESCRIPTION
## Root cause
`tests/hooks/useRosters.test.ts` — the "PII migration > moves students[] out of Firestore into Drive and removes the field" test polled `waitFor(() => expect(uploadFile).toHaveBeenCalledTimes(1))`, but `uploadFile` is recorded synchronously the instant `driveService.uploadFile(...)` is invoked — several microtask-hops *before* the subsequent `await updateDoc(...)` in `runMigrationIfNeeded` (`hooks/useRosters.ts`) actually fires. The test then made **unguarded synchronous assertions** on `mockUpdateDoc`, `deleteField`, and `result.current.rosters[0].students[0].id`, assuming those later events had already landed just because the earlier one had.

This is a genuine race in the test's synchronization strategy, previously logged in the project's nightly-debugger memory doc as "flaky under concurrent-worktree CPU contention." Independently reproduced deterministically (5/5 failures) by combining `dev-paul`'s original assertion ordering with a realistic delayed `uploadFile` mock (production Drive calls are never same-tick) — confirming it's a real race, not just host-load noise.

## Fix
Poll on the actual downstream events instead of an early proxy signal: wait for `mockUpdateDoc` to have been called (not just `uploadFile`), and wait for `rosters[0].students[0].id` to settle (not just the localStorage migration flag). Also made the `uploadFile` mock resolve on a real macrotask (`setTimeout(..., 0)`) instead of instantly, so the test is representative of real async latency rather than a scheduler-luck artifact. (Originally used a 5ms delay; tightened to 0ms per Gemini review — 0ms still defers to the next macrotask, achieving the same synchronization guarantee without the arbitrary constant.)

## Rejected band-aid
Bumping `waitFor`'s timeout or wrapping the whole test in a broader `act(async () => ...)` would only narrow the race window, not close it — the same "hope the scheduler behaves" approach the bug already exploits. Production code (`hooks/useRosters.ts`) was not touched — the migration sequencing there is logically correct; the bug is purely in what the test decided to treat as "done."

## Test evidence
- **Fail before**: with `dev-paul`'s original assertion ordering + a realistic delayed mock, the test fails deterministically — 5/5 runs failed when independently reproduced by the orchestrator.
- **Pass after**: 5/5 sequential runs pass with the fix; stable under repeated re-runs (re-verified again after tightening the delay to 0ms).

## Evidence
Independently reproduced by the orchestrator: combined `dev-paul`'s original assertions with a delayed `uploadFile` mock — failed 5/5 runs. Confirmed the fixed version passes 5/5 runs. `pnpm run validate` and `pnpm run build` both pass on this branch.

## Backlog audit (no fix needed, confirmed clean)
- SSRF `maxRedirects: 0` guard: all URL-blocklist-validating `axios` calls already covered; other `axios.get` sites hit fixed API endpoints, not user-supplied URLs.
- `GEMINI_SPECIFIC_FEATURES`: all 11 entries match the 11 `specificFeatureId` writers in `functions/src/aiGeneration.ts` / `index.ts`. No new `genType` since the last audit.
- `firestore.rules` OR-branch/list-query pattern (per #2150/#2158): all 4 `isOrgMember(...)` occurrences checked; the 2 list-query sites are already correctly scoped client-side.

**Risk: contained**

🤖 Generated as part of the automated nightly code-health run.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>