### PR TITLE
fix(i18n): ES sidebar.nav.plcs + plc.errors — PLC acronym drift to Comunidad

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -82,7 +82,7 @@
       "boards": "Tableros",
       "backgrounds": "Fondos",
       "classes": "Mis Clases",
-      "plcs": "Mis PLCs",
+      "plcs": "Mis Comunidades",
       "widgets": "Widgets",
       "globalStyle": "Estilo Global",
       "generalSettings": "Ajustes Generales",
@@ -273,17 +273,17 @@
   "plc": {
     "errors": {
       "notSignedIn": "Debes iniciar sesión para hacer eso.",
-      "nameRequired": "Se requiere el nombre de la PLC.",
-      "accountEmailRequired": "Se requiere un correo electrónico de cuenta para crear una PLC.",
-      "plcNotFound": "PLC no encontrada.",
-      "leadCannotLeave": "El líder debe transferir el liderazgo antes de abandonar la PLC.",
-      "leadCannotBeRemoved": "No se puede eliminar al líder; transfiere el liderazgo o elimina la PLC.",
-      "notAMember": "Esa persona no es miembro de esta PLC.",
+      "nameRequired": "Se requiere el nombre de la Comunidad.",
+      "accountEmailRequired": "Se requiere un correo electrónico de cuenta para crear una Comunidad.",
+      "plcNotFound": "Comunidad no encontrada.",
+      "leadCannotLeave": "El líder debe transferir el liderazgo antes de abandonar la Comunidad.",
+      "leadCannotBeRemoved": "No se puede eliminar al líder; transfiere el liderazgo o elimina la Comunidad.",
+      "notAMember": "Esa persona no es miembro de esta Comunidad.",
       "targetNotActiveMember": "Solo puedes transferir el liderazgo a un miembro activo.",
-      "cannotDemoteLead": "Usa «Transferir liderazgo» para cambiar quién lidera la PLC.",
-      "invalidRole": "Ese no es un rol válido de la PLC.",
-      "alreadyLead": "Ese miembro ya es el líder de esta PLC.",
-      "orgRequired": "Las PLC solo están disponibles para los miembros de una organización."
+      "cannotDemoteLead": "Usa «Transferir liderazgo» para cambiar quién lidera la Comunidad.",
+      "invalidRole": "Ese no es un rol válido de la Comunidad.",
+      "alreadyLead": "Ese miembro ya es el líder de esta Comunidad.",
+      "orgRequired": "Las Comunidades solo están disponibles para los miembros de una organización."
     }
   },
   "plcDashboard": {

--- a/tests/i18n/esPlcErrorsComunidadTerminologyLocales.test.ts
+++ b/tests/i18n/esPlcErrorsComunidadTerminologyLocales.test.ts
@@ -1,0 +1,127 @@
+// ES locale's `sidebar.nav.plcs` label and `plc.errors.*` namespace used the untranslated
+// English acronym "PLC" instead of the project's established Spanish term "Comunidad" (see
+// plcDashboard.subtitle: "Panel de la Comunidad", sidebar.plcs.* — e.g. sidebar.plcs.yourPlcs:
+// "Tus Comunidades" — and plcDashboard.members.*). This is the ES sibling of the DE PLC->PLG
+// drift fixed in dePlcErrorsPlgTerminologyLocales.test.ts (#2193): a separate namespace from
+// plcDashboard (covered by esPlcDashboardComunidadLocales.test.ts / #2214), so it needs its own
+// scoped recursive scan to avoid conflicting with legitimately-scoped "PLC" usage elsewhere in
+// es.json (e.g. admin.plc.recovery, an admin-only namespace that intentionally keeps "PLC").
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+
+/** Dotted path walker — returns the leaf string or undefined. */
+function getLeaf(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
+/** Recursively collects [path, value] pairs for every string leaf. */
+function collectStrings(
+  obj: unknown,
+  path: string,
+  out: Array<[string, string]>
+): void {
+  if (obj == null || typeof obj !== 'object') return;
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const p = path ? `${path}.${key}` : key;
+    if (typeof value === 'string') {
+      out.push([p, value]);
+    } else if (value && typeof value === 'object') {
+      collectStrings(value, p, out);
+    }
+  }
+}
+
+const AFFECTED_KEYS: Array<{ path: string; expectedEs: string }> = [
+  { path: 'sidebar.nav.plcs', expectedEs: 'Mis Comunidades' },
+  {
+    path: 'plc.errors.nameRequired',
+    expectedEs: 'Se requiere el nombre de la Comunidad.',
+  },
+  {
+    path: 'plc.errors.accountEmailRequired',
+    expectedEs:
+      'Se requiere un correo electrónico de cuenta para crear una Comunidad.',
+  },
+  { path: 'plc.errors.plcNotFound', expectedEs: 'Comunidad no encontrada.' },
+  {
+    path: 'plc.errors.leadCannotLeave',
+    expectedEs:
+      'El líder debe transferir el liderazgo antes de abandonar la Comunidad.',
+  },
+  {
+    path: 'plc.errors.leadCannotBeRemoved',
+    expectedEs:
+      'No se puede eliminar al líder; transfiere el liderazgo o elimina la Comunidad.',
+  },
+  {
+    path: 'plc.errors.notAMember',
+    expectedEs: 'Esa persona no es miembro de esta Comunidad.',
+  },
+  {
+    path: 'plc.errors.cannotDemoteLead',
+    expectedEs:
+      'Usa «Transferir liderazgo» para cambiar quién lidera la Comunidad.',
+  },
+  {
+    path: 'plc.errors.invalidRole',
+    expectedEs: 'Ese no es un rol válido de la Comunidad.',
+  },
+  {
+    path: 'plc.errors.alreadyLead',
+    expectedEs: 'Ese miembro ya es el líder de esta Comunidad.',
+  },
+  {
+    path: 'plc.errors.orgRequired',
+    expectedEs:
+      'Las Comunidades solo están disponibles para los miembros de una organización.',
+  },
+];
+
+describe('EN locale — affected keys baseline', () => {
+  it.each(AFFECTED_KEYS)('en.$path exists', ({ path }) => {
+    expect(getLeaf(en, path), `en.${path} is missing`).toBeDefined();
+  });
+});
+
+describe('ES locale — "PLC" terminology replaced with "Comunidad" in sidebar.nav.plcs / plc.errors', () => {
+  it.each(AFFECTED_KEYS)(
+    'es.$path is the Comunidad-based translation, not the PLC drift',
+    ({ path, expectedEs }) => {
+      const value = getLeaf(es, path);
+      expect(value, `es.${path} is missing`).toBeDefined();
+      expect(
+        value,
+        `es.${path} should be "${expectedEs}" (this namespace's established Spanish term is ` +
+          `"Comunidad", not the untranslated English acronym "PLC") but got "${value}"`
+      ).toBe(expectedEs);
+    }
+  );
+
+  it('has no remaining "PLC"/"PLCs" usages in plc.errors', () => {
+    const all: Array<[string, string]> = [];
+    collectStrings(
+      (es as unknown as { plc: { errors: unknown } }).plc.errors,
+      'plc.errors',
+      all
+    );
+    const offenders = all.filter(([, value]) => /\bPLCs?\b/i.test(value));
+    expect(
+      offenders,
+      `Found ${offenders.length} ES plc.errors value(s) using the untranslated acronym "PLC" ` +
+        `instead of the established "Comunidad" translation: ` +
+        `${offenders.map(([p, v]) => `${p}="${v}"`).join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('sidebar.nav.plcs has no remaining "PLC"/"PLCs" usage', () => {
+    const value = getLeaf(es, 'sidebar.nav.plcs') ?? '';
+    expect(/\bPLCs?\b/i.test(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause

`locales/es.json`'s `sidebar.nav.plcs` ("Mis PLCs") and 10 of the 12 leaf strings in `plc.errors.*` used the raw, untranslated English acronym "PLC" instead of the Spanish locale's established term "Comunidad" (established elsewhere: `plcDashboard.subtitle` = "Panel de la Comunidad", `sidebar.plcs.yourPlcs` = "Tus Comunidades"). This is the ES sibling of the DE "PLC"→"PLG" drift already fixed for this exact namespace (#2193) — that fix covered DE only; the ES leg of `plc.errors`/`sidebar.nav.plcs` (distinct from the separately-fixed `plcDashboard` namespace, #2214) was never addressed. i18next resolves whatever value is stored regardless of correctness (`defaultValue` only fires when a key is absent), so this was silently shown to every ES teacher interacting with PLC membership actions (create/leave/transfer/remove) and the sidebar nav label.

## Fix

Pure terminology swap of "PLC"/"PLCs" → "Comunidad"/"Comunidades" (with existing gender agreement already correct) across `sidebar.nav.plcs` and the 10 drifted `plc.errors.*` keys. The remaining 2 `plc.errors` keys (`notSignedIn`, `targetNotActiveMember`) contained no "PLC" and were correctly left untouched.

## Band-aid rejected

Patching only `sidebar.nav.plcs` (the smallest, most visible instance) and leaving `plc.errors.*` alone — rejected because the error strings are user-facing (toast/dialog copy shown on real membership-mutation failures) and are the same bug class in the same feature area; fixing only the nav label would leave 10 more silent English-acronym leaks for the identical root cause.

## Regression test

`tests/i18n/esPlcErrorsComunidadTerminologyLocales.test.ts` — modeled on the established `dePlcErrorsPlgTerminologyLocales.test.ts` pattern: per-key exact-value assertions plus a recursive "no remaining PLC" sweep scoped only to `sidebar.nav.plcs` + `plc.errors` (deliberately not whole-file, to avoid false-positiving on the legitimately-untranslated `admin.plc.recovery` namespace).
- **Before fix:** 13/24 assertions fail.
- **After fix:** 24/24 pass.
- Verified independently by the orchestrator: reverted only `locales/es.json` to `dev-paul`, confirmed 13/24 fail; restored the fix, confirmed 24/24 pass.

## Validation

- `pnpm run validate` — pass (type-check, lint, format, root + functions test suites, test-count guard)
- `pnpm run build` — pass

## Backlog (not fixed tonight, logged for a future run)

- FR `sidebar.nav.plcs` ("Mes PLCs") — same drift, should be "CAP" (FR's `plc.errors.*` already correct).
- ES `plcRoute.*` and `plcDirectory.*` — same "PLC" drift, same gap in test coverage.

**Risk:** contained (locale file + scoped test only).

---
🤖 Nightly code-health run — orchestrated by Claude Code.
