### PR TITLE
fix(functions): SECURITY — relock activity_wall_sessions after gallery share expires/revokes

### DIFF
--- a/functions/src/expireActivityWallShares.test.ts
+++ b/functions/src/expireActivityWallShares.test.ts
@@ -132,6 +132,11 @@ function makeStubDb(seed: {
       if (name === 'activity_wall_sessions') {
         return {
           doc: (sessionId: string) => ({
+            get: () =>
+              Promise.resolve({
+                exists: sessionId in sessions,
+                data: () => sessions[sessionId],
+              }),
             update: (data: Record<string, unknown>) => {
               if (!(sessionId in sessions)) {
                 const err = new Error('no such document') as Error & {
@@ -252,7 +257,7 @@ describe('runExpireActivityWallShares', () => {
     expect(sessions.teacher1_act1.publiclyShared).toBe(false);
 
     const second = await runExpireActivityWallShares(db, NOW);
-    expect(second).toEqual({ lapsedShares: 1, sessionsRelocked: 1 });
+    expect(second).toEqual({ lapsedShares: 1, sessionsRelocked: 0 });
     expect(sessions.teacher1_act1.publiclyShared).toBe(false);
   });
 

--- a/functions/src/expireActivityWallShares.test.ts
+++ b/functions/src/expireActivityWallShares.test.ts
@@ -1,0 +1,305 @@
+// Unit tests for the `expireActivityWallShares` nightly-style sweep.
+//
+// Regression coverage for the bug: `ActivityWallShareModal` flips
+// `publiclyShared: true` onto `activity_wall_sessions/{sessionId}` when a
+// gallery link is created, but nothing ever flipped it back to `false` when
+// the corresponding `shared_activity_walls` share expired or was revoked.
+// Since firestore.rules gates the `submissions` subcollection read (and the
+// Storage photo read) on that flag alone — not on the share doc's
+// `revoked`/`expiresAt` — a caller who already knows `sessionId` could keep
+// reading every submission/photo forever after the teacher's link "expired".
+//
+// Two layers, mirroring `gcPlcOrphans.test.ts`:
+//   1. PURE DECISION HELPER — `isLapsedShare`.
+//   2. SWEEP — `runExpireActivityWallShares` against a stub Firestore that
+//      emulates the Admin SDK surface used (where/limit/get, doc().update()).
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  firestore: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2', () => ({
+  setGlobalOptions: vi.fn(),
+}));
+
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: (_opts: unknown, handler: () => Promise<void>) => handler,
+}));
+
+import {
+  isLapsedShare,
+  runExpireActivityWallShares,
+} from './expireActivityWallShares';
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('isLapsedShare', () => {
+  it('is NOT lapsed when permanent (expiresAt null/absent) and not revoked', () => {
+    expect(isLapsedShare({ expiresAt: null }, NOW)).toBe(false);
+    expect(isLapsedShare({}, NOW)).toBe(false);
+  });
+
+  it('is NOT lapsed while expiresAt is still in the future', () => {
+    expect(isLapsedShare({ expiresAt: NOW + DAY }, NOW)).toBe(false);
+  });
+
+  it('IS lapsed once expiresAt has passed', () => {
+    expect(isLapsedShare({ expiresAt: NOW - 1 }, NOW)).toBe(true);
+    expect(isLapsedShare({ expiresAt: NOW }, NOW)).toBe(true);
+  });
+
+  it('IS lapsed when revoked, regardless of expiresAt', () => {
+    expect(isLapsedShare({ revoked: true, expiresAt: NOW + DAY }, NOW)).toBe(
+      true
+    );
+    expect(isLapsedShare({ revoked: true, expiresAt: null }, NOW)).toBe(true);
+  });
+
+  it('ignores a malformed expiresAt (non-number) — treated as permanent', () => {
+    expect(isLapsedShare({ expiresAt: 'nope' }, NOW)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Sweep against a stub Firestore
+// ===========================================================================
+
+interface StubShareDoc {
+  id: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * In-memory Firestore mirroring the Admin SDK surface
+ * `runExpireActivityWallShares` uses:
+ *   db.collection('shared_activity_walls').where(f, op, v).limit(n).get()
+ *   db.collection('activity_wall_sessions').doc(id).update(data)
+ * Only the where clauses this sweep issues are supported (le/eq on
+ * expiresAt/revoked/sessionId) — enough to faithfully exercise the sweep
+ * without pulling in the Firestore emulator.
+ */
+function makeStubDb(seed: {
+  shares?: StubShareDoc[];
+  sessions?: Record<string, Record<string, unknown>>;
+}) {
+  const shares = seed.shares ?? [];
+  const sessions: Record<string, Record<string, unknown>> = {
+    ...(seed.sessions ?? {}),
+  };
+  const updates: Record<string, Record<string, unknown>[]> = {};
+
+  function matches(
+    doc: StubShareDoc,
+    filters: Array<[string, string, unknown]>
+  ): boolean {
+    return filters.every(([field, op, value]) => {
+      const actual = doc.data[field];
+      if (op === '<=')
+        return typeof actual === 'number' && actual <= (value as number);
+      if (op === '==') return actual === value;
+      throw new Error(`Unsupported op in stub: ${op}`);
+    });
+  }
+
+  function sharedActivityWallsCollection(
+    filters: Array<[string, string, unknown]> = [],
+    lim?: number
+  ) {
+    return {
+      where: (field: string, op: string, value: unknown) =>
+        sharedActivityWallsCollection([...filters, [field, op, value]], lim),
+      limit: (n: number) => sharedActivityWallsCollection(filters, n),
+      get: () => {
+        const rows = shares.filter((d) => matches(d, filters));
+        const sliced = lim === undefined ? rows : rows.slice(0, lim);
+        return Promise.resolve({
+          docs: sliced.map((d) => ({ id: d.id, data: () => d.data })),
+        });
+      },
+    };
+  }
+
+  const db = {
+    collection: (name: string) => {
+      if (name === 'shared_activity_walls') {
+        return sharedActivityWallsCollection();
+      }
+      if (name === 'activity_wall_sessions') {
+        return {
+          doc: (sessionId: string) => ({
+            update: (data: Record<string, unknown>) => {
+              if (!(sessionId in sessions)) {
+                const err = new Error('no such document') as Error & {
+                  code: number;
+                };
+                err.code = 5;
+                return Promise.reject(err);
+              }
+              sessions[sessionId] = { ...sessions[sessionId], ...data };
+              updates[sessionId] = [...(updates[sessionId] ?? []), data];
+              return Promise.resolve();
+            },
+          }),
+        };
+      }
+      throw new Error(`Unexpected collection in stub: ${name}`);
+    },
+  };
+
+  return {
+    db: db as unknown as Parameters<typeof runExpireActivityWallShares>[0],
+    sessions,
+    updates,
+  };
+}
+
+describe('runExpireActivityWallShares', () => {
+  it('relocks a session once its only share has expired', async () => {
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-1',
+          data: { sessionId: 'teacher1_act1', expiresAt: NOW - DAY },
+        },
+      ],
+      sessions: { teacher1_act1: { publiclyShared: true } },
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result).toEqual({ lapsedShares: 1, sessionsRelocked: 1 });
+    expect(sessions.teacher1_act1.publiclyShared).toBe(false);
+  });
+
+  it('relocks a session once its only share is revoked (expiresAt still in the future)', async () => {
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-1',
+          data: {
+            sessionId: 'teacher1_act1',
+            revoked: true,
+            expiresAt: NOW + DAY,
+          },
+        },
+      ],
+      sessions: { teacher1_act1: { publiclyShared: true } },
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result).toEqual({ lapsedShares: 1, sessionsRelocked: 1 });
+    expect(sessions.teacher1_act1.publiclyShared).toBe(false);
+  });
+
+  it('does NOT relock a session that still has a live (permanent) share', async () => {
+    // Re-share scenario: one expired link + one permanent link still active
+    // for the SAME session — publiclyShared must stay true.
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-old',
+          data: { sessionId: 'teacher1_act1', expiresAt: NOW - DAY },
+        },
+        {
+          id: 'share-new',
+          data: { sessionId: 'teacher1_act1', expiresAt: null },
+        },
+      ],
+      sessions: { teacher1_act1: { publiclyShared: true } },
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result).toEqual({ lapsedShares: 1, sessionsRelocked: 0 });
+    expect(sessions.teacher1_act1.publiclyShared).toBe(true);
+  });
+
+  it('leaves a permanent (never-expiring) share untouched', async () => {
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-1',
+          data: { sessionId: 'teacher1_act1', expiresAt: null },
+        },
+      ],
+      sessions: { teacher1_act1: { publiclyShared: true } },
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result).toEqual({ lapsedShares: 0, sessionsRelocked: 0 });
+    expect(sessions.teacher1_act1.publiclyShared).toBe(true);
+  });
+
+  it('is idempotent — a second run on an already-relocked session finds nothing new to do', async () => {
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-1',
+          data: { sessionId: 'teacher1_act1', expiresAt: NOW - DAY },
+        },
+      ],
+      sessions: { teacher1_act1: { publiclyShared: true } },
+    });
+
+    await runExpireActivityWallShares(db, NOW);
+    expect(sessions.teacher1_act1.publiclyShared).toBe(false);
+
+    const second = await runExpireActivityWallShares(db, NOW);
+    expect(second).toEqual({ lapsedShares: 1, sessionsRelocked: 1 });
+    expect(sessions.teacher1_act1.publiclyShared).toBe(false);
+  });
+
+  it('does not throw when the session doc no longer exists (nothing to relock)', async () => {
+    const { db } = makeStubDb({
+      shares: [
+        {
+          id: 'share-1',
+          data: { sessionId: 'deleted-session', expiresAt: NOW - DAY },
+        },
+      ],
+      sessions: {},
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+    expect(result).toEqual({ lapsedShares: 1, sessionsRelocked: 0 });
+  });
+
+  it('handles multiple lapsed shares across different sessions', async () => {
+    const { db, sessions } = makeStubDb({
+      shares: [
+        {
+          id: 'share-a',
+          data: { sessionId: 'teacherA_act1', expiresAt: NOW - DAY },
+        },
+        {
+          id: 'share-b',
+          data: { sessionId: 'teacherB_act1', revoked: true, expiresAt: null },
+        },
+      ],
+      sessions: {
+        teacherA_act1: { publiclyShared: true },
+        teacherB_act1: { publiclyShared: true },
+      },
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result).toEqual({ lapsedShares: 2, sessionsRelocked: 2 });
+    expect(sessions.teacherA_act1.publiclyShared).toBe(false);
+    expect(sessions.teacherB_act1.publiclyShared).toBe(false);
+  });
+});
+
+describe('expireActivityWallShares — scheduled wrapper', () => {
+  it('imports and exposes the onSchedule handler', async () => {
+    const mod = await import('./expireActivityWallShares');
+    expect(typeof mod.expireActivityWallShares).toBe('function');
+  });
+});

--- a/functions/src/expireActivityWallShares.ts
+++ b/functions/src/expireActivityWallShares.ts
@@ -118,6 +118,17 @@ export async function runExpireActivityWallShares(
     );
     if (stillLive) continue;
 
+    // Expired share docs are never deleted, so every subsequent run
+    // re-finds the same lapsed shares — skip the write once a session is
+    // already relocked, or the write count grows forever with no bound.
+    const sessionSnap = await db
+      .collection('activity_wall_sessions')
+      .doc(sessionId)
+      .get();
+    if (!sessionSnap.exists || sessionSnap.data()?.publiclyShared !== true) {
+      continue;
+    }
+
     try {
       await db
         .collection('activity_wall_sessions')

--- a/functions/src/expireActivityWallShares.ts
+++ b/functions/src/expireActivityWallShares.ts
@@ -1,0 +1,153 @@
+/**
+ * Hourly sweep that re-locks an Activity Wall session once every gallery
+ * share pointing at it has lapsed (expired or revoked).
+ *
+ * `components/widgets/ActivityWall/ShareModal.tsx` flips
+ * `publiclyShared: true` onto `activity_wall_sessions/{sessionId}` when a
+ * teacher creates a `shared_activity_walls/{shareId}` gallery link — that
+ * flag is what unlocks the `submissions` subcollection read (firestore.rules)
+ * and the `activity_wall_photos/{sessionId}/*` Storage read for anonymous
+ * gallery viewers. Firestore rules cannot look up "is there a live share for
+ * this session" directly (rules only support `get()`/`exists()` on an EXACT
+ * document path, not a query, and shareId is an unrelated random UUID — not
+ * derived from sessionId), so `publiclyShared` has to be a server-maintained
+ * mirror of "does at least one live share exist".
+ *
+ * The share doc itself is correctly gated on `revoked`/`expiresAt` at read
+ * time (see `a55c956` / #2242), and the client only *subscribes* to
+ * submissions after confirming the share is live (`ActivityWallGalleryView`).
+ * But nothing ever flipped `publiclyShared` back to `false` — so a caller who
+ * captured `sessionId` from the share doc while it was live (e.g. browser
+ * devtools, or a saved Firestore SDK snippet) could keep reading every
+ * submission (text + photo storage paths) and downloading every photo
+ * directly, forever, even after the teacher's chosen expiration date passed.
+ * A permanent share (`expiresAt: null`) is untouched by this sweep — that's
+ * the intended "never expires" case.
+ *
+ * Modeled on `expireSubShares.ts` / `gcPlcOrphans.ts`: an `onSchedule`
+ * function with pinned `memory`/`timeZone` and a per-run cap. Unlike those
+ * sweeps, this one does NOT delete the share doc — the owner/admin can still
+ * read a lapsed share for management (mirrors the sibling rule), so only the
+ * session-level unlock flag is corrected.
+ */
+
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+import './functionsInit';
+
+/** Cap per-run lapsed-share lookups to keep one slow sweep from monopolising. */
+export const MAX_LAPSED_SHARES_PER_RUN = 500;
+
+type Firestore = admin.firestore.Firestore;
+type QueryDocSnap = admin.firestore.QueryDocumentSnapshot;
+
+interface SharedActivityWallData {
+  sessionId?: unknown;
+  expiresAt?: unknown;
+  revoked?: unknown;
+}
+
+/**
+ * A share has lapsed when it's explicitly revoked OR its `expiresAt` is a
+ * number in the past. `expiresAt: null`/absent means "permanent" and never
+ * lapses on its own.
+ */
+export function isLapsedShare(
+  data: SharedActivityWallData,
+  now: number
+): boolean {
+  if (data.revoked === true) return true;
+  return typeof data.expiresAt === 'number' && data.expiresAt <= now;
+}
+
+/** Extracts a valid non-empty `sessionId` string, or null if malformed/missing. */
+function sessionIdOf(data: SharedActivityWallData): string | null {
+  return typeof data.sessionId === 'string' && data.sessionId.length > 0
+    ? data.sessionId
+    : null;
+}
+
+/**
+ * Core sweep, extracted from the scheduler wrapper so it can be exercised
+ * against a stub Firestore in tests (mirrors `runGcPlcOrphans`).
+ *
+ * 1. Find every `shared_activity_walls` doc that is revoked OR past its
+ *    `expiresAt` (two single-field queries — no composite index needed).
+ * 2. Group the lapsed docs by `sessionId` (a session can have been shared
+ *    more than once — teachers re-share rather than edit an existing link).
+ * 3. For each affected session, re-check ALL its shares (not just the lapsed
+ *    ones) — if none are still live, flip `publiclyShared` back to `false`.
+ *    A session with even one still-live share is left untouched.
+ */
+export async function runExpireActivityWallShares(
+  db: Firestore,
+  now: number = Date.now()
+): Promise<{ lapsedShares: number; sessionsRelocked: number }> {
+  const [expiredSnap, revokedSnap] = await Promise.all([
+    db
+      .collection('shared_activity_walls')
+      .where('expiresAt', '<=', now)
+      .limit(MAX_LAPSED_SHARES_PER_RUN)
+      .get(),
+    db
+      .collection('shared_activity_walls')
+      .where('revoked', '==', true)
+      .limit(MAX_LAPSED_SHARES_PER_RUN)
+      .get(),
+  ]);
+
+  const lapsedById = new Map<string, QueryDocSnap>();
+  for (const doc of [...expiredSnap.docs, ...revokedSnap.docs]) {
+    lapsedById.set(doc.id, doc);
+  }
+
+  const sessionIds = new Set<string>();
+  for (const doc of lapsedById.values()) {
+    const sessionId = sessionIdOf(doc.data() as SharedActivityWallData);
+    if (sessionId) sessionIds.add(sessionId);
+  }
+
+  let relocked = 0;
+  for (const sessionId of sessionIds) {
+    const allSharesSnap = await db
+      .collection('shared_activity_walls')
+      .where('sessionId', '==', sessionId)
+      .get();
+    const stillLive = allSharesSnap.docs.some(
+      (doc) => !isLapsedShare(doc.data() as SharedActivityWallData, now)
+    );
+    if (stillLive) continue;
+
+    try {
+      await db
+        .collection('activity_wall_sessions')
+        .doc(sessionId)
+        .update({ publiclyShared: false });
+      relocked += 1;
+    } catch (err) {
+      // The session doc may have been deleted independently of its shares —
+      // that's not an error for this sweep (nothing left to relock).
+      const code = (err as { code?: number | string }).code;
+      if (code !== 5 && code !== 'not-found') throw err;
+    }
+  }
+
+  return { lapsedShares: lapsedById.size, sessionsRelocked: relocked };
+}
+
+export const expireActivityWallShares = onSchedule(
+  {
+    schedule: 'every 60 minutes',
+    timeZone: 'America/Chicago',
+    memory: '256MiB',
+    timeoutSeconds: 120,
+  },
+  async () => {
+    const db = admin.firestore();
+    const { lapsedShares, sessionsRelocked } =
+      await runExpireActivityWallShares(db);
+    console.log(
+      `[expireActivityWallShares] found ${lapsedShares} lapsed share(s); relocked ${sessionsRelocked} session(s)`
+    );
+  }
+);

--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -2995,6 +2995,7 @@ describe('index barrel — deployed export set', () => {
     // Admin analytics snapshot + maintenance
     'recomputeAdminAnalytics',
     'expireSubShares',
+    'expireActivityWallShares',
     'finalizeIdleQuizAttempts',
     // Google / Spotify OAuth
     'exchangeGoogleAuthCode',

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -104,6 +104,7 @@ export { mirrorPlcIndex } from './mirrorPlcIndex';
 export { migratePlcs } from './migratePlcs';
 export { recomputeAdminAnalytics } from './adminAnalyticsSnapshot';
 export { expireSubShares } from './expireSubShares';
+export { expireActivityWallShares } from './expireActivityWallShares';
 export { finalizeIdleQuizAttempts } from './finalizeIdleQuizAttempts';
 export {
   exchangeGoogleAuthCode,


### PR DESCRIPTION
## Root cause — SECURITY

`ShareModal.tsx` flips `activity_wall_sessions/{sessionId}.publiclyShared` to `true` when a teacher creates a `shared_activity_walls/{shareId}` gallery link. `firestore.rules` gates the `submissions` subcollection read — and `storage.rules` gates the `activity_wall_photos` read — on that flag **alone** (`firestore.rules:3774`, confirmed by direct read), not on the share doc's `revoked`/`expiresAt`. Nothing in the codebase ever flipped `publiclyShared` back to `false` (confirmed via full-repo grep). The share doc itself is already correctly gated on `revoked`/`expiresAt` (#2242, and the just-shipped comments/likes follow-up), but that only protects the share doc — not the underlying session data the gallery actually displays. A caller who captured `sessionId` from a live share (devtools, a saved SDK snippet) could keep reading every submission and downloading every photo directly, forever, past the teacher's chosen expiration or a future revoke.

## Fix

`functions/src/expireActivityWallShares.ts` — a new hourly `onSchedule` sweep (modeled on `expireSubShares.ts`/`gcPlcOrphans.ts`) that finds lapsed `shared_activity_walls` docs, groups them by `sessionId`, and flips `publiclyShared` back to `false` for each session **only if no other share for that session is still live** (teachers can re-share the same session). Permanent shares (`expiresAt: null`) are left untouched.

## Band-aid rejected

Patching `firestore.rules` to check the share doc's `revoked`/`expiresAt` directly from the `submissions` read rule isn't possible: Firestore rules only support `get()`/`exists()` on an exact document path, not a query, and `shareId` is a random UUID unrelated to `sessionId` — the rule can't look up "is there a live share for this session" without already knowing which `shareId` to check. A server-maintained mirror is the architecturally correct fix, matching this codebase's established sweep pattern.

## Regression tests

`functions/src/expireActivityWallShares.test.ts` (13 tests) — covers the pure `isLapsedShare` decision helper and the sweep against a stub Firestore (expire-relocks, revoke-relocks, re-share-keeps-session-open, permanent-share-untouched, missing-session-doc, idempotency, multi-session). Orchestrator independently re-verified with a stronger check than the subagent's own (module-deletion) fail-before test: mutated the `isLapsedShare` revoked-check logic (`=== true` → `=== false`) and confirmed 3/13 tests fail with a concrete wrong-value diff; restored the correct logic and confirmed all 13 pass again.

## Evidence

`pnpm run validate` (type-check:all, lint app+functions, format:check, root tests 573/573 – 6986/6986, functions tests 38/38 – 719/719) and `pnpm run build` both green. `firestore.rules`/`storage.rules` were not modified, so `test:rules` was not required.

## Risk

**Contained** — new isolated Cloud Function, no changes to existing read paths or rules. Worst case of a bug in the sweep is a session staying unlocked slightly longer (same as today) or a false-positive relock (client just re-shares, cheap).

## Follow-up (flagged, not implemented — out of scope for one bug)

No client UI currently writes `revoked: true` on `shared_activity_walls` (no revoke button exists yet), so today's exploitable window is specifically the `expiresAt` path. The sweep also handles `revoked` for when that UI ships, but reacts up to an hour late — an `onDocumentUpdated` trigger for immediate revoke-response would be a good addition once a revoke button exists.

---
🤖 Nightly code-health run — automated bug hunt + orchestrator review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M33BZjYmSCA3LhUBqhaCX3)_