### PR TITLE
fix(DraggableWindow): cancel touch long-press timers on unmount

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -51,6 +51,10 @@ interface GlassCardProps {
   children: React.ReactNode;
   className?: string;
   onPointerDown?: (e: React.PointerEvent) => void;
+  onPointerDownCapture?: (e: React.PointerEvent) => void;
+  onPointerMoveCapture?: (e: React.PointerEvent) => void;
+  onPointerUpCapture?: (e: React.PointerEvent) => void;
+  onPointerCancelCapture?: (e: React.PointerEvent) => void;
   onClick?: (e: React.MouseEvent) => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
   onTouchStart?: (e: React.TouchEvent) => void;
@@ -76,6 +80,10 @@ vi.mock('./GlassCard', () => {
         children,
         className,
         onPointerDown,
+        onPointerDownCapture,
+        onPointerMoveCapture,
+        onPointerUpCapture,
+        onPointerCancelCapture,
         onClick,
         onKeyDown,
         onTouchStart,
@@ -92,6 +100,10 @@ vi.mock('./GlassCard', () => {
         data-testid="draggable-window"
         className={className}
         onPointerDown={onPointerDown}
+        onPointerDownCapture={onPointerDownCapture}
+        onPointerMoveCapture={onPointerMoveCapture}
+        onPointerUpCapture={onPointerUpCapture}
+        onPointerCancelCapture={onPointerCancelCapture}
         onClick={onClick}
         onKeyDown={onKeyDown}
         onTouchStart={onTouchStart}
@@ -524,6 +536,37 @@ describe('DraggableWindow', () => {
     unmount();
 
     expect(document.body.classList.contains('is-dragging-widget')).toBe(false);
+  });
+
+  // Regression: a 1-finger touch long-press (screenshot gesture) starts a
+  // 600ms setTimeout. If the widget is removed (Firestore-driven delete,
+  // dashboard switch, admin force-remove) while the finger is still down,
+  // onPointerUp never runs because the host node already detached, so
+  // nothing clears the timer. The stale callback then fires after unmount,
+  // calling takeScreenshot() and closing tools (setSelectedWidgetId(null))
+  // against whatever the app is doing by the time it fires.
+  it('cancels the pending long-press screenshot timer when the widget unmounts mid-press', () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderComponent();
+      const windowEl = screen.getByTestId('draggable-window');
+
+      fireEvent.pointerDown(windowEl, {
+        clientX: 110,
+        clientY: 110,
+        pointerId: 1,
+        pointerType: 'touch',
+      });
+
+      unmount();
+
+      vi.advanceTimersByTime(700);
+
+      expect(mockTakeScreenshot).not.toHaveBeenCalled();
+      expect(mockSetSelectedWidgetId).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // Regression: pointer capture can be silently dropped mid-gesture (browser-

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -1995,6 +1995,23 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const longPressMoved = useRef(0);
   const activeTouchCount = useRef(0);
 
+  // Guards the two long-press setTimeouts below: if the widget is removed
+  // (Firestore-driven delete, dashboard switch, admin force-remove) while a
+  // touch is still held down, onPointerUp never runs — the host node has
+  // already detached — so nothing clears the pending timer. Without this
+  // flag the stale callback later fires takeScreenshot()/setIsAnnotating()
+  // and closes tools (setSelectedWidgetId(null)) against whatever the app
+  // is doing by the time it fires. This ref is only ever written here (by
+  // the unmount effect) and only ever read in the timer callbacks below, so
+  // it doesn't need the activeGestureCleanupRef-style indirection those
+  // gestures use.
+  const isUnmountedRef = useRef(false);
+  useEffect(() => {
+    return () => {
+      isUnmountedRef.current = true;
+    };
+  }, []);
+
   const handleWidgetPointerDown = (e: React.PointerEvent) => {
     // Same portal-events guard as `handlePointerDown` — see the comment
     // there. A modal click bubbling through the React tree should not
@@ -2014,6 +2031,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         // Start a 2-finger long press timer
         twoFingerLongPressTimer.current = setTimeout(() => {
           twoFingerLongPressTimer.current = null;
+          if (isUnmountedRef.current) return;
           if (activeTouchCount.current >= 2) {
             setIsAnnotating((prev) => !prev);
             handleCloseTools();
@@ -2027,6 +2045,7 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         longPressMoved.current = 0;
         longPressTimer.current = setTimeout(() => {
           longPressTimer.current = null;
+          if (isUnmountedRef.current) return;
           const LONG_PRESS_MOVE_TOLERANCE_PX = 15;
           if (
             activeTouchCount.current === 1 &&


### PR DESCRIPTION
## Root cause

The 1-finger (screenshot) and 2-finger (annotation-toggle) touch long-press `setTimeout`s in `DraggableWindow.tsx` were only cleared in `onPointerUp`/`onPointerCancel`. If a widget is removed while a touch is still held down (Firestore-driven delete from another session, dashboard switch, admin force-remove), the host DOM node detaches, so `onPointerUp` never fires and nothing clears the timer. 600ms later the stale callback fires anyway, calling `takeScreenshot()`/`setIsAnnotating()` plus `handleCloseTools()` — the latter calls the dashboard-wide `setSelectedWidgetId(null)`, which can clear whatever widget the user has since selected. Confirmed reachable — wired via `onPointerDownCapture`/`onPointerUpCapture` on every widget, not dead code.

## Fix

A write-once-read-only `isUnmountedRef` boolean, set by a dedicated unmount effect and checked at the top of both timer callbacks — matches the file's existing defense-in-depth pattern for drag/resize gesture cleanup (`activeGestureCleanupRef`).

## Band-aid rejected

A naive `useEffect` cleanup reading `longPressTimer.current`/`twoFingerLongPressTimer.current` directly (`clearTimeout` in the cleanup function) trips `eslint-plugin-react-hooks` v7's `react-hooks/immutability` rule once those refs are read in an effect, and destabilizes 5 pre-existing, necessary `react-hooks/refs` disable-comments elsewhere in this file. The write-once-read-only ref sidesteps this without touching unrelated lint suppressions.

## Regression test

`cancels the pending long-press screenshot timer when the widget unmounts mid-press` — fires a touch `pointerdown`, unmounts before the 600ms timer fires, advances fake timers 700ms, asserts `takeScreenshot`/`setSelectedWidgetId` were never called. Orchestrator independently re-verified: reverted just the source fix, confirmed the test fails (`expected ... not to be called ... called 1 times`); restored the fix, confirmed all 71 tests in the file pass.

## Evidence

Subagent-run `pnpm run validate` + `pnpm run build` both green. Orchestrator re-ran the full test file (71/71 passing) after the fail-before/pass-after check.

## Risk

**Contained** — localized to two `setTimeout` callbacks in one widget-chrome component, matches an established in-file pattern, no API/type/behavior change for the non-buggy path.

## Backlog (investigated, not pursued)

- `components/layout/sidebar/SidebarWidgets.tsx` has no `canAccessWidget` permission gate on its `TOOLS` list (unlike `Dock.tsx`), but the component has zero live consumers (`Sidebar.tsx` never imports it) — dead code, not user-reachable today.

---
🤖 Nightly code-health run — automated bug hunt + orchestrator review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M33BZjYmSCA3LhUBqhaCX3)_