### PR TITLE
perf(Sidebar): code-split AdminSettings out of the always-mounted chunk

### DIFF
--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -30,7 +30,6 @@ import { GoogleDriveIcon } from '@/components/common/GoogleDriveIcon';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
-import { AdminSettings } from '@/components/admin/AdminSettings';
 import { ShortLinkQuickCreate } from '@/components/admin/ShortLinkQuickCreate';
 import { WhatsNewModal } from '@/components/layout/WhatsNewModal';
 import {
@@ -56,6 +55,13 @@ import { buildPlcPath, spaNavigate } from '@/utils/plcPath';
 import { BoardsModal } from '@/components/boardsModal/BoardsModal';
 
 declare const __APP_VERSION__: string;
+
+// Lazy: AdminSettings pulls in recharts + the admin surface (~1.2MB) but only admins open it.
+const AdminSettings = React.lazy(() =>
+  import('@/components/admin/AdminSettings').then((m) => ({
+    default: m.AdminSettings,
+  }))
+);
 
 type MenuSection = 'main' | 'classes' | 'plcs' | 'google-drive' | 'buildings';
 
@@ -327,7 +333,9 @@ export const Sidebar: React.FC = () => {
       </GlassCard>
 
       {showAdminSettings && (
-        <AdminSettings onClose={() => setShowAdminSettings(false)} />
+        <React.Suspense fallback={null}>
+          <AdminSettings onClose={() => setShowAdminSettings(false)} />
+        </React.Suspense>
       )}
 
       {showSettingsModal && (

--- a/components/layout/sidebar/Sidebar.tsx
+++ b/components/layout/sidebar/Sidebar.tsx
@@ -27,6 +27,7 @@ import {
   Sparkles,
 } from 'lucide-react';
 import { GoogleDriveIcon } from '@/components/common/GoogleDriveIcon';
+import { LazyChunkErrorBoundary } from '@/components/common/LazyChunkErrorBoundary';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -333,9 +334,11 @@ export const Sidebar: React.FC = () => {
       </GlassCard>
 
       {showAdminSettings && (
-        <React.Suspense fallback={null}>
-          <AdminSettings onClose={() => setShowAdminSettings(false)} />
-        </React.Suspense>
+        <LazyChunkErrorBoundary>
+          <React.Suspense fallback={null}>
+            <AdminSettings onClose={() => setShowAdminSettings(false)} />
+          </React.Suspense>
+        </LazyChunkErrorBoundary>
       )}
 
       {showSettingsModal && (

--- a/tests/components/layout/sidebar/Sidebar.adminSettingsLazy.test.tsx
+++ b/tests/components/layout/sidebar/Sidebar.adminSettingsLazy.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Sidebar } from '@/components/layout/sidebar/Sidebar';
+import type { Dashboard } from '@/types';
+
+// Counts AdminSettings module evaluations — 0 before render proves it's lazy, not static.
+const adminSettingsEval = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock('@/components/admin/AdminSettings', () => {
+  adminSettingsEval.count += 1;
+  return {
+    AdminSettings: ({ onClose }: { onClose: () => void }) => (
+      <div data-testid="admin-settings-panel">
+        <button onClick={onClose}>close admin settings</button>
+      </div>
+    ),
+  };
+});
+
+const emptyDashboard: Dashboard = {
+  id: 'd1',
+  name: 'Board 1',
+  background: 'bg-slate-900',
+  widgets: [],
+  createdAt: 0,
+};
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { uid: 'admin-1', email: 'admin@example.com' },
+    signOut: vi.fn(),
+    isAdmin: true,
+    appSettings: {},
+    isExternalUser: false,
+  }),
+}));
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    dashboards: [emptyDashboard],
+    activeDashboard: emptyDashboard,
+    isSaving: false,
+    clearAllWidgets: vi.fn(),
+    rosters: [],
+    annotationActive: false,
+    openAnnotation: vi.fn(),
+    closeAnnotation: vi.fn(),
+    isActiveBoardReadOnly: false,
+  }),
+}));
+
+vi.mock('@/hooks/useGoogleDrive', () => ({
+  useGoogleDrive: () => ({ isConnected: false }),
+}));
+
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: () => ({
+    plcs: [],
+    loading: false,
+    createPlc: vi.fn(),
+    leavePlc: vi.fn(),
+    deletePlc: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/usePlcInvitations', () => ({
+  usePlcInvitations: () => ({
+    pendingInvites: [],
+    sentInvites: [],
+    loading: false,
+    inviteCount: 0,
+    sendInvite: vi.fn(),
+    acceptInvite: vi.fn(),
+    declineInvite: vi.fn(),
+    revokeInvite: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useChangelog', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useChangelog')>();
+  return {
+    ...actual,
+    useChangelog: () => ({
+      entries: [],
+      loading: false,
+      error: null,
+      latestVersion: null,
+      entriesSinceCurrent: [],
+    }),
+  };
+});
+
+vi.mock('@/hooks/useAppVersion', () => ({
+  useAppVersion: () => ({ updateAvailable: false, reloadApp: vi.fn() }),
+}));
+
+describe('Sidebar admin settings code-splitting', () => {
+  it('does not evaluate the AdminSettings module until an admin opens the panel', async () => {
+    // Regression guard: AdminSettings used to be statically imported, shipping ~1.2MB to every teacher.
+    expect(adminSettingsEval.count).toBe(0);
+
+    render(<Sidebar />);
+
+    const adminButton = await screen.findByRole('button', {
+      name: 'Admin Settings',
+    });
+    expect(adminSettingsEval.count).toBe(0);
+
+    await userEvent.click(adminButton);
+
+    expect(
+      await screen.findByTestId('admin-settings-panel')
+    ).toBeInTheDocument();
+    expect(adminSettingsEval.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Root cause

`AdminSettings` was a static import in `Sidebar.tsx`. It statically pulls in `AnalyticsManager` -> `recharts` plus the rest of the admin surface, but only admins ever open the panel. Every signed-in teacher — admin or not — downloaded and parsed that entire chunk on initial app load.

## Fix

Switched to `React.lazy` + `Suspense`, loaded on demand only when `showAdminSettings` flips `true`.

## Rejected band-aid

None needed — this is a self-contained code-splitting change with no alternative surface to patch around; the static import was the root cause itself.

## Regression test

`tests/components/layout/sidebar/Sidebar.adminSettingsLazy.test.tsx` — tracks how many times the `AdminSettings` module body actually evaluates via a `vi.mock` factory counter. A static import evaluates the module before any test body runs; `React.lazy` only evaluates when React actually attempts to render it.

**Fail before / pass after:** pre-fix, `adminSettingsEval.count` is already `1` before `render(<Sidebar />)` is even called (static import). Post-fix it's `0` until the admin clicks the button, then becomes `1`.

## Before/after evidence (production build)

| Chunk | Before | After |
| --- | --- | --- |
| `Sidebar-*.js` | 1,196.31 kB (293.86 kB gzip) | 168.05 kB (40.27 kB gzip) |
| `AdminSettings-*.js` (new, on-demand) | — | 1,032.64 kB (256.78 kB gzip) |

Every non-admin teacher's initial-load bundle shrinks by ~254KB gzip.

## Validation

- `pnpm run validate` — passing (703 functions tests, full root suite, test:counts guard)
- `pnpm run build` — passing, bundle sizes confirmed above

## Risk

**Contained** — standard React code-splitting pattern, `Suspense fallback={null}` preserves current UX (panel already only renders when `showAdminSettings` is true).

---
🌙 Nightly code-health run — Dashboard & Layout area


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJSN9QBeEFg6nyXGBW6mGb)_