### PR TITLE
fix(i18n): ES plcRoute/plcDirectory + FR sidebar.nav.plcs — PLC acronym drift

### DIFF
--- a/locales/es.json
+++ b/locales/es.json
@@ -1716,28 +1716,28 @@
     }
   },
   "plcRoute": {
-    "loading": "Cargando PLC…",
-    "notFoundTitle": "PLC no encontrada",
-    "notFoundBody": "Esta PLC no existe o ya no eres miembro de ella.",
+    "loading": "Cargando Comunidad…",
+    "notFoundTitle": "Comunidad no encontrada",
+    "notFoundBody": "Esta Comunidad no existe o ya no eres miembro de ella.",
     "backToBoard": "Volver a mi tablero",
-    "hubTitle": "Mis PLC",
+    "hubTitle": "Mis Comunidades",
     "hubSubtitle": "Abre una Comunidad de Aprendizaje Profesional para colaborar con tu equipo.",
-    "hubEmptyTitle": "Aún no hay PLC",
-    "hubEmptySubtitle": "Crea una PLC desde la barra lateral e invita a tus colegas.",
+    "hubEmptyTitle": "Aún no hay Comunidades",
+    "hubEmptySubtitle": "Crea una Comunidad desde la barra lateral e invita a tus colegas.",
     "leadBadge": "Líder",
     "memberCount": "{{count}} miembro",
     "memberCount_other": "{{count}} miembros"
   },
   "plcDirectory": {
-    "heading": "PLC en mi edificio",
+    "heading": "Comunidades en mi edificio",
     "subtitle": "Equipos de tu edificio a los que puedes pedir unirte.",
     "memberCount": "{{count}} miembro",
     "memberCount_other": "{{count}} miembros",
     "requestToJoin": "Pedir unirse",
     "requestHint": "Pide a un miembro que invite a {{email}}.",
-    "emptyTitle": "No hay otras PLC para mostrar",
-    "emptySubtitle": "Ahora mismo no hay otras PLC en tu edificio.",
+    "emptyTitle": "No hay otras Comunidades para mostrar",
+    "emptySubtitle": "Ahora mismo no hay otras Comunidades en tu edificio.",
     "noOrgTitle": "Directorio del edificio no disponible",
-    "noOrgSubtitle": "Tu cuenta aún no está vinculada a una escuela, por lo que no podemos mostrar PLC cercanas."
+    "noOrgSubtitle": "Tu cuenta aún no está vinculada a una escuela, por lo que no podemos mostrar Comunidades cercanas."
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -82,7 +82,7 @@
       "boards": "Tableaux",
       "backgrounds": "Arrière-plans",
       "classes": "Mes Classes",
-      "plcs": "Mes PLCs",
+      "plcs": "Mes CAP",
       "widgets": "Widgets",
       "globalStyle": "Style global",
       "generalSettings": "Paramètres généraux",

--- a/tests/i18n/esPlcRouteDirectoryComunidadTerminologyLocales.test.ts
+++ b/tests/i18n/esPlcRouteDirectoryComunidadTerminologyLocales.test.ts
@@ -1,0 +1,125 @@
+// ES `plcRoute.*` and `plcDirectory.*` used the untranslated English acronym "PLC" instead of
+// the project's established Spanish term "Comunidad" (see plcDashboard.subtitle: "Panel de la
+// Comunidad", sidebar.plcs.title: "Mis Comunidades", and plc.errors.plcNotFound: "Comunidad no
+// encontrada." — fixed in esPlcErrorsComunidadTerminologyLocales.test.ts / #2229). These are
+// sibling namespaces to plcDashboard/plc.errors/sidebar.plcs (not covered by their scoped
+// recursive scans), so they need their own scoped scan to avoid conflicting with legitimately-
+// scoped "PLC" usage elsewhere in es.json (e.g. admin.plc.recovery, an admin-only namespace that
+// intentionally keeps "PLC").
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+
+/** Dotted path walker — returns the leaf string or undefined. */
+function getLeaf(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
+/** Recursively collects [path, value] pairs for every string leaf. */
+function collectStrings(
+  obj: unknown,
+  path: string,
+  out: Array<[string, string]>
+): void {
+  if (obj == null || typeof obj !== 'object') return;
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const p = path ? `${path}.${key}` : key;
+    if (typeof value === 'string') {
+      out.push([p, value]);
+    } else if (value && typeof value === 'object') {
+      collectStrings(value, p, out);
+    }
+  }
+}
+
+const AFFECTED_KEYS: Array<{ path: string; expectedEs: string }> = [
+  { path: 'plcRoute.loading', expectedEs: 'Cargando Comunidad…' },
+  { path: 'plcRoute.notFoundTitle', expectedEs: 'Comunidad no encontrada' },
+  {
+    path: 'plcRoute.notFoundBody',
+    expectedEs: 'Esta Comunidad no existe o ya no eres miembro de ella.',
+  },
+  { path: 'plcRoute.hubTitle', expectedEs: 'Mis Comunidades' },
+  { path: 'plcRoute.hubEmptyTitle', expectedEs: 'Aún no hay Comunidades' },
+  {
+    path: 'plcRoute.hubEmptySubtitle',
+    expectedEs:
+      'Crea una Comunidad desde la barra lateral e invita a tus colegas.',
+  },
+  {
+    path: 'plcDirectory.heading',
+    expectedEs: 'Comunidades en mi edificio',
+  },
+  {
+    path: 'plcDirectory.emptyTitle',
+    expectedEs: 'No hay otras Comunidades para mostrar',
+  },
+  {
+    path: 'plcDirectory.emptySubtitle',
+    expectedEs: 'Ahora mismo no hay otras Comunidades en tu edificio.',
+  },
+  {
+    path: 'plcDirectory.noOrgSubtitle',
+    expectedEs:
+      'Tu cuenta aún no está vinculada a una escuela, por lo que no podemos mostrar Comunidades cercanas.',
+  },
+];
+
+describe('EN locale — affected keys baseline', () => {
+  it.each(AFFECTED_KEYS)('en.$path exists', ({ path }) => {
+    expect(getLeaf(en, path), `en.${path} is missing`).toBeDefined();
+  });
+});
+
+describe('ES locale — "PLC" terminology replaced with "Comunidad" in plcRoute / plcDirectory', () => {
+  it.each(AFFECTED_KEYS)(
+    'es.$path is the Comunidad-based translation, not the PLC drift',
+    ({ path, expectedEs }) => {
+      const value = getLeaf(es, path);
+      expect(value, `es.${path} is missing`).toBeDefined();
+      expect(
+        value,
+        `es.${path} should be "${expectedEs}" (this namespace's established Spanish term is ` +
+          `"Comunidad", not the untranslated English acronym "PLC") but got "${value}"`
+      ).toBe(expectedEs);
+    }
+  );
+
+  it('has no remaining "PLC"/"PLCs" usages in plcRoute', () => {
+    const all: Array<[string, string]> = [];
+    collectStrings(
+      (es as unknown as { plcRoute: unknown }).plcRoute,
+      'plcRoute',
+      all
+    );
+    const offenders = all.filter(([, value]) => /\bPLCs?\b/i.test(value));
+    expect(
+      offenders,
+      `Found ${offenders.length} ES plcRoute value(s) using the untranslated acronym "PLC" ` +
+        `instead of the established "Comunidad" translation: ` +
+        `${offenders.map(([p, v]) => `${p}="${v}"`).join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('has no remaining "PLC"/"PLCs" usages in plcDirectory', () => {
+    const all: Array<[string, string]> = [];
+    collectStrings(
+      (es as unknown as { plcDirectory: unknown }).plcDirectory,
+      'plcDirectory',
+      all
+    );
+    const offenders = all.filter(([, value]) => /\bPLCs?\b/i.test(value));
+    expect(
+      offenders,
+      `Found ${offenders.length} ES plcDirectory value(s) using the untranslated acronym "PLC" ` +
+        `instead of the established "Comunidad" translation: ` +
+        `${offenders.map(([p, v]) => `${p}="${v}"`).join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/tests/i18n/frSidebarNavPlcsCapTerminologyLocales.test.ts
+++ b/tests/i18n/frSidebarNavPlcsCapTerminologyLocales.test.ts
@@ -1,0 +1,41 @@
+// FR `sidebar.nav.plcs` still used the raw English acronym "PLC" ("Mes PLCs") instead of the
+// established FR term "CAP" used throughout plc.errors.* (e.g. plc.errors.plcNotFound: "CAP
+// introuvable.") and plcRoute.* (e.g. plcRoute.hubTitle: "Mes CAP"). This is the FR sibling of
+// the DE PLC->PLG (#2193) and ES PLC->Comunidad (#2229) sidebar.nav.plcs drift fixes.
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import fr from '@/locales/fr.json';
+
+function getLeaf(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
+describe('EN locale — sidebar.nav.plcs baseline', () => {
+  it('en.sidebar.nav.plcs exists', () => {
+    expect(getLeaf(en, 'sidebar.nav.plcs')).toBeDefined();
+  });
+});
+
+describe('FR locale — "PLC" terminology replaced with "CAP" in sidebar.nav.plcs', () => {
+  it('fr.sidebar.nav.plcs is the CAP-based translation, not the PLC drift', () => {
+    const value = getLeaf(fr, 'sidebar.nav.plcs');
+    expect(value, 'fr.sidebar.nav.plcs is missing').toBeDefined();
+    expect(
+      value,
+      `fr.sidebar.nav.plcs should be "Mes CAP" (this namespace's established French term is ` +
+        `"CAP", matching plc.errors.* and plcRoute.hubTitle, not the untranslated English ` +
+        `acronym "PLC") but got "${value}"`
+    ).toBe('Mes CAP');
+  });
+
+  it('sidebar.nav.plcs has no remaining "PLC"/"PLCs" usage', () => {
+    const value = getLeaf(fr, 'sidebar.nav.plcs') ?? '';
+    expect(/\bPLCs?\b/i.test(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Root cause

Two sibling namespaces to the already-fixed `plcDashboard`/`sidebar.plcs`/`plc.errors` namespaces (ES → "Comunidad" in #2214/#2229, FR → "CAP") still carried the raw, untranslated English acronym "PLC":

1. **ES `plcRoute.*` (6 keys) and `plcDirectory.*` (4 keys)** — e.g. `plcRoute.hubTitle: "Mis PLC"`, `plcDirectory.heading: "PLC en mi edificio"`. DE's equivalent namespaces already correctly use "PLG" throughout, confirming this is drift, not intentional.
2. **FR `sidebar.nav.plcs`** = `"Mes PLCs"` — FR's own `plc.errors.*` and `plcRoute.hubTitle` already correctly use "CAP", so this single key was the last untranslated holdout.

This is the same terminology-drift bug class fixed repeatedly this routine (#2162, #2180, #2193, #2214, #2229) — a genuine (not verbatim-EN-copy) translation that nonetheless uses the wrong word for a concept the rest of the locale translates consistently.

## Fix

`locales/es.json`: 10 `plcRoute`/`plcDirectory` values swapped to the "Comunidad" translations matching established sibling namespaces.
`locales/fr.json`: `sidebar.nav.plcs` changed from `"Mes PLCs"` to `"Mes CAP"`.

## Regression tests

New: `tests/i18n/esPlcRouteDirectoryComunidadTerminologyLocales.test.ts`, `tests/i18n/frSidebarNavPlcsCapTerminologyLocales.test.ts`. Pattern mirrors existing sibling tests: exact-value assertions per key (not just "≠ EN") plus a namespace-scoped recursive sweep for leftover `/\bPLCs?\b/i` — scoped strictly to `plcRoute`/`plcDirectory`/`sidebar.nav.plcs` to avoid false-positiving on the intentionally-untranslated `admin.plc.recovery`.

**Fail-before** (orchestrator-verified against unmodified `dev-paul` locale files with the new tests applied):
```
Test Files  2 failed (2)
     Tests  14 failed | 11 passed (25)
```

**Pass-after**: 25/25 passed. Full `tests/i18n/` suite also green (39 files, 1555 tests).

## Verification

- `pnpm run validate` — green (type-check, lint, format, 573 root test files / 6978 tests, 37 functions test files / 706 tests, test:counts guard)
- `pnpm run build` — green (client + SSR + prerender)

## Follow-up flagged (not fixed here)

FR's `admin.plc.recovery` namespace is fully translated to "CAP" while DE/ES still say raw "PLC" — the existing "intentionally keeps PLC" assumption for DE/ES (relied on by #2162/#2214 to justify leaving that namespace alone) may itself be stale. Needs a product/design confirmation before touching, since two prior PRs already explicitly reasoned about this namespace.

## Risk

**Contained** — locale-value changes + new scoped tests only, no code/logic changes.

---
🌙 Nightly code-health run — run 30 (2026-07-19)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RenmR9eXRsJqw7oUtbA6cX)_