### PR TITLE
fix(rules): close moderation-bypass on activity_wall_sessions submissions

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3698,6 +3698,14 @@ service cloud.firestore {
         function awSessionClassIds() {
           return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('classIds', []);
         }
+        // Moderation flag: when true the client submits 'pending' for teacher
+        // review; when false/absent it auto-approves. Pinning create's status
+        // to this value (instead of allowing either) closes a bypass where a
+        // submitter could set status: 'approved' directly and skip the review
+        // queue even though the teacher enabled moderation.
+        function awSessionModerationEnabled() {
+          return get(/databases/$(database)/documents/activity_wall_sessions/$(sessionId)).data.get('moderationEnabled', false);
+        }
 
         // Any authed user (incl. anon) can create a submission (photo subs may
         // carry storage metadata for Drive archiving). studentRole users must be
@@ -3710,7 +3718,7 @@ service cloud.firestore {
           request.resource.data.content.size() > 0 &&
           request.resource.data.content.size() <= 5000 &&
           request.resource.data.submittedAt is int &&
-          request.resource.data.status in ['approved', 'pending'] &&
+          request.resource.data.status == (awSessionModerationEnabled() ? 'pending' : 'approved') &&
           (!('participantLabel' in request.resource.data) || request.resource.data.participantLabel is string) &&
           (!('storagePath' in request.resource.data) || request.resource.data.storagePath is string) &&
           (!('archiveStatus' in request.resource.data) || request.resource.data.archiveStatus == 'firebase') &&

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -967,7 +967,7 @@ describe('activity_wall_sessions/submissions — moderation status gate', () => 
   const col = 'activity_wall_sessions';
   const MODERATED_SESSION = 'session-moderated';
   const OPEN_SESSION = 'session-open';
-  const subFor = (session: string, status: 'approved' | 'pending') => ({
+  const subFor = (status: 'approved' | 'pending') => ({
     id: 'sub-1',
     content: 'Hello world',
     submittedAt: 1000,
@@ -997,7 +997,7 @@ describe('activity_wall_sessions/submissions — moderation status gate', () => 
     await assertFails(
       addDoc(
         collection(asStudentA(), `${col}/${MODERATED_SESSION}/submissions`),
-        subFor(MODERATED_SESSION, 'approved')
+        subFor('approved')
       )
     );
   });
@@ -1006,7 +1006,7 @@ describe('activity_wall_sessions/submissions — moderation status gate', () => 
     await assertSucceeds(
       addDoc(
         collection(asStudentA(), `${col}/${MODERATED_SESSION}/submissions`),
-        subFor(MODERATED_SESSION, 'pending')
+        subFor('pending')
       )
     );
   });
@@ -1015,7 +1015,7 @@ describe('activity_wall_sessions/submissions — moderation status gate', () => 
     await assertSucceeds(
       addDoc(
         collection(asStudentA(), `${col}/${OPEN_SESSION}/submissions`),
-        subFor(OPEN_SESSION, 'approved')
+        subFor('approved')
       )
     );
   });
@@ -1024,7 +1024,7 @@ describe('activity_wall_sessions/submissions — moderation status gate', () => 
     await assertFails(
       addDoc(
         collection(asStudentA(), `${col}/${OPEN_SESSION}/submissions`),
-        subFor(OPEN_SESSION, 'pending')
+        subFor('pending')
       )
     );
   });

--- a/tests/rules/studentRoleClassGate.test.ts
+++ b/tests/rules/studentRoleClassGate.test.ts
@@ -823,11 +823,12 @@ describe('activity_wall_sessions/submissions — student-role gate', () => {
   const col = 'activity_wall_sessions';
   const subCol = (session: string) =>
     collection(asStudentA(), `${col}/${session}/submissions`);
+  // seedSessions() has no moderationEnabled field, so rules default to false → 'approved'.
   const validSub = () => ({
     id: 'sub-1',
     content: 'Hello world',
     submittedAt: 1000,
-    status: 'pending' as const,
+    status: 'approved' as const,
   });
 
   beforeEach(async () => {
@@ -890,11 +891,12 @@ describe('activity_wall_sessions/submissions — student-role gate', () => {
 // above, which seeds `classId` and still passes unchanged).
 describe('activity_wall_sessions/submissions — Phase-5A compat (classIds list)', () => {
   const col = 'activity_wall_sessions';
+  // No moderationEnabled field seeded → rules default false → 'approved'.
   const validSub = () => ({
     id: 'sub-1',
     content: 'Hello world',
     submittedAt: 1000,
-    status: 'pending' as const,
+    status: 'approved' as const,
   });
 
   beforeEach(async () => {
@@ -948,6 +950,81 @@ describe('activity_wall_sessions/submissions — Phase-5A compat (classIds list)
       addDoc(
         collection(asAnonStudent(), `${col}/${SESSION_A}/submissions`),
         validSub()
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activity_wall_sessions/submissions — moderation status is server-enforced
+// ---------------------------------------------------------------------------
+// The client always writes status: moderationEnabled ? 'pending' : 'approved'
+// (see ActivityWallStudentApp.tsx). Prior to this gate the create rule only
+// checked `status in ['approved', 'pending']`, so a submitter could set
+// status: 'approved' directly on a moderated session and skip the teacher's
+// review queue entirely.
+describe('activity_wall_sessions/submissions — moderation status gate', () => {
+  const col = 'activity_wall_sessions';
+  const MODERATED_SESSION = 'session-moderated';
+  const OPEN_SESSION = 'session-open';
+  const subFor = (session: string, status: 'approved' | 'pending') => ({
+    id: 'sub-1',
+    content: 'Hello world',
+    submittedAt: 1000,
+    status,
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore();
+      await setDoc(doc(db, `${col}/${MODERATED_SESSION}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+        moderationEnabled: true,
+      });
+      await setDoc(doc(db, `${col}/${OPEN_SESSION}`), {
+        teacherUid: TEACHER_UID,
+        classId: CLASS_A,
+        status: 'active',
+        moderationEnabled: false,
+      });
+    });
+  });
+
+  it('cannot self-approve a submission when moderation is enabled', async () => {
+    await assertFails(
+      addDoc(
+        collection(asStudentA(), `${col}/${MODERATED_SESSION}/submissions`),
+        subFor(MODERATED_SESSION, 'approved')
+      )
+    );
+  });
+
+  it('can submit as pending when moderation is enabled', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asStudentA(), `${col}/${MODERATED_SESSION}/submissions`),
+        subFor(MODERATED_SESSION, 'pending')
+      )
+    );
+  });
+
+  it('auto-approves when moderation is disabled', async () => {
+    await assertSucceeds(
+      addDoc(
+        collection(asStudentA(), `${col}/${OPEN_SESSION}/submissions`),
+        subFor(OPEN_SESSION, 'approved')
+      )
+    );
+  });
+
+  it('cannot submit as pending when moderation is disabled', async () => {
+    await assertFails(
+      addDoc(
+        collection(asStudentA(), `${col}/${OPEN_SESSION}/submissions`),
+        subFor(OPEN_SESSION, 'pending')
       )
     );
   });


### PR DESCRIPTION
## Root cause

**Security.** The `activity_wall_sessions/{session}/submissions` create rule only checked `request.resource.data.status in ['approved', 'pending']` — accepting either value regardless of the session's `moderationEnabled` flag. The client always writes `status: moderationEnabled ? 'pending' : 'approved'` (`ActivityWallStudentApp.tsx:365`), but nothing server-side enforced that contract. Any submitter (including anonymous/PIN-based students) could set `status: 'approved'` directly on a moderated session and skip the teacher's review queue entirely — a moderation bypass.

## Fix

Added `awSessionModerationEnabled()` helper (mirrors the existing `awSessionClassIds()` pattern in the same rule block) and pinned `create`'s `status` field to the value the moderation flag implies:
```
request.resource.data.status == (awSessionModerationEnabled() ? 'pending' : 'approved')
```

## Rejected band-aid

Considered leaving the rule as an `in [...]` check and instead relying on the client to "always do the right thing." Rejected — the whole point of Firestore security rules is to not trust the client for anything security-relevant; the client-side ternary is UX, not enforcement.

## Regression test

`tests/rules/studentRoleClassGate.test.ts` — new `activity_wall_sessions/submissions — moderation status gate` suite (4 tests): cannot self-approve when moderation is enabled, can submit pending when moderation is enabled, auto-approves when moderation is disabled, cannot submit pending when moderation is disabled. Also updated 2 pre-existing describe blocks whose seeded sessions have no `moderationEnabled` field (rules default `false`) to expect `'approved'` instead of `'pending'`, since their old expectation was only ever passing because the old rule accepted both values unconditionally.

**Fail before / pass after:** ran the new suite in isolation against unfixed `firestore.rules` — 2/4 new tests fail (the two bypass-prevention assertions: self-approve-when-moderated succeeds when it should fail, submit-pending-when-open succeeds when it should fail). Full `pnpm run test:rules` suite: 1116/1116 passing post-fix (1112 baseline + 4 new).

## Validation

- `pnpm run validate` — passing (703 functions tests, full root suite, test:counts guard)
- `pnpm run test:rules` — passing, 47 files / 1116 tests (Firestore emulator)
- `pnpm run build:all` — passing

## Risk

**Contained** — single rule-file change scoped to one collection's create path, verified against the real Firestore emulator with full before/after evidence, no client code changes required (the client was already writing the correct value).

---
🌙 Nightly code-health run — Build & Tooling area


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJSN9QBeEFg6nyXGBW6mGb)_