### PR TITLE
refactor(syntax-framer): unify Mode settings label to group-heading pattern

### DIFF
--- a/components/widgets/SyntaxFramer/Settings.tsx
+++ b/components/widgets/SyntaxFramer/Settings.tsx
@@ -13,6 +13,7 @@ export const SyntaxFramerSettings: React.FC<SyntaxFramerSettingsProps> = ({
 }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as SyntaxFramerConfig;
+  const syntaxFramerModeLabelId = `syntaxframer-mode-label-${widget.id}`;
 
   // Derive initial input from existing tokens
   const initialInput = config.tokens
@@ -101,8 +102,14 @@ export const SyntaxFramerSettings: React.FC<SyntaxFramerSettingsProps> = ({
       </div>
 
       <div>
-        <SettingsLabel icon={Calculator}>Mode</SettingsLabel>
-        <div className="flex gap-2 mb-4">
+        <SettingsLabel as="span" id={syntaxFramerModeLabelId} icon={Calculator}>
+          Mode
+        </SettingsLabel>
+        <div
+          className="flex gap-2 mb-4"
+          role="group"
+          aria-labelledby={syntaxFramerModeLabelId}
+        >
           <button
             className={`flex-1 flex items-center justify-center gap-2 py-2 px-3 rounded-lg border text-sm font-medium transition-colors ${
               config.mode === 'text'


### PR DESCRIPTION
## Nightly Unifier — D3: Settings Panel Label Primitives (run 40)

**Canonical form:** `<SettingsLabel as="span" id="...">Heading</SettingsLabel>` paired with `role="group" aria-labelledby="..."` on the sibling-control container, for `SettingsLabel` call sites that head a *group* of controls (a row of toggle buttons) rather than pairing 1:1 with one input. A bare `<label>` in that shape is semantically orphaned (no single associated control). This variant already exists on `SettingsLabel` (added in PR #2141) and has an established multi-run retrofit precedent in this same widget family (`RevealGrid` — PRs #2197, #2245, #2254; `DrawingWidget` — PR #2183; `MusicWidget` — PRs #2218, #2224; `RandomSettings` — PRs #2207, #2236).

**Instance unified:** `components/widgets/SyntaxFramer/Settings.tsx:104` — the "Mode" label heading the 2-button Text/Math toggle group.

```diff
-        <SettingsLabel icon={Calculator}>Mode</SettingsLabel>
-        <div className="flex gap-2 mb-4">
+        <SettingsLabel as="span" id={syntaxFramerModeLabelId} icon={Calculator}>
+          Mode
+        </SettingsLabel>
+        <div
+          className="flex gap-2 mb-4"
+          role="group"
+          aria-labelledby={syntaxFramerModeLabelId}
+        >
```

Id is scoped to `widget.id` (`syntaxframer-mode-label-${widget.id}`), since `SyntaxFramerSettings` renders per-widget-instance via `DraggableWindow` and a static id would collide with 2+ instances open concurrently (the exact bug class caught by an automated review in an earlier run of this series).

**Enforcement:** None needed — semantics-only accessibility fix using an already-canonical component variant; no new anti-pattern to guard against regrowing.

**Behavior/visual preservation evidence:**
- Read `components/common/SettingsLabel.tsx` directly (orchestrator-verified, not just subagent-claimed): the `as="label"` and `as="span"` branches compute the identical `combinedClasses` string and only differ in wrapping tag (`<label>` vs `<span>`) and `htmlFor` presence. This call site has no `htmlFor`, so the rendered class string and content are byte-identical — zero visual delta.
- `pnpm run validate`: 575 files / 6997 tests (root), 38 files / 719 tests (functions) — all green. `pnpm run build`: exit 0.
- Orchestrator independently re-ran `eslint`/`prettier --check` on the changed file after the subagent's full validate — clean.
- No test references `SyntaxFramer` settings by label text/role that this change would affect.

**Risk tag: mechanical** (pure equivalence — no visual change, semantics-only).

**Deferred to backlog (not touched this run):** `components/widgets/SyntaxFramer/Settings.tsx:158` ("Alignment") is a second confirmed instance of the same group-heading shape in this file — left for a future nightly run (one unification per dimension per night).

---
🤖 Generated by the nightly SpartBoard consistency routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AN2Bib4srRys1fL954DG37)_