### PR TITLE
Retrofit MusicWidget "Layout" label to group-heading SettingsLabel form

### DIFF
--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -180,8 +180,18 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
       {/* ── Layout selector ── */}
       <div className="space-y-2 pt-1 border-t border-slate-100">
-        <SettingsLabel icon={LayoutGrid}>Layout</SettingsLabel>
-        <div className="grid grid-cols-3 gap-2">
+        <SettingsLabel
+          as="span"
+          icon={LayoutGrid}
+          id={`music-layout-label-${widget.id}`}
+        >
+          Layout
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-3 gap-2"
+          role="group"
+          aria-labelledby={`music-layout-label-${widget.id}`}
+        >
           {LAYOUT_OPTIONS.map((opt) => {
             const isActive = layout === opt.value;
             return (


### PR DESCRIPTION
## Canonical form
`<SettingsLabel as="span" id="...">Label</SettingsLabel>` + `role="group" aria-labelledby="..."` on the sibling-controls container — used when a `SettingsLabel` heads a *group* of controls rather than pairing 1:1 with one input (a bare `<label>` in that case is semantically orphaned). This is the same pattern shipped in PRs #2144/#2168/#2183/#2197/#2207.

## Instance unified
`components/widgets/MusicWidget/Settings.tsx:183` — the "Layout" `<SettingsLabel icon={LayoutGrid}>` headed a `grid grid-cols-3` of 3 sibling layout-option buttons with no 1:1 control pairing. Converted to `as="span"` with `id={`music-layout-label-${widget.id}`}`, and added `role="group"`/`aria-labelledby` to the button-grid container. The `widget.id`-interpolation idiom was used (not `useId()`) since `MusicSettings` renders per-widget-instance and `widget` was already in scope — matching the idiom used in the DrawingWidget/RevealGrid conversions in this same retrofit series.

This is the last of the "3 remaining candidates" tracked across runs 32/33/34 (DrawingWidget, RevealGrid, RandomSettings) — the named retrofit series is now complete. One new candidate was spotted in the same file (`Settings.tsx:137` "Source" label, same shape) and left for a future run per the one-unification-per-dimension-per-night rule.

## Enforcement
None added — this is a retrofit of a pre-existing pattern, not a new bug class; the underlying `SettingsLabel` component already supports `as="span"` from a prior PR (#2141).

## Behavior/visual-preservation evidence
Read `components/common/SettingsLabel.tsx` directly: `combinedClasses` is computed identically regardless of the `as` prop, and both branches render the same icon+children content — only the tag name and `htmlFor` differ. `as="span"` is pixel-identical to `as="label"`; the only functional change is `role="group"`/`aria-labelledby` wiring, a pure accessibility-semantics improvement (no visual delta).

**Risk tag: mechanical** (pure equivalence — semantics-only accessibility fix, zero visual delta).

## Validation
`pnpm run validate` ✅ (type-check, lint, format-check, 703 root tests + 703 functions tests, test-count guard) and `pnpm run build` ✅ (including SSR prerender of /privacy, /terms, /support).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8Ti8WpkyQ9yf1dwSegxnT)_