### PR TITLE
fix(RemoteControlMenu): clear stale copy-link timer on rapid re-click

### DIFF
--- a/components/layout/RemoteControlMenu.test.tsx
+++ b/components/layout/RemoteControlMenu.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import RemoteControlMenu from './RemoteControlMenu';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -65,5 +65,56 @@ describe('RemoteControlMenu', () => {
       '_blank'
     );
     expect(onClose).toHaveBeenCalled();
+  });
+
+  describe('copy link "copied" indicator', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('keeps showing "copied" for a full 2s after the most recent click, not the first', async () => {
+      render(<RemoteControlMenu onClose={onClose} anchorRect={anchorRect} />);
+      const copyButton = screen.getByTitle('Copy Remote Link');
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(copyButton.className).toContain('bg-green-500');
+
+      // Re-click 1s later, before the first timer would fire — this should
+      // restart the 2s countdown from this second click.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+      expect(copyButton.className).toContain('bg-green-500');
+
+      // 2s after the FIRST click (only 1s after the second) — the stale
+      // first timer must not clear the indicator early.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(copyButton.className).toContain('bg-green-500');
+
+      // 2s after the second (most recent) click — now it should clear.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(copyButton.className).not.toContain('bg-green-500');
+    });
   });
 });

--- a/components/layout/RemoteControlMenu.test.tsx
+++ b/components/layout/RemoteControlMenu.test.tsx
@@ -92,8 +92,7 @@ describe('RemoteControlMenu', () => {
       });
       expect(copyButton.className).toContain('bg-green-500');
 
-      // Re-click 1s later, before the first timer would fire — this should
-      // restart the 2s countdown from this second click.
+      // Re-click 1s later, before the first timer fires; this should restart the 2s countdown.
       act(() => {
         vi.advanceTimersByTime(1000);
       });
@@ -103,14 +102,13 @@ describe('RemoteControlMenu', () => {
       });
       expect(copyButton.className).toContain('bg-green-500');
 
-      // 2s after the FIRST click (only 1s after the second) — the stale
-      // first timer must not clear the indicator early.
+      // 2s after the first click, but only 1s after the second — must still be showing.
       act(() => {
         vi.advanceTimersByTime(1000);
       });
       expect(copyButton.className).toContain('bg-green-500');
 
-      // 2s after the second (most recent) click — now it should clear.
+      // 2s after the second (most recent) click — now it clears.
       act(() => {
         vi.advanceTimersByTime(1000);
       });

--- a/components/layout/RemoteControlMenu.tsx
+++ b/components/layout/RemoteControlMenu.tsx
@@ -17,6 +17,7 @@ const RemoteControlMenu: React.FC<Props> = ({ onClose, anchorRect }) => {
   const { remoteControlEnabled: enabled, updateAccountPreferences } = useAuth();
   const menuRef = useRef<HTMLDivElement>(null);
   const [copied, setCopied] = useState(false);
+  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remoteUrlObject = new URL('/remote', window.location.origin);
   if (activeDashboard) {
     remoteUrlObject.searchParams.set('boardId', activeDashboard.id);
@@ -30,11 +31,21 @@ const RemoteControlMenu: React.FC<Props> = ({ onClose, anchorRect }) => {
     try {
       await navigator.clipboard.writeText(remoteUrl);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      copiedTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+        copiedTimeoutRef.current = null;
+      }, 2000);
     } catch (err) {
       console.error('Failed to copy text: ', err);
     }
   };
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/components/layout/RemoteControlMenu.tsx
+++ b/components/layout/RemoteControlMenu.tsx
@@ -30,8 +30,8 @@ const RemoteControlMenu: React.FC<Props> = ({ onClose, anchorRect }) => {
   const handleCopyLink = async () => {
     try {
       await navigator.clipboard.writeText(remoteUrl);
-      setCopied(true);
       if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      setCopied(true);
       copiedTimeoutRef.current = setTimeout(() => {
         setCopied(false);
         copiedTimeoutRef.current = null;


### PR DESCRIPTION
## Root cause

`RemoteControlMenu.tsx`'s `handleCopyLink` scheduled a bare `setTimeout(() => setCopied(false), 2000)` on every click without tracking or clearing the previous timer. Re-clicking "Copy Link" within 2 seconds of the first click left the original timer alive; it fired at the *first* click's 2s mark and cleared the "copied" checkmark early — even though the user had just re-copied and the UI should hold the confirmation for a full 2s from the *most recent* click.

This is the real, observable bug behind a backlog item previously filed as "hygiene, low-impact" (missing unmount cleanup). The missing cleanup isn't just a harmless unmount no-op (React 18 already no-ops setState-after-unmount) — it's a stale-timer race that misfires during normal rapid-reclick usage.

## Rejected band-aid

Simply adding a `useEffect` cleanup keyed on unmount (the originally-flagged "hygiene" fix) would not address the actual bug — it only guards against setState-after-unmount. The real defect is the lack of timer cancellation *within* the component's lifetime on re-click.

## Fix

Store the timeout id in a ref, clear it before scheduling a new one on each click, and also clear on unmount for correctness — matching the existing pattern already used correctly elsewhere in the codebase (`ViewOnlyShareModal.tsx`).

## Regression test

`components/layout/RemoteControlMenu.test.tsx`: click → advance 1s → re-click → advance to 2s-after-first-click (assert indicator still shown) → advance to 2s-after-second-click (assert indicator cleared).

**Fail-before** (orchestrator-verified against unmodified `dev-paul` source with the new test applied):
```
AssertionError: expected 'shrink-0 p-1 rounded-md transition-al…' to contain 'bg-green-500'
Expected: "bg-green-500"
Received: "shrink-0 p-1 rounded-md transition-all text-slate-400 hover:text-slate-600 hover:bg-slate-200/50"
```

**Pass-after**: 2/2 tests passed.

## Verification

- `pnpm run validate` — green (type-check, lint, format, 571 root test files / 6954 tests, 37 functions test files / 706 tests, test:counts guard). One transient CPU-contention timeout in an unrelated test (`TypographySettings.test.tsx`) on the first pass — confirmed as noise (passes in isolation) and a clean full re-run confirmed.
- `pnpm run build` — green (client + SSR + prerender)

## Risk

**Contained** — single-component fix (ref-tracked timeout), scoped regression test, no data-shape or API changes.

---
🌙 Nightly code-health run — run 30 (2026-07-19)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RenmR9eXRsJqw7oUtbA6cX)_