### PR TITLE
fix(FolderTree): dismiss the folder overflow menu on outside click/Escape

### DIFF
--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -22,6 +22,8 @@ import {
 } from 'lucide-react';
 import { useDroppable } from '@dnd-kit/core';
 import type { LibraryFolder } from '@/types';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 import { folderDroppableId, type FolderDropData } from './folderDropTargets';
 import { useFolderPanelMode } from './LibraryFolderPanelContext';
 
@@ -191,6 +193,26 @@ const FolderRow: React.FC<FolderRowProps> = ({
   });
   const isOver = enableDrop && droppable.isOver;
 
+  // The overflow popover has no backdrop, so a click anywhere else on the
+  // page (another folder row, the item grid, a different widget) must
+  // dismiss it — every other kebab/overflow menu in this codebase does this
+  // (e.g. SidebarPlcs's PlcRow). `menuRef` is only attached while the popover
+  // is rendered, so `useClickOutside` is a no-op (ref.current is null) when
+  // the menu is closed.
+  const menuRef = useRef<HTMLDivElement>(null);
+  const kebabRef = useRef<HTMLButtonElement>(null);
+  useClickOutside(menuRef, () => onOpenMenu(null), [kebabRef]);
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      onOpenMenu(null);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isMenuOpen, onOpenMenu]);
+
   // Rail mode: render a single icon button per folder so the tiny rail is
   // still navigable. Nesting/rename/menu affordances are suppressed; the
   // user can expand the panel to access them.
@@ -356,6 +378,7 @@ const FolderRow: React.FC<FolderRowProps> = ({
             </span>
           )}
           <button
+            ref={kebabRef}
             type="button"
             onClick={(e) => {
               e.stopPropagation();
@@ -379,6 +402,7 @@ const FolderRow: React.FC<FolderRowProps> = ({
       {/* Overflow menu popover. */}
       {isMenuOpen && (
         <div
+          ref={menuRef}
           role="menu"
           onClick={(e) => e.stopPropagation()}
           className="absolute right-1 top-full mt-1 z-20 min-w-[160px] rounded-xl bg-white shadow-xl border border-slate-200 p-1 text-sm"

--- a/tests/components/common/library/FolderTree.menuDismiss.test.tsx
+++ b/tests/components/common/library/FolderTree.menuDismiss.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Regression test: a folder row's kebab overflow menu (Rename / New
+ * subfolder / Move to root / Delete) must dismiss when the user interacts
+ * outside it — clicking another folder row, the item grid, or anywhere else
+ * in the widget, or pressing Escape.
+ *
+ * BUG: `FolderRow` (components/common/library/FolderTree.tsx) toggled
+ * `openMenuId` only from the kebab button itself and from the menu's own
+ * item buttons. There was no outside-click or Escape listener, unlike every
+ * other kebab/overflow menu in this codebase (e.g. SidebarPlcs's PlcRow uses
+ * `useClickOutside` + an Escape `keydown` listener). `FolderSidebar` is
+ * wired into the Quiz/Video Activity/Guided Learning/Mini App library
+ * managers, so a teacher opening a folder's actions menu and then clicking
+ * anywhere else on the widget would find the menu still floating open.
+ *
+ * FIX: `FolderRow` now attaches `useClickOutside` (ignoring the kebab
+ * button itself) plus an Escape `keydown` listener, both of which call
+ * `onOpenMenu(null)` — matching the PlcRow pattern.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { LibraryFolder } from '@/types';
+import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+
+// Mock @dnd-kit/core to avoid needing a full DndContext in unit tests.
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+const makeFolder = (id: string, name: string): LibraryFolder => ({
+  id,
+  name,
+  parentId: null,
+  order: 0,
+  createdAt: 0,
+});
+
+describe('FolderTree — overflow menu dismissal', () => {
+  it('closes the menu on an outside click', () => {
+    render(
+      <FolderSidebar
+        widget="quiz"
+        folders={[makeFolder('f1', 'Unit 2')]}
+        selectedFolderId={null}
+        onSelectFolder={vi.fn()}
+        itemCounts={{}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Unit 2' }));
+    expect(
+      screen.getByRole('menuitem', { name: 'Rename' })
+    ).toBeInTheDocument();
+
+    // Click somewhere else entirely — e.g. the "All items" row.
+    fireEvent.pointerDown(screen.getByRole('button', { name: /all items/i }));
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Rename' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on Escape', () => {
+    render(
+      <FolderSidebar
+        widget="quiz"
+        folders={[makeFolder('f1', 'Unit 2')]}
+        selectedFolderId={null}
+        onSelectFolder={vi.fn()}
+        itemCounts={{}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Unit 2' }));
+    expect(
+      screen.getByRole('menuitem', { name: 'Rename' })
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(
+      screen.queryByRole('menuitem', { name: 'Rename' })
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Root cause

`FolderRow`'s kebab overflow menu (Rename / New subfolder / Move to root / Delete) in `components/common/library/FolderTree.tsx` only closed via its own kebab toggle or one of its own menu items — there was no outside-click or Escape handler, unlike every other kebab/overflow menu in this codebase (e.g. `SidebarPlcs`'s `PlcRow`, which uses `useClickOutside` plus an Escape `keydown` listener).

`FolderSidebar`/`FolderTree` is wired into `QuizManager`, `VideoActivityManager`, `GuidedLearningManager`, and `MiniAppManager` — all live, everyday teacher surfaces — so opening a folder's actions menu and then clicking anywhere else in the widget (another folder, the item grid, etc.) left the menu floating open indefinitely.

## Fix

Added `useClickOutside` (ignoring the kebab button) and an Escape `keydown` listener to `FolderRow`, matching the established `PlcRow` pattern exactly. Both are no-ops while the menu is closed (`menuRef` is null).

## Band-aid rejected

None needed — this is the already-proven, established pattern used by every other overflow menu in the codebase; there was no alternative shortcut worth taking instead of applying it here too.

## Regression test

`tests/components/common/library/FolderTree.menuDismiss.test.tsx` — renders `FolderSidebar` (the real stateful owner), opens a folder's menu, and asserts it closes on (1) a click elsewhere in the sidebar and (2) Escape.
- **Before fix:** both assertions fail — the menu stays open in both cases.
- **After fix:** both pass; full pre-existing `FolderTree`/`FolderSidebar` suite (11/11) still passes, no regressions.
- Verified independently by the orchestrator: reverted only the source file to `dev-paul`, confirmed both new assertions fail; restored the fix, confirmed both pass.

## Note on scope

An earlier draft of this fix targeted `PeriodSelector.tsx`'s Escape handling (same missing-guard bug class), but that component currently has zero live consumers anywhere in the app (dead/staged code pending future wiring) — discarded in favor of this genuinely reachable bug and logged as a backlog item instead.

## Validation

- `pnpm run validate` — pass (type-check, lint, format, root + functions test suites, test-count guard)
- `pnpm run build` — pass

**Risk:** contained (single shared component, isolated dismissal-guard addition mirroring an existing pattern).

---
🤖 Nightly code-health run — orchestrated by Claude Code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DYzHXdbjXHWv3AsJ1RjMpt)_