### PR TITLE
fix(WorkSymbolsConfigurationPanel): repair undefined SettingsLabel breaking lint CI

### DIFF
--- a/components/admin/WorkSymbolsConfigurationPanel.tsx
+++ b/components/admin/WorkSymbolsConfigurationPanel.tsx
@@ -8,6 +8,7 @@ import {
   TextSizePreset,
 } from '@/types';
 import { Card } from '@/components/common/Card';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { FONTS } from '@/config/fonts';
 import { HexColorField } from './HexColorField';
 
@@ -69,9 +70,9 @@ export const WorkSymbolsConfigurationPanel: React.FC<
     <div className="space-y-6">
       {/* Building Selector */}
       <div>
-        <label className="text-xxs font-bold text-slate-500 uppercase mb-2 block">
-        <SettingsLabel as="span">Configure Building Work Symbols Defaults</SettingsLabel>
-        </label>
+        <SettingsLabel as="span">
+          Configure Building Work Symbols Defaults
+        </SettingsLabel>
         <BuildingSelector
           selectedId={selectedBuildingId}
           onSelect={setSelectedBuildingId}


### PR DESCRIPTION
## What & why

The `dev-paul` branch's CI (PR #2186) was red on the **Code Quality Checks / lint** job:

```
components/admin/WorkSymbolsConfigurationPanel.tsx
  73:9   error  Replace `<SettingsLabel·as="span">Configure·Building·Work·Symbols·Defaults`…  prettier/prettier
  73:10  error  'SettingsLabel' is not defined                                                react/jsx-no-undef
```

A `<SettingsLabel as="span">` group heading was added for the building selector but `SettingsLabel` was never imported, and it was left nested inside a leftover `<label>` wrapper — tripping `react/jsx-no-undef` plus a Prettier formatting error and failing lint (which runs with `--max-warnings 0`).

The other red jobs on that run (Build, Unit Tests, type-check) failed on transient GitHub Actions infrastructure errors (`Internal Server Error` / `Service Unavailable` while resolving `actions/checkout@v6`), not on code — they pass locally and will pass on re-run.

## Fix

- Import `SettingsLabel` from `@/components/common/SettingsLabel`.
- Replace the orphaned `<label>` wrapper with a clean `SettingsLabel` group heading.

`BuildingSelector` already renders its own `role="tablist"` + `aria-label="Building Selection"`, so no extra `role="group"` / `aria-labelledby` wiring is needed — the `as="span"` heading is purely a section label.

## Verification (local, Node 22)

- ✅ `pnpm run lint` (app + functions) — exit 0
- ✅ `pnpm run type-check`
- ✅ `prettier --check` on the file
- ✅ Touched test files (ImportWizard, useRosters, useSyncedQuizGroups, frDashboardCapTerminology, adminBuildingConfig, TalkingTool) — 136 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXMSJCbwRQdh8a1s4p8WkS)_