### PR TITLE
a11y: convert RandomSettings "Operation Mode" label to group heading

### DIFF
--- a/components/widgets/random/RandomSettings.tsx
+++ b/components/widgets/random/RandomSettings.tsx
@@ -40,6 +40,7 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
   const firstNamesId = useId();
   const lastNamesId = useId();
   const animationStyleId = useId();
+  const operationModeId = useId();
 
   const stationsWidget = activeDashboard?.widgets.find(
     (w) => w.type === 'stations'
@@ -360,8 +361,14 @@ export const RandomSettings: React.FC<{ widget: WidgetData }> = ({
       )}
 
       <div>
-        <SettingsLabel>Operation Mode</SettingsLabel>
-        <div className="grid grid-cols-4 gap-2">
+        <SettingsLabel as="span" id={operationModeId}>
+          Operation Mode
+        </SettingsLabel>
+        <div
+          role="group"
+          aria-labelledby={operationModeId}
+          className="grid grid-cols-4 gap-2"
+        >
           {modes.map((m) => (
             <button
               key={m.id}


### PR DESCRIPTION
## Summary

Nightly consistency routine (D3 — Settings Panel Label Primitives). Continues the `SettingsLabel` group-heading retrofit series (PRs #2144, #2168, #2183, #2197, #2207, #2218, #2224).

- **Canonical form:** `<SettingsLabel as="span" id="...">` + `role="group" aria-labelledby="..."` on the sibling-control container, for `SettingsLabel` call sites that head a *group* of controls rather than pairing 1:1 with a single form control (where the default `as="label"` would render an orphaned `<label>`).
- **Instance unified:** `components/widgets/random/RandomSettings.tsx:363` — "Operation Mode" heads a `grid grid-cols-4` of 4 sibling mode-selector buttons, with no single associated control. Added a `useId()`-scoped id (`operationModeId`), matching this file's own established convention for other group headings (`groupSizeId`, `animationStyleId`, etc.) rather than a static string, since this component renders per-widget-instance.
- **Enforcement:** none new — this is a retrofit of the existing canonical pattern (`SettingsLabel`'s `as` prop, added in a prior PR), not a new anti-pattern discovery.

## Behavior-preservation evidence

`components/common/SettingsLabel.tsx`'s `combinedClasses` is built identically regardless of the `as` prop — only the wrapping element (`<span>` vs `<label>`) and its `htmlFor`/`id` attributes differ. Verified directly against the component source; this is a pure accessibility-semantics fix (fixes an orphaned `<label>` with no associated control) with **zero visual delta**.

**Risk tag: mechanical** (pure equivalence, single file, single call site).

## Test plan

- [x] `pnpm run type-check:all`
- [x] `pnpm run lint` (app + functions)
- [x] `pnpm run format:check`
- [x] `pnpm run test` (root) — 571/571 files, 6953/6953 tests
- [x] `pnpm -C functions test` — 37/37 files, 706/706 tests
- [x] `pnpm run test:counts` — guard passed
- [x] `pnpm run build` — client + SSR prerender succeeded
- Orchestrator independently re-ran the full `pnpm run validate` + `pnpm run build` chain after the subagent's own validation, both clean.

🤖 Generated by the SpartBoard nightly unifier routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HmT6MNof9m6anMfY4ZE8jT)_