### PR TITLE
fix(TimeTool): re-enable "+" button once a ceiling-started run decays below it

### DIFF
--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -560,10 +560,7 @@ describe('TimeToolWidget', () => {
     });
 
     it('re-enables the "+" button once a run started at the ceiling decays below it', () => {
-      // Regression: the run-start baseline (config.elapsedTime) never updates
-      // while running, so gating `disabled` on it (in addition to the live
-      // displayTime) kept "+" disabled for the timer's entire remaining run
-      // even once the countdown had visibly dropped well below the ceiling.
+      // Regression: disabled must gate on the live displayTime, not the frozen run-start baseline.
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,

--- a/components/widgets/TimeTool/TimeToolWidget.test.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.test.tsx
@@ -559,8 +559,11 @@ describe('TimeToolWidget', () => {
       expect(mockUpdateWidget).not.toHaveBeenCalled();
     });
 
-    it('keeps the "+" button disabled while running at the ceiling, even after the display decays below it', () => {
-      // Regression: displayTime alone re-enables the button once it decays below the ceiling; config.elapsedTime must also gate it.
+    it('re-enables the "+" button once a run started at the ceiling decays below it', () => {
+      // Regression: the run-start baseline (config.elapsedTime) never updates
+      // while running, so gating `disabled` on it (in addition to the live
+      // displayTime) kept "+" disabled for the timer's entire remaining run
+      // even once the countdown had visibly dropped well below the ceiling.
       const widget = createWidget({
         mode: 'timer',
         isRunning: true,
@@ -571,11 +574,13 @@ describe('TimeToolWidget', () => {
       });
       renderWidget(widget);
 
+      expect(screen.getByLabelText('Add time')).toBeDisabled();
+
       act(() => {
         vi.advanceTimersByTime(1000);
       });
 
-      expect(screen.getByLabelText('Add time')).toBeDisabled();
+      expect(screen.getByLabelText('Add time')).not.toBeDisabled();
     });
 
     it('adjustTime is a no-op when running at the ceiling, avoiding a write-storm/startTime-reset loop', () => {

--- a/components/widgets/TimeTool/TimeToolWidget.tsx
+++ b/components/widgets/TimeTool/TimeToolWidget.tsx
@@ -602,10 +602,7 @@ export const TimeToolWidget: React.FC<{ widget: WidgetData }> = ({
                       <AdjustButton
                         sign={1}
                         step={effectiveAdjustStep}
-                        disabled={
-                          displayTime >= TIME_TOOL_MAX_DURATION_SECONDS ||
-                          config.elapsedTime >= TIME_TOOL_MAX_DURATION_SECONDS
-                        }
+                        disabled={displayTime >= TIME_TOOL_MAX_DURATION_SECONDS}
                         ariaLabel={t('widgets.timeTool.addTime')}
                         onAdjust={adjustTime}
                       />


### PR DESCRIPTION
## Root cause

`TimeToolWidget.tsx`'s "+" `AdjustButton` was disabled on:
```
displayTime >= TIME_TOOL_MAX_DURATION_SECONDS || config.elapsedTime >= TIME_TOOL_MAX_DURATION_SECONDS
```
`config.elapsedTime` is the run-start baseline persisted once when a timer starts and never updated while running — only the live `displayTime` decays via the RAF tick loop. A timer started exactly at the 999m59s ceiling kept "+" disabled for its *entire remaining run*, even after the visible countdown had dropped well below the cap.

This was a deferred backlog item (open since 2026-07-05, PR #2147) — the `config.elapsedTime` check was added defensively at the time to guard a "premature enable within one frame" scenario that, on inspection, can't actually occur: `displayTime` starts exactly equal to `config.elapsedTime` and only decreases monotonically, so gating on `displayTime` alone already produces correct behavior in both the running and non-running cases.

## Rejected band-aid

Just loosening the guard without understanding *why* `config.elapsedTime` was added would risk reintroducing the write-storm or press-drop regressions from #2147. Instead, traced `adjustTime`'s existing no-op guard (`next === current`, comparing against the live decaying value, not the persisted baseline) and confirmed it independently protects against write-storms — so removing the stale `config.elapsedTime` check from `disabled` is safe on its own merits.

## Fix

`disabled={displayTime >= TIME_TOOL_MAX_DURATION_SECONDS}` — single condition, root cause removed.

## Regression test

`components/widgets/TimeTool/TimeToolWidget.test.tsx`: starts a running timer at the 59999s ceiling, asserts "+" is disabled immediately, advances fake timers 1s, asserts "+" becomes enabled.

**Fail-before** (orchestrator-verified against unmodified `dev-paul` source with the new test applied):
```
FAIL ... > re-enables the "+" button once a run started at the ceiling decays below it
Error: expect(element).not.toBeDisabled()
Received element is disabled: <button aria-label="Add time" ... disabled="" .../>
```

**Pass-after**: full `components/widgets/TimeTool/` suite — 44/44 tests passed, including all #2147 write-storm/press-drop regression tests (unaffected).

## Verification

- `pnpm run validate` — green (type-check, lint, format, 571 root test files / 6954 tests, 37 functions test files / 706 tests, test:counts guard)
- `pnpm run build` — green (client + SSR + prerender)

## Risk

**Contained** — single conditional simplification in one widget, scoped regression test, no data-shape or API changes.

---
🌙 Nightly code-health run — run 30 (2026-07-19)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RenmR9eXRsJqw7oUtbA6cX)_