### PR TITLE
fix(RevealGrid): unify "Game Mode" settings label to SettingsLabel as="span"

### DIFF
--- a/components/widgets/RevealGrid/Settings.tsx
+++ b/components/widgets/RevealGrid/Settings.tsx
@@ -311,8 +311,14 @@ export const RevealGridSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Game Mode */}
       <div>
-        <SettingsLabel>Game Mode</SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <SettingsLabel as="span" id={`revealgrid-gamemode-label-${widget.id}`}>
+          Game Mode
+        </SettingsLabel>
+        <div
+          role="group"
+          aria-labelledby={`revealgrid-gamemode-label-${widget.id}`}
+          className="flex bg-slate-100 p-1 rounded-xl"
+        >
           <button
             type="button"
             onClick={() =>


### PR DESCRIPTION
## Nightly unifier — D3 Settings Panel Label Primitives (run 38, 2026-07-20)

**Canonical form:** `<SettingsLabel as="span" id="...">...</SettingsLabel>` paired with `role="group" aria-labelledby="..."` on the sibling-control container, for `SettingsLabel` instances that head a *group* of controls (no single 1:1-associated control) rather than pairing with exactly one form control. The default `as="label"` renders an orphaned `<label>` in that case; `as="span"` avoids it while keeping identical visual styling.

**Instance unified:** `components/widgets/RevealGrid/Settings.tsx:314` — the "Game Mode" label heading a 2-button (Review/Memory) selector group. Converted to `as="span" id={`revealgrid-gamemode-label-${widget.id}`}`, matching the exact id-scoping convention already established one block above in the same file for "Columns" (line 283). `widget.id` interpolation (not `useId()`) was used because it matches this file's own existing convention and `RevealGridSettings` renders per-widget-instance via `DraggableWindow`, so a static id would collide across multiple simultaneous RevealGrid instances on one dashboard.

This is the 8th instance in an established retrofit series (PRs #2144, #2168, #2183, #2197, #2207, #2218, #2224 previously converted `MagicLayoutModal.tsx`, `LibraryManager.tsx`, `SaveAsWidgetModal.tsx`, `DrawingWidget` "Color Presets", `RevealGrid` "Columns", `RandomSettings` "Animation Style"/"Operation Mode", `MusicWidget` "Layout"/"Source"). Remaining candidates for future nights: `RevealGrid/Settings.tsx:357` "Reveal Mode", `SyntaxFramer/Settings.tsx:104` "Mode", `SyntaxFramer/Settings.tsx:158` "Alignment".

**Enforcement:** None added — this is a retrofit of a pre-existing shape (semantics-only correction), not a new-code anti-pattern with a regrowth vector; each instance is inspected individually as part of the ongoing sweep.

**Behavior/visual preservation evidence:**
- Verified directly against `components/common/SettingsLabel.tsx` source: `combinedClasses` (`text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2` + optional icon layout) is computed once and applied identically regardless of the `as` value — only the wrapping tag (`<label>` vs `<span>`) differs. Zero visual delta.
- `pnpm run type-check` ✅, `pnpm exec eslint components/widgets/RevealGrid/Settings.tsx --max-warnings 0` ✅ (orchestrator independently re-ran both after the subagent's own validation — clean)
- Subagent's own full validation (run in the worktree, staged individually since the combined `pnpm run validate` exceeded a 10-minute single-call cap under concurrent sibling-worktree load): `pnpm run type-check` ✅, `pnpm run lint` (app+functions) ✅, `pnpm run format:check` ✅, `pnpm run test` — 573 files / 6986 tests passed ✅, `pnpm -C functions test` — 37 files / 706 tests passed ✅ (including the known-flaky `googleOAuth.test.ts revokeGoogleRefreshToken` suite, which passed clean), `pnpm run test:counts` ✅, `pnpm run build` ✅

**Risk tag:** mechanical (pure semantic-HTML equivalence, zero visual/behavioral delta)

**Deferred to backlog:** `RevealGrid/Settings.tsx:357` "Reveal Mode", `SyntaxFramer/Settings.tsx:104` "Mode", `SyntaxFramer/Settings.tsx:158` "Alignment" — left for future nights per this routine's one-unification-per-dimension-per-night pacing.

---
Part of the automated nightly consistency ("unifier") routine. See `docs/routines/unifier.md` for full context — that doc's run 38 log entry will be updated in a follow-up PR.

🤖 Generated by an automated nightly routine (Claude Code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6Y8Vce7xs54Efcfq5nwce)_