### PR TITLE
D3: retrofit DrawingWidget "Color Presets" label to as="span" group heading

### DIFF
--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -84,13 +84,13 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
         <SettingsLabel
           icon={Palette}
           as="span"
-          id="drawing-color-presets-label"
+          id={`drawing-color-presets-label-${widget.id}`}
         >
           Color Presets
         </SettingsLabel>
         <div
           role="group"
-          aria-labelledby="drawing-color-presets-label"
+          aria-labelledby={`drawing-color-presets-label-${widget.id}`}
           className="flex gap-2 px-2"
         >
           {customColors.map((c, i) => (

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -81,8 +81,18 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
   return (
     <div className="space-y-6">
       <div>
-        <SettingsLabel icon={Palette}>Color Presets</SettingsLabel>
-        <div className="flex gap-2 px-2">
+        <SettingsLabel
+          icon={Palette}
+          as="span"
+          id="drawing-color-presets-label"
+        >
+          Color Presets
+        </SettingsLabel>
+        <div
+          role="group"
+          aria-labelledby="drawing-color-presets-label"
+          className="flex gap-2 px-2"
+        >
           {customColors.map((c, i) => (
             <div
               key={i}


### PR DESCRIPTION
## Nightly Consistency Routine — D3 Settings Panel Label Primitives

**Dimension:** D3 — Settings Panel Label Primitives

**Canonical form:** `<SettingsLabel>` supports an `as="span"` variant (added outside this routine, PR #2141; formalized as canon in run 30) for the case where a label heads a *group* of sibling controls rather than pairing 1:1 with a single control — the default `as="label"` render is semantically orphaned in that shape (no associated control), so the group-heading form pairs `as="span" id="..."` with `role="group" aria-labelledby="..."` on the sibling-controls container.

**Instance unified:** `components/widgets/DrawingWidget/Settings.tsx` — the "Color Presets" `<SettingsLabel icon={Palette}>` sits above a `flex` row of 8 color-swatch `<div>`s, each wrapping its own `<input type="color">`. It's a canonical `SettingsLabel` already (not hand-rolled HTML) using the default `as="label"`, but heads a group of controls with no single control it pairs to — the same shape already fixed for 3 other instances in runs 26/29/30 (`MagicLayoutModal.tsx`, `InstructionalRoutines/LibraryManager.tsx`, `MiniApp/components/SaveAsWidgetModal.tsx`). Converted to `as="span" id="drawing-color-presets-label"` + `role="group" aria-labelledby="drawing-color-presets-label"` on the swatch container.

**Enforcement:** None added — this is a manual per-instance retrofit of a pre-existing shared-component call site, not a new anti-pattern needing a lint guard. A larger backlog item (auditing the remaining pre-`as="span"`-era `SettingsLabel` group-heading call sites for the same retrofit) is logged in the nightly doc for future runs — at least 3 more confirmed candidates (`RevealGrid/Settings.tsx` "Columns", `random/RandomSettings.tsx` "Animation Style", `MusicWidget/Settings.tsx` "Layout"), one per night per the routine's own pacing rule.

**Behavior-preservation evidence:**
- `SettingsLabel`'s `as="span"` branch renders the *identical* `combinedClasses` string as `as="label"` (verified by reading `components/common/SettingsLabel.tsx` directly) — only the DOM tag changes (`<span>` vs `<label>`) plus the added ARIA wiring. Zero visual delta.
- Orchestrator independently confirmed the "Color Presets" section is a genuine control-group (8 swatches, each with its own `<input type="color">`), not a 1:1-pairable label — the correct target shape for this conversion.
- `pnpm run validate` — all green (type-check, lint, format-check, root tests 560/560 files / 6784 tests, functions tests 37/37 files / 703 tests, test-count guard).
- `pnpm run build` — succeeded (Vite build + SSR prerender).

**Risk tag:** `mechanical` (pure accessibility-semantics change — identical rendered classes, no visual output change).

🤖 Generated by the nightly `unifier` consistency routine (`docs/routines/unifier.md`, run 32).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJenSUEoWdhqPHHifcP7AG)_