### PR TITLE
D3: retrofit RandomSettings "Animation Style" to SettingsLabel group-heading

### DIFF
--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -39,6 +39,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   const expertGroupCountId = useId();
   const firstNamesId = useId();
   const lastNamesId = useId();
+  const animationStyleId = useId();
 
   const stationsWidget = activeDashboard?.widgets.find(
     (w) => w.type === 'stations'
@@ -390,8 +391,14 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
 
       {mode === 'single' && (
         <div>
-          <SettingsLabel>Animation Style</SettingsLabel>
-          <div className="grid grid-cols-3 gap-2">
+          <SettingsLabel as="span" id={animationStyleId}>
+            Animation Style
+          </SettingsLabel>
+          <div
+            role="group"
+            aria-labelledby={animationStyleId}
+            className="grid grid-cols-3 gap-2"
+          >
             {styles.map((s) => (
               <button
                 key={s.id}


### PR DESCRIPTION
Nightly consistency routine (D3 — Settings Panel Label Primitives, group-heading retrofit).

**Canonical form:** `<SettingsLabel as="span" id="...">` + `role="group" aria-labelledby="..."` on the sibling-control container, for an existing `SettingsLabel` that heads a group of controls (no 1:1 pairing) rather than a single form control. (`as="span"`/`id` added to `SettingsLabel` outside this routine, PR #2141; formalized as canon after runs 26/30 retrofitted 3 other instances the same way.)

**Instance unified:** `components/widgets/random/RandomSettings.tsx:393` — `<SettingsLabel>Animation Style</SettingsLabel>` heading a `grid grid-cols-3` of 3 style-selector buttons, no associated single control (previously rendered an orphaned `<label>`).

**Enforcement:** N/A — this is a retrofit of a pre-existing canonical usage, not a new bug class.

**Behavior/visual-preservation evidence:**
- `components/common/SettingsLabel.tsx`: both the `as="span"` and default `as="label"` branches render the identical `combinedClasses` string computed once before the branch — confirmed directly against source, zero visual delta.
- **Instance-scoping**: `RandomSettings` is lazily loaded per-widget-instance (`WidgetRegistry.ts`), so multiple `RandomWidget`s can be flipped to settings concurrently. Rather than a hardcoded static `id` (which caused a real duplicate-DOM-id bug in a prior run's `DrawingWidget` retrofit), this instance uses `useId()` — already this file's established convention for other label associations (`groupSizeId`, `firstNamesId`, etc.) — which is unique per mounted component instance and correctly avoids the collision.

**Validation:** `pnpm run validate` — all green (full chain incl. type-check, lint `--max-warnings 0`, format-check, root + functions test suites, test-count guard). `pnpm run build` — succeeded (client bundle, SSR bundle, prerendered legal pages).

**Risk tag:** mechanical (semantics-only, zero visual delta)

**Deferred to backlog:** `components/widgets/MusicWidget/Settings.tsx:183` (`<SettingsLabel icon={LayoutGrid}>Layout</SettingsLabel>`) is the last remaining confirmed candidate from this retrofit family — left for a future night (one unification per dimension per run).

🤖 Generated by the nightly SpartBoard unifier routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvFKgaPLg3d8Ac3LMmJVfd)_