### PR TITLE
fix(auth): decode raw HTML entity in InviteAcceptance default error message

### DIFF
--- a/components/auth/InviteAcceptance.tsx
+++ b/components/auth/InviteAcceptance.tsx
@@ -249,7 +249,7 @@ const getErrorContent = (
       return {
         title: 'Something went wrong',
         message:
-          'We couldn&rsquo;t accept this invitation. Try again, or contact your admin.',
+          "We couldn't accept this invitation. Try again, or contact your admin.",
       };
   }
 };

--- a/tests/components/auth/InviteAcceptance.errorEntities.test.tsx
+++ b/tests/components/auth/InviteAcceptance.errorEntities.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Regression: InviteAcceptance's default-branch error message is built from a
+// plain JS string literal containing the raw HTML entity `&rsquo;`
+// ("We couldn&rsquo;t accept this invitation..."). Unlike JSX text children
+// (which the JSX transform decodes as HTML), a plain string interpolated via
+// `{message}` is inserted into the DOM verbatim — so users hit with any
+// unrecognized claim-error code see the literal characters "&rsquo;" instead
+// of an apostrophe. Reproduce by forcing the claim callable to reject with a
+// code outside the four explicitly-handled cases (falls through to the
+// "Something went wrong" default branch).
+
+const mockClaim = vi.fn();
+
+vi.mock('@/config/firebase', () => ({
+  functions: {},
+}));
+
+vi.mock('firebase/functions', () => ({
+  httpsCallable: () => mockClaim,
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { uid: 'u1', email: 'teacher@example.com' },
+    loading: false,
+    signOut: vi.fn(),
+  }),
+}));
+
+import { InviteAcceptance } from '@/components/auth/InviteAcceptance';
+
+describe('InviteAcceptance default error message', () => {
+  beforeEach(() => {
+    mockClaim.mockReset();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...window.location, pathname: '/invite/tok123', search: '' },
+    });
+  });
+
+  it('renders a real apostrophe, not the literal "&rsquo;" entity, for an unhandled claim error code', async () => {
+    mockClaim.mockRejectedValue(
+      Object.assign(new Error('boom'), { code: 'functions/internal' })
+    );
+
+    render(<InviteAcceptance />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    });
+
+    const message = await screen.findByText(/accept this invitation/i);
+    expect(message.textContent).not.toContain('&rsquo;');
+    expect(message.textContent).toContain("couldn't accept this invitation");
+  });
+});


### PR DESCRIPTION
## Root cause

`components/auth/InviteAcceptance.tsx`'s `getErrorContent()` default-branch error message was authored as a plain JS string literal containing the raw HTML entity `&rsquo;`: `'We couldn&rsquo;t accept this invitation. Try again, or contact your admin.'`. JSX only decodes HTML entities in literal JSX text children, not in ordinary string literals interpolated via `{message}`.

Any `/invite/:token` claim failure whose Firebase callable error code isn't one of the four explicitly handled (`not-found`, `failed-precondition`, `deadline-exceeded`, `permission-denied`) — e.g. `internal`, `unavailable`, `invalid-argument`, or any transient/unexpected code — rendered the literal text "We couldn&rsquo;t accept this invitation…" on screen instead of a real apostrophe.

## Fix

Swapped the string to a double-quoted literal with a real apostrophe. Swept `components/admin/**`, `components/auth/**`, and `config/**` for the same anti-pattern (HTML entities embedded in JS string literals rather than JSX text) to rule out sibling drift — no other instance found; the other `&amp;`-family hits in-repo are legitimate HTML-escaping utility code inside JSX children, unrelated to this bug.

## Band-aid rejected

None needed — already a single-line, one-string root cause with no broader pattern in scope.

## Regression test

`tests/components/auth/InviteAcceptance.errorEntities.test.tsx` — mocks an unhandled Firebase callable error code and asserts the rendered error text contains a real apostrophe, not the literal substring `&rsquo;`.

**Fail-before** (orchestrator-verified against `dev-paul` source): fails — `Received: "We couldn&rsquo;t accept this invitation..."`.
**Pass-after**: passes.

## Validation

`pnpm run validate` (root tests 581 files/7046 tests, functions tests 38 files/719 tests, 0 lint/type errors) and `pnpm run build` both pass. Also ran a key-by-key diff of `plcDashboard`, `importSharedCollection`/`shareCollection` i18n namespaces against DE/ES/FR (all clean, zero drift found — not included in this diff). Orchestrator independently re-ran the fail-before/pass-after swap against `dev-paul` and confirmed the same result.

## Risk

**Contained** — single string literal fix plus one new test file.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NoLERgruS2i9St7oLA1ph)_