### PR TITLE
D3 nightly unify: SyntaxFramer Alignment label → SettingsLabel group-heading form

### DIFF
--- a/components/widgets/SyntaxFramer/Settings.tsx
+++ b/components/widgets/SyntaxFramer/Settings.tsx
@@ -152,6 +152,7 @@ export const SyntaxFramerAppearanceSettings: React.FC<
 > = ({ widget }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as SyntaxFramerConfig;
+  const syntaxFramerAlignmentLabelId = `syntaxframer-alignment-label-${widget.id}`;
 
   const handleUpdate = (updates: Partial<SyntaxFramerConfig>) => {
     updateWidget(widget.id, {
@@ -162,8 +163,18 @@ export const SyntaxFramerAppearanceSettings: React.FC<
   return (
     <div className="space-y-4">
       <div>
-        <SettingsLabel icon={AlignLeft}>Alignment</SettingsLabel>
-        <div className="flex gap-2">
+        <SettingsLabel
+          as="span"
+          id={syntaxFramerAlignmentLabelId}
+          icon={AlignLeft}
+        >
+          Alignment
+        </SettingsLabel>
+        <div
+          className="flex gap-2"
+          role="group"
+          aria-labelledby={syntaxFramerAlignmentLabelId}
+        >
           <button
             className={`flex-1 flex items-center justify-center py-2 px-3 rounded-lg border transition-colors ${
               config.alignment === 'left'


### PR DESCRIPTION
## Summary

Nightly Unifier routine (run 41), dimension D3 — Settings Panel Label Primitives.

- **Canonical form:** `<SettingsLabel>` group-heading variant (`as="span" id="..."` + `role="group" aria-labelledby="..."` on the sibling-controls container) for labels that head a group of buttons/chips rather than pairing 1:1 with a single control, where a bare `<label>` would be semantically orphaned. This variant was added in an earlier PR (#2141) and this routine has been retrofitting pre-existing group-heading `SettingsLabel` call sites to it since run 31/32.
- **Instance unified:** `components/widgets/SyntaxFramer/Settings.tsx` — the "Alignment" label heading a 2-button (left/center) alignment-selector group. Converted from bare `<SettingsLabel icon={AlignLeft}>` to `as="span" id={syntaxframer-alignment-label-${widget.id}}` + `role="group" aria-labelledby` on the button-group `<div>`. `widget.id`-scoped (not `useId()`) to match this same file's existing convention for the sibling "Mode" label (converted last run, PR #2259) — `SyntaxFramerAppearanceSettings` renders per-widget-instance via `DraggableWindow`, so a static id would collide across two simultaneously-flipped instances of the widget.
- This closes the multi-run group-heading retrofit series tracked since run 31 (DrawingWidget → RevealGrid ×2 → RandomSettings → MusicWidget ×2 → SyntaxFramer ×2). No further candidates found.

## Behavior/visual preservation evidence

Read `components/common/SettingsLabel.tsx` directly: `combinedClasses` (the only thing that affects rendering) is computed once from `baseClasses`/`layoutClasses`/`className` before branching on `as` — the `as="span"` and default `as="label"` branches apply the identical class string to their respective element. Zero visual delta.

## Validation

- `pnpm run type-check:all`: 0 errors (root + functions)
- `pnpm run lint` (app + functions): 0 errors/warnings
- `pnpm run format:check`: clean
- `pnpm test`: 580/580 test files, 7045/7045 tests passing
- `pnpm -C functions test`: 38/38 test files, 719/719 tests passing
- `pnpm run test:counts`: guard passed
- `pnpm run build`: succeeds (main bundle + SSR prerender)

## Risk tag

**mechanical** (pure equivalence — semantics-only accessibility fix, zero visual delta, single-file diff)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xn6YCxEk4coK8xHEUPgtp7)_