### PR TITLE
D4: widen plc import-escape ESLint regex to cover assessments/todos

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,14 +164,7 @@ export default tseslint.config(
     // this pattern, since it only fires when the segment immediately after
     // the last '../' is itself a plc subdirectory name (or `sections`, the
     // module at the center of the recurring bug).
-    //
-    // The regex's identifier list is intentionally forward-looking: it
-    // includes every canonical id in `PLC_SECTIONS` (components/plc/sections.ts),
-    // not just directories that currently exist, so a relative import into a
-    // not-yet-created section directory is still caught. `assessments` and
-    // `todos` were added 2026-07-15 after a nightly D4 sweep found they were
-    // real `PLC_SECTIONS` ids missing from this list. If sections.ts ever
-    // grows a new id, add it here too.
+    // Intentionally forward-looking: mirrors PLC_SECTIONS ids in sections.ts — update in lockstep when that list grows.
     files: ['components/plc/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,6 +164,14 @@ export default tseslint.config(
     // this pattern, since it only fires when the segment immediately after
     // the last '../' is itself a plc subdirectory name (or `sections`, the
     // module at the center of the recurring bug).
+    //
+    // The regex's identifier list is intentionally forward-looking: it
+    // includes every canonical id in `PLC_SECTIONS` (components/plc/sections.ts),
+    // not just directories that currently exist, so a relative import into a
+    // not-yet-created section directory is still caught. `assessments` and
+    // `todos` were added 2026-07-15 after a nightly D4 sweep found they were
+    // real `PLC_SECTIONS` ids missing from this list. If sections.ts ever
+    // grows a new id, add it here too.
     files: ['components/plc/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [
@@ -172,7 +180,7 @@ export default tseslint.config(
           patterns: [
             {
               regex:
-                '^(\\.\\./)+(activity|assignments|authoring|bodies|comments|docs|home|meeting|members|presence|resources|search|sections|settings|sharedBoards|sharedData|sync|tabs|versions|viewer)(/.*)?$',
+                '^(\\.\\./)+(activity|assessments|assignments|authoring|bodies|comments|docs|home|meeting|members|presence|resources|search|sections|settings|sharedBoards|sharedData|sync|tabs|todos|versions|viewer)(/.*)?$',
               caseSensitive: true,
               message:
                 "Cross-subdirectory plc import — use '@/components/plc/<dir>/...' instead of a relative path that escapes this subdirectory (see D4 in docs/routines/unifier.md).",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -164,7 +164,7 @@ export default tseslint.config(
     // this pattern, since it only fires when the segment immediately after
     // the last '../' is itself a plc subdirectory name (or `sections`, the
     // module at the center of the recurring bug).
-    // Intentionally forward-looking: mirrors PLC_SECTIONS ids in sections.ts — update in lockstep when that list grows.
+    // Covers existing components/plc/ subdirectory names plus forward-looking PLC_SECTIONS ids from sections.ts (e.g. assessments/todos, no dir yet) — keep both in sync.
     files: ['components/plc/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-imports': [


### PR DESCRIPTION
Nightly consistency routine (D4 — Import Path Convention, enforcement-only).

**Canonical form:** Use the `@/` alias for all cross-directory imports; the existing `components/plc/**` ESLint `no-restricted-imports` rule blocks relative imports that escape into a sibling `plc/` subdirectory (or a canonical `PLC_SECTIONS` id from `components/plc/sections.ts`), even before that subdirectory exists, so the bug can't regrow the moment a new section directory is created.

**No source files changed.** This run's fresh repo-wide sweep (multi-level relative imports, single-level escapes, dynamic `import()`/`require()`, the 5 newer top-level `components/` directories, and `functions/`) found zero new anti-pattern instances — D4 remains fully aligned on actual source. The only gap found was in the *enforcement rule itself*: `components/plc/sections.ts`'s `PLC_SECTIONS` canonical list includes `assessments` and `todos`, but the ESLint rule's regex (intentionally forward-looking, to catch escapes into not-yet-created section directories) was missing both. Widened the regex to add them, plus a comment noting the list is meant to track `PLC_SECTIONS` 1:1.

**Verification that `assessments`/`todos` are real, not hypothetical:** confirmed both exist as `id:` entries in `components/plc/sections.ts`'s `PLC_SECTIONS` array.

**Validation:** `pnpm run validate` — all green (type-check, lint `--max-warnings 0`, format-check, root + functions test suites, test-count guard). `pnpm run build` — succeeded. Additionally re-ran a full-repo `pnpm exec eslint . --max-warnings 0` independently after the regex change — zero output, confirming no false positives anywhere in the repo.

**Risk tag:** mechanical (lint-config-only change, no source diff)

**Backlog notes:**
- `components/classroomAddon/`, `components/landing/`, `components/legal/`, `components/lti/`, `components/poll/` — confirmed clean this run (no relative cross-directory imports at all).
- `functions/` confirmed structurally out of scope for D4 (no path alias configured in `functions/tsconfig.json`).
- Standing watch-item: whenever `PLC_SECTIONS` gains a new id, this regex needs updating in lockstep — this is the second time this specific drift has appeared.

🤖 Generated by the nightly SpartBoard unifier routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvFKgaPLg3d8Ac3LMmJVfd)_