### PR TITLE
D1: convert QuizManager active/archive empty state to ScaledEmptyState

### DIFF
--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -105,6 +105,7 @@ import {
 } from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 import { useSessionViewCount } from '@/hooks/useSessionViewCount';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { useAuth } from '@/context/useAuth';
 import { useDialog } from '@/context/useDialog';
 import { getQuizBehavior, formatBehaviorSummary } from '@/utils/quizBehavior';
@@ -2064,13 +2065,7 @@ const AssignmentsList: React.FC<{
   }
   if (assignments.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center flex-1 text-center text-brand-blue-primary/60 gap-3 py-10">
-        <Inbox className="w-10 h-10 opacity-40" />
-        <p className="font-semibold text-brand-blue-dark text-sm">
-          {emptyTitle}
-        </p>
-        <p className="text-xs max-w-[360px]">{emptySub}</p>
-      </div>
+      <ScaledEmptyState icon={Inbox} title={emptyTitle} subtitle={emptySub} />
     );
   }
 


### PR DESCRIPTION
Nightly consistency routine (D1 — Widget Empty States).

**Canonical form:** `<ScaledEmptyState icon={IconName} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx`.

**Instance unified:** `components/widgets/QuizWidget/components/QuizManager.tsx` — the `AssignmentsList` component's active/archive-tab empty state (~line 2065). Replaced a hand-rolled `<div className="flex flex-col items-center justify-center ...">` with icon + title + subtitle divs with a single `<ScaledEmptyState icon={Inbox} title={emptyTitle} subtitle={emptySub} />`.

**Enforcement:** N/A — this is a straight instance conversion, not a new recurring bug class needing a lint rule.

**Behavior/visual-preservation evidence:**
- Confirmed this is genuine widget front-face content (`QuizManager` is `QuizWidget`'s default rendered view, not a back-face settings panel).
- Distinct from the already-exempted D1-E6 "library tab" empty state (which has a CTA button + dashed border) — this is the plain active/archive tab state with no CTA.
- Checked the container-query sub-panel trap that burned a prior ActivityWall conversion (PR #2143): for active/archive tabs, `LibraryShell`'s folder sidebar doesn't render, so the tabpanel content spans the full widget container-query scope — not a narrower sub-panel.
- **Direct precedent verified by the orchestrator**: the sibling `VideoActivityWidget/components/VideoActivityManager.tsx:1007` already ships the identical pattern — a bare, no-color-override `ScaledEmptyState` for its own active/archive `AssignmentsList`-equivalent, inside the same shared `LibraryShell` component. This PR extends an already-established, already-merged pattern rather than introducing a new one.

**Validation:** `pnpm run validate` — all green (root: 6863/6863 tests; functions: 703/703 tests; type-check, lint `--max-warnings 0`, format-check all clean). `pnpm run build` — succeeded (client + SSR + prerendered legal pages).

**Risk tag:** mechanical

**Deferred to backlog (not touched this run):** `MiniApp/components/AssignmentsModal.tsx`/`SubmissionsModal.tsx` empty states (blocked — modal has no `container-type: size` boundary, same class of problem as the ActivityWall visual-risk items); `QuizEditor.tsx` "No questions yet" (same family as the already-exempted `VideoActivityEditor.tsx` pattern); `CustomWidget/Widget.tsx` "No content configured." (text-only, no icon — would need a design decision); `Catalyst/CatalystSetPickerPopover.tsx` (portal popover, not cqmin-scoped).

🤖 Generated by the nightly SpartBoard unifier routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvFKgaPLg3d8Ac3LMmJVfd)_