### PR TITLE
fix(gcPlcOrphans): paginate PLC/synced-group sweeps past the first page

### DIFF
--- a/functions/src/gcPlcOrphans.test.ts
+++ b/functions/src/gcPlcOrphans.test.ts
@@ -29,7 +29,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('firebase-admin', () => ({
   apps: [{ name: '[DEFAULT]' }],
   initializeApp: vi.fn(),
-  firestore: vi.fn(),
+  // The sweep paginates with admin.firestore.FieldPath.documentId(); expose it
+  // as the '__name__' sentinel so the stub ColRef.orderBy gets a stable value
+  // (the stub sorts a documentId()-ordered query by doc id — see makeStubDb).
+  firestore: Object.assign(vi.fn(), {
+    FieldPath: { documentId: vi.fn(() => '__name__') },
+  }),
 }));
 
 // `./functionsInit` calls `setGlobalOptions` at import time.
@@ -55,6 +60,8 @@ import {
   ACTIVITY_RETENTION_MS,
   VERSION_HISTORY_LIMIT,
   SOFT_DELETE_SUBCOLLECTIONS,
+  PLC_PAGE_SIZE,
+  GROUP_PAGE_SIZE,
 } from './gcPlcOrphans';
 
 // ===========================================================================
@@ -194,10 +201,14 @@ interface StubDoc {
 
 /**
  * In-memory Firestore mirroring the Admin SDK surface `runGcPlcOrphans` uses:
- *   db.collection(name).limit(n).get() → { docs, size }
+ *   db.collection(name).orderBy(FieldPath.documentId()).limit(n).startAfter(d).get()
  *   docSnap.ref.collection('versions').get()
  *   db.batch().delete(ref).commit()
  * Deletes mutate the backing arrays so post-sweep assertions read true state.
+ * `orderBy`/`startAfter` mirror `plcWeeklyDigest.test.ts`'s stub: sort by doc
+ * id ascending (the '__name__' sentinel the mocked FieldPath.documentId()
+ * returns) and slice past the cursor doc — this is what actually exercises
+ * cross-page pagination in the regression tests below.
  */
 function makeStubDb(seed: {
   plcs?: StubDoc[];
@@ -219,6 +230,8 @@ function makeStubDb(seed: {
   }
   interface CollectionRef {
     limit: (n: number) => CollectionRef;
+    orderBy: (field: unknown) => CollectionRef;
+    startAfter: (cursor: DocSnap) => CollectionRef;
     get: () => Promise<{ docs: DocSnap[]; size: number }>;
   }
   interface DocSnap {
@@ -239,13 +252,23 @@ function makeStubDb(seed: {
 
   const makeCollectionRef = (
     backing: StubDoc[],
-    limit = Infinity
+    opts: { lim?: number; ordered?: boolean; afterId?: string } = {}
   ): CollectionRef => ({
-    limit: (n: number) => makeCollectionRef(backing, n),
+    limit: (n: number) => makeCollectionRef(backing, { ...opts, lim: n }),
+    orderBy: () => makeCollectionRef(backing, { ...opts, ordered: true }),
+    startAfter: (cursor: DocSnap) =>
+      makeCollectionRef(backing, { ...opts, afterId: cursor.id }),
     get: () => {
-      const slice = backing.slice(
+      let rows = opts.ordered
+        ? [...backing].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+        : [...backing];
+      if (opts.afterId !== undefined) {
+        const i = rows.findIndex((d) => d.id === opts.afterId);
+        if (i >= 0) rows = rows.slice(i + 1);
+      }
+      const slice = rows.slice(
         0,
-        limit === Infinity ? backing.length : limit
+        opts.lim === undefined ? rows.length : opts.lim
       );
       return Promise.resolve({
         size: slice.length,
@@ -488,6 +511,86 @@ describe('runGcPlcOrphans — full sweep summary', () => {
     // A second run on the now-clean DB still deletes nothing.
     const second = await runGcPlcOrphans(db, NOW);
     expect(second).toEqual(counts);
+  });
+});
+
+// ===========================================================================
+// 3. Pagination regressions — a PLC/group past the first page must still be
+//    swept. Before the fix, `runGcPlcOrphans` read a single un-paginated
+//    `.limit()` page per collection, so anything past PLC_PAGE_SIZE /
+//    GROUP_PAGE_SIZE was silently never visited by ANY run, forever (the
+//    exact bug `plcWeeklyDigest` was already fixed for — see its "Fixes the
+//    prior single limit() page" comment).
+// ===========================================================================
+
+describe('runGcPlcOrphans — PLC pagination past the first page', () => {
+  it('sweeps stale presence in a PLC beyond PLC_PAGE_SIZE, not just the first page', async () => {
+    // One PLC per id 'plc-000' .. 'plc-{PLC_PAGE_SIZE}', each with a single
+    // stale presence doc. Zero-padded ids sort lexicographically in doc-id
+    // order, matching the production orderBy(FieldPath.documentId()) cursor.
+    const total = PLC_PAGE_SIZE + 5;
+    const plcs = Array.from({ length: total }, (_, i) => ({
+      id: `plc-${String(i).padStart(6, '0')}`,
+      data: {},
+      sub: {
+        presence: [
+          { id: 'stale', data: { lastActiveAt: NOW - 10 * 60 * 1000 } },
+        ],
+      },
+    }));
+    const { db, root } = makeStubDb({ plcs });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    // Every PLC's stale presence doc must be pruned in a single run — not
+    // just the first PLC_PAGE_SIZE of them.
+    expect(counts.presence).toBe(total);
+    for (const plc of root.plcs) {
+      expect(plc.sub!.presence).toHaveLength(0);
+    }
+  });
+});
+
+describe('runGcPlcOrphans — synced-group pagination past the first page', () => {
+  it('reaps empty groups beyond GROUP_PAGE_SIZE, not just the first page', async () => {
+    const total = GROUP_PAGE_SIZE + 5;
+    const synced_quizzes = Array.from({ length: total }, (_, i) => ({
+      id: `grp-${String(i).padStart(6, '0')}`,
+      data: { participants: {} },
+    }));
+    const { db, root } = makeStubDb({ synced_quizzes });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    expect(counts.emptyGroups).toBe(total);
+    expect(root.synced_quizzes).toHaveLength(0);
+  });
+
+  it('trims version overflow for a group beyond GROUP_PAGE_SIZE, not just the first page', async () => {
+    const versions = Array.from({ length: 13 }, (_, i) => ({
+      id: String(i + 1),
+      data: { version: i + 1 },
+    }));
+    // Pad the target group's version-overflow victim to the very end of the
+    // collection (past GROUP_PAGE_SIZE) with filler live groups ahead of it.
+    const filler = Array.from({ length: GROUP_PAGE_SIZE + 5 }, (_, i) => ({
+      id: `filler-${String(i).padStart(6, '0')}`,
+      data: { participants: { uidA: { joinedAt: 1 } } },
+    }));
+    const target = {
+      id: 'zzz-target',
+      data: { participants: { uidA: { joinedAt: 1 } } },
+      sub: { versions },
+    };
+    const { db, root } = makeStubDb({
+      synced_quizzes: [...filler, target],
+    });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    expect(counts.versionOverflow).toBe(3);
+    const targetDoc = root.synced_quizzes.find((d) => d.id === 'zzz-target')!;
+    expect(targetDoc.sub!.versions).toHaveLength(VERSION_HISTORY_LIMIT);
   });
 });
 

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -272,6 +272,11 @@ async function sweepEmptyGroups(db: Firestore): Promise<number> {
       lastDoc = page.docs[page.docs.length - 1];
       if (page.size < GROUP_PAGE_SIZE) break;
     }
+    if (visited >= MAX_GROUPS_PER_RUN) {
+      console.warn(
+        `[gcPlcOrphans] hit MAX_GROUPS_PER_RUN ceiling (${MAX_GROUPS_PER_RUN}) on ${collection} — raise it or shard the sweep`
+      );
+    }
   }
   return total;
 }
@@ -395,6 +400,11 @@ export async function runGcPlcOrphans(
 
       lastGroupDoc = page.docs[page.docs.length - 1];
       if (page.size < GROUP_PAGE_SIZE) break;
+    }
+    if (groupsVisited >= MAX_GROUPS_PER_RUN) {
+      console.warn(
+        `[gcPlcOrphans] hit MAX_GROUPS_PER_RUN ceiling (${MAX_GROUPS_PER_RUN}) on ${collection} — raise it or shard the sweep`
+      );
     }
   }
 

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -40,8 +40,12 @@
  *       publish); this sweeps any overflow that publish-time pruning missed
  *       (e.g. a publish that crashed before pruning).
  *
- * PLCs are iterated via a BOUNDED collection scan (cap per run) — the sweep is
- * idempotent and any PLCs not reached this run are picked up the next night.
+ * PLCs (and synced groups) are iterated via a PAGINATED collection scan
+ * (startAfter cursor on document id, mirrors `plcWeeklyDigest`), so every PLC
+ * up to the MAX_PLCS_PER_RUN safety ceiling is visited every run — not just
+ * the first page. The sweep is also idempotent, so a run that hits the
+ * ceiling (an unrealistically large tenant) picks up where pagination would
+ * have continued on the next scheduled run.
  *
  * All time comparisons go through tolerant parsers: a field may be a Firestore
  * `Timestamp` (the canonical serverTimestamp write) OR a legacy numeric millis
@@ -68,11 +72,31 @@ export const TOMBSTONE_GRACE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 /** Bounded version-history depth (mirrors `VERSION_HISTORY_LIMIT` client-side). */
 export const VERSION_HISTORY_LIMIT = 10;
 
-/** Max PLCs visited per run — keeps one sweep from monopolising the slot. */
-export const MAX_PLCS_PER_RUN = 200;
+/**
+ * Overall safety ceiling on PLCs visited per run — a runaway guard, NOT an
+ * expected limit. The sweep PAGINATES (PLC_PAGE_SIZE pages, startAfter
+ * cursor — mirrors `plcWeeklyDigest`'s fix for the identical bug), so every
+ * PLC up to this ceiling is covered every run; set far above any realistic
+ * single-district tenant. Prior to this, a single un-paginated `.limit()`
+ * page meant any PLC past the cap was silently never visited by ANY nightly
+ * run (activity/presence/tombstones for it would grow unbounded forever).
+ */
+export const MAX_PLCS_PER_RUN = 5000;
 
-/** Max synced groups (per collection) scanned per run for empty-group reaping. */
-export const MAX_GROUPS_PER_RUN = 500;
+/** Page size for the paginated PLC sweep (startAfter cursor on document id). */
+export const PLC_PAGE_SIZE = 200;
+
+/**
+ * Overall safety ceiling on synced groups (per collection) visited per run —
+ * same rationale as `MAX_PLCS_PER_RUN`. The empty-group reap and
+ * version-overflow sweeps both paginate (GROUP_PAGE_SIZE pages, startAfter
+ * cursor) so a group past the old single-page cap is no longer permanently
+ * unreachable.
+ */
+export const MAX_GROUPS_PER_RUN = 5000;
+
+/** Page size for the paginated synced-group sweeps (startAfter cursor on document id). */
+export const GROUP_PAGE_SIZE = 500;
 
 /** Max doc deletes per category per PLC per run (defensive batching). */
 export const MAX_DELETES_PER_CATEGORY = 500;
@@ -216,23 +240,37 @@ async function deleteRefs(
 /**
  * Reap empty synced groups across both canonical collections. A group is
  * deleted only when its `participants` map is empty (no teacher still shares
- * it). Bounded by `MAX_GROUPS_PER_RUN` per collection.
+ * it). Paginated (startAfter cursor on document id) so every group up to
+ * `MAX_GROUPS_PER_RUN` is visited, not just the first `GROUP_PAGE_SIZE` —
+ * a single un-paginated page silently starved any group past the cap forever.
  */
 async function sweepEmptyGroups(db: Firestore): Promise<number> {
   let total = 0;
   for (const collection of SYNCED_GROUP_COLLECTIONS) {
-    const snap = await db
-      .collection(collection)
-      .limit(MAX_GROUPS_PER_RUN)
-      .get();
-    const reapable: admin.firestore.DocumentReference[] = [];
-    for (const doc of snap.docs) {
-      if (isEmptyGroup(doc.data() as { participants?: unknown })) {
-        reapable.push(doc.ref);
+    let lastDoc: QueryDocSnap | undefined;
+    let visited = 0;
+    while (visited < MAX_GROUPS_PER_RUN) {
+      let pageQuery = db
+        .collection(collection)
+        .orderBy(admin.firestore.FieldPath.documentId())
+        .limit(GROUP_PAGE_SIZE);
+      if (lastDoc) pageQuery = pageQuery.startAfter(lastDoc);
+      const page = await pageQuery.get();
+      if (page.size === 0) break;
+
+      const reapable: admin.firestore.DocumentReference[] = [];
+      for (const doc of page.docs) {
+        visited += 1;
+        if (isEmptyGroup(doc.data() as { participants?: unknown })) {
+          reapable.push(doc.ref);
+        }
       }
-    }
-    if (reapable.length > 0) {
-      total += await deleteRefs(db, reapable);
+      if (reapable.length > 0) {
+        total += await deleteRefs(db, reapable);
+      }
+
+      lastDoc = page.docs[page.docs.length - 1];
+      if (page.size < GROUP_PAGE_SIZE) break;
     }
   }
   return total;
@@ -335,22 +373,64 @@ export async function runGcPlcOrphans(
   // (a) + (e) operate on the canonical synced-group collections (PLC-independent).
   counts.emptyGroups = await sweepEmptyGroups(db);
   for (const collection of SYNCED_GROUP_COLLECTIONS) {
-    const snap = await db
-      .collection(collection)
-      .limit(MAX_GROUPS_PER_RUN)
-      .get();
-    for (const doc of snap.docs) {
-      counts.versionOverflow += await sweepVersionOverflow(db, doc.ref);
+    // Paginated (startAfter cursor on document id) — mirrors sweepEmptyGroups
+    // above. A single un-paginated page silently skipped every group past
+    // GROUP_PAGE_SIZE, forever (that group's version-history overflow would
+    // never be trimmed by any run).
+    let lastGroupDoc: QueryDocSnap | undefined;
+    let groupsVisited = 0;
+    while (groupsVisited < MAX_GROUPS_PER_RUN) {
+      let pageQuery = db
+        .collection(collection)
+        .orderBy(admin.firestore.FieldPath.documentId())
+        .limit(GROUP_PAGE_SIZE);
+      if (lastGroupDoc) pageQuery = pageQuery.startAfter(lastGroupDoc);
+      const page = await pageQuery.get();
+      if (page.size === 0) break;
+
+      for (const doc of page.docs) {
+        groupsVisited += 1;
+        counts.versionOverflow += await sweepVersionOverflow(db, doc.ref);
+      }
+
+      lastGroupDoc = page.docs[page.docs.length - 1];
+      if (page.size < GROUP_PAGE_SIZE) break;
     }
   }
 
-  // (b) + (c) + (d) are per-PLC. Bounded collection scan.
-  const plcsSnap = await db.collection('plcs').limit(MAX_PLCS_PER_RUN).get();
-  for (const plcDoc of plcsSnap.docs) {
-    const perPlc = await sweepPlc(db, plcDoc.ref, now);
-    counts.activity += perPlc.activity;
-    counts.presence += perPlc.presence;
-    counts.tombstones += perPlc.tombstones;
+  // (b) + (c) + (d) are per-PLC. Paginated (startAfter cursor on document id,
+  // mirrors `plcWeeklyDigest`'s fix for the identical bug) so EVERY PLC is
+  // covered, not just the first page — bounded by MAX_PLCS_PER_RUN (runaway
+  // guard) and the function timeout. A single un-paginated page silently
+  // skipped any PLC past the cap every run: its activity/presence/tombstones
+  // would grow unbounded forever since no nightly run would ever reach it.
+  let lastPlcDoc: QueryDocSnap | undefined;
+  let plcsVisited = 0;
+  while (plcsVisited < MAX_PLCS_PER_RUN) {
+    let pageQuery = db
+      .collection('plcs')
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(PLC_PAGE_SIZE);
+    if (lastPlcDoc) pageQuery = pageQuery.startAfter(lastPlcDoc);
+    const page = await pageQuery.get();
+    if (page.size === 0) break;
+
+    for (const plcDoc of page.docs) {
+      plcsVisited += 1;
+      const perPlc = await sweepPlc(db, plcDoc.ref, now);
+      counts.activity += perPlc.activity;
+      counts.presence += perPlc.presence;
+      counts.tombstones += perPlc.tombstones;
+    }
+
+    lastPlcDoc = page.docs[page.docs.length - 1];
+    if (page.size < PLC_PAGE_SIZE) break;
+  }
+
+  if (plcsVisited >= MAX_PLCS_PER_RUN) {
+    console.warn(
+      `[gcPlcOrphans] hit MAX_PLCS_PER_RUN safety ceiling (${MAX_PLCS_PER_RUN}) — raise it or shard the sweep`
+    );
   }
 
   return counts;


### PR DESCRIPTION
## Root cause

`functions/src/gcPlcOrphans.ts` (the nightly PLC garbage-collection sweep) read exactly **one un-paginated `.limit()` page** per collection scan — `plcs`, `synced_quizzes`, `synced_video_activities` — with no `orderBy`. Any PLC or synced group beyond the first page (200 / 500 docs) was **silently never visited by any nightly run, forever**: its stale activity events, stale presence heartbeats, and expired soft-delete tombstones would accumulate unbounded.

This is the identical bug already found and fixed in the sibling function `plcWeeklyDigest.ts` (whose own comment reads "Fixes the prior single `limit()` page, which silently skipped any PLC past the cap every run"). `gcPlcOrphans.ts` never received the same fix, and had zero test coverage for pagination.

## Fix

Added cursor-based pagination (`orderBy(FieldPath.documentId())` + `startAfter`, looped until a short page or a safety ceiling) to all three scans — the `plcs` sweep, the empty-synced-group reap, and the version-overflow sweep — mirroring `plcWeeklyDigest`'s already-validated pattern. `MAX_PLCS_PER_RUN`/`MAX_GROUPS_PER_RUN` are now genuine safety ceilings (raised to 5000, matching the digest's rationale), with new `PLC_PAGE_SIZE`/`GROUP_PAGE_SIZE` constants for the per-request `.limit()`.

## Band-aid rejected

Just raising the old `MAX_PLCS_PER_RUN`/`MAX_GROUPS_PER_RUN` values would only move the same permanent-starvation cliff further out, not eliminate it. Pagination is the only fix that actually reaches every document.

## Regression test

`functions/src/gcPlcOrphans.test.ts` — 3 new tests (plus `orderBy`/`startAfter` stub support mirroring `plcWeeklyDigest.test.ts`'s stub):
- Seeds `PLC_PAGE_SIZE + 5` PLCs, each with a stale presence doc → asserts all are pruned in one run.
- Seeds `GROUP_PAGE_SIZE + 5` empty synced-quiz groups → asserts all are reaped in one run.
- Seeds a version-overflow group placed past `GROUP_PAGE_SIZE` filler docs → asserts its overflow is trimmed.

**Before fix / after fix**, verified independently by the orchestrator: reverted only `gcPlcOrphans.ts` to `dev-paul` (keeping the new test file), confirmed 2 of the 3 new pagination tests fail; restored the fix, confirmed all 32 tests in the file (29 pre-existing + 3 new) pass.

## Validation

- `pnpm run validate` (all constituent steps, run individually due to a 600s sandbox ceiling on the aggregate command under concurrent nightly load) — pass: type-check, lint, format, root suite (6924+ tests), functions suite (706 tests), test-count guard.
- `pnpm run build:all` — pass.
- `pnpm run test:rules` — pass (investigated a separate backlog lead, `firestore.rules` untouched by this PR).

**Risk:** contained (single Cloud Function, mirrors an already-shipped and validated sibling pattern).

---
🤖 Nightly code-health run — orchestrated by Claude Code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DYzHXdbjXHWv3AsJ1RjMpt)_