### PR TITLE
ci: retry firebase deploy on transient Google API errors

### DIFF
--- a/.github/scripts/firebase-deploy-with-retry.sh
+++ b/.github/scripts/firebase-deploy-with-retry.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Deploy the Firebase backend (functions, Firestore rules + indexes,
+# storage) with automatic retry on transient Google API failures.
+#
+# Background: `firebase deploy` makes many googleapis calls while it
+# reconciles Firestore fields/indexes, uploads functions, and enables
+# APIs. Those calls occasionally return transient errors from the GitHub
+# runner — HTTP 5xx ("The service is currently unavailable"), 429 rate
+# limits, or socket resets ("premature close", ECONNRESET). A single
+# transient blip (e.g. a 503 on the field-reconciliation read that runs
+# early in `--only firestore`) fails the whole deploy even though nothing
+# is wrong with the code being shipped.
+#
+# This wrapper retries the deploy a few times with exponential backoff
+# when the output matches a known transient signature, mirroring the
+# retry-on-blip philosophy already used in wait-for-firestore-indexes.sh.
+# A `firebase deploy` of these targets is idempotent (rules/indexes/storage
+# reconcile to the committed manifest; functions redeploy the same source),
+# so re-running after a partial transient failure is safe.
+#
+# Non-transient failures (e.g. a rules compile error, a bad function
+# signature) don't match the transient signatures and fail immediately
+# without burning the retry budget.
+#
+# Usage: ./firebase-deploy-with-retry.sh <project-id>
+# Required env: GOOGLE_APPLICATION_CREDENTIALS pointing at a service
+# account JSON file with deploy permissions.
+# Optional env: FIREBASE_DEPLOY_MAX_ATTEMPTS (default 4).
+
+set -uo pipefail
+
+PROJECT_ID="${1:?usage: $0 <project-id>}"
+MAX_ATTEMPTS="${FIREBASE_DEPLOY_MAX_ATTEMPTS:-4}"
+
+LOG_FILE="$(mktemp)"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+# Case-insensitive substrings that mark a transient, retryable failure
+# rather than a real deploy error. `HTTP Error: 5[0-9][0-9]` covers every
+# 5xx server error (503 is the one seen in the wild); the rest cover
+# rate limiting and socket-level resets from the runner.
+TRANSIENT_PATTERN='HTTP Error: 5[0-9][0-9]|HTTP Error: 429|service is currently unavailable|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|premature close|Client network socket disconnected|Deadline exceeded|code.?UNAVAILABLE'
+
+attempt=1
+backoff=10
+while true; do
+  echo "::group::firebase deploy (attempt ${attempt}/${MAX_ATTEMPTS})"
+  # `tee` keeps the deploy output streaming in the CI log while also
+  # capturing it for the transient-error check. PIPESTATUS[0] is the
+  # firebase exit code (tee always succeeds).
+  pnpm exec firebase deploy --only functions,firestore,storage --project "$PROJECT_ID" --force 2>&1 | tee "$LOG_FILE"
+  code=${PIPESTATUS[0]}
+  echo "::endgroup::"
+
+  if [[ "$code" -eq 0 ]]; then
+    exit 0
+  fi
+
+  if (( attempt >= MAX_ATTEMPTS )); then
+    echo "ERROR: firebase deploy failed after ${attempt} attempt(s) (exit ${code})." >&2
+    exit "$code"
+  fi
+
+  if grep -qiE "$TRANSIENT_PATTERN" "$LOG_FILE"; then
+    echo "::warning::Transient Google API error during firebase deploy; retrying in ${backoff}s (attempt ${attempt}/${MAX_ATTEMPTS})."
+    sleep "$backoff"
+    attempt=$((attempt + 1))
+    backoff=$((backoff * 2))
+    continue
+  fi
+
+  echo "ERROR: firebase deploy failed with a non-transient error (exit ${code}); not retrying." >&2
+  exit "$code"
+done

--- a/.github/scripts/firebase-deploy-with-retry.sh
+++ b/.github/scripts/firebase-deploy-with-retry.sh
@@ -39,7 +39,9 @@ trap 'rm -f "$LOG_FILE"' EXIT
 # Case-insensitive substrings that mark a transient, retryable failure
 # rather than a real deploy error. `HTTP Error: 5[0-9][0-9]` covers every
 # 5xx server error (503 is the one seen in the wild); the rest cover
-# rate limiting and socket-level resets from the runner.
+# rate limiting and socket-level resets from the runner. The `.?` in
+# `code.?UNAVAILABLE` matches the gRPC UNAVAILABLE status whether the
+# Firebase SDK logs it as "code: UNAVAILABLE" or "code=UNAVAILABLE".
 TRANSIENT_PATTERN='HTTP Error: 5[0-9][0-9]|HTTP Error: 429|service is currently unavailable|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|premature close|Client network socket disconnected|Deadline exceeded|code.?UNAVAILABLE'
 
 attempt=1

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -76,8 +76,13 @@ jobs:
       - name: Create Service Account File
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > service-account.json
 
+      # Wrapped in a retry helper: `firebase deploy` occasionally hits a
+      # transient Google API blip (e.g. an HTTP 503 on the Firestore
+      # field/index reconciliation read) that fails the whole deploy even
+      # though the code is fine. The script retries those transient
+      # signatures with exponential backoff and fails fast on real errors.
       - name: Deploy Firebase Rules, Indexes, Functions, Storage
-        run: pnpm exec firebase deploy --only functions,firestore,storage --project spartboard --force
+        run: ./.github/scripts/firebase-deploy-with-retry.sh spartboard
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
 

--- a/.github/workflows/firebase-dev-deploy.yml
+++ b/.github/workflows/firebase-dev-deploy.yml
@@ -85,8 +85,13 @@ jobs:
       - name: Create Service Account File
         run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > service-account.json
 
+      # Wrapped in a retry helper: `firebase deploy` occasionally hits a
+      # transient Google API blip (e.g. an HTTP 503 on the Firestore
+      # field/index reconciliation read) that fails the whole deploy even
+      # though the code is fine. The script retries those transient
+      # signatures with exponential backoff and fails fast on real errors.
       - name: Deploy Firebase Rules, Indexes, Functions, Storage
-        run: pnpm exec firebase deploy --only functions,firestore,storage --project spartboard --force
+        run: ./.github/scripts/firebase-deploy-with-retry.sh spartboard
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ./service-account.json
 


### PR DESCRIPTION
## Problem

The dev-branch deploy for PR #2233 (`dev-paul → main`) failed CI, but every code check passed — build, type-check, lint, unit tests, E2E, Firestore rules, and CodeQL were all green. The only red job was `deploy`, and it failed on a **transient Google API error**, not on anything in the diff:

```
Error: Request to https://firestore.googleapis.com/v1/projects/.../databases/(default)/collectionGroups/-/fields?filter=indexConfig.usesAncestorConfig=false OR ttlConfig:*
had HTTP Error: 503, The service is currently unavailable.
```

That 503 came from the Firestore field/index **reconciliation read** that runs early inside `firebase deploy --only firestore`. It is a Google-side blip — the exact class of failure the repo already anticipates elsewhere (`.github/scripts/wait-for-firestore-indexes.sh` explicitly backs off and retries "transient API blips" rather than failing the deploy). The `firebase deploy` step itself had no such protection, so a single blip failed the whole run.

## Change

- **New `.github/scripts/firebase-deploy-with-retry.sh`** — runs the same `firebase deploy --only functions,firestore,storage --project spartboard --force` command, but retries with exponential backoff when the output matches a transient signature (HTTP `5xx`/`429`, `ECONNRESET`, `premature close`, `socket hang up`, etc.). It **fails fast on non-transient errors** (e.g. a rules compile error) so real failures aren't hidden behind retries. Deploying these targets is idempotent, so re-running after a partial transient failure is safe.
- **Both deploy workflows** (`firebase-dev-deploy.yml` and `firebase-deploy.yml`) now call the wrapper instead of invoking `firebase deploy` inline, keeping the dev and production deploy paths in sync.

Behavior on success is byte-identical to before; the only difference is that a transient blip now retries instead of failing the run.

## Testing

- Syntax-checked the script (`bash -n`) and unit-tested the two branches with a mock `pnpm`:
  - non-transient error (HTTP 400 compile error) → fails immediately, no retry ✓
  - transient 503 → retries with backoff and succeeds on the next attempt ✓
- `.yml` changes validated as well-formed YAML and pass Prettier.
- No TypeScript/JS touched, so type-check, lint, and build are unaffected.

## Note on PR #2233

This wrapper hardens future deploys once merged. The already-red run on `dev-paul` was cleared by re-running its transiently-failed deploy job (the 503 was momentary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUAcz9qSTN2pmFZAPCjgz4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUAcz9qSTN2pmFZAPCjgz4)_