### PR TITLE
Unify ActivityWall library empty state onto ScaledEmptyState

### DIFF
--- a/components/widgets/ActivityWall/Widget.tsx
+++ b/components/widgets/ActivityWall/Widget.tsx
@@ -37,6 +37,7 @@ import {
   type ActivityWallActivityDefaults,
 } from './buildingDefaults';
 import { WidgetLayout } from '@/components/widgets/WidgetLayout';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { db, functions, storage } from '@/config/firebase';
 import {
   collection,
@@ -1543,29 +1544,23 @@ export const ActivityWallWidget: React.FC<{ widget: WidgetData }> = ({
               style={{ padding: 'min(10px, 2.8cqmin)' }}
             >
               {activities.length === 0 ? (
-                <div className="h-full w-full flex flex-col items-center justify-center text-center bg-slate-50 rounded-xl border border-slate-200">
-                  <LibraryBig
-                    className="text-brand-blue-primary"
-                    style={{
-                      width: 'min(40px, 14cqmin)',
-                      height: 'min(40px, 14cqmin)',
-                    }}
+                // This region is shorter than the full widget (the header
+                // above it eats vertical space), so it needs its own
+                // container-query boundary — otherwise ScaledEmptyState's
+                // cqmin sizing would resolve against the taller outer widget
+                // box and render larger than this actual space allows.
+                <div
+                  className="h-full w-full rounded-xl border border-slate-200 bg-slate-50"
+                  style={{ containerType: 'size' }}
+                >
+                  <ScaledEmptyState
+                    icon={LibraryBig}
+                    title="No Activities Yet"
+                    subtitle="Create your first activity to launch a wall."
+                    iconClassName="text-brand-blue-primary"
+                    titleClassName="text-slate-800"
+                    subtitleClassName="text-slate-500"
                   />
-                  <p
-                    className="font-black text-slate-800"
-                    style={{
-                      fontSize: 'min(14px, 5.5cqmin)',
-                      marginTop: 'min(8px, 2cqmin)',
-                    }}
-                  >
-                    No activities yet
-                  </p>
-                  <p
-                    className="text-slate-500 font-medium"
-                    style={{ fontSize: 'min(11px, 3.6cqmin)' }}
-                  >
-                    Create your first activity to launch a wall.
-                  </p>
                 </div>
               ) : (
                 <div className="space-y-2">


### PR DESCRIPTION
## Canonical form
`<ScaledEmptyState icon={IconName} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx` — the shared, container-query-scaled empty state for widget front-face content.

## Instance unified
`components/widgets/ActivityWall/Widget.tsx` — the Activity Library's "No activities yet" hand-rolled empty state (`LibraryBig` icon + title + subtitle in a `bg-slate-50 rounded-xl border` card), a long-standing **VISUAL-RISK** backlog item (re-confirmed as recently as run 27) that was previously blocked on a real container-scoping issue: `ScaledEmptyState`'s `cqmin` sizing resolves against the nearest ancestor with `container-type: size`, which today is only established once at the whole-widget level. This empty state lives in a sub-panel shorter than the full widget (a header above it eats vertical space), so converting without a fix would size the icon/text off the taller outer widget box, not the actual available space — a real, visible size mismatch, not a cosmetic one.

**Fix applied**: added a `container-type: size` boundary scoped *only* to the empty-state branch's own wrapper div (not shared with the populated-list branch, which is a separate ternary arm) — so the previously-documented risk of "rescoping affecting other cqmin content in the same panel" doesn't apply here; the populated view's sizing is untouched. This same nested-container-boundary pattern is already established elsewhere in the codebase (`Checklist/Widget.tsx`, `MaterialsWidget/index.tsx`, `Stations/components/StationCard.tsx`, `ConceptWeb/Widget.tsx`), independently verified by grep before shipping.

The `bg-slate-50 rounded-xl border border-slate-200` card background is preserved via the outer wrapper div's className (not `ScaledEmptyState`'s own, which stays transparent by default) — `ScaledEmptyState` renders fully inside it at `h-full w-full`.

## Visual-preservation notes (disclosed honestly, not claimed as pixel-perfect)
- Icon, icon color (`text-brand-blue-primary`), title color (`text-slate-800`), subtitle color (`text-slate-500`), and the card background/border are all preserved via `iconClassName`/`titleClassName`/`subtitleClassName` overrides and the wrapper div.
- `ScaledEmptyState`'s title styling hardcodes `uppercase tracking-widest` — the original title ("No activities yet") was sentence-case with no letter-spacing; it will now render as "NO ACTIVITIES YET" with tracking. This is the same accepted canonical delta as prior shipped D1 conversions (e.g. `RandomGroups.tsx`, `WorkSymbols/Widget.tsx`) — adopting the shared component's established title treatment, not a regression.
- Minor cqmin-scaling-constant differences vs. the original hand-rolled values (title clamp `4cqmin` vs. original `5.5cqmin`, subtitle `3cqmin` vs. `3.6cqmin`; both keep the same px caps) — consistent with the "canonical alignment" precedent accepted in other D1/D3 conversions.

## Enforcement
None added — this converts an existing hand-rolled instance to the already-canonical shared component; no new bug class introduced.

## Risk tag: visual-risk (flagging for eyes-on review, despite the fix)
While the container-scoping fix and background-preservation are structurally sound and grep-verified against precedent, this was a previously-flagged VISUAL-RISK item specifically because of this exact class of bug — recommend a quick look at the rendered widget (e.g. preview deploy) before merging, not just trusting the code-level analysis.

## Validation
Both the shipping subagent and the orchestrator independently ran `pnpm run validate` (type-check, lint, format-check, 703 root tests + 703 functions tests, test-count guard) — green both times — and `pnpm run build` — green (Vite build + SSR prerender of /privacy, /terms, /support).

## Deferred (not part of this PR)
- `components/widgets/QuizWidget/components/QuizEditor.tsx:189-193` ("No questions yet" context-pane box) — investigated, but its original text-only/no-icon treatment matches the already-documented no-icon exception family (D1-E9/E15/E16/E17: converting would add an unwanted new icon + force uppercase title casing). Recommending this be formalized as a new intentional exception rather than converted — flagged for the memory doc, not touched here.
- `MiniApp/components/AssignmentsModal.tsx:123` / `SubmissionsModal.tsx:132` — remain VISUAL-RISK (no `container-type: size` boundary in their modal overlays), untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8Ti8WpkyQ9yf1dwSegxnT)_