### PR TITLE
fix(GuidedLearning): count building sets in "All items" sidebar badge

### DIFF
--- a/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
+++ b/components/widgets/GuidedLearning/components/GuidedLearningManager.tsx
@@ -65,6 +65,7 @@ import { LibraryPreviewPane } from '@/components/common/library/LibraryPreviewPa
 import {
   countItemsByFolder,
   filterSourcedEntriesByFolder,
+  ROOT_FOLDER_COUNT_KEY,
 } from '@/components/common/library/folderFilters';
 import { useFolders } from '@/hooks/useFolders';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
@@ -439,9 +440,15 @@ export const GuidedLearningManager: React.FC<GuidedLearningManagerProps> = ({
     setSelectedFolderId(null);
   }
 
-  // Only personal sets participate in folders. Building sets are always at
-  // root (they're shared at the building level and have no folderId field).
-  const folderItemCounts = useMemo(() => countItemsByFolder(sets), [sets]);
+  // Building sets have no folderId; fold them into the root bucket so "All items" counts them.
+  const folderItemCounts = useMemo(() => {
+    const counts = countItemsByFolder(sets);
+    if (buildingSets.length > 0) {
+      counts[ROOT_FOLDER_COUNT_KEY] =
+        (counts[ROOT_FOLDER_COUNT_KEY] ?? 0) + buildingSets.length;
+    }
+    return counts;
+  }, [sets, buildingSets]);
 
   const allEntries = useMemo(
     () =>

--- a/tests/components/widgets/GuidedLearningManager.folderCounts.test.tsx
+++ b/tests/components/widgets/GuidedLearningManager.folderCounts.test.tsx
@@ -1,0 +1,92 @@
+// Regression test: "All items" badge must count building sets, not just personal sets.
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+import { GuidedLearningManager } from '@/components/widgets/GuidedLearning/components/GuidedLearningManager';
+import type { GuidedLearningSet, GuidedLearningSetMetadata } from '@/types';
+
+vi.mock('@/hooks/useFolders', () => ({
+  useFolders: () => ({
+    folders: [],
+    loading: false,
+    error: null,
+    createFolder: vi.fn(),
+    renameFolder: vi.fn(),
+    moveFolder: vi.fn(),
+    deleteFolder: vi.fn(),
+    moveItem: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useSessionViewCount', () => ({
+  useSessionViewCount: () => ({ count: 0 }),
+}));
+
+const personalSet: GuidedLearningSetMetadata = {
+  id: 'set-1',
+  title: 'Personal Set',
+  stepCount: 3,
+  mode: 'guided',
+  imageUrl: '',
+  driveFileId: 'drive-1',
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+const buildingSet: GuidedLearningSet = {
+  id: 'building-1',
+  title: 'Building Set',
+  imageUrls: [],
+  steps: [],
+  mode: 'guided',
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+describe('GuidedLearningManager — folder sidebar item counts', () => {
+  it('includes building sets in the "All items" badge total', async () => {
+    render(
+      <GuidedLearningManager
+        userId="teacher-1"
+        sets={[personalSet]}
+        buildingSets={[buildingSet]}
+        assignments={[]}
+        loading={false}
+        buildingLoading={false}
+        assignmentsLoading={false}
+        isDriveConnected={true}
+        isAdmin={false}
+        onPlay={vi.fn()}
+        onEdit={vi.fn()}
+        onAssign={vi.fn()}
+        onDeletePersonal={vi.fn()}
+        onDeleteBuilding={vi.fn()}
+        onCreateNewPersonal={vi.fn()}
+        onCreateNewBuilding={vi.fn()}
+        onOpenAIAuthoring={vi.fn()}
+        onReorderPersonal={vi.fn()}
+        recentSessionIds={{}}
+        onViewResults={vi.fn()}
+        onAssignmentCopyLink={vi.fn()}
+        onAssignmentOpenResults={vi.fn()}
+        onAssignmentArchive={vi.fn()}
+        onAssignmentUnarchive={vi.fn()}
+        onAssignmentDelete={vi.fn()}
+      />
+    );
+
+    // Both cards are visible — the "All items" view shows personal + building.
+    await screen.findByText('Personal Set');
+    await screen.findByText('Building Set');
+
+    const allItemsRow = screen.getByText('All items').closest('button');
+    expect(allItemsRow).not.toBeNull();
+
+    // Badge must equal all visible entries (1 personal + 1 building), not just personal.
+    expect(
+      within(allItemsRow as HTMLElement).getByText('2')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Root cause

`GuidedLearningManager.tsx`'s `folderItemCounts` was computed via `countItemsByFolder(sets)` — personal sets only. But the Library tab's "All items" view (`filterSourcedEntriesByFolder` with `selectedFolderId === null`) always shows personal + building sets together, and `FolderSidebar`'s "All items" badge sums every bucket in `itemCounts`. Since building sets never contributed to any bucket, the badge undercounted by `buildingSets.length` whenever any building sets existed — even though "All items" is exactly the view that shows them.

## Fix

Fold `buildingSets.length` into the root bucket (`ROOT_FOLDER_COUNT_KEY`), since building sets have no `folderId` and are never rendered as their own folder row — only summed into the "All items" total.

## Rejected band-aid

Considered recomputing the total directly inside `FolderSidebar` via a separately-passed "total override" prop. Rejected because `FolderSidebar`/`folderFilters.ts` is a shared primitive used by Quiz/VideoActivity/GuidedLearning/MiniApp, and none of the sibling widgets mix a "building set" concept into personal sets the way GuidedLearning does — special-casing the shared component for one caller would leak a GuidedLearning-specific concept into generic library infrastructure. Fixing it at the source keeps the shared primitives generic and honest.

## Regression test

`tests/components/widgets/GuidedLearningManager.folderCounts.test.tsx` — renders `GuidedLearningManager` with 1 personal set + 1 building set, asserts the "All items" badge equals 2.

**Fail before / pass after:** badge shows `1` pre-fix (fails — only counts the personal set), `2` post-fix (passes).

## Validation

- `pnpm run validate` — passing (703 functions tests, full root suite, test:counts guard)
- `pnpm run build` — passing

## Risk

**Contained** — single widget-local memo change, additive test coverage, no shared-component API changes.

---
🌙 Nightly code-health run — Widgets area


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJSN9QBeEFg6nyXGBW6mGb)_