### PR TITLE
fix(deps): override ts-deepmerge to ^8.0.0 in functions (GHSA-87mf-gv2c-c62c)

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -42,7 +42,8 @@
       "body-parser": "^2.2.1",
       "lodash": "^4.17.23",
       "protobufjs": "^7.5.6",
-      "qs": "^6.15.2"
+      "qs": "^6.15.2",
+      "ts-deepmerge": "^8.0.0"
     }
   },
   "private": true

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   lodash: ^4.17.23
   protobufjs: ^7.5.6
   qs: ^6.15.2
+  ts-deepmerge: ^8.0.0
 
 importers:
 
@@ -2578,8 +2579,9 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  ts-deepmerge@2.0.7:
-    resolution: {integrity: sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg==}
+  ts-deepmerge@8.0.0:
+    resolution: {integrity: sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==}
+    engines: {node: '>=14.13.1'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4387,7 +4389,7 @@ snapshots:
       firebase-functions: 7.2.5(firebase-admin@13.6.0)
       jest: 30.2.0(@types/node@25.6.0)
       lodash: 4.17.23
-      ts-deepmerge: 2.0.7
+      ts-deepmerge: 8.0.0
 
   firebase-functions@7.2.5(firebase-admin@13.6.0):
     dependencies:
@@ -5810,7 +5812,7 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-deepmerge@2.0.7: {}
+  ts-deepmerge@8.0.0: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary

Resolves the MEDIUM `ts-deepmerge` prototype-method-override DoS (**GHSA-87mf-gv2c-c62c** / **CVE-2026-12644**) in `functions/`. Versions <8.0.0 mishandle built-in `Object.prototype` methods (`toString`, `valueOf`); user-controlled input with those keys produces a broken merged object that throws `TypeError` on any subsequent string operation.

It reached the tree via `firebase-functions-test@3.4.1 > ts-deepmerge@2.0.7`. Test-only devDependency — **no production runtime impact**.

## Change

Adds `"ts-deepmerge": "^8.0.0"` to `pnpm.overrides` in `functions/package.json` (+ the corresponding `functions/pnpm-lock.yaml` update). Diff is exactly those two files.

## Why an override (not a dependency bump)

`ts-deepmerge` is patched only in `>=8.0.0`, and `firebase-functions-test@3.5.0` (latest) still pins `ts-deepmerge: ^2.0.1`. Upgrading the package therefore would not lift the transitive version — a `pnpm.overrides` entry is the only deterministic fix.

## Compatibility note

`ts-deepmerge` dropped its default export at v3.0.0 (v2 = `export default merge`; v3+ = named `{ merge }`), and `firebase-functions-test@3.4.1` consumes it as `ts_deepmerge_1.default(...)` in its cloudevent helper. No patched version keeps that default export, so the override forces an incompatible major on that helper. This is safe here because **`firebase-functions-test` is not imported by any functions test** (zero imports; the only textual matches are two comments referencing the "functions-test posture" testing style). If a future test starts using fft's v2 cloudevent `wrap()`, this override must be revisited.

## Verification

- `pnpm -C functions why ts-deepmerge` → single `ts-deepmerge@8.0.0`
- `pnpm -C functions audit | grep GHSA-87mf-gv2c-c62c` → 0
- `pnpm -C functions type-check` → 0 errors
- `pnpm -C functions build` → tsc succeeds
- `pnpm -C functions test` → 37 files / 703 tests pass
- `prettier --check functions/package.json` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANmmQNZuyv6WC2kidFUraW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANmmQNZuyv6WC2kidFUraW)_