### PR TITLE
fix(rules): SECURITY — gate shared_activity_walls read on revoked/expiresAt

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1097,7 +1097,23 @@ service cloud.firestore {
     // doc for the sessionId + toggles (allowComments/allowCommentResponses/
     // allowLikes). Readable by any signed-in caller (incl. anonymous students).
     match /shared_activity_walls/{shareId} {
-      allow read: if request.auth != null;
+      // READ: any authed caller (incl. anonymous gallery viewers) may read a
+      // live share; host and admin can still read past revoke/expiry for
+      // management/cleanup. Mirrors the expiresAt cutoff already enforced on
+      // /shared_boards and /shared_collections — without this, the
+      // "Available until X" / revoke UX in ActivityWallGalleryView is
+      // cosmetic only, since a caller that bypasses the client UI can keep
+      // reading a gallery's title/prompt/sessionId/identificationMode
+      // forever after the teacher revokes it or its expiresAt passes.
+      allow read: if request.auth != null && (
+        resource.data.get('originalAuthor', null) == request.auth.uid
+        || isAdmin()
+        || (
+          resource.data.get('revoked', false) != true
+          && (resource.data.get('expiresAt', null) == null
+              || resource.data.get('expiresAt', 0) > request.time.toMillis())
+        )
+      );
 
       // Identity fields + the sessionId-ownership check force the doc to be
       // created by the teacher who owns the underlying session (can't publish

--- a/tests/rules/sharedActivityWalls.test.ts
+++ b/tests/rules/sharedActivityWalls.test.ts
@@ -235,6 +235,18 @@ describe('shared_activity_walls — read gating (expiresAt / revoked)', () => {
     );
   });
 
+  it('viewer can read a permanent share (expiresAt null / unset)', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload()
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asViewer(), `shared_activity_walls/${SHARE_ID}`))
+    );
+  });
+
   it('viewer cannot read a revoked share', async () => {
     await testEnv.withSecurityRulesDisabled(async (ctx) => {
       await setDoc(

--- a/tests/rules/sharedActivityWalls.test.ts
+++ b/tests/rules/sharedActivityWalls.test.ts
@@ -17,7 +17,7 @@ import {
   assertFails,
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
-import { setDoc, updateDoc, deleteDoc, doc } from 'firebase/firestore';
+import { setDoc, updateDoc, deleteDoc, doc, getDoc } from 'firebase/firestore';
 
 const PROJECT_ID = 'spartboard-shared-activity-walls';
 const TEACHER_UID = 'teacher-uid';
@@ -188,6 +188,98 @@ describe('shared_activity_walls — teacher create', () => {
         doc(asTeacher(), `shared_activity_walls/${SHARE_ID}`),
         sharedDocPayload({ revoked: false })
       )
+    );
+  });
+});
+
+// Root cause: the READ rule was `if request.auth != null` with no reference
+// to `revoked` / `expiresAt` at all, even though those fields exist
+// specifically so ActivityWallGalleryView can show a "revoked" / "expired"
+// state. The client-side check is purely cosmetic — any direct Firestore
+// SDK/REST caller can keep reading a gallery's title/prompt/sessionId/
+// identificationMode forever after the teacher revokes or the link expires.
+// Sibling collections /shared_boards and /shared_collections already gate
+// their substitute-mode reads on expiresAt; this collection was the
+// asymmetric one that never got the same treatment.
+describe('shared_activity_walls — read gating (expiresAt / revoked)', () => {
+  const asViewer = () =>
+    testEnv
+      .authenticatedContext('viewer-uid', {
+        firebase: { sign_in_provider: 'anonymous' },
+      })
+      .firestore();
+
+  const asAdminUser = () =>
+    testEnv
+      .authenticatedContext('admin-uid', {
+        email: 'admin@example.com',
+        firebase: { sign_in_provider: 'google.com' },
+      })
+      .firestore();
+
+  beforeEach(async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(doc(ctx.firestore(), 'admins/admin@example.com'), {});
+    });
+  });
+
+  it('viewer can read a live (non-revoked, non-expired) share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload({ expiresAt: Date.now() + 1_000_000 })
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asViewer(), `shared_activity_walls/${SHARE_ID}`))
+    );
+  });
+
+  it('viewer cannot read a revoked share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload({ revoked: true })
+      );
+    });
+    await assertFails(
+      getDoc(doc(asViewer(), `shared_activity_walls/${SHARE_ID}`))
+    );
+  });
+
+  it('viewer cannot read a share past its expiresAt', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload({ expiresAt: Date.now() - 1_000 })
+      );
+    });
+    await assertFails(
+      getDoc(doc(asViewer(), `shared_activity_walls/${SHARE_ID}`))
+    );
+  });
+
+  it('original author can still read their own revoked share (cleanup/management)', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload({ revoked: true })
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asTeacher(), `shared_activity_walls/${SHARE_ID}`))
+    );
+  });
+
+  it('admin can still read an expired share', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await setDoc(
+        doc(ctx.firestore(), `shared_activity_walls/${SHARE_ID}`),
+        sharedDocPayload({ expiresAt: Date.now() - 1_000 })
+      );
+    });
+    await assertSucceeds(
+      getDoc(doc(asAdminUser(), `shared_activity_walls/${SHARE_ID}`))
     );
   });
 });


### PR DESCRIPTION
## SECURITY

## Root cause

`firestore.rules`' `shared_activity_walls/{shareId}` READ rule was `allow read: if request.auth != null;` — unconditional for any authenticated caller. The doc schema carries `expiresAt` and `revoked` fields whose entire purpose (per `ActivityWallGalleryView.tsx`) is to gate access — the client shows "revoked"/"expired" states when these trip, but that enforcement was **UI-only**. A caller bypassing the app (direct Firestore SDK/REST call) could read a gallery share's `title`, `prompt`, `sessionId`, `identificationMode`, etc. forever, regardless of revoke or expiry.

Sibling collections `/shared_boards` and `/shared_collections` already enforce an `expiresAt` cutoff on their substitute-mode reads (see #2150) — `shared_activity_walls` was the asymmetric sibling that never got the same treatment, matching a recurring pattern in this routine's history.

Confirmed the affected client reads are all single-doc `getDoc()` calls (`ActivityWallGalleryView.tsx`, `ShareModal.tsx`) — no live `onSnapshot` list queries against this collection, so this fix does not carry the "list query silently breaks" risk documented for time-gated rule changes on other collections (#2150).

## Rejected band-aid

Widening the client-side expiry check would do nothing — the whole point is a non-client caller bypasses the client entirely. The only real fix is in the security rule itself.

## Fix

`allow read` now requires: original author (management/cleanup) OR admin OR (`revoked` is not `true` AND (`expiresAt` unset OR in the future)).

## Regression test

`tests/rules/sharedActivityWalls.test.ts` — 5 new tests: live share readable, revoked share denied, expired share denied, host can still read a revoked share, admin can still read an expired share.

**Fail-before** (orchestrator-verified against unmodified `dev-paul` rules with the new tests applied, real Firestore emulator):
```
FAIL ... > viewer cannot read a revoked share
Error: Expected request to fail, but it succeeded.
FAIL ... > viewer cannot read a share past its expiresAt
Error: Expected request to fail, but it succeeded.
Tests  2 failed | 24 passed (26)
```

**Pass-after**: 26/26 passed. Full `pnpm run test:rules` suite (orchestrator re-ran independently): **47 files / 1121 tests, all passing** — no regressions in sibling rule suites.

## Verification

- `pnpm run validate` — green (type-check, lint, format, tests, functions tests, test:counts)
- `pnpm run build:all` — green (Vite build + SSR prerender + functions `tsc` build)
- `pnpm run test:rules` — green, full suite, orchestrator-verified independently against the real Firestore emulator

## Follow-up flagged (not fixed here, out of this area's glob)

`activity_wall_sessions.publiclyShared` is set `true` on share but never flipped back to `false` on revoke/expire — the underlying submission photos/text (a separate collection from the share doc fixed here) stay world-readable indefinitely once shared, independent of this share doc's own revoke/expiry state. Needs both a rules change (or a scheduled sweep function, mirroring `expireSubShares.ts`) and client wiring — spans outside `firestore.rules`/`functions/**` alone; recommend a dedicated cross-area follow-up.

## Risk

**Architectural** (security-rule tightening on a live collection) — but verified narrowly contained: single-doc reads only, no live-listener breakage risk, full sibling rules suite green.

---
🌙 Nightly code-health run — run 30 (2026-07-19)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RenmR9eXRsJqw7oUtbA6cX)_