### PR TITLE
fix(Countdown): parse bare-date startDate/eventDate as local noon, not UTC midnight

### DIFF
--- a/components/widgets/Countdown/Widget.test.tsx
+++ b/components/widgets/Countdown/Widget.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CountdownWidget } from './Widget';
+import { parseConfigDate } from './utils';
 import { CountdownConfig, WidgetData, DEFAULT_GLOBAL_STYLE } from '@/types';
 import { useGlobalStyle } from '@/context/dashboardCanvasStore';
 
@@ -106,12 +107,29 @@ describe('CountdownWidget', () => {
   });
 });
 
-describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', () => {
-  // Overrides the suite's global TZ=UTC pin (tests/setTz.ts) — this bug only reproduces in a real non-UTC zone.
-  const originalTz = process.env.TZ;
+describe('parseConfigDate (bare-date UTC-midnight parsing regression)', () => {
+  it('anchors a bare YYYY-MM-DD string at local noon, not UTC midnight', () => {
+    // Timezone-independent: `new Date(year, month, day, 12)`'s own local
+    // getters always echo back what was constructed, in any process TZ.
+    // The pre-fix `new Date('2026-12-25')` parses as UTC midnight, which
+    // reads back as hour 0 (not 12) under this suite's TZ=UTC pin regardless
+    // of the host machine's real timezone.
+    const result = parseConfigDate('2026-12-25');
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(11);
+    expect(result.getDate()).toBe(25);
+    expect(result.getHours()).toBe(12);
+  });
 
+  it('falls through to plain Date parsing for full ISO timestamps', () => {
+    const result = parseConfigDate('2026-12-25T12:00:00.000Z');
+    expect(result.toISOString()).toBe('2026-12-25T12:00:00.000Z');
+  });
+});
+
+describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', () => {
   beforeEach(() => {
-    process.env.TZ = 'America/Chicago';
+    vi.stubEnv('TZ', 'America/Chicago');
     vi.mocked(useGlobalStyle).mockReturnValue({
       ...DEFAULT_GLOBAL_STYLE,
       fontFamily: 'sans',
@@ -123,7 +141,7 @@ describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', (
 
   afterEach(() => {
     vi.useRealTimers();
-    process.env.TZ = originalTz;
+    vi.unstubAllEnvs();
   });
 
   it('counts a bare-date eventDate against its intended local calendar day', () => {

--- a/components/widgets/Countdown/Widget.test.tsx
+++ b/components/widgets/Countdown/Widget.test.tsx
@@ -107,13 +107,7 @@ describe('CountdownWidget', () => {
 });
 
 describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', () => {
-  // config.startDate/eventDate can arrive as a bare "YYYY-MM-DD" string (raw
-  // admin building-config JSON, hand-edited dashboard imports) rather than the
-  // full-ISO-at-local-noon string the Settings picker writes. `new
-  // Date('YYYY-MM-DD')` parses as UTC midnight, which normalizeDate's local
-  // getters read as the PRIOR calendar day in any negative-UTC-offset
-  // timezone — so this only reproduces with a real non-UTC zone, not under
-  // the suite's global TZ=UTC pin (see tests/setTz.ts).
+  // Overrides the suite's global TZ=UTC pin (tests/setTz.ts) — this bug only reproduces in a real non-UTC zone.
   const originalTz = process.env.TZ;
 
   beforeEach(() => {
@@ -145,9 +139,6 @@ describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', (
     );
 
     // Dec 20 (today, CST) through Dec 24 counted, event lands on Dec 25 → 5.
-    // Before the fix, the bare "2026-12-25" parsed as UTC midnight reads as
-    // Dec 24, 6:00 PM CST — normalizeDate then floors it to Dec 24 local,
-    // one day early, so the widget showed 4.
     expect(screen.getByText('5')).toBeInTheDocument();
   });
 });

--- a/components/widgets/Countdown/Widget.test.tsx
+++ b/components/widgets/Countdown/Widget.test.tsx
@@ -105,3 +105,49 @@ describe('CountdownWidget', () => {
     expect(screen.queryByText('3')).not.toBeInTheDocument();
   });
 });
+
+describe('CountdownWidget bare-date config (UTC-midnight parsing regression)', () => {
+  // config.startDate/eventDate can arrive as a bare "YYYY-MM-DD" string (raw
+  // admin building-config JSON, hand-edited dashboard imports) rather than the
+  // full-ISO-at-local-noon string the Settings picker writes. `new
+  // Date('YYYY-MM-DD')` parses as UTC midnight, which normalizeDate's local
+  // getters read as the PRIOR calendar day in any negative-UTC-offset
+  // timezone — so this only reproduces with a real non-UTC zone, not under
+  // the suite's global TZ=UTC pin (see tests/setTz.ts).
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = 'America/Chicago';
+    vi.mocked(useGlobalStyle).mockReturnValue({
+      ...DEFAULT_GLOBAL_STYLE,
+      fontFamily: 'sans',
+    });
+    vi.useFakeTimers();
+    // 8:00 AM CST, Dec 20 2026 (14:00 UTC). December avoids DST ambiguity.
+    vi.setSystemTime(new Date('2026-12-20T14:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = originalTz;
+  });
+
+  it('counts a bare-date eventDate against its intended local calendar day', () => {
+    render(
+      <CountdownWidget
+        widget={buildWidget({
+          startDate: '2026-12-01T12:00:00.000Z',
+          eventDate: '2026-12-25',
+          countToday: true,
+          includeWeekends: true,
+        })}
+      />
+    );
+
+    // Dec 20 (today, CST) through Dec 24 counted, event lands on Dec 25 → 5.
+    // Before the fix, the bare "2026-12-25" parsed as UTC midnight reads as
+    // Dec 24, 6:00 PM CST — normalizeDate then floors it to Dec 24 local,
+    // one day early, so the widget showed 4.
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/components/widgets/Countdown/Widget.tsx
+++ b/components/widgets/Countdown/Widget.tsx
@@ -18,6 +18,25 @@ const normalizeDate = (value: Date): Date => {
   return normalized;
 };
 
+const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// `config.startDate`/`config.eventDate` are written two different ways: a bare
+// "YYYY-MM-DD" string (raw admin building-config JSON, hand-edited dashboard
+// imports, older data) or a full ISO timestamp anchored at local noon (the
+// Settings picker, via parseLocalDateInput). `new Date('YYYY-MM-DD')` parses
+// as UTC midnight per spec — normalizeDate's local getters then read that as
+// the PRIOR calendar day in any negative-UTC-offset timezone (all US zones).
+// Parsing bare dates as local noon (matching Settings) keeps both forms
+// resolving to the same intended calendar day everywhere.
+const parseConfigDate = (value: string): Date => {
+  const match = BARE_DATE_RE.exec(value);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(Number(year), Number(month) - 1, Number(day), 12);
+  }
+  return new Date(value);
+};
+
 const isWeekendDate = (value: Date): boolean => {
   const dayOfWeek = value.getDay();
   return dayOfWeek === 0 || dayOfWeek === 6;
@@ -60,8 +79,8 @@ export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
   }, []);
 
   const calculatedDays = useMemo(() => {
-    const start = normalizeDate(new Date(startDate));
-    const event = normalizeDate(new Date(eventDate));
+    const start = normalizeDate(parseConfigDate(startDate));
+    const event = normalizeDate(parseConfigDate(eventDate));
     const todayAtMidnight = new Date(todayMidnightMs);
 
     const countStart = new Date(
@@ -91,8 +110,8 @@ export const CountdownWidget: React.FC<{ widget: WidgetData }> = ({
   }, [startDate, eventDate, includeWeekends, countToday, todayMidnightMs]);
 
   const gridData = useMemo(() => {
-    const start = normalizeDate(new Date(startDate));
-    const event = normalizeDate(new Date(eventDate));
+    const start = normalizeDate(parseConfigDate(startDate));
+    const event = normalizeDate(parseConfigDate(eventDate));
     const today = new Date(todayMidnightMs);
     const countStart = new Date(Math.max(today.getTime(), start.getTime()));
 

--- a/components/widgets/Countdown/Widget.tsx
+++ b/components/widgets/Countdown/Widget.tsx
@@ -3,6 +3,7 @@ import { WidgetData, CountdownConfig } from '@/types';
 import { WidgetLayout } from '../WidgetLayout';
 import { getFontClass, hexToRgba } from '@/utils/styles';
 import { useGlobalStyle } from '@/context/dashboardCanvasStore';
+import { parseConfigDate } from './utils';
 
 interface CountdownDay {
   date: Date;
@@ -16,18 +17,6 @@ const normalizeDate = (value: Date): Date => {
   const normalized = new Date(value);
   normalized.setHours(0, 0, 0, 0);
   return normalized;
-};
-
-const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
-
-// Bare "YYYY-MM-DD" values parse as UTC midnight, which normalizeDate's local getters then read as the prior calendar day in negative-UTC-offset zones.
-const parseConfigDate = (value: string): Date => {
-  const match = BARE_DATE_RE.exec(value);
-  if (match) {
-    const [, year, month, day] = match;
-    return new Date(Number(year), Number(month) - 1, Number(day), 12);
-  }
-  return new Date(value);
 };
 
 const isWeekendDate = (value: Date): boolean => {

--- a/components/widgets/Countdown/Widget.tsx
+++ b/components/widgets/Countdown/Widget.tsx
@@ -20,14 +20,7 @@ const normalizeDate = (value: Date): Date => {
 
 const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
 
-// `config.startDate`/`config.eventDate` are written two different ways: a bare
-// "YYYY-MM-DD" string (raw admin building-config JSON, hand-edited dashboard
-// imports, older data) or a full ISO timestamp anchored at local noon (the
-// Settings picker, via parseLocalDateInput). `new Date('YYYY-MM-DD')` parses
-// as UTC midnight per spec — normalizeDate's local getters then read that as
-// the PRIOR calendar day in any negative-UTC-offset timezone (all US zones).
-// Parsing bare dates as local noon (matching Settings) keeps both forms
-// resolving to the same intended calendar day everywhere.
+// Bare "YYYY-MM-DD" values parse as UTC midnight, which normalizeDate's local getters then read as the prior calendar day in negative-UTC-offset zones.
 const parseConfigDate = (value: string): Date => {
   const match = BARE_DATE_RE.exec(value);
   if (match) {

--- a/components/widgets/Countdown/utils.ts
+++ b/components/widgets/Countdown/utils.ts
@@ -1,0 +1,11 @@
+const BARE_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// Bare "YYYY-MM-DD" values parse as UTC midnight, which normalizeDate's local getters then read as the prior calendar day in negative-UTC-offset zones.
+export const parseConfigDate = (value: string): Date => {
+  const match = BARE_DATE_RE.exec(value);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(Number(year), Number(month) - 1, Number(day), 12);
+  }
+  return new Date(value);
+};


### PR DESCRIPTION
## Root cause

`components/widgets/Countdown/Widget.tsx` parsed `config.startDate`/`config.eventDate` with a bare `new Date(value)`. When the stored value is a bare `"YYYY-MM-DD"` string (written by raw admin building-config JSON, or hand-edited dashboard imports), JS parses that as **UTC midnight**. `normalizeDate()` then floors that instant using *local* getters, which lands on the **prior calendar day** in any negative-UTC-offset timezone — i.e. every US timezone. `CountdownSettings.tsx` already had a defensive bare-date branch (`parseLocalDateInput`, anchoring at local noon) for its own date-input display, but `Widget.tsx` — the actual classroom-facing countdown — never got the equivalent treatment, so the headline count and grid highlighting were off by one day whenever a bare date made it into config.

## Fix

Added a `parseConfigDate()` helper that anchors bare `"YYYY-MM-DD"` strings at local noon (matching the Settings panel's existing `parseLocalDateInput` approach), falling through to plain `new Date(value)` for full ISO timestamps. Applied at all 4 call sites in `Widget.tsx` (`calculatedDays` and `gridData`, start + event each) — one fix, not four ad-hoc patches.

## Band-aid rejected

Special-casing the render output (e.g. nudging the day count when a bare string is detected) would have papered over the symptom at one call site and left the parsing ambiguity itself intact for any future consumer of these config fields.

## Regression test

`components/widgets/Countdown/Widget.test.tsx` — simulates a `America/Chicago` teacher with a bare-date `eventDate`.
- **Before fix:** test fails — widget renders `4` (event misread as one day early).
- **After fix:** test passes — widget renders `5` (correct count against the intended local calendar day).
- Verified independently by the orchestrator: reverted only the source file to `dev-paul`, confirmed the test fails; restored the fix, confirmed it passes.

## Validation

- `pnpm run validate` — pass (type-check, lint, format, root + functions test suites, test-count guard)
- `pnpm run build` — pass

**Risk:** contained (single widget, isolated date-parsing helper).

---
🤖 Nightly code-health run — orchestrated by Claude Code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DYzHXdbjXHWv3AsJ1RjMpt)_