### PR TITLE
D3: unify MusicWidget "Source" label onto SettingsLabel group-heading form

### DIFF
--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -120,6 +120,7 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const { stations, isLoading } = useMusicStations();
   const { layout = 'default', source = 'curated' } = config;
   const layoutLabelId = useId();
+  const sourceLabelId = useId();
 
   const activeStation = stations.find((s) => s.id === config.stationId);
   const isCuratedSpotify = activeStation?.url
@@ -135,8 +136,14 @@ export const MusicSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       {/* ── Source selector (gated behind personal-spotify feature) ── */}
       {canUsePersonal && (
         <div className="space-y-2">
-          <SettingsLabel icon={Music2}>Source</SettingsLabel>
-          <div className="grid grid-cols-2 gap-2">
+          <SettingsLabel as="span" icon={Music2} id={sourceLabelId}>
+            Source
+          </SettingsLabel>
+          <div
+            className="grid grid-cols-2 gap-2"
+            role="group"
+            aria-labelledby={sourceLabelId}
+          >
             {SOURCE_OPTIONS.map((opt) => {
               const isActive = source === opt.value;
               const Icon = opt.icon;


### PR DESCRIPTION
## Nightly Unifier — D3 Settings Panel Label Primitives

**Canonical form:** `<SettingsLabel as="span" id="...">Group Heading</SettingsLabel>` + `role="group" aria-labelledby="..."` on the sibling-controls container, for a `SettingsLabel` that heads a *group* of controls (no 1:1 control pairing) rather than the default `as="label"` form (which is correct only when the label pairs 1:1 with exactly one control).

**Instance unified:** `components/widgets/MusicWidget/Settings.tsx` — the "Source" label heads a 2-button `SOURCE_OPTIONS` group (curated/personal Spotify). This was the last of the originally-known retrofit candidates flagged in run 31/32's audit that hadn't yet been converted (DrawingWidget "Color Presets", RevealGrid "Columns", RandomSettings "Animation Style", and this same file's own "Layout" label were converted in runs 32–35).

Converted to:
```tsx
<SettingsLabel as="span" icon={Music2} id={sourceLabelId}>Source</SettingsLabel>
<div className="grid grid-cols-2 gap-2" role="group" aria-labelledby={sourceLabelId}>
  ...
</div>
```
`sourceLabelId = useId()`, matching this same file's existing `layoutLabelId` convention (correct here since `MusicSettings` mounts once per widget instance — a hardcoded static id would collide if 2+ MusicWidgets were both flipped to settings simultaneously).

**Enforcement:** none added — this is the last instance of a small, closed retrofit series (4 named candidates across runs 32–35, now all converted), not an open-ended recurring pattern needing a lint rule.

**Behavior/visual-preservation evidence:**
- `components/common/SettingsLabel.tsx` computes `combinedClasses` once, before branching on `as` — both the `<span>` and `<label>` render paths receive the identical class string (`text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2` + icon-flex layout). Only the wrapping tag and `htmlFor`/`role`/`aria-labelledby` semantics differ. Verified directly against source.
- `pnpm run validate`: type-check (root + functions) ✅, eslint `--max-warnings 0` (app + functions) ✅, Prettier ✅, root vitest 569/569 files / 6924 tests ✅, functions vitest 37/37 files / 703 tests ✅, `test:counts` guard ✅.
- `pnpm run build`: Vite build + SSR prerender ✅.
- Independently re-verified by the orchestrator: `tsc --noEmit`, `eslint --max-warnings 0` on the changed file, and `prettier --check` on the changed file, all clean.

**Risk tag:** mechanical (pure DOM-tag/ARIA-attribute equivalence — zero visual delta).

**Deferred to backlog (not touched this run):** D1/D2/D4/D5 all confirmed aligned this run (see the accompanying doc-log PR). New D3 group-heading candidates spotted for a future run: `random/RandomSettings.tsx:363` ("Operation Mode"), `RevealGrid/Settings.tsx:314` ("Game Mode") and `:357` ("Reveal Mode"), `SyntaxFramer/Settings.tsx:104` ("Mode") and `:158` ("Alignment").

🤖 Generated by the nightly SpartBoard consistency routine (Claude Code).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EHfZQE7BYouy5FqrZBpc5C)_