### PR TITLE
fix(widgets): NextUp auto-expiry never re-checks day rollover without a config write

### DIFF
--- a/components/widgets/NextUp/Widget.test.tsx
+++ b/components/widgets/NextUp/Widget.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/**
+ * Regression test for the NextUp auto-expiry day-rollover check.
+ *
+ * Bug: the widget's auto-expiry `useEffect` only re-ran when
+ * `config.isActive`/`config.createdAt` changed identity — there was no
+ * time-based re-trigger. A session left active on an idle classroom display
+ * overnight (no student joining the queue, no other config write) stayed
+ * "active" indefinitely past midnight instead of auto-expiring at the next
+ * calendar day, because nothing ever caused the effect to re-run and
+ * re-evaluate `new Date()` against the stored `createdAt`. Same root cause
+ * as CountdownWidget (#1774) and CalendarWidget (#1955): a date comparison
+ * with no ticking dependency.
+ *
+ * Fix: added a `nowTick` state that ticks every 60s via `setInterval` and is
+ * included in the auto-expiry effect's dependency array, so the day
+ * comparison (extracted to the pure, independently-tested
+ * `shouldExpireNextUpQueue` in nextUpQueueUtils.ts) re-runs periodically
+ * regardless of whether `config` changed.
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextUpWidget } from './Widget';
+import { NextUpConfig, WidgetData } from '@/types';
+
+const mockUpdateWidget = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    updateWidget: mockUpdateWidget,
+    activeDashboard: { widgets: [] },
+  }),
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'teacher-1' } }),
+}));
+
+vi.mock('@/hooks/useGoogleDrive', () => ({
+  useGoogleDrive: () => ({ driveService: null }),
+}));
+
+const buildWidget = (config: Partial<NextUpConfig>): WidgetData =>
+  ({
+    id: 'nextup-widget',
+    type: 'nextUp',
+    x: 0,
+    y: 0,
+    w: 350,
+    h: 500,
+    z: 1,
+    flipped: false,
+    config: {
+      activeDriveFileId: null,
+      sessionName: 'Help Queue',
+      isActive: false,
+      createdAt: 0,
+      lastUpdated: 0,
+      displayCount: 3,
+      styling: {
+        fontFamily: 'lexend',
+        themeColor: '#2d3f89',
+        animation: 'slide',
+      },
+      ...config,
+    } satisfies NextUpConfig,
+  }) as WidgetData;
+
+describe('NextUpWidget auto-expiry', () => {
+  beforeEach(() => {
+    mockUpdateWidget.mockClear();
+    vi.useFakeTimers();
+    // A few minutes before local midnight.
+    vi.setSystemTime(new Date('2026-07-23T23:58:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not expire an active session created earlier the same day', () => {
+    render(
+      <NextUpWidget
+        widget={buildWidget({
+          isActive: true,
+          createdAt: new Date('2026-07-23T08:00:00').getTime(),
+        })}
+      />
+    );
+
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+  });
+
+  it('auto-expires an idle overnight session once the clock ticks past midnight', () => {
+    render(
+      <NextUpWidget
+        widget={buildWidget({
+          isActive: true,
+          // Created a few minutes before the fake "now" above — matches
+          // today, so no expiry on mount.
+          createdAt: new Date('2026-07-23T23:50:00').getTime(),
+        })}
+      />
+    );
+
+    // No config write yet — the session was created today.
+    expect(mockUpdateWidget).not.toHaveBeenCalled();
+
+    // Advance past midnight with NO other state change (mirrors an idle
+    // classroom display: no student joins the queue overnight).
+    act(() => {
+      vi.advanceTimersByTime(5 * 60 * 1000); // +5 minutes → 00:03 next day
+    });
+
+    expect(mockUpdateWidget).toHaveBeenCalledWith('nextup-widget', {
+      config: expect.objectContaining({ isActive: false }),
+    });
+  });
+});

--- a/components/widgets/NextUp/Widget.tsx
+++ b/components/widgets/NextUp/Widget.tsx
@@ -10,7 +10,10 @@ import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { WidgetLayout } from '../WidgetLayout';
 import { resumeAudio } from '@/utils/timeToolAudio';
-import { advanceNextUpQueue } from './nextUpQueueUtils';
+import {
+  advanceNextUpQueue,
+  shouldExpireNextUpQueue,
+} from './nextUpQueueUtils';
 import {
   collection,
   onSnapshot,
@@ -45,16 +48,39 @@ export const NextUpWidget: React.FC<WidgetComponentProps> = ({ widget }) => {
     return `${user.uid}_${safeWidgetId}`;
   }, [user, widget.id]);
 
+  // Tick every minute so the auto-expiry check below re-evaluates across a
+  // midnight boundary even when `config` never changes (e.g. a queue with no
+  // student activity left open on a classroom display overnight). Without
+  // this ticker the effect only re-runs when config.isActive/createdAt
+  // change identity, so a session active before midnight would stay
+  // "active" indefinitely until some unrelated config write happened to
+  // occur — same class of bug as CountdownWidget (#1774) and CalendarWidget
+  // (#1955).
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   // Auto-expiry check: Deactivate session if it's from a previous day
   useEffect(() => {
-    if (config.isActive && config.createdAt) {
-      const createdDate = new Date(config.createdAt).toDateString();
-      const today = new Date().toDateString();
-      if (createdDate !== today) {
-        updateWidget(widget.id, { config: { ...config, isActive: false } });
-      }
+    if (
+      shouldExpireNextUpQueue(
+        config.isActive,
+        config.createdAt,
+        new Date(nowTick)
+      )
+    ) {
+      updateWidget(widget.id, { config: { ...config, isActive: false } });
     }
-  }, [config.isActive, config.createdAt, widget.id, updateWidget, config]);
+  }, [
+    config.isActive,
+    config.createdAt,
+    widget.id,
+    updateWidget,
+    config,
+    nowTick,
+  ]);
 
   // Sync from Drive when triggered by Firestore
   useEffect(() => {

--- a/components/widgets/NextUp/nextUpQueue.test.ts
+++ b/components/widgets/NextUp/nextUpQueue.test.ts
@@ -16,7 +16,10 @@
 
 import { describe, it, expect } from 'vitest';
 import type { NextUpQueueItem } from '@/types';
-import { advanceNextUpQueue } from './nextUpQueueUtils';
+import {
+  advanceNextUpQueue,
+  shouldExpireNextUpQueue,
+} from './nextUpQueueUtils';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -115,5 +118,66 @@ describe('advanceNextUpQueue', () => {
     expect(result[0].status).toBe('done');
     expect(result[1].status).toBe('done');
     expect(result[2].status).toBe('done');
+  });
+});
+
+/**
+ * Regression tests for the NextUp auto-expiry day-rollover check.
+ *
+ * Bug: the widget's auto-expiry `useEffect` only re-ran when
+ * `config.isActive`/`config.createdAt` changed identity. A session created
+ * (and left active) before midnight, with no further config writes overnight
+ * — e.g. an idle classroom display with no student joining the queue — never
+ * re-evaluated the day comparison, so it stayed "active" indefinitely past
+ * midnight instead of auto-expiring. Same root cause as CountdownWidget
+ * (#1774) and CalendarWidget (#1955): a date comparison with no
+ * time-based re-trigger. Fixed by extracting the comparison to this pure
+ * function and driving it from a `now` value that ticks every 60s
+ * (see Widget.tsx `nowTick`), independent of config identity.
+ */
+describe('shouldExpireNextUpQueue', () => {
+  it('does not expire when the session was created today', () => {
+    const now = new Date('2026-07-23T20:00:00');
+    const createdAt = new Date('2026-07-23T08:00:00').getTime();
+
+    expect(shouldExpireNextUpQueue(true, createdAt, now)).toBe(false);
+  });
+
+  it('expires once `now` has rolled over to the next calendar day', () => {
+    const createdAt = new Date('2026-07-23T20:00:00').getTime();
+    // Just after local midnight the next day.
+    const now = new Date('2026-07-24T00:01:00');
+
+    expect(shouldExpireNextUpQueue(true, createdAt, now)).toBe(true);
+  });
+
+  it('does not expire when the session is not active, regardless of date', () => {
+    const createdAt = new Date('2026-07-20T08:00:00').getTime();
+    const now = new Date('2026-07-24T00:01:00');
+
+    expect(shouldExpireNextUpQueue(false, createdAt, now)).toBe(false);
+  });
+
+  it('does not expire when createdAt is missing', () => {
+    const now = new Date('2026-07-24T00:01:00');
+
+    expect(shouldExpireNextUpQueue(true, undefined, now)).toBe(false);
+  });
+
+  it('models the reported gap: an idle overnight session stays expired-detectable only once `now` ticks past midnight', () => {
+    // A session created at 11:50pm, still active. With `now` frozen at
+    // 11:55pm (matching the un-ticked bug — the widget's `nowTick` state
+    // never advances without a config change), the session incorrectly
+    // reads as still valid past its creation day boundary.
+    const createdAt = new Date('2026-07-23T23:50:00').getTime();
+    const stillBeforeMidnight = new Date('2026-07-23T23:55:00');
+    const afterMidnightTick = new Date('2026-07-24T00:05:00');
+
+    expect(shouldExpireNextUpQueue(true, createdAt, stillBeforeMidnight)).toBe(
+      false
+    );
+    expect(shouldExpireNextUpQueue(true, createdAt, afterMidnightTick)).toBe(
+      true
+    );
   });
 });

--- a/components/widgets/NextUp/nextUpQueueUtils.ts
+++ b/components/widgets/NextUp/nextUpQueueUtils.ts
@@ -21,3 +21,23 @@ export function advanceNextUpQueue(
     return item;
   });
 }
+
+/**
+ * Determine whether an active NextUp session should be auto-expired because
+ * it was created on a previous calendar day (local time).
+ *
+ * Pure so it can be driven by an explicit `now`, independent of a live
+ * ticking clock — the caller is responsible for re-invoking this on a
+ * periodic tick (see Widget.tsx) so day-rollover is detected even when
+ * `config` hasn't otherwise changed since before midnight.
+ */
+export function shouldExpireNextUpQueue(
+  isActive: boolean | undefined,
+  createdAt: number | undefined,
+  now: Date
+): boolean {
+  if (!isActive || !createdAt) return false;
+  const createdDate = new Date(createdAt).toDateString();
+  const today = now.toDateString();
+  return createdDate !== today;
+}


### PR DESCRIPTION
## Root cause

`NextUpWidget`'s auto-expiry `useEffect` (`components/widgets/NextUp/Widget.tsx`) compared `config.createdAt`'s date against `new Date()` inside an effect whose dependencies were `[config.isActive, config.createdAt, widget.id, updateWidget, config]` — no time-based dependency. A queue left `isActive: true` on an idle classroom display overnight (no student joining, no other config write) never re-ran the day check, so it stayed "active" indefinitely past midnight instead of auto-expiring.

Same root-cause class as two previously-fixed bugs in this codebase: `CountdownWidget` (#1774) and `CalendarWidget` (#1955) — a date comparison with no ticking dependency to re-trigger it across a midnight boundary.

## Fix

Extracted the comparison into a pure, testable `shouldExpireNextUpQueue(isActive, createdAt, now)` in `nextUpQueueUtils.ts`, and added a `nowTick` state ticked every 60s via `setInterval` (mirrors `CountdownWidget`'s `todayMidnightMs` pattern), wired into the effect's dependency array.

## Band-aid rejected

Patching the effect to also fire on the existing Firestore `entries` listener callback (which already calls `updateWidget` when students join). Rejected because it doesn't cover the actual failure scenario — a queue with zero student activity overnight would still never re-check. The fix needed a real time-based tick, not a symptom patch tied to unrelated activity.

## Regression test

`components/widgets/NextUp/Widget.test.tsx` — "auto-expires an idle overnight session once the clock ticks past midnight", plus 5 new pure-function unit tests for `shouldExpireNextUpQueue` in `nextUpQueue.test.ts`.

- **Fail-before** (orchestrator-verified against `dev-paul` source): `TypeError: shouldExpireNextUpQueue is not a function` / assertion failures — 6 failed, 9 passed (15 total).
- **Pass-after**: 15/15 passed.

## Validation

`pnpm run validate` (type-check root+functions, lint `--max-warnings 0`, format-check, root tests 581 files/7052 tests, functions tests 38 files/719 tests, test:counts guard) and `pnpm run build` both pass with exit code 0. Orchestrator independently re-ran the fail-before/pass-after swap against `dev-paul` and confirmed the same result.

## Risk

**Contained** — single widget, isolated pure-function extraction + one new `setInterval` ticker, no cross-widget or persisted-schema impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NoLERgruS2i9St7oLA1ph)_