### PR TITLE
fix(LunchCount): key assignments by roster student id, not display name

### DIFF
--- a/components/widgets/LunchCount/Widget.test.tsx
+++ b/components/widgets/LunchCount/Widget.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { LunchCountWidget } from './Widget';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -132,6 +132,42 @@ describe('LunchCountWidget', () => {
     expect(chip).toBeInTheDocument();
     // We can't easily simulate the full dnd-kit drag-and-drop in jsdom
     // without more setup, but we've verified the refactor structure.
+  });
+
+  it('keeps two same-name students independently assigned (no name-collision)', async () => {
+    // Regression test: assignments must be keyed by the roster student `id`,
+    // not the display name. Two students who share a name (e.g. two "Emma
+    // Smith"s) previously collided on the same `assignments` key, so
+    // assigning one silently moved/overwrote the other's assignment.
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockDashboardContext,
+      rosters: [
+        {
+          id: 'roster-1',
+          name: 'Class 1A',
+          students: [
+            { id: 's1', firstName: 'Emma', lastName: 'Smith' },
+            { id: 's2', firstName: 'Emma', lastName: 'Smith' },
+          ],
+        },
+      ],
+    });
+
+    const widget = createWidget({
+      assignments: { s1: 'hot', s2: 'bento' },
+    });
+
+    render(<LunchCountWidget widget={widget} />);
+
+    const chips = await screen.findAllByText('Emma Smith');
+    expect(chips).toHaveLength(2);
+
+    const hotZone = screen.getByTestId('hot-zone');
+    const bentoZone = screen.getByTestId('bento-zone');
+
+    expect(within(hotZone).getAllByText('Emma Smith')).toHaveLength(1);
+    expect(within(bentoZone).getAllByText('Emma Smith')).toHaveLength(1);
+    expect(screen.queryByText('Assign 2 More Students')).toBeNull();
   });
 
   it('renders correctly for middle school without interactive DND', () => {

--- a/components/widgets/LunchCount/Widget.test.tsx
+++ b/components/widgets/LunchCount/Widget.test.tsx
@@ -186,6 +186,27 @@ describe('LunchCountWidget', () => {
     expect(await within(homeZone).findByText('John Doe')).toBeInTheDocument();
   });
 
+  it('can unassign a student whose assignment only exists under the legacy name key', async () => {
+    // Regression test: the read-path fallback (previous test) kept legacy
+    // assignments visible, but the write path originally only ever deleted
+    // `assignments[id]` — a no-op when the entry lives under the name key —
+    // so a legacy-keyed student could never actually be unassigned by click.
+    const widget = createWidget({
+      assignments: { 'John Doe': 'home' },
+    });
+
+    render(<LunchCountWidget widget={widget} />);
+
+    const homeZone = screen.getByTestId('home-zone');
+    const chip = await within(homeZone).findByText('John Doe');
+    chip.click();
+
+    const [, updatePayload] = mockDashboardContext.updateWidget.mock.calls.at(
+      -1
+    ) as [string, { config: LunchCountConfig }];
+    expect(updatePayload.config.assignments).not.toHaveProperty('John Doe');
+  });
+
   it('renders correctly for middle school without interactive DND', () => {
     const widget = createWidget({
       schoolSite: 'orono-middle-school',

--- a/components/widgets/LunchCount/Widget.test.tsx
+++ b/components/widgets/LunchCount/Widget.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import { LunchCountWidget } from './Widget';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
@@ -199,7 +199,7 @@ describe('LunchCountWidget', () => {
 
     const homeZone = screen.getByTestId('home-zone');
     const chip = await within(homeZone).findByText('John Doe');
-    chip.click();
+    fireEvent.click(chip);
 
     const [, updatePayload] = mockDashboardContext.updateWidget.mock.calls.at(
       -1

--- a/components/widgets/LunchCount/Widget.test.tsx
+++ b/components/widgets/LunchCount/Widget.test.tsx
@@ -170,6 +170,22 @@ describe('LunchCountWidget', () => {
     expect(screen.queryByText('Assign 2 More Students')).toBeNull();
   });
 
+  it('still honors a legacy name-keyed assignment saved before the id-keying fix', async () => {
+    // Regression test: dashboards saved before assignments were keyed by
+    // student id stored them under the display name instead (e.g.
+    // "John Doe": "hot"). Switching the read path to id-only would silently
+    // reset every pre-existing assignment to "unassigned" on load. The
+    // widget must still honor a name-keyed entry when no id-keyed one exists.
+    const widget = createWidget({
+      assignments: { 'John Doe': 'home' },
+    });
+
+    render(<LunchCountWidget widget={widget} />);
+
+    const homeZone = screen.getByTestId('home-zone');
+    expect(await within(homeZone).findByText('John Doe')).toBeInTheDocument();
+  });
+
   it('renders correctly for middle school without interactive DND', () => {
     const widget = createWidget({
       schoolSite: 'orono-middle-school',

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -379,12 +379,13 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
   const updateAssignment = useCallback(
     (student: string, type: 'hot' | 'bento' | 'home' | null) => {
       const newAssignments = { ...assignments };
+      // Always clear a legacy name-keyed entry for this student — otherwise
+      // it either keeps re-surfacing via the read-path fallback after an
+      // unassign, or lingers as orphaned data after a direct reassignment.
+      const legacyName = activeRoster.find((s) => s.id === student)?.name;
+      if (legacyName) delete newAssignments[legacyName];
       if (type === null) {
         delete newAssignments[student];
-        // Also clear a legacy name-keyed entry for this student, or the
-        // read-path fallback keeps re-surfacing it as still assigned.
-        const legacyName = activeRoster.find((s) => s.id === student)?.name;
-        if (legacyName) delete newAssignments[legacyName];
       } else {
         newAssignments[student] = type;
       }

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -354,7 +354,9 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
     const unassigned: { id: string; name: string }[] = [];
 
     activeRoster.forEach((student) => {
-      const assignment = assignments[student.id];
+      // Falls back to a legacy name-keyed entry when no id-keyed one exists,
+      // so dashboards saved before this fix don't lose their assignments.
+      const assignment = assignments[student.id] ?? assignments[student.name];
       if (assignment === 'hot') hot.push(student);
       else if (assignment === 'bento') bento.push(student);
       else if (assignment === 'home') home.push(student);
@@ -895,6 +897,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
               {/* Home Lunch Drop Zone */}
               <DroppableZone
                 id="home"
+                data-testid="home-zone"
                 className="bg-brand-blue-lighter/20 border-2 border-dashed border-brand-blue-lighter rounded-2xl flex flex-col transition-all group"
                 style={{ padding: 'min(10px, 2cqmin)' }}
                 activeClassName="border-solid border-brand-blue-primary bg-brand-blue-lighter/40 scale-[1.02]"

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -381,6 +381,10 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
       const newAssignments = { ...assignments };
       if (type === null) {
         delete newAssignments[student];
+        // Also clear a legacy name-keyed entry for this student, or the
+        // read-path fallback keeps re-surfacing it as still assigned.
+        const legacyName = activeRoster.find((s) => s.id === student)?.name;
+        if (legacyName) delete newAssignments[legacyName];
       } else {
         newAssignments[student] = type;
       }
@@ -388,7 +392,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
         config: { ...config, assignments: newAssignments },
       });
     },
-    [widget.id, config, assignments, updateWidget]
+    [widget.id, config, assignments, updateWidget, activeRoster]
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -403,15 +407,18 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
       setActiveId(null);
 
       const student = active.id as string;
+      const legacyName = activeRoster.find((s) => s.id === student)?.name;
+      const isCurrentlyAssigned =
+        !!assignments[student] || (!!legacyName && !!assignments[legacyName]);
 
       if (over?.id === 'hot' || over?.id === 'bento' || over?.id === 'home') {
         updateAssignment(student, over.id);
-      } else if (assignments[student]) {
+      } else if (isCurrentlyAssigned) {
         // Dropped in 'unassigned' zone or outside all zones — only write if currently assigned
         updateAssignment(student, null);
       }
     },
-    [assignments, updateAssignment]
+    [assignments, activeRoster, updateAssignment]
   );
 
   const handleDragCancel = useCallback(() => {

--- a/components/widgets/LunchCount/Widget.tsx
+++ b/components/widgets/LunchCount/Widget.tsx
@@ -327,25 +327,34 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
     })
   );
 
-  const activeRoster = useMemo((): string[] => {
-    if (rosterMode === 'custom') return roster;
+  // Each entry pairs a stable identity (`id`) with the display `name`.
+  // `assignments` is keyed by `id` — class-roster students use their roster
+  // `id` so two students who share a display name (e.g. two "Emma Smith"s)
+  // get independent assignments instead of colliding on the same key.
+  // Custom-list mode has no backing student record, so the typed name is the
+  // only identity available there.
+  const activeRoster = useMemo((): { id: string; name: string }[] => {
+    if (rosterMode === 'custom') {
+      return roster.map((name) => ({ id: name, name }));
+    }
     const currentRoster =
       rosters.find((r) => r.id === activeRosterId) ?? rosters[0];
     return (
-      currentRoster?.students.map((s) =>
-        `${s.firstName} ${s.lastName}`.trim()
-      ) ?? []
+      currentRoster?.students.map((s) => ({
+        id: s.id,
+        name: `${s.firstName} ${s.lastName}`.trim(),
+      })) ?? []
     );
   }, [rosterMode, roster, rosters, activeRosterId]);
 
   const groupedStudents = useMemo(() => {
-    const hot: string[] = [];
-    const bento: string[] = [];
-    const home: string[] = [];
-    const unassigned: string[] = [];
+    const hot: { id: string; name: string }[] = [];
+    const bento: { id: string; name: string }[] = [];
+    const home: { id: string; name: string }[] = [];
+    const unassigned: { id: string; name: string }[] = [];
 
     activeRoster.forEach((student) => {
-      const assignment = assignments[student];
+      const assignment = assignments[student.id];
       if (assignment === 'hot') hot.push(student);
       else if (assignment === 'bento') bento.push(student);
       else if (assignment === 'home') home.push(student);
@@ -808,10 +817,10 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                 >
                   {groupedStudents.hot.map((student) => (
                     <DraggableStudent
-                      key={student}
-                      id={student}
-                      name={student}
-                      onClick={() => updateAssignment(student, null)}
+                      key={student.id}
+                      id={student.id}
+                      name={student.name}
+                      onClick={() => updateAssignment(student.id, null)}
                       className={studentItemClass}
                       style={studentItemStyle}
                     />
@@ -822,6 +831,7 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
               {/* Bento Box Drop Zone */}
               <DroppableZone
                 id="bento"
+                data-testid="bento-zone"
                 className="bg-emerald-50 border-2 border-dashed border-emerald-300 rounded-2xl flex flex-col transition-all group"
                 style={{ padding: 'min(10px, 2cqmin)' }}
                 activeClassName="border-solid border-emerald-500 bg-emerald-100/50 scale-[1.02]"
@@ -871,10 +881,10 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                 >
                   {groupedStudents.bento.map((student) => (
                     <DraggableStudent
-                      key={student}
-                      id={student}
-                      name={student}
-                      onClick={() => updateAssignment(student, null)}
+                      key={student.id}
+                      id={student.id}
+                      name={student.name}
+                      onClick={() => updateAssignment(student.id, null)}
                       className={studentItemClass}
                       style={studentItemStyle}
                     />
@@ -936,10 +946,10 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                 >
                   {groupedStudents.home.map((student) => (
                     <DraggableStudent
-                      key={student}
-                      id={student}
-                      name={student}
-                      onClick={() => updateAssignment(student, null)}
+                      key={student.id}
+                      id={student.id}
+                      name={student.name}
+                      onClick={() => updateAssignment(student.id, null)}
                       className={studentItemClass}
                       style={studentItemStyle}
                     />
@@ -995,9 +1005,9 @@ export const LunchCountWidget: React.FC<{ widget: WidgetData }> = ({
                   >
                     {groupedStudents.unassigned.map((student) => (
                       <DraggableStudent
-                        key={student}
-                        id={student}
-                        name={student}
+                        key={student.id}
+                        id={student.id}
+                        name={student.name}
                         className={studentItemClass}
                         style={studentItemStyle}
                       />


### PR DESCRIPTION
## Root cause

`LunchCountWidget`'s `assignments` map (student → `hot`/`bento`/`home`) was keyed by the derived display-name string `${firstName} ${lastName}`.trim()` instead of the roster's stable `student.id`. Two students sharing a display name (e.g. two "Emma Smith"s in the same class — siblings, twins, common names) collapsed onto the same object key, so assigning one silently overwrote/merged the other's lunch assignment. A real classroom scenario, not an edge case.

## Fix

`activeRoster` now returns `{id, name}` pairs — class-roster mode keys/drags/drops by `student.id` (already available, already used elsewhere for absence tracking) and displays `student.name`. Custom free-text mode keeps using the typed name as its identity (no backing student record — a separate, pre-existing limitation, unchanged).

**Orchestrator addition during review:** switching the read path to `assignments[student.id]` alone would have silently reset every dashboard saved *before* this fix to "unassigned" — those configs have assignments stored under the old name key. Added a fallback (`assignments[student.id] ?? assignments[student.name]`) so already-saved dashboards keep working; all new writes go through the id key exclusively.

## Band-aid rejected

Deduping by appending an index suffix to colliding names (e.g. `"Emma Smith (2)"`) was considered and rejected — fragile (breaks on roster reorder), and treats the symptom instead of the real problem: the assignment key should be identity, not a display label.

## Regression tests

- `keeps two same-name students independently assigned (no name-collision)` — renders two roster students both named "Emma Smith" with distinct assignments, asserts each lands in its own zone (not merged into "unassigned"). Fails on unpatched source (both collapse to unassigned); passes after.
- `still honors a legacy name-keyed assignment saved before the id-keying fix` (orchestrator-added) — asserts a pre-existing name-keyed assignment still renders correctly. Fails without the fallback; passes with it.

Both independently re-verified fail-before/pass-after by the orchestrator (reverted each fix in isolation, confirmed the specific test fails, restored, confirmed green).

## Evidence

`pnpm run validate` (type-check:all, lint, format:check, root tests 573/573 files – 6988/6988 tests, functions tests 37/37 – 706/706, test:counts guard) and `pnpm run build` (app + SSR + prerender) both green on this branch.

## Backlog (not fixed here, flagged for a future run)

- `components/widgets/Stations/Widget.tsx` has the same name-keyed-assignment collision bug, but fixing it properly requires also reworking the Randomizer widget's `RandomGroup.names` (no stable student-ID concept today) — architectural, spans 2+ widgets.
- `RevealGrid/Widget.tsx` comment claims an "undefined or null" guard but only checks `undefined` — investigated, no live path currently sets `null`; not reachable today.

## Risk

**Contained** — isolated to one widget file + its test, no shared/utility or cross-widget contract changes.

---
🤖 Nightly code-health run — automated bug hunt + orchestrator review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M33BZjYmSCA3LhUBqhaCX3)_