### PR TITLE
refactor(reveal-grid): unify Reveal Mode settings label to group-heading pattern

### DIFF
--- a/components/widgets/RevealGrid/Settings.tsx
+++ b/components/widgets/RevealGrid/Settings.tsx
@@ -360,8 +360,17 @@ export const RevealGridSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Reveal Mode */}
       <div>
-        <SettingsLabel>Reveal Mode</SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <SettingsLabel
+          as="span"
+          id={`revealgrid-revealmode-label-${widget.id}`}
+        >
+          Reveal Mode
+        </SettingsLabel>
+        <div
+          role="group"
+          aria-labelledby={`revealgrid-revealmode-label-${widget.id}`}
+          className="flex bg-slate-100 p-1 rounded-xl"
+        >
           {(['flip', 'fade'] as const).map((mode) => (
             <button
               key={mode}


### PR DESCRIPTION
## Nightly Unifier — D3: Settings Panel Label Primitives (run 39)

**Canonical form:** `<SettingsLabel as="span" id="...">Heading</SettingsLabel>` paired with `role="group" aria-labelledby="..."` on the sibling-control container, for `SettingsLabel` call sites that head a *group* of controls (a row of toggle buttons) rather than pairing 1:1 with one input. A bare `<label>` in that shape is semantically orphaned (no single associated control). This variant already exists on `SettingsLabel` (added in PR #2141) and has an established multi-run retrofit precedent in this same file (`Columns` → PR #2197, `Game Mode` → PR #2245).

**Instance unified:** `components/widgets/RevealGrid/Settings.tsx:363` — the "Reveal Mode" label heading the 2-button `flip`/`fade` toggle group. This was the last of the group-heading candidates in this file (`Columns` and `Game Mode` were converted in prior nightly runs).

```diff
-        <SettingsLabel>Reveal Mode</SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <SettingsLabel as="span" id={`revealgrid-revealmode-label-${widget.id}`}>
+          Reveal Mode
+        </SettingsLabel>
+        <div role="group" aria-labelledby={`revealgrid-revealmode-label-${widget.id}`} className="flex bg-slate-100 p-1 rounded-xl">
```

Id is scoped to `widget.id` (matching the two sibling conversions already in this file), since `RevealGridSettings` renders per-widget-instance and a static id would collide if 2+ instances are open concurrently.

**Enforcement:** None needed — this is a semantics-only accessibility fix using an already-canonical component variant; no new pattern to guard against regrowing.

**Behavior/visual preservation evidence:**
- Read `components/common/SettingsLabel.tsx` directly: the `as="label"` and `as="span"` branches compute the identical `combinedClasses` string and only differ in wrapping tag (`<label>` vs `<span>`) and `htmlFor` presence. This call site has no `htmlFor`/`icon`, so the rendered class string and content are byte-identical — zero visual delta, purely a semantic/accessibility improvement (fixes an orphaned `<label>`).
- `pnpm run validate` (type-check root+functions, eslint --max-warnings 0, prettier --check, tests): green — 575 files / 6997 tests (root), 38 files / 719 tests (functions), test-count guard passed. Independently re-verified by the orchestrator in a fresh validate run against this exact branch.
- `pnpm run build`: exit 0, app + SSR bundles + prerendered routes all built successfully. Independently re-verified by the orchestrator.

**Risk tag: mechanical** (pure equivalence — no visual change, semantics-only).

**Deferred to backlog (not touched this run):** `components/widgets/SyntaxFramer/Settings.tsx:104` ("Mode") and `:158` ("Alignment") are two more confirmed instances of the same group-heading shape in a different file — left for a future nightly run (one unification per dimension per night).

---
🤖 Generated by the nightly SpartBoard consistency routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_019cdE3GbJkqWtcMa8gyQ3RM)_