### PR TITLE
fix(classroomAddon): dedup question ids when computing pushed maxPoints

### DIFF
--- a/components/classroomAddon/TeacherDiscoveryRoute.tsx
+++ b/components/classroomAddon/TeacherDiscoveryRoute.tsx
@@ -43,6 +43,8 @@ import {
   getVideoActivityBehavior,
   formatVideoActivityBehaviorSummary,
 } from '@/utils/videoActivityBehavior';
+import { quizMaxPoints } from '@/utils/quizMaxPoints';
+import { videoActivityMaxPoints } from '@/utils/videoActivityGrading';
 import { buildPlcLinkage } from '@/utils/plcLinkage';
 import { logError } from '@/utils/logError';
 import { ensureGis, requestAccessToken } from './gisOAuth';
@@ -412,11 +414,8 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     append(`Loading "${selectedQuiz.title}"…`);
     const quizData = await loadQuizData(selectedQuiz.driveFileId);
 
-    // The Classroom grade scale = the quiz's total points, so a 17/20 quiz
-    // reads as 17/20 in Classroom (not a percentage out of 100). Fall back to
-    // 100 only when the quiz has no questions/points to sum.
-    const quizMaxPoints =
-      quizData.questions.reduce((s, q) => s + (q.points ?? 1), 0) || 100;
+    // Classroom grade scale = quiz's total points (e.g. 17/20), not a percentage.
+    const maxPoints = quizMaxPoints(quizData.questions);
 
     const targeting = await resolveClassTargeting();
 
@@ -481,7 +480,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
       {
         quizCode: code,
         kind: 'quiz',
-        maxPoints: quizMaxPoints,
+        maxPoints,
       }
     );
     append(
@@ -498,7 +497,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         attachmentId,
         courseId,
         itemId,
-        maxPoints: quizMaxPoints,
+        maxPoints,
         attachedAt: Date.now(),
       };
       try {
@@ -558,11 +557,8 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
     append(`Loading "${selectedActivity.title}"…`);
     const activityData = await loadActivityData(selectedActivity.driveFileId);
 
-    // The Classroom grade scale = the activity's total points, so pushed grades
-    // read identically in Classroom (not a percentage out of 100). Fall back to
-    // 100 only when the activity has no questions/points to sum.
-    const vaMaxPoints =
-      activityData.questions.reduce((s, q) => s + (q.points ?? 1), 0) || 100;
+    // Classroom grade scale = activity's total points (e.g. 17/20), not a percentage.
+    const maxPoints = videoActivityMaxPoints(activityData.questions);
 
     const targeting = await resolveClassTargeting();
 
@@ -629,7 +625,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
       {
         sessionId,
         kind: 'va',
-        maxPoints: vaMaxPoints,
+        maxPoints,
       }
     );
     append(
@@ -646,7 +642,7 @@ export const ClassroomAddonTeacherSpike: React.FC = () => {
         attachmentId,
         courseId,
         itemId,
-        maxPoints: vaMaxPoints,
+        maxPoints,
         attachedAt: Date.now(),
       };
       try {

--- a/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
+++ b/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
@@ -80,17 +80,38 @@ vi.mock('@/hooks/useQuizAssignments', () => ({
   useQuizAssignments: () => ({ createAssignment }),
 }));
 
+const duplicatedActivityQuestions = [dupQuestion, dupQuestion];
+
+const loadActivityData = vi.fn(() => ({
+  id: 'va-1',
+  title: 'My Video Activity',
+  questions: duplicatedActivityQuestions,
+  createdAt: 0,
+  updatedAt: 0,
+}));
+
 vi.mock('@/hooks/useVideoActivity', () => ({
   useVideoActivity: () => ({
-    activities: [],
-    loadActivityData: vi.fn(),
+    activities: [
+      {
+        id: 'va-1',
+        title: 'My Video Activity',
+        driveFileId: 'drive-file-2',
+        questionCount: 2,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    ],
+    loadActivityData,
     loading: false,
   }),
 }));
 
+const createVaAssignment = vi.fn(() => ({ id: 'assign-2', code: 'DEF456' }));
+
 vi.mock('@/hooks/useVideoActivityAssignments', () => ({
   useVideoActivityAssignments: () => ({
-    createAssignment: vi.fn(),
+    createAssignment: createVaAssignment,
   }),
 }));
 
@@ -120,8 +141,30 @@ describe('ClassroomAddonTeacherSpike attach flow — maxPoints dedup', () => {
 
     await waitFor(() => expect(mockCallable).toHaveBeenCalled());
 
-    const params = mockCallable.mock.calls[0][0];
+    const lastCall = mockCallable.mock.calls.at(-1);
+    if (!lastCall) throw new Error('mockCallable was not called');
     // Two entries of the SAME 10-point question id must dedup to 10, not 20.
-    expect(params.maxPoints).toBe(10);
+    expect(lastCall[0].maxPoints).toBe(10);
+  });
+
+  it('dedupes duplicate question ids when computing the attached video activity maxPoints', async () => {
+    render(<ClassroomAddonTeacherSpike />);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Video Activity' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Video Activity' }));
+    fireEvent.click(
+      await screen.findByRole('option', { name: 'My Video Activity' })
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /attach video activity/i })
+    );
+
+    await waitFor(() => expect(mockCallable).toHaveBeenCalled());
+
+    const lastCall = mockCallable.mock.calls.at(-1);
+    if (!lastCall) throw new Error('mockCallable was not called');
+    // Two entries of the SAME 10-point question id must dedup to 10, not 20.
+    expect(lastCall[0].maxPoints).toBe(10);
   });
 });

--- a/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
+++ b/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import type { QuizQuestion } from '@/types';
+import type { QuizQuestion, VideoActivityQuestion } from '@/types';
 
 // Regression: attach flow's maxPoints must dedup duplicate question ids like other LMS-attach surfaces.
 
@@ -80,7 +80,16 @@ vi.mock('@/hooks/useQuizAssignments', () => ({
   useQuizAssignments: () => ({ createAssignment }),
 }));
 
-const duplicatedActivityQuestions = [dupQuestion, dupQuestion];
+const dupVaQuestion: VideoActivityQuestion = {
+  id: 'q-dup',
+  type: 'MC',
+  points: 10,
+  timestamp: 0,
+} as unknown as VideoActivityQuestion;
+const duplicatedActivityQuestions: VideoActivityQuestion[] = [
+  dupVaQuestion,
+  dupVaQuestion,
+];
 
 const loadActivityData = vi.fn(() => ({
   id: 'va-1',

--- a/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
+++ b/tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { QuizQuestion } from '@/types';
+
+// Regression: attach flow's maxPoints must dedup duplicate question ids like other LMS-attach surfaces.
+
+const mockCallable = vi.fn((_params: { maxPoints: number }) => ({
+  data: { attachmentId: 'att-1' },
+}));
+
+vi.mock('@/config/firebase', () => ({
+  db: {},
+  functions: {},
+}));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => mockCallable,
+}));
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(() => ({})),
+  getDoc: vi.fn(() => ({ exists: () => false })),
+  updateDoc: vi.fn(() => undefined),
+}));
+
+vi.mock('@/components/classroomAddon/gisOAuth', () => ({
+  ensureGis: vi.fn(() => undefined),
+  requestAccessToken: vi.fn(() => 'addon-access-token'),
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { uid: 'teacher-1', email: 't@example.com', displayName: 'T' },
+    signInWithGoogle: vi.fn(),
+    googleAccessToken: 'drive-token',
+    ensureGoogleScope: vi.fn(() => null),
+  }),
+}));
+
+// Two entries sharing the same id — simulates a Drive-sync/arrayUnion duplicate.
+const dupQuestion: QuizQuestion = {
+  id: 'q-dup',
+  type: 'MC',
+  points: 10,
+} as unknown as QuizQuestion;
+const duplicatedQuestions: QuizQuestion[] = [dupQuestion, dupQuestion];
+
+const loadQuizData = vi.fn(() => ({
+  id: 'quiz-1',
+  title: 'My Quiz',
+  questions: duplicatedQuestions,
+  createdAt: 0,
+  updatedAt: 0,
+}));
+
+const createAssignment = vi.fn(() => ({
+  id: 'assign-1',
+  code: 'ABC123',
+}));
+
+vi.mock('@/hooks/useQuiz', () => ({
+  useQuiz: () => ({
+    quizzes: [
+      {
+        id: 'quiz-1',
+        title: 'My Quiz',
+        driveFileId: 'drive-file-1',
+        questionCount: 2,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    ],
+    loadQuizData,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useQuizAssignments', () => ({
+  useQuizAssignments: () => ({ createAssignment }),
+}));
+
+vi.mock('@/hooks/useVideoActivity', () => ({
+  useVideoActivity: () => ({
+    activities: [],
+    loadActivityData: vi.fn(),
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useVideoActivityAssignments', () => ({
+  useVideoActivityAssignments: () => ({
+    createAssignment: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: () => ({ plcs: [] }),
+}));
+
+import { ClassroomAddonTeacherSpike } from '@/components/classroomAddon/TeacherDiscoveryRoute';
+
+describe('ClassroomAddonTeacherSpike attach flow — maxPoints dedup', () => {
+  beforeEach(() => {
+    mockCallable.mockClear();
+    window.history.pushState(
+      {},
+      '',
+      '/classroom-addon/teacher?courseId=course-1&itemId=item-1&addOnToken=tok-1'
+    );
+  });
+
+  it('dedupes duplicate question ids when computing the attached quiz maxPoints', async () => {
+    render(<ClassroomAddonTeacherSpike />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Quiz' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'My Quiz' }));
+
+    fireEvent.click(screen.getByRole('button', { name: /attach quiz/i }));
+
+    await waitFor(() => expect(mockCallable).toHaveBeenCalled());
+
+    const params = mockCallable.mock.calls[0][0];
+    // Two entries of the SAME 10-point question id must dedup to 10, not 20.
+    expect(params.maxPoints).toBe(10);
+  });
+});


### PR DESCRIPTION
## Root cause

`ClassroomAddonTeacherSpike`'s `attachQuiz`/`attachVideoActivity` handlers summed question points with a bare inline `reduce` (no id dedup), unlike every other LMS-attach surface which routes through the shared `quizMaxPoints`/`videoActivityMaxPoints` helpers. A Drive-sync/`arrayUnion` race that duplicates a question id inflates the Classroom attachment's `scoreMaximum` above what a student can ever actually earn. This is the 8th confirmed instance of this dedup-fence bug class in this codebase (see #1728 and its successors: #1777, #1787, #1803, #1827, #1855, #1935, #2093).

This file (`components/classroomAddon/**`) has been flagged in the nightly memory doc as a real, well-understood, but **unowned** bug for two prior runs — it isn't covered by any of the 5 code areas' globs. Fixed here as a deliberate one-time exception (State & Data area, since the fix is exactly the established dedup-fence pattern that area owns everywhere else).

## Fix

Switched both handlers to the shared `quizMaxPoints(quizData.questions)` / `videoActivityMaxPoints(activityData.questions)` helpers, which already dedupe by question id.

## Rejected band-aid

Considered adding an inline `Set<string>` dedup fence directly in `TeacherDiscoveryRoute.tsx` (matching the raw-reduce style already there). Rejected in favor of reusing the shared helpers — duplicating the dedup logic a 9th time would just create another drift point if the shared helpers' semantics ever change.

## Regression test

`tests/components/classroomAddon/TeacherDiscoveryRoute.test.tsx` — mocks a quiz with two entries sharing the same 10-point question id, drives the attach-quiz UI flow, and asserts the Classroom callable is invoked with `maxPoints: 10`.

**Fail before / pass after:** `params.maxPoints` is `20` pre-fix (inflated), `10` post-fix (correct).

## Validation

- `pnpm run validate` — passing (703 functions tests, full root suite, test:counts guard)
- `pnpm run build` — passing

## Risk

**Contained** — swaps an inline reduce for an existing, already-tested shared helper; no behavior change for the non-duplicate case.

---
🌙 Nightly code-health run — State & Data area


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJSN9QBeEFg6nyXGBW6mGb)_