### PR TITLE
fix(functions): paginate expireActivityWallShares lapsed-share lookup

### DIFF
--- a/functions/src/expireActivityWallShares.test.ts
+++ b/functions/src/expireActivityWallShares.test.ts
@@ -19,7 +19,12 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('firebase-admin', () => ({
   apps: [{ name: '[DEFAULT]' }],
   initializeApp: vi.fn(),
-  firestore: vi.fn(),
+  // The sweep paginates with admin.firestore.FieldPath.documentId(); expose
+  // it as the '__name__' sentinel so the stub CollectionRef.orderBy gets a
+  // stable value (mirrors gcPlcOrphans.test.ts's stub).
+  firestore: Object.assign(vi.fn(), {
+    FieldPath: { documentId: vi.fn(() => '__name__') },
+  }),
 }));
 
 vi.mock('firebase-functions/v2', () => ({
@@ -33,6 +38,7 @@ vi.mock('firebase-functions/v2/scheduler', () => ({
 import {
   isLapsedShare,
   runExpireActivityWallShares,
+  LAPSED_SHARE_PAGE_SIZE,
 } from './expireActivityWallShares';
 
 const NOW = 1_700_000_000_000;
@@ -77,11 +83,16 @@ interface StubShareDoc {
 /**
  * In-memory Firestore mirroring the Admin SDK surface
  * `runExpireActivityWallShares` uses:
- *   db.collection('shared_activity_walls').where(f, op, v).limit(n).get()
+ *   db.collection('shared_activity_walls').where(f, op, v)
+ *     .orderBy(field).limit(n).startAfter(docSnap).get()
  *   db.collection('activity_wall_sessions').doc(id).update(data)
  * Only the where clauses this sweep issues are supported (le/eq on
  * expiresAt/revoked/sessionId) — enough to faithfully exercise the sweep
- * without pulling in the Firestore emulator.
+ * without pulling in the Firestore emulator. `orderBy`/`startAfter` mirror
+ * `gcPlcOrphans.test.ts`'s stub: sort by the ordered field(s) (falling back to
+ * doc id for the '__name__' sentinel) and slice past the cursor doc's
+ * ordering-field values — this is what actually exercises cross-page
+ * pagination in the regression test below.
  */
 function makeStubDb(seed: {
   shares?: StubShareDoc[];
@@ -93,10 +104,10 @@ function makeStubDb(seed: {
   };
   const updates: Record<string, Record<string, unknown>[]> = {};
 
-  function matches(
-    doc: StubShareDoc,
-    filters: Array<[string, string, unknown]>
-  ): boolean {
+  type Filter = [string, string, unknown];
+  type DocSnap = { id: string; data: () => Record<string, unknown> };
+
+  function matches(doc: StubShareDoc, filters: Filter[]): boolean {
     return filters.every(([field, op, value]) => {
       const actual = doc.data[field];
       if (op === '<=')
@@ -106,18 +117,75 @@ function makeStubDb(seed: {
     });
   }
 
+  function fieldValue(doc: StubShareDoc, field: string): unknown {
+    return field === '__name__' ? doc.id : doc.data[field];
+  }
+
+  /** Lexicographic compare; undefined sorts first (treated as "smallest"). */
+  function compareValues(a: unknown, b: unknown): number {
+    if (a === b) return 0;
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    return (a as string | number) < (b as string | number) ? -1 : 1;
+  }
+
   function sharedActivityWallsCollection(
-    filters: Array<[string, string, unknown]> = [],
-    lim?: number
+    filters: Filter[] = [],
+    order: string[] = [],
+    lim?: number,
+    afterDoc?: StubShareDoc
   ) {
     return {
       where: (field: string, op: string, value: unknown) =>
-        sharedActivityWallsCollection([...filters, [field, op, value]], lim),
-      limit: (n: number) => sharedActivityWallsCollection(filters, n),
+        sharedActivityWallsCollection(
+          [...filters, [field, op, value]],
+          order,
+          lim,
+          afterDoc
+        ),
+      orderBy: (field: string) =>
+        sharedActivityWallsCollection(
+          filters,
+          [...order, field],
+          lim,
+          afterDoc
+        ),
+      limit: (n: number) =>
+        sharedActivityWallsCollection(filters, order, n, afterDoc),
+      startAfter: (cursor: DocSnap) => {
+        const cursorDoc = shares.find((d) => d.id === cursor.id);
+        return sharedActivityWallsCollection(filters, order, lim, cursorDoc);
+      },
       get: () => {
-        const rows = shares.filter((d) => matches(d, filters));
+        let rows = shares.filter((d) => matches(d, filters));
+        if (order.length > 0) {
+          rows = [...rows].sort((a, b) => {
+            for (const field of order) {
+              const cmp = compareValues(
+                fieldValue(a, field),
+                fieldValue(b, field)
+              );
+              if (cmp !== 0) return cmp;
+            }
+            return 0;
+          });
+        }
+        if (afterDoc) {
+          const afterValues = order.map((f) => fieldValue(afterDoc, f));
+          rows = rows.filter((d) => {
+            for (let i = 0; i < order.length; i++) {
+              const cmp = compareValues(
+                fieldValue(d, order[i]),
+                afterValues[i]
+              );
+              if (cmp !== 0) return cmp > 0;
+            }
+            return false;
+          });
+        }
         const sliced = lim === undefined ? rows : rows.slice(0, lim);
         return Promise.resolve({
+          size: sliced.length,
           docs: sliced.map((d) => ({ id: d.id, data: () => d.data })),
         });
       },
@@ -299,6 +367,89 @@ describe('runExpireActivityWallShares', () => {
     expect(result).toEqual({ lapsedShares: 2, sessionsRelocked: 2 });
     expect(sessions.teacherA_act1.publiclyShared).toBe(false);
     expect(sessions.teacherB_act1.publiclyShared).toBe(false);
+  });
+});
+
+// ===========================================================================
+// Pagination regression — a lapsed share past the first page must still be
+// found and its session relocked. Before the fix, both `shared_activity_walls`
+// lookups (expired-by-date, revoked) were a single un-paginated `.limit()`
+// page, so once more than one page of lapsed shares accumulated (share docs
+// are never deleted), the same top page (by document-ID order) was
+// reprocessed every run and a session whose only lapsed share sorted past the
+// cap was NEVER relocked, forever — the exact bug `gcPlcOrphans` was already
+// fixed for.
+// ===========================================================================
+
+describe('runExpireActivityWallShares — pagination past the first page', () => {
+  it('relocks a session whose only lapsed (expired) share sorts past LAPSED_SHARE_PAGE_SIZE', async () => {
+    // Zero-padded ids sort lexicographically in doc-id order, matching the
+    // production orderBy(expiresAt).orderBy(FieldPath.documentId()) cursor
+    // (all filler shares share the same expiresAt, so id is the tiebreaker).
+    const total = LAPSED_SHARE_PAGE_SIZE + 5;
+    const filler: StubShareDoc[] = Array.from(
+      { length: total - 1 },
+      (_, i) => ({
+        id: `share-${String(i).padStart(6, '0')}`,
+        data: { sessionId: `filler-session-${i}`, expiresAt: NOW - DAY },
+      })
+    );
+    // The target share/session sorts last (past the first page).
+    const target: StubShareDoc = {
+      id: 'share-zzz-target',
+      data: { sessionId: 'target-session', expiresAt: NOW - DAY },
+    };
+    const sessions: Record<string, Record<string, unknown>> = {
+      'target-session': { publiclyShared: true },
+    };
+    for (let i = 0; i < filler.length; i++) {
+      sessions[`filler-session-${i}`] = { publiclyShared: true };
+    }
+
+    const { db, sessions: liveSessions } = makeStubDb({
+      shares: [...filler, target],
+      sessions,
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result.lapsedShares).toBe(total);
+    // The regression: every session must be relocked, including the one
+    // whose only lapsed share sorted past the first page.
+    expect(liveSessions['target-session'].publiclyShared).toBe(false);
+    expect(result.sessionsRelocked).toBe(total);
+  });
+
+  it('relocks a session whose only lapsed (revoked) share sorts past LAPSED_SHARE_PAGE_SIZE', async () => {
+    const total = LAPSED_SHARE_PAGE_SIZE + 5;
+    const filler: StubShareDoc[] = Array.from(
+      { length: total - 1 },
+      (_, i) => ({
+        id: `share-${String(i).padStart(6, '0')}`,
+        data: { sessionId: `filler-session-${i}`, revoked: true },
+      })
+    );
+    const target: StubShareDoc = {
+      id: 'share-zzz-target',
+      data: { sessionId: 'target-session', revoked: true },
+    };
+    const sessions: Record<string, Record<string, unknown>> = {
+      'target-session': { publiclyShared: true },
+    };
+    for (let i = 0; i < filler.length; i++) {
+      sessions[`filler-session-${i}`] = { publiclyShared: true };
+    }
+
+    const { db, sessions: liveSessions } = makeStubDb({
+      shares: [...filler, target],
+      sessions,
+    });
+
+    const result = await runExpireActivityWallShares(db, NOW);
+
+    expect(result.lapsedShares).toBe(total);
+    expect(liveSessions['target-session'].publiclyShared).toBe(false);
+    expect(result.sessionsRelocked).toBe(total);
   });
 });
 

--- a/functions/src/expireActivityWallShares.ts
+++ b/functions/src/expireActivityWallShares.ts
@@ -29,14 +29,32 @@
  * sweeps, this one does NOT delete the share doc — the owner/admin can still
  * read a lapsed share for management (mirrors the sibling rule), so only the
  * session-level unlock flag is corrected.
+ *
+ * Both `shared_activity_walls` lookups (expired-by-date, revoked) are
+ * PAGINATED (startAfter cursor on `orderBy(FieldPath.documentId())`, mirrors
+ * `gcPlcOrphans.ts`'s fix for the identical bug) so every lapsed share up to
+ * `MAX_LAPSED_SHARES_PER_RUN` is visited every run — not just the first
+ * `LAPSED_SHARE_PAGE_SIZE`. Share docs are never deleted (see above), so a
+ * single un-paginated `.limit()` page meant that once more than one page of
+ * lapsed shares accumulated, the same top page (by document-ID order) was
+ * reprocessed every run and any session whose only lapsed share sorted past
+ * the cap was NEVER relocked, forever.
  */
 
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
 import './functionsInit';
 
-/** Cap per-run lapsed-share lookups to keep one slow sweep from monopolising. */
-export const MAX_LAPSED_SHARES_PER_RUN = 500;
+/**
+ * Overall safety ceiling on lapsed shares visited per run (per query) — a
+ * runaway guard, NOT an expected limit. The sweep paginates (see
+ * `LAPSED_SHARE_PAGE_SIZE`), so every lapsed share up to this ceiling is
+ * covered every run; set far above any realistic accumulation.
+ */
+export const MAX_LAPSED_SHARES_PER_RUN = 5000;
+
+/** Page size for the paginated lapsed-share sweeps (startAfter cursor on document id). */
+export const LAPSED_SHARE_PAGE_SIZE = 500;
 
 type Firestore = admin.firestore.Firestore;
 type QueryDocSnap = admin.firestore.QueryDocumentSnapshot;
@@ -68,11 +86,51 @@ function sessionIdOf(data: SharedActivityWallData): string | null {
 }
 
 /**
+ * Paginates a `shared_activity_walls` query up to `MAX_LAPSED_SHARES_PER_RUN`
+ * using a `startAfter` cursor, `LAPSED_SHARE_PAGE_SIZE` docs at a time. The
+ * inequality query (expired-by-date) must `orderBy` the filtered field before
+ * any tiebreaker (a Firestore requirement for range queries), so the caller
+ * supplies the ordering; the equality query (revoked) orders by document id
+ * alone. Either way, `startAfter` takes the cursor's ordering-field values
+ * from the last doc of the previous page, so pagination is correct regardless
+ * of which fields are ordered on.
+ */
+async function fetchLapsedSharesPaginated(
+  db: Firestore,
+  buildQuery: (page: admin.firestore.Query) => admin.firestore.Query
+): Promise<QueryDocSnap[]> {
+  const results: QueryDocSnap[] = [];
+  let lastDoc: QueryDocSnap | undefined;
+  let visited = 0;
+  while (visited < MAX_LAPSED_SHARES_PER_RUN) {
+    let query = buildQuery(db.collection('shared_activity_walls')).limit(
+      LAPSED_SHARE_PAGE_SIZE
+    );
+    if (lastDoc) query = query.startAfter(lastDoc);
+    const page = await query.get();
+    if (page.size === 0) break;
+
+    results.push(...page.docs);
+    visited += page.size;
+    lastDoc = page.docs[page.docs.length - 1];
+    if (page.size < LAPSED_SHARE_PAGE_SIZE) break;
+  }
+  if (visited >= MAX_LAPSED_SHARES_PER_RUN) {
+    console.warn(
+      `[expireActivityWallShares] hit MAX_LAPSED_SHARES_PER_RUN ceiling (${MAX_LAPSED_SHARES_PER_RUN}) — raise it or shard the sweep`
+    );
+  }
+  return results;
+}
+
+/**
  * Core sweep, extracted from the scheduler wrapper so it can be exercised
  * against a stub Firestore in tests (mirrors `runGcPlcOrphans`).
  *
  * 1. Find every `shared_activity_walls` doc that is revoked OR past its
- *    `expiresAt` (two single-field queries — no composite index needed).
+ *    `expiresAt` (two single-field queries — no composite index needed),
+ *    each PAGINATED (startAfter cursor) so every lapsed share up to
+ *    `MAX_LAPSED_SHARES_PER_RUN` is found, not just the first page.
  * 2. Group the lapsed docs by `sessionId` (a session can have been shared
  *    more than once — teachers re-share rather than edit an existing link).
  * 3. For each affected session, re-check ALL its shares (not just the lapsed
@@ -83,21 +141,22 @@ export async function runExpireActivityWallShares(
   db: Firestore,
   now: number = Date.now()
 ): Promise<{ lapsedShares: number; sessionsRelocked: number }> {
-  const [expiredSnap, revokedSnap] = await Promise.all([
-    db
-      .collection('shared_activity_walls')
-      .where('expiresAt', '<=', now)
-      .limit(MAX_LAPSED_SHARES_PER_RUN)
-      .get(),
-    db
-      .collection('shared_activity_walls')
-      .where('revoked', '==', true)
-      .limit(MAX_LAPSED_SHARES_PER_RUN)
-      .get(),
+  const [expiredDocs, revokedDocs] = await Promise.all([
+    fetchLapsedSharesPaginated(db, (q) =>
+      q
+        .where('expiresAt', '<=', now)
+        .orderBy('expiresAt')
+        .orderBy(admin.firestore.FieldPath.documentId())
+    ),
+    fetchLapsedSharesPaginated(db, (q) =>
+      q
+        .where('revoked', '==', true)
+        .orderBy(admin.firestore.FieldPath.documentId())
+    ),
   ]);
 
   const lapsedById = new Map<string, QueryDocSnap>();
-  for (const doc of [...expiredSnap.docs, ...revokedSnap.docs]) {
+  for (const doc of [...expiredDocs, ...revokedDocs]) {
     lapsedById.set(doc.id, doc);
   }
 


### PR DESCRIPTION
## Root cause

`functions/src/expireActivityWallShares.ts` (the hourly sweep that re-locks an Activity Wall session once every gallery share pointing at it has lapsed) queried `shared_activity_walls` for expired-by-date and revoked shares with a single `.limit(500)` call and **no cursor**. Lapsed share docs are never deleted (owners/admins can still read them for management, mirroring the sibling rule). Once more than 500 lapsed shares accumulated, every subsequent run re-fetched the identical top-500 (by document-ID order) forever, and any session whose only lapsed share sorted past position 500 was **never** relocked.

This is a real, unbounded privacy gap: `publiclyShared` stays `true` on the session doc, so a caller who captured a `sessionId` while a share was live could keep reading every submission and photo indefinitely past the teacher's expiration/revoke, once share volume passed the page cap. Flagged (not fixed) on #2251; this run implements the fix.

## Fix

Paginated both lookups with a `startAfter` cursor, mirroring the identical fix already applied in `gcPlcOrphans.ts` (#2230) for the same bug class:
- Expired-by-date query: `orderBy('expiresAt').orderBy(FieldPath.documentId())` (Firestore requires ordering the range-filtered field first; the document-id tiebreaker needs no additional composite index — Firestore implicitly appends it to any single-field-ordered query).
- Revoked query: `orderBy(FieldPath.documentId())` alone.
- `MAX_LAPSED_SHARES_PER_RUN` (500 → 5000) is now a safety ceiling with a `console.warn` if hit, not a silent hard cap; `LAPSED_SHARE_PAGE_SIZE` (500) is the per-page size.

## Band-aid rejected

Simply raising `MAX_LAPSED_SHARES_PER_RUN` to a bigger fixed number — this only pushes the same silent cliff further out without eliminating it. Rejected in favor of the root-cause cursor-pagination fix already proven correct for this exact bug class in `gcPlcOrphans.ts`.

## Regression tests

`functions/src/expireActivityWallShares.test.ts` — two new tests seeding 505 lapsed shares (expired and revoked variants) with the target session's share sorting last:
- "relocks a session whose only lapsed (expired) share sorts past LAPSED_SHARE_PAGE_SIZE"
- "relocks a session whose only lapsed (revoked) share sorts past LAPSED_SHARE_PAGE_SIZE"

**Fail-before** (orchestrator-verified against `dev-paul` source): both fail — `expected 1 to be NaN` (pre-fix code has no `LAPSED_SHARE_PAGE_SIZE` export, only found the hardcoded 500-doc cap; the target session's share, sorted past it, was left unlocked).
**Pass-after**: 15/15 tests pass in the file — all 505 lapsed shares found, every session (including the one past the old page boundary) relocked.

## Validation

`pnpm run validate` (root tests 580 files/7045 tests, functions tests 38 files/721 tests, 0 lint/type errors) and `pnpm run build` both pass. `firestore.rules` untouched, so `test:rules` doesn't apply here. Also swept `functions/src/` for the sibling SSR F redirect-guard pattern (`maxRedirects: 0` on blocklisted-URL fetches) — confirmed both existing guarded call sites (`fetchExternalProxy`, `checkUrlCompatibility`) are correct and no ungated call site exists. Orchestrator independently re-ran the fail-before/pass-after swap against `dev-paul` and confirmed the same result.

## Risk

**Architectural** — this closes an unbounded-accumulation gap in a privacy-relevant scheduled sweep; tagging architectural (not contained) since it changes the query/pagination contract of a production Cloud Function, even though the change itself mirrors an already-shipped, proven pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_016NoLERgruS2i9St7oLA1ph)_