### PR TITLE
fix(rosters): assignPins no longer collides with manually-set PINs

### DIFF
--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -17,6 +17,7 @@ import { db, functions, isAuthBypass } from '@/config/firebase';
 import { useGoogleDrive } from '@/hooks/useGoogleDrive';
 import { getLocalIsoDate } from '@/utils/localDate';
 import { mapWithConcurrency } from '@/utils/mapWithConcurrency';
+import { assignPins } from '@/utils/rosterPins';
 
 /**
  * Phase 3 — rebuild the per-roster pin_index sidecar after a roster save.
@@ -81,17 +82,6 @@ async function syncRosterPinIndex(
   } catch (err) {
     console.warn('[useRosters] commitRosterPinIndexV1 failed:', err);
   }
-}
-
-/**
- * Assigns zero-padded sequential PINs to students that don't have one yet.
- * Returns a new array — does not mutate the input.
- */
-function assignPins(students: Student[]): Student[] {
-  return students.map((s, i) => ({
-    ...s,
-    pin: s.pin || String(i + 1).padStart(2, '0'),
-  }));
 }
 
 /**

--- a/tests/utils/rosterPins.test.ts
+++ b/tests/utils/rosterPins.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { assignPins } from '@/utils/rosterPins';
+import type { Student } from '@/types';
+
+const student = (id: string, pin = ''): Student => ({
+  id,
+  firstName: id,
+  lastName: '',
+  pin,
+});
+
+describe('assignPins', () => {
+  it('leaves students with an existing pin untouched', () => {
+    const result = assignPins([student('a', '07')]);
+    expect(result[0].pin).toBe('07');
+  });
+
+  it('backfills blank pins sequentially, zero-padded', () => {
+    const result = assignPins([student('a'), student('b'), student('c')]);
+    expect(result.map((s) => s.pin)).toEqual(['01', '02', '03']);
+  });
+
+  it('does not overwrite the array in place', () => {
+    const input = [student('a')];
+    const result = assignPins(input);
+    expect(input[0].pin).toBe('');
+    expect(result).not.toBe(input);
+  });
+
+  it('never hands out a fallback pin that collides with a manually-set pin later in the roster', () => {
+    // Student at index 4 (position 5) is blank; a manually-set pin "05"
+    // already exists later in the roster. The naive `String(i+1)` fallback
+    // used to assign "05" to the blank student too, producing a silent
+    // duplicate that breaks PIN-based student login (two students would
+    // resolve to the same pin_index entry).
+    const students = [
+      student('s1'),
+      student('s2'),
+      student('s3'),
+      student('s4'),
+      student('s5'), // blank — naive fallback would be "05"
+      student('s6'),
+      student('s7', '05'), // manually assigned, collides with the naive fallback
+    ];
+
+    const result = assignPins(students);
+    const pins = result.map((s) => s.pin);
+
+    expect(new Set(pins).size).toBe(pins.length);
+    expect(result.find((s) => s.id === 's7')?.pin).toBe('05');
+    expect(result.find((s) => s.id === 's5')?.pin).not.toBe('05');
+  });
+
+  it('skips over multiple manually-set pins when backfilling', () => {
+    const students = [
+      student('a', '01'),
+      student('b'),
+      student('c', '02'),
+      student('d'),
+    ];
+    const result = assignPins(students);
+    const pins = result.map((s) => s.pin);
+    expect(new Set(pins).size).toBe(pins.length);
+    expect(result.find((s) => s.id === 'b')?.pin).toBe('03');
+    expect(result.find((s) => s.id === 'd')?.pin).toBe('04');
+  });
+});

--- a/utils/rosterPins.ts
+++ b/utils/rosterPins.ts
@@ -1,0 +1,36 @@
+import { Student } from '@/types';
+
+/**
+ * Assigns zero-padded sequential PINs to students that don't have one yet.
+ *
+ * Never hands out a fallback PIN that collides with any PIN already present
+ * in the roster (manually entered or previously assigned) — position-based
+ * fallbacks (`String(i + 1).padStart(2, '0')`) skip over any value already
+ * taken and keep advancing until they find a free one. Without this, a
+ * teacher who hand-sets a PIN like "05" while leaving an earlier student's
+ * PIN blank would silently get two students sharing "05", which breaks the
+ * PIN-based student login/SSO bridge (see `syncRosterPinIndex` in
+ * `hooks/useRosters.ts`).
+ *
+ * Returns a new array — does not mutate the input.
+ */
+export function assignPins(students: Student[]): Student[] {
+  const used = new Set(
+    students.map((s) => s.pin).filter((pin): pin is string => !!pin)
+  );
+  let next = 1;
+  const takeNextAvailablePin = (): string => {
+    let candidate = String(next).padStart(2, '0');
+    while (used.has(candidate)) {
+      next += 1;
+      candidate = String(next).padStart(2, '0');
+    }
+    used.add(candidate);
+    next += 1;
+    return candidate;
+  };
+
+  return students.map((s) =>
+    s.pin ? s : { ...s, pin: takeNextAvailablePin() }
+  );
+}


### PR DESCRIPTION
## Root cause

`assignPins()` (`hooks/useRosters.ts`) backfilled a blank student PIN using pure array position — `String(i + 1).padStart(2, '0')` — with no check against PINs other students in the same roster already had. The roster editor's duplicate-PIN warning runs against pre-assignment (still-blank) state, so it can never catch a collision between a manually-typed PIN and one that will later be auto-derived from position. Example: student #5 left blank, student #7 manually set to `"05"` — the editor shows no warning, but `assignPins()` silently gives student #5 `"05"` too. Both feed `syncRosterPinIndex()`, which writes the sidecar the PIN-based ClassLink/SSO login flow uses to resolve student identity — a collision there is a real correctness/identity-resolution bug on login, not cosmetic.

## Fix

Extracted `assignPins` to `utils/rosterPins.ts` (mirrors the existing `utils/rosterRestrictions.ts` extraction pattern for testability). The new implementation builds a `Set` of every PIN already in use (manual or previously assigned) and advances a running counter past any taken value before handing out a fallback PIN.

## Band-aid rejected

Widening `findDuplicatePins` to warn in the editor UI was considered and rejected — it only nags after the fact, doesn't prevent the collision if the teacher ignores/misses it, or if the save routes through a different path that doesn't hit that specific editor hook (ClassLink re-sync, Drive import merge). Fixing `assignPins()` itself closes the hole at the one chokepoint every save path already goes through.

## Regression test

`tests/utils/rosterPins.test.ts` (5 cases) — key case reproduces the exact blank-then-manual-collision scenario and asserts no duplicate PINs result. Orchestrator independently re-verified: reverted `rosterPins.ts` to the old position-only logic, confirmed 2/5 tests fail (`expected 3 to be 4` / duplicate PINs); restored the fix, confirmed all 5 pass.

## Evidence

Subagent-run `pnpm run validate` + `pnpm run build` both green (root 6991/6991, functions 706/706).

## Risk

**Contained** — pure, localized change to a fallback-value algorithm inside one utility function; no call-signature or consumer-behavior change beyond the returned PINs now being guaranteed collision-free.

## Backlog (investigated, ruled out)

- `useCatalystSets.ts:46`'s lexicographic sort — confirmed unreachable: the admin UI hard-caps catalyst sets at 4, so a 10th set (needed to trigger the mis-sort) can never be created.

---
🤖 Nightly code-health run — automated bug hunt + orchestrator review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M33BZjYmSCA3LhUBqhaCX3)_