### PR TITLE
fix(dock): stop Escape leaking from popovers into the global widget-minimize handler

### DIFF
--- a/components/layout/ClassRosterMenu.tsx
+++ b/components/layout/ClassRosterMenu.tsx
@@ -48,6 +48,12 @@ const ClassRosterMenu: React.FC<Props> = ({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(event)) return;
+      // This menu is portalled outside any `.widget` DraggableWindow, so
+      // without stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget on the board — a completely
+      // unrelated widget disappearing just because the menu was dismissed.
+      event.stopPropagation();
       onClose();
     };
 

--- a/components/layout/RemoteControlMenu.tsx
+++ b/components/layout/RemoteControlMenu.tsx
@@ -69,6 +69,12 @@ const RemoteControlMenu: React.FC<Props> = ({ onClose, anchorRect }) => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(event)) return;
+      // This menu is portalled outside any `.widget` DraggableWindow, so
+      // without stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget on the board — a completely
+      // unrelated widget disappearing just because the menu was dismissed.
+      event.stopPropagation();
       onClose();
     };
 

--- a/components/layout/dock/ToolDockItem.tsx
+++ b/components/layout/dock/ToolDockItem.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { RefreshCcw, Trash2, Plus, X } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useClickOutside } from '@/hooks/useClickOutside';
 import { useLongPress } from '@/hooks/useLongPress';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 import { GlassCard } from '@/components/common/GlassCard';
 import { DockIcon } from './DockIcon';
 import { DockLabel } from './DockLabel';
@@ -83,6 +84,29 @@ export const ToolDockItem = React.memo(
 
     // Close popover when clicking outside
     useClickOutside(popoverRef, () => setShowPopover(false), [buttonRef]);
+
+    // Close popover on Escape, matching every other click-to-dismiss popover
+    // in the dock/library (e.g. SidebarPlcs's PlcRow, FolderTree's overflow
+    // menu). Critically, this ALSO calls stopPropagation(): the popover
+    // trigger button lives outside any `.widget` DraggableWindow, so without
+    // stopping propagation an unhandled Escape here bubbles all the way to
+    // DashboardView's global window-level Escape handler, which (finding no
+    // typing field and no widget ancestor for the dock button) falls back to
+    // targeting the topmost z-index widget and minimizes it — a completely
+    // unrelated widget disappearing just because the user pressed Escape to
+    // dismiss this popover.
+    useEffect(() => {
+      if (!showPopover) return undefined;
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key !== 'Escape') return;
+        if (isEscapeFromWidgetInput(e)) return;
+        e.stopPropagation();
+        setShowPopover(false);
+        buttonRef.current?.focus();
+      };
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [showPopover, buttonRef]);
 
     const handleClick = (e: React.MouseEvent) => {
       if (isEditMode) {

--- a/tests/components/layout/ClassRosterMenu.escapePropagation.test.tsx
+++ b/tests/components/layout/ClassRosterMenu.escapePropagation.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Regression test: ClassRosterMenu's Escape handler already closed the
+ * menu, but never called stopPropagation(). Because the menu is portalled
+ * outside any `.widget` DraggableWindow, the unhandled keydown continued
+ * bubbling up to DashboardView's global `window`-level Escape handler,
+ * which — finding no typing field and no `.widget` ancestor for the menu —
+ * falls back to targeting the topmost z-index widget and minimizes it.
+ * Net effect: dismissing this menu with Escape could also silently
+ * minimize an unrelated widget on the live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * onClose(), matching the same fix applied to ToolDockItem and
+ * RemoteControlMenu.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    rosters: [{ id: 'r1', name: 'Period 1' }],
+    activeRosterId: null,
+    setActiveRoster: vi.fn(),
+  }),
+}));
+
+import ClassRosterMenu from '@/components/layout/ClassRosterMenu';
+
+afterEach(cleanup);
+
+const anchorRect = {
+  left: 10,
+  right: 50,
+  top: 10,
+  bottom: 40,
+  width: 40,
+  height: 30,
+} as DOMRect;
+
+describe('ClassRosterMenu — Escape does not leak to window-level handlers', () => {
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    const onClose = vi.fn();
+    render(
+      <ClassRosterMenu
+        onClose={onClose}
+        onOpenFullEditor={vi.fn()}
+        anchorRect={anchorRect}
+      />
+    );
+
+    expect(
+      screen.getByRole('dialog', { name: /class selection menu/i })
+    ).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(onClose).toHaveBeenCalled();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/tests/components/layout/RemoteControlMenu.escapePropagation.test.tsx
+++ b/tests/components/layout/RemoteControlMenu.escapePropagation.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * Regression test: RemoteControlMenu's Escape handler already closed the
+ * menu, but never called stopPropagation(). Because the menu is portalled
+ * outside any `.widget` DraggableWindow, the unhandled keydown continued
+ * bubbling up to DashboardView's global `window`-level Escape handler,
+ * which — finding no typing field and no `.widget` ancestor for the menu —
+ * falls back to targeting the topmost z-index widget and minimizes it.
+ * Net effect: dismissing this menu with Escape could also silently
+ * minimize an unrelated widget on the live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * onClose(), matching the same fix applied to ToolDockItem and
+ * ClassRosterMenu.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ activeDashboard: { id: 'board-1' } }),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    remoteControlEnabled: false,
+    updateAccountPreferences: vi.fn(),
+  }),
+}));
+
+import RemoteControlMenu from '@/components/layout/RemoteControlMenu';
+
+afterEach(cleanup);
+
+const anchorRect = {
+  left: 10,
+  right: 50,
+  top: 10,
+  bottom: 40,
+  width: 40,
+  height: 30,
+} as DOMRect;
+
+describe('RemoteControlMenu — Escape does not leak to window-level handlers', () => {
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    const onClose = vi.fn();
+    render(<RemoteControlMenu onClose={onClose} anchorRect={anchorRect} />);
+
+    expect(
+      screen.getByRole('dialog', { name: /remote control menu/i })
+    ).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(onClose).toHaveBeenCalled();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/tests/components/layout/ToolDockItem.test.tsx
+++ b/tests/components/layout/ToolDockItem.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Regression test for a missing-Escape-handler bug in ToolDockItem's
+ * "restore minimized widgets" popover.
+ *
+ * BUG: The popover (opened by clicking a dock icon that has minimized
+ * widgets) only dismissed via useClickOutside — there was no Escape
+ * handler, unlike every other click-to-dismiss popover in this codebase
+ * (e.g. SidebarPlcs's PlcRow, FolderTree's overflow menu — see #2228).
+ *
+ * That absence isn't just a missing convenience: the dock lives OUTSIDE
+ * any `.widget` DraggableWindow, so an unhandled Escape here bubbles all
+ * the way up to DashboardView's global `window`-level Escape handler.
+ * That handler finds no typing field and no `.widget` ancestor for the
+ * dock button, so it falls back to targeting the topmost z-index widget
+ * on the board and dispatches a 'widget-keyboard-action' Escape event —
+ * which DraggableWindow's handler interprets as "minimize this widget".
+ * Net effect: a teacher opens the dock's restore-widget popover, presses
+ * Escape to dismiss it, and an unrelated widget on their live board
+ * (e.g. a running timer) silently minimizes instead.
+ *
+ * FIX: ToolDockItem now closes the popover on Escape AND calls
+ * `stopPropagation()`, so the keydown never reaches the window-level
+ * listener that DashboardView installs.
+ *
+ * This test simulates that window-level listener directly (rather than
+ * mounting the full DashboardView, which pulls in nearly the entire app)
+ * to prove both halves of the fix: the popover closes, and the event
+ * does not leak past the popover's own handler.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import type { ToolMetadata, WidgetData, GlobalStyle } from '@/types';
+
+vi.mock('@dnd-kit/sortable', () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Translate: { toString: () => undefined } },
+}));
+// DockLabel reads global dock styling from the dashboard canvas store, which
+// requires a DashboardProvider ancestor. Stub it out — irrelevant to this
+// Escape-dismissal regression.
+vi.mock('@/context/dashboardCanvasStore', () => ({
+  useGlobalStyle: () => ({
+    fontFamily: 'sans',
+    dockTextColor: '#ffffff',
+    dockTextShadow: false,
+  }),
+}));
+
+import { ToolDockItem } from '@/components/layout/dock/ToolDockItem';
+
+afterEach(cleanup);
+
+const tool: ToolMetadata = {
+  type: 'time-tool',
+  icon: () => null,
+  label: 'Timer',
+  color: 'bg-blue-500',
+};
+
+const globalStyle = {} as GlobalStyle;
+
+const makeMinimizedWidget = (id: string): WidgetData =>
+  ({
+    id,
+    type: 'time-tool',
+    x: 0,
+    y: 0,
+    w: 300,
+    h: 200,
+    z: 1,
+    flipped: false,
+    minimized: true,
+    config: {},
+  }) as unknown as WidgetData;
+
+function renderPopover(): void {
+  render(
+    <ToolDockItem
+      tool={tool}
+      minimizedWidgets={[makeMinimizedWidget('w1')]}
+      onAdd={vi.fn()}
+      onRestore={vi.fn()}
+      onDelete={vi.fn()}
+      onDeleteAll={vi.fn()}
+      onRemoveFromDock={vi.fn()}
+      isEditMode={false}
+      onLongPress={vi.fn()}
+      globalStyle={globalStyle}
+    />
+  );
+  // The dock button toggles the "restorable" popover open since there's a
+  // minimized widget for this tool.
+  fireEvent.click(screen.getByRole('button', { name: /timer/i }));
+}
+
+describe('ToolDockItem — restore popover Escape dismissal', () => {
+  it('closes the popover when Escape is pressed', () => {
+    renderPopover();
+    expect(screen.getByText('Restorable')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+    expect(screen.queryByText('Restorable')).not.toBeInTheDocument();
+  });
+
+  it('does not leak the Escape keydown to window-level listeners (would otherwise let DashboardView minimize an unrelated widget)', () => {
+    renderPopover();
+    expect(screen.getByText('Restorable')).toBeInTheDocument();
+
+    // Stand-in for DashboardView's `window.addEventListener('keydown', ...)`
+    // global handler, which (with nothing else to guide it) would dispatch
+    // a 'widget-keyboard-action' Escape event at the topmost widget.
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

`DashboardView.tsx` installs a global `window`-level Escape keydown handler that, when it finds no active typing field and no `.widget` ancestor for the focused element, falls back to targeting the topmost z-index widget and dispatches a `'widget-keyboard-action'` Escape event — which `DraggableWindow` interprets as "minimize this widget."

The dock's `ToolDockItem` "restore minimized widgets" popover had **no Escape handler at all**, and lives outside any `.widget` ancestor (it's portalled). An unhandled Escape bubbled straight through to the global handler. **A teacher opening the dock's restore-widget popover and pressing Escape to dismiss it would instead silently minimize an unrelated widget on their live board** (e.g. a running timer, mid-lesson).

Auditing sibling popovers (`RemoteControlMenu.tsx`, `ClassRosterMenu.tsx`) found the identical leak: both already had `onClose()` Escape handlers but never called `stopPropagation()`, so the same bug occurred there too.

## Fix

All three now call `event.stopPropagation()` in their Escape handler before closing. `ToolDockItem` also gained the handler itself (it had none), plus focus-return to the trigger button on dismiss.

## Band-aid rejected

Just adding a close-on-Escape handler to `ToolDockItem` (matching what `RemoteControlMenu`/`ClassRosterMenu` already had) would still leak propagation to the global handler — exactly the latent bug those two already had. The real root cause is the missing `stopPropagation()`, not the missing close call, so all three needed the same fix rather than patching only the component that started the investigation.

## Regression tests

- `tests/components/layout/ToolDockItem.test.tsx` — "closes the popover when Escape is pressed" + "does not leak the Escape keydown to window-level listeners"
- `tests/components/layout/RemoteControlMenu.escapePropagation.test.tsx`
- `tests/components/layout/ClassRosterMenu.escapePropagation.test.tsx`

**Fail-before** (orchestrator-verified against `dev-paul` source for all 3 files): 4/4 new tests fail — popover stays open / a stand-in `window` keydown spy fires once.
**Pass-after**: 4/4 pass.

## Validation

`pnpm run validate` (583 root test files/7049 tests, 38 functions test files/719 tests, 0 lint/type errors) and `pnpm run build` both pass. Orchestrator independently re-ran the fail-before/pass-after swap against `dev-paul` and confirmed the same result.

## Risk

**Contained** — event-propagation fix confined to 3 popover/menu components; no state-shape or persistence changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NoLERgruS2i9St7oLA1ph)_