### PR TITLE
audit(thursday): daily=[0 issues] weekly=[4 issues] — 2026-07-23

### DIFF
--- a/components/widgets/SoundWidget/Widget.tsx
+++ b/components/widgets/SoundWidget/Widget.tsx
@@ -37,8 +37,6 @@ export const SoundWidget: React.FC<{
   // Timer that releases the mic + AudioContext after a long hide (see effect below).
   const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { w, h } = widget;
-
   const {
     sensitivity = 1,
     visual = 'thermometer',
@@ -297,9 +295,7 @@ export const SoundWidget: React.FC<{
         <div className="flex-1 min-h-0 relative w-full h-full p-2">
           {visual === 'thermometer' && <ThermometerView volume={volume} />}
           {visual === 'speedometer' && <SpeedometerView volume={volume} />}
-          {visual === 'balls' && (
-            <PopcornBallsView volume={volume} width={w} height={h - 60} />
-          )}
+          {visual === 'balls' && <PopcornBallsView volume={volume} />}
           {visual === 'line' && (
             <div className="w-full h-full bg-black/20 rounded-2xl p-2">
               <svg

--- a/components/widgets/SoundWidget/components/PopcornBallsView.tsx
+++ b/components/widgets/SoundWidget/components/PopcornBallsView.tsx
@@ -1,12 +1,20 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { POSTER_LEVELS } from '../constants';
 
+/**
+ * Bouncing-balls noise visualizer. Renders to a `<canvas>`, whose 2D drawing
+ * buffer requires concrete pixel dimensions, so this component measures its own
+ * container with a `ResizeObserver` rather than receiving pre-computed pixel
+ * props. This keeps the canvas resolution in lock-step with the actual rendered
+ * area (which the parent's `container-type: size` context governs) instead of
+ * relying on the widget's stored dimensions minus a hard-coded header offset.
+ */
 export const PopcornBallsView: React.FC<{
   volume: number;
-  width: number;
-  height: number;
-}> = ({ volume, width, height }) => {
+}> = ({ volume }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [{ width, height }, setSize] = useState({ width: 0, height: 0 });
   const balls = useRef<{ x: number; y: number; vy: number; color: string }[]>(
     []
   );
@@ -17,8 +25,25 @@ export const PopcornBallsView: React.FC<{
     volumeRef.current = volume;
   }, [volume]);
 
+  // Measure the actual rendered canvas area. The container fills the widget
+  // content region, so its size already excludes header/footer chrome — no
+  // magic pixel subtraction required.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width: w, height: h } = entry.contentRect;
+        setSize({ width: Math.round(w), height: Math.round(h) });
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   // Handle resizing and ball re-initialization
   useEffect(() => {
+    if (width === 0 || height === 0) return;
     balls.current = []; // Reset balls on resize to reposition them
     for (let i = 0; i < 30; i++) {
       balls.current.push({
@@ -32,6 +57,7 @@ export const PopcornBallsView: React.FC<{
   }, [width, height]);
 
   useEffect(() => {
+    if (width === 0 || height === 0) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
@@ -67,11 +93,13 @@ export const PopcornBallsView: React.FC<{
   }, [width, height]);
 
   return (
-    <canvas
-      ref={canvasRef}
-      className="w-full h-full"
-      width={width}
-      height={height}
-    />
+    <div ref={containerRef} className="w-full h-full">
+      <canvas
+        ref={canvasRef}
+        className="w-full h-full"
+        width={width}
+        height={height}
+      />
+    </div>
   );
 };

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -4,7 +4,7 @@ _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
 _Last audited: 2026-07-23_
-_Last action: 2026-07-20 — MEDIUM ActivityWall photo grid `gridAutoRows` switched from JS-measured px to `minmax(clamp(120px, 45cqmin, 320px), 1fr)`; removed the dead `rowHeight` measurement path so rows track resize continuously while still filling tall widgets at low photo counts_
+_Last action: 2026-07-23 — MEDIUM SoundWidget `PopcornBallsView` no longer receives `width={w} height={h - 60}` (stored widget dims minus a magic header offset); the canvas component now self-measures its own container via `ResizeObserver`, matching the NumberLine idiom, so the draw buffer tracks the actual rendered area with no hard-coded pixel subtraction_
 
 ---
 
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-07-23 (action): Resolved the MEDIUM `SoundWidget PopcornBallsView` item — the highest-severity Open across today's reading list. Selection: today is Thursday; reading list = three dailies (widget-registry, css-scaling, typescript-eslint) + the weeklies audited last night (skill-freshness, dependency-audit). widget-registry and typescript-eslint have no open items; skill-freshness open items are all LOW; dependency-audit's open items are all headed MEDIUM (weekly). css-scaling (daily) also has exactly one MEDIUM, so the daily-before-weekly tiebreak among equal MEDIUM severity selects it, and it is first among the dailies with an open MEDIUM. File-recency check passed: `SoundWidget/Widget.tsx` last touched at `5cff8b93` (#1907) and `PopcornBallsView.tsx` at `24df0289` (#1846) — both far outside the last 5 branch commits. Fix note: the journal's suggested "replace with `cqh` CSS" does not fit a `<canvas>` (its 2D draw buffer requires concrete pixel dimensions), so the anti-pattern was instead removed at its root — `PopcornBallsView` no longer receives `width={w} height={h - 60}` (where `w`/`h` were the widget's **stored** dimensions, not `useMeasure` as the 2026-07-22 note assumed, minus a hard-coded 60px header estimate). It now self-measures its own container with a `ResizeObserver` (SSR-guarded, `Math.round`ed `contentRect`), matching the existing `NumberLine/Widget.tsx` idiom, so the canvas resolution tracks the actual rendered content area (which already excludes header/footer chrome) with zero magic offsets. Removed the now-unused `const { w, h } = widget;` destructure from `Widget.tsx`. Updated the existing `PopcornBallsView.test.tsx` to the new self-measuring API (mocked `ResizeObserver`, driving a synthetic resize; 2 tests green). `pnpm type-check` (0 errors), `eslint --max-warnings 0` on all three changed files (exit 0), `prettier --check` (clean), SoundWidget + PopcornBallsView suites green (10 tests). Moved item to Completed. PR opened against dev-paul._
 
 _2026-07-23: Targeted scan (Thursday). No new dev-paul commits absorbed (rebase not performed — dev-paul diverged). Agent scan of all widget front-face files. ZERO new anti-patterns found. All existing open items confirmed present and unresolved._
 
@@ -166,13 +168,6 @@ _2026-05-12: Scanned all Widget.tsx and index.tsx files for hardcoded text-size 
 
 _2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.tsx and UrlWidget/Widget.tsx both use `cqmin` units throughout; no new scaling violations introduced._
 
-### MEDIUM SoundWidget passes raw JS-measured pixel height to PopcornBallsView, bypassing container queries
-
-- **Detected:** 2026-07-22
-- **File:** components/widgets/SoundWidget/Widget.tsx:301
-- **Detail:** `<PopcornBallsView height={h - 60} ... />` where `h` is the measured pixel height of the widget container (obtained from `useMeasure`). The `- 60` constant is a hardcoded estimate of the header height. This bypasses the CSS container query system entirely: the component receives a raw pixel number rather than responding to the container's CQ context. Consequences: (1) Any header height change silently breaks the calculation. (2) The layout cannot be tested in jsdom (no layout engine). (3) It creates a hard coupling between the outer widget measurement and `PopcornBallsView`'s internal sizing. Widget has `skipScaling: true`.
-- **Fix:** Remove the `height` prop from `PopcornBallsView` and replace its internal height-dependent sizing with `cqh`-based CSS (`height: 100%` fill plus `cqmin` for inner elements). The widget content area is a CSS container (`container-type: size`), so `100cqh` inside `PopcornBallsView` accurately tracks the available height without any JS measurement. If `PopcornBallsView` needs to know the exact header height for layout, express it as a CSS variable or a `cqh`-relative calculation rather than a raw pixel subtraction.
-
 ### LOW ActivityWall three front-face view branches have hardcoded Tailwind spacing
 
 - **Detected:** 2026-07-18
@@ -258,6 +253,17 @@ _2026-05-05: New widgets from dev-paul merge audited — BlendingBoard/Widget.ts
 ---
 
 ## Completed
+
+### MEDIUM SoundWidget passes raw JS-measured pixel height to PopcornBallsView, bypassing container queries
+
+- **Detected:** 2026-07-22
+- **Completed:** 2026-07-23
+- **File:** components/widgets/SoundWidget/Widget.tsx:301, components/widgets/SoundWidget/components/PopcornBallsView.tsx
+- **Detail:** `<PopcornBallsView volume={volume} width={w} height={h - 60} />` passed the widget's **stored** dimensions (`const { w, h } = widget;` — not `useMeasure` as the 2026-07-22 detection note assumed) minus a hard-coded 60px header estimate into the canvas visualizer. This bypassed the CSS container query system: the component received a raw pixel number rather than tracking the container's actual rendered area, so any header/footer height change silently broke the calculation, and the sizing was untestable in jsdom (no layout engine). Widget has `skipScaling: true`.
+- **Fix applied:** The journal's suggested `cqh`-CSS conversion does not fit a `<canvas>` (its 2D draw buffer requires concrete pixel dimensions), so the anti-pattern was removed at its root instead. `PopcornBallsView` dropped its `width`/`height` props and now self-measures its own container with a `ResizeObserver` (SSR-guarded via `typeof ResizeObserver === 'undefined'`, `Math.round`ed `contentRect`), matching the `NumberLine/Widget.tsx` idiom. The container fills the widget content region, which already excludes header/footer chrome, so the canvas resolution tracks the real available area with zero magic offsets. The ball-init and animation effects gate on non-zero measured size. Removed the now-unused `const { w, h } = widget;` destructure from `Widget.tsx`.
+- **Selection rationale:** Thursday run. Reading list = three dailies (widget-registry, css-scaling, typescript-eslint) + the weeklies audited last night (skill-freshness, dependency-audit). Nothing In Progress anywhere. No heading-level HIGH open items across the list; highest Open severity is MEDIUM. widget-registry and typescript-eslint have no open items; skill-freshness open items are all LOW; dependency-audit's open items are headed MEDIUM but it is a weekly journal — the daily-before-weekly tiebreak among equal MEDIUM severity selects css-scaling's single MEDIUM. File-recency check passed: `SoundWidget/Widget.tsx` last touched at `5cff8b93` (#1907), `PopcornBallsView.tsx` at `24df0289` (#1846) — both outside the last 5 branch commits.
+- **Verification:** `pnpm type-check` (0 errors); `eslint --max-warnings 0` on the three changed files (exit 0); `prettier --check` (clean); `PopcornBallsView.test.tsx` rewritten to the self-measuring API (mocked `ResizeObserver` + synthetic resize) and `SoundWidget/Widget.test.tsx` — 10 tests green.
+- **PR:** opened against dev-paul.
 
 ### MEDIUM ActivityWall photo grid uses JS-measured px for gridAutoRows
 

--- a/docs/scheduled-tasks/css-scaling.md
+++ b/docs/scheduled-tasks/css-scaling.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-07-22_
+_Last audited: 2026-07-23_
 _Last action: 2026-07-20 — MEDIUM ActivityWall photo grid `gridAutoRows` switched from JS-measured px to `minmax(clamp(120px, 45cqmin, 320px), 1fr)`; removed the dead `rowHeight` measurement path so rows track resize continuously while still filling tall widgets at low photo counts_
 
 ---
@@ -21,6 +21,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-07-23: Targeted scan (Thursday). No new dev-paul commits absorbed (rebase not performed — dev-paul diverged). Agent scan of all widget front-face files. ZERO new anti-patterns found. All existing open items confirmed present and unresolved._
 
 _2026-07-22: Targeted scan (Wednesday). No new dev-paul commits absorbed (rebase not performed — dev-paul diverged). Agent scan of recently-active widget files. ONE new MEDIUM finding: `SoundWidget/Widget.tsx:301` — `<PopcornBallsView height={h - 60} ... />` where `h` is the raw JS-measured pixel height of the widget container (obtained via `useMeasure`). This passes a hard pixel value into `PopcornBallsView` instead of letting CSS container queries govern layout, bypassing the CQ system entirely. The `- 60` subtracts a fixed header offset, so any change to the header height silently breaks the calculation. This is a CSS anti-pattern distinct from the existing SoundWidget spacing items in the group LOW item. Also re-confirmed: RevealGrid `gap-4` at line 183 (already tracked in the LOW RevealGrid open item — note: line 185 in the detail text is stale, actual line is 183 per 2026-07-12 confirmation). Zero other new anti-patterns._
 

--- a/docs/scheduled-tasks/dependency-audit.md
+++ b/docs/scheduled-tasks/dependency-audit.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-07-21_
+_Last audited: 2026-07-23_
 _Last action: 2026-07-21_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-07-23: `pnpm audit` IS working — returned full vulnerability data. Root: **141 vulnerabilities** (9 low | 62 moderate | 66 high | 4 critical) — up from 139 on 2026-07-21. Functions: **73 vulnerabilities** — up from 71 on 2026-07-21. THREE NEW items detected: (1) NEW MEDIUM `protobufjs` GHSA-wcpc-wj8m-hjx6 HIGH — DoS via unbounded recursive expansion of `Any` fields (affected <=7.6.0, patched >=7.6.1); via `@google/genai>protobufjs` in both root and functions; existing `"protobufjs": "^7.5.6"` override is insufficient — must be updated to `"^7.6.1"` in both `package.json` and `functions/package.json`. (2) NEW MEDIUM `ws` HIGH in functions — via `@google/genai>ws` chain; root's `"ws@8": "^8.21.1"` scoped override does not cover functions/; need identical scoped override in `functions/package.json`. (3) NEW LOW `fast-uri` HIGH in functions — new advisory in functions/ audit output. `pnpm outdated` updates since 2026-07-21: `@google/genai` latest → 2.13.0 (was 2.12.0); `jose` (functions) latest → 6.2.4 (was 6.2.3); `react`/`react-dom` → 19.2.8. LOW major-versions item updated. All other existing items remain valid._
 
 _2026-07-21 (action): Resolved the MEDIUM `ws` uninitialized-memory-disclosure item. Selection: today is Tuesday; reading list = three dailies (widget-registry, css-scaling, typescript-eslint) + Tuesday weeklies dependency-audit / skill-freshness. widget-registry and typescript-eslint have no open items; css-scaling and skill-freshness open items are all LOW. The MEDIUM/HIGH items today are all dependency-audit MEDIUMs, so this weekly wins the severity tiebreak (severity outranks daily-before-weekly). In document order the first MEDIUM is the `pnpm audit` 410 tooling item — **skipped as not a safe unattended auto-fix**: its own 2026-07-21 update note records that audit is working again this run, and the residual "fix" is an open-ended policy call (confirm-in-CI / switch scanner / adopt Dependabot) that targets repo automation, not a mechanical override. The next actionable MEDIUM in document order is `ws`. File-recency check on `package.json` passed (no touch in the last 5 branch commits). Applied a **scoped** override — `"ws@8": "^8.20.1"` — after first confirming that a bare `"ws"` override also (unnecessarily) forced firebase-tools' non-vulnerable `ws@7.5.x` up to 8.x; the `ws@8` selector (matching the file's existing `path-to-regexp@8` convention) bumps only the vulnerable 8.x line to `ws@8.21.1` and leaves `ws@7.5.13` alone. After `pnpm install`, `pnpm why ws` = `ws@8.21.1` + `ws@7.5.13` (8.19.0/8.20.0 gone; zero residual matches in the lockfile); `pnpm audit` reports no `ws` advisory. Dev-only (jsdom/vitest) — no production runtime impact. Verified clean: `prettier --check package.json` (clean), `pnpm run type-check` (0 errors), `pnpm run test` (575 files / 6997 tests all pass). Moved item to Completed. PR #2257 opened against dev-paul (draft). Remaining MEDIUM items (pnpm-audit-410, yaml, hono, axios, firebase-tools, firebase-admin, MCP SDK, lodash) and the LOW items all still active._
 
@@ -132,6 +134,27 @@ _2026-06-16: pnpm audit (root): 135 vulnerabilities (12 low | 59 moderate | 62 h
 - **Detail:** HIGH — lodash >=4.0.0 <=4.17.23 vulnerable to code injection via `_.template`. This comes via `firebase-functions-test > lodash`. Only in test infrastructure, not production runtime.
 - **Fix:** Update `firebase-functions-test` from 3.4.1 to latest — check if newer version depends on a patched lodash. This is a test-only devDependency.
 
+### MEDIUM `protobufjs@7.5.6` has new HIGH DoS via `Any` field expansion — override must be updated to >=7.6.1
+
+- **Detected:** 2026-07-23
+- **File:** package.json, functions/package.json (`pnpm.overrides.protobufjs`)
+- **Detail:** GHSA-wcpc-wj8m-hjx6 (HIGH): DoS via unbounded recursive expansion of `Any` fields in `protobufjs` <=7.6.0. Patched in >=7.6.1. Via `@google/genai > protobufjs` in both root and functions. The existing `"protobufjs": "^7.5.6"` override was added to address CRITICAL GHSA-xq3m-2v4x-88gg but resolves within the new HIGH's affected range (<=7.6.0). Must be tightened to `"^7.6.1"`.
+- **Fix:** Update `"protobufjs": "^7.5.6"` → `"protobufjs": "^7.6.1"` in BOTH root `package.json` and `functions/package.json` pnpm.overrides. Run `pnpm install && pnpm -C functions install`, verify `pnpm why protobufjs` reports >=7.6.1 in both. Verify `pnpm audit` clears GHSA-wcpc-wj8m-hjx6. Run type-check, lint, and tests.
+
+### MEDIUM `ws` HIGH in `functions/` — scoped override from root does not cover functions workspace
+
+- **Detected:** 2026-07-23
+- **File:** functions/package.json (`pnpm.overrides`)
+- **Detail:** HIGH `ws` advisory via `@google/genai > ws` chain in functions/. Root `package.json` has `"ws@8": "^8.21.1"` (added 2026-07-21 for the root `ws` advisory) but pnpm.overrides in root does NOT propagate to the functions/ workspace — each workspace needs its own overrides block.
+- **Fix:** Add `"ws@8": "^8.21.1"` to `pnpm.overrides` in `functions/package.json`. Run `pnpm -C functions install`, verify `pnpm -C functions why ws` reports >=8.21.1 for the 8.x line, and run type-check and tests.
+
+### LOW `fast-uri` HIGH in `functions/` — new advisory in functions audit
+
+- **Detected:** 2026-07-23
+- **File:** functions/package.json (transitive dependency)
+- **Detail:** `fast-uri` has a new HIGH advisory in the 2026-07-23 `pnpm audit` output for functions/. The specific GHSA identifier and patched version will be confirmed on next detailed audit run.
+- **Fix:** Confirm GHSA and fix version, then add pnpm.overrides entry for `fast-uri` in `functions/package.json`.
+
 ### LOW `@types/tesseract.js@2.0.0` is deprecated — may become a resolution problem
 
 - **Detected:** 2026-06-30
@@ -143,13 +166,13 @@ _2026-06-16: pnpm audit (root): 135 vulnerabilities (12 low | 59 moderate | 62 h
 
 - **Detected:** 2026-07-07
 - **File:** functions/package.json (direct dependency `jose@4.15.9`)
-- **Detail:** `jose` is the JWT/JWK library used in Firebase Cloud Functions for LTI and student auth token verification. Current installed version is 4.15.9; latest is 6.2.3 (2 major versions ahead). No active CVE on jose 4.x is currently reported by `pnpm audit`, but being 2 major versions behind on a security-sensitive JWT library is a maintenance risk. jose 5.x and 6.x include important security-relevant changes (e.g., stricter algorithm validation, updated algorithm support). This is a production dependency (not dev-only), unlike most other outdated packages.
-- **Fix:** Review the jose 5.x and 6.x migration guides for breaking API changes. Update `functions/package.json` `jose` to `^6.2.3` and run `pnpm -C functions type-check`, `pnpm -C functions test` to catch any breaking changes. Priority: plan migration within the next 2-4 weeks before a CVE is published against jose 4.x.
+- **Detail:** `jose` is the JWT/JWK library used in Firebase Cloud Functions for LTI and student auth token verification. Current installed version is 4.15.9; latest is 6.2.4 (2 major versions ahead; updated 2026-07-23). No active CVE on jose 4.x is currently reported by `pnpm audit`, but being 2 major versions behind on a security-sensitive JWT library is a maintenance risk. jose 5.x and 6.x include important security-relevant changes (e.g., stricter algorithm validation, updated algorithm support). This is a production dependency (not dev-only), unlike most other outdated packages.
+- **Fix:** Review the jose 5.x and 6.x migration guides for breaking API changes. Update `functions/package.json` `jose` to `^6.2.4` and run `pnpm -C functions type-check`, `pnpm -C functions test` to catch any breaking changes. Priority: plan migration within the next 2-4 weeks before a CVE is published against jose 4.x.
 
 ### LOW Major version updates available — require planned migration
 
 - **Detected:** 2026-04-14
-- **Updated:** 2026-07-21
+- **Updated:** 2026-07-23
 - **File:** package.json
 - **Detail:** Several packages have major version releases available that require migration planning (breaking changes):
   - `tailwindcss`: 3.4.19 → **4.3.2** (major — config format changed completely)
@@ -164,12 +187,12 @@ _2026-06-16: pnpm audit (root): 135 vulnerabilities (12 low | 59 moderate | 62 h
   - `@types/node`: 24.12.2 → **26.1.1** (2 major versions behind — verify Node 24 compat)
   - `jsdom`: 27.4.0 → **29.1.1** (2 majors ahead — test environment only; also resolves ws CVE)
   - `lint-staged`: 16.2.7 → **17.0.8** (major — check husky integration compatibility)
-  - `@google/genai`: 1.51.0 → **2.12.0** (major — AI API surface may have breaking changes; test all generation flows after upgrade; also affects functions/; updated 2026-07-21)
+  - `@google/genai`: 1.51.0 → **2.13.0** (major — AI API surface may have breaking changes; test all generation flows after upgrade; also affects functions/; updated 2026-07-23)
   - `firebase`: 12.8.0 → **12.16.0** (latest as of 2026-07-21; update to resolve fast-xml-parser and node-forge transitive CVEs)
   - `firebase-admin` (functions): 13.6.0 → **14.2.0** (1 major — review migration guide for breaking changes; updated 2026-07-21)
-  - `jose` (functions): 4.15.9 → **6.2.3** (2 majors — separate LOW item above for JWT security context)
+  - `jose` (functions): 4.15.9 → **6.2.4** (2 majors — separate LOW item above for JWT security context; updated 2026-07-23)
   - `@testing-library/jest-dom`: 6.x → **7.x** (major — NEW 2026-07-21; check matcher API changes)
-    Also notable patch/minor updates: `react`/`react-dom` 19.2.4 → **19.2.7**, `firebase-tools` 15.8.0 → **15.24.0** (latest 2026-07-21), `@playwright/test` 1.58.0 → **1.61.1**, `@typescript-eslint/*` 8.54.0 → **8.62.1**, `vitest` (root) 4.1.8 → **4.1.10**, `hono` 4.12.15 → **4.12.30** (also has active MEDIUM CVE — see separate item), `dompurify` 3.4.2 → **3.4.12**, `postcss` 8.5.6 → **8.5.19**, `prettier` 3.8.1 → **3.9.4**, `eslint-plugin-prettier` 5.5.5 → **5.5.6**, `eslint-plugin-react-hooks` 7.0.1 → **7.1.1**, `globals` 17.2.0 → **17.7.0**, `@firebase/rules-unit-testing` 5.0.0 → **5.0.1**, `google-auth-library` (functions) 10.5.0 → **10.9.0**, functions `axios` 1.15.0 → **1.18.1**, functions `@google-cloud/functions-framework` 5.0.0 → **5.0.5**, `axios` (root) 1.15.0 → **1.18.1** (also active separate MEDIUM CVE — upgrade resolves), `recharts` 3.8.1 → **3.9.2**, `react-i18next` 16.5.4 → **17.0.10** (major).
+    Also notable patch/minor updates: `react`/`react-dom` 19.2.4 → **19.2.8** (updated 2026-07-23), `firebase-tools` 15.8.0 → **15.24.0** (latest 2026-07-21), `@playwright/test` 1.58.0 → **1.61.1**, `@typescript-eslint/*` 8.54.0 → **8.62.1**, `vitest` (root) 4.1.8 → **4.1.10**, `hono` 4.12.15 → **4.12.30** (also has active MEDIUM CVE — see separate item), `dompurify` 3.4.2 → **3.4.12**, `postcss` 8.5.6 → **8.5.19**, `prettier` 3.8.1 → **3.9.4**, `eslint-plugin-prettier` 5.5.5 → **5.5.6**, `eslint-plugin-react-hooks` 7.0.1 → **7.1.1**, `globals` 17.2.0 → **17.7.0**, `@firebase/rules-unit-testing` 5.0.0 → **5.0.1**, `google-auth-library` (functions) 10.5.0 → **10.9.0**, functions `axios` 1.15.0 → **1.18.1**, functions `@google-cloud/functions-framework` 5.0.0 → **5.0.5**, `axios` (root) 1.15.0 → **1.18.1** (also active separate MEDIUM CVE — upgrade resolves), `recharts` 3.8.1 → **3.9.2**, `react-i18next` 16.5.4 → **17.0.10** (major).
     These should not be done in a single commit — each needs its own migration PR with testing.
 - **Fix:** Prioritize security patches first. Schedule tailwindcss 4 migration separately (config rewrite required). typescript 7 migration after ensuring all types are clean. Coordinate eslint 9→10 with typescript-eslint team compatibility matrix. `@google/genai` major bump warrants dedicated testing of all AI generation flows (quiz, mini-app, widget builder, OCR, etc.). jsdom update to v29 also resolves the ws CVE tracked separately.
 

--- a/docs/scheduled-tasks/skill-freshness.md
+++ b/docs/scheduled-tasks/skill-freshness.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: weekly — Tuesday_
-_Last audited: 2026-07-21_
+_Last audited: 2026-07-23_
 _Last action: 2026-07-09 — MEDIUM SpecialistSchedule Appearance.tsx/co-located-Settings pattern documented + stale `.agents/` reference row corrected in new-widget skill (both mirrors)_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-07-23: Skill files NOT accessible at `/mnt/skills/user/` in this environment (path does not exist — consistent with all prior runs). Codebase-side verification via sub-agent. No new dev-paul commits since 2026-07-21 (rebase not performed). Key findings: (1) `ScheduleConfigurationPanel.tsx` — direct bash verification confirmed the file EXISTS at `components/admin/ScheduleConfigurationPanel.tsx` (and its test `ScheduleConfigurationPanel.test.tsx`). The 2026-07-21 directory scan was incorrect. LOW item moved to Completed (file is present; skill reference is valid). (2) NEW LOW: `spart-new-widget` skill cites `QRWidget/Widget.tsx` as a "Good empty state usage" reference, but QRWidget/Widget.tsx does NOT use `ScaledEmptyState` — it uses hand-rolled empty-state markup. Better reference implementations include `UrlWidget/Widget.tsx`, `Checklist/Widget.tsx`, and `RecessGear/Widget.tsx`. Remaining open: 6 LOWs._
 
 _2026-07-21: Skill files NOT accessible at `/mnt/skills/user/` in this environment (path does not exist — consistent with all prior runs). Codebase-side verification via sub-agent: new dev-paul commits since 2026-07-20 (absorbed via rebase): fix(activity-wall) photo-grid rowHeight cqmin fix (#2253 — Widget.tsx only, no skill-relevant files). Full checklist verification: all 8 required files (types.ts, config/tools.ts, config/widgetDefaults.ts, config/widgetGradeLevels.ts, components/widgets/WidgetRegistry.ts, components/admin/, components/admin/FeaturePermissionsManager.tsx) confirmed present. `SpecialistSchedule/` still has `SpecialistScheduleWidget.tsx`, `Settings.tsx`, `index.ts`, `utils.ts` — reference note from 2026-07-09 accurate. `lazyNamed()` convention correct in WidgetRegistry.ts. All 6 reference widget implementations confirmed present. ONE NEW LOW item: `spart-widget-admin-config` Path B example list references `ScheduleConfigurationPanel.tsx` — no file by that name exists in `components/admin/` (directory scan confirms only `ClockConfigurationPanel.tsx` and `DiceConfigurationPanel.tsx` among the examples; `ScheduleConfigurationPanel.tsx` is absent). All 4 pre-existing LOW items remain valid. Total open: 5 LOW._
 
@@ -50,12 +52,12 @@ _2026-05-05: Skill files not accessible at `/mnt/skills/user/` in this audit env
 
 _2026-06-23 action: Fixed MEDIUM `admin-widget-config` reference to non-existent `SpecialistScheduleSettings.tsx`. Both skill copies (`.claude/skills/admin-widget-config/SKILL.md:222` and `.agents/skills/admin-widget-config/SKILL.md:185`) updated to reference the correct path `components/widgets/SpecialistSchedule/Settings.tsx`. Verified the target file exists and reads `featurePermissions` (Settings.tsx:48). File-recency check passed: skill files last touched at 19b6ae40 — outside the last 5 branch commits. Documentation-only change; PR opened against dev-paul. Item moved to Completed. 2 LOW open items remain._
 
-### LOW `spart-widget-admin-config` Path B example references non-existent `ScheduleConfigurationPanel.tsx`
+### LOW `spart-new-widget` cites `QRWidget/Widget.tsx` as a "Good empty state usage" reference — but it uses hand-rolled markup, not `ScaledEmptyState`
 
-- **Detected:** 2026-07-21
-- **File:** `.claude/skills/admin-widget-config/SKILL.md` — Path B example list
-- **Detail:** The skill's Path B section mentions `ScheduleConfigurationPanel.tsx` as an example of an existing panel alongside `ClockConfigurationPanel.tsx` and `DiceConfigurationPanel.tsx`. No file named `ScheduleConfigurationPanel.tsx` exists in `components/admin/` — a full directory scan confirms its absence. The schedule widget's admin configuration is handled differently (likely via `SpecialistScheduleConfigurationModal.tsx` which does exist). A developer following the example literally cannot find the referenced file. Both `ClockConfigurationPanel.tsx` and `DiceConfigurationPanel.tsx` do exist and are valid examples; only the schedule entry is stale.
-- **Fix:** Replace `ScheduleConfigurationPanel.tsx` in the Path B example list with a panel that exists — e.g., `SoundboardConfigurationPanel.tsx` or `CountdownConfigurationPanel.tsx` — or remove the stale entry and reference `SpecialistScheduleConfigurationModal.tsx` (which does exist) with a note that complex widgets use a modal pattern.
+- **Detected:** 2026-07-23
+- **File:** `.claude/skills/new-widget/SKILL.md` — "Reference Implementations" section
+- **Detail:** The skill's Reference Implementations table lists `QRWidget/Widget.tsx` under "Good empty state usage." However, `QRWidget/Widget.tsx` does not use the shared `ScaledEmptyState` component — it uses hand-rolled empty-state markup (a custom `div` with inline icon and text). This contradicts CLAUDE.md guidance that widgets should use `ScaledEmptyState`. Better reference implementations for empty state usage include `UrlWidget/Widget.tsx`, `Checklist/Widget.tsx`, and `RecessGear/Widget.tsx`, all of which use `ScaledEmptyState` correctly.
+- **Fix:** Update the Reference Implementations table in the skill to replace `QRWidget/Widget.tsx` with a widget that genuinely uses `ScaledEmptyState` — e.g., `UrlWidget/Widget.tsx` or `RecessGear/Widget.tsx`.
 
 ### LOW `spart-new-widget` admin config step understates the number of code changes required
 
@@ -99,6 +101,14 @@ _2026-06-23 action: Fixed MEDIUM `admin-widget-config` reference to non-existent
 ---
 
 ## Completed
+
+### LOW `spart-widget-admin-config` Path B example references `ScheduleConfigurationPanel.tsx`
+
+- **Detected:** 2026-07-21
+- **Completed:** 2026-07-23
+- **File:** `.claude/skills/admin-widget-config/SKILL.md` — Path B example list
+- **Detail:** The 2026-07-21 directory scan reported no file named `ScheduleConfigurationPanel.tsx` in `components/admin/`, concluding the skill reference was stale. Bash verification on 2026-07-23 confirmed the file DOES exist at `components/admin/ScheduleConfigurationPanel.tsx` (and its test `components/admin/ScheduleConfigurationPanel.test.tsx`). The 2026-07-21 scan result was incorrect.
+- **Resolution (2026-07-23):** `components/admin/ScheduleConfigurationPanel.tsx` confirmed to exist — skill reference is valid. No fix needed.
 
 ### MEDIUM `spart-new-widget` documents SpecialistSchedule as having a separate `Appearance.tsx` — actual pattern co-locates appearance in `Settings.tsx`
 

--- a/docs/scheduled-tasks/typescript-eslint.md
+++ b/docs/scheduled-tasks/typescript-eslint.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-07-22_
+_Last audited: 2026-07-23_
 _Last action: never_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-07-23. TypeScript: 0 errors (exit 0). ESLint: 0 errors, 0 warnings (`--max-warnings 0`, both root and functions, exit 0). No new dev-paul commits absorbed (rebase not performed — dev-paul diverged; auditing current branch state). Codebase remains fully type-safe and lint-clean._
 
 _No open items. Both `pnpm type-check` and `pnpm lint` pass cleanly as of 2026-07-22. TypeScript: 0 errors (exit 0). ESLint: 0 errors, 0 warnings (`--max-warnings 0`, both root and functions, exit 0). No new dev-paul commits absorbed (rebase not performed — dev-paul diverged; auditing current branch state). Codebase remains fully type-safe and lint-clean._
 

--- a/docs/scheduled-tasks/widget-registry.md
+++ b/docs/scheduled-tasks/widget-registry.md
@@ -3,7 +3,7 @@
 _Audit model: claude-sonnet-4-6_
 _Action model: claude-opus-4-6_
 _Audit cadence: daily_
-_Last audited: 2026-07-22_
+_Last audited: 2026-07-23_
 _Last action: 2026-06-25_
 
 ---
@@ -15,6 +15,8 @@ _Nothing currently in progress._
 ---
 
 ## Open
+
+_2026-07-23: Full audit. No new dev-paul commits since 2026-07-22 (rebase not performed — dev-paul diverged; auditing current branch state). VERIFIED COUNT: 63 WidgetType members (unchanged). All registrations across WIDGET_COMPONENTS, WIDGET_SETTINGS_COMPONENTS, WIDGET_APPEARANCE_COMPONENTS, WIDGET_SCALING_CONFIG, config/tools.ts, config/widgetDefaults.ts, and config/widgetGradeLevels.ts verified correct. pnpm type-check (exit 0), pnpm lint (exit 0). Zero new gaps._
 
 _2026-07-22: Full audit. No new dev-paul commits since 2026-07-21 (rebase not performed — dev-paul has diverged with code changes; auditing current branch state). VERIFIED COUNT: 63 WidgetType members (unchanged). All registrations across WIDGET_COMPONENTS, WIDGET_SETTINGS_COMPONENTS, WIDGET_APPEARANCE_COMPONENTS, WIDGET_SCALING_CONFIG, config/tools.ts, config/widgetDefaults.ts, and config/widgetGradeLevels.ts verified correct. RevealGrid uses barrel aliases 'Widget'/'Settings' in WIDGET_COMPONENTS/WIDGET_SETTINGS_COMPONENTS but full name 'RevealGridAppearanceSettings' in WIDGET_APPEARANCE_COMPONENTS — intentional but fragile; already documented. pnpm type-check (exit 0), pnpm lint (exit 0). Zero new gaps._
 

--- a/tests/components/widgets/SoundWidget/components/PopcornBallsView.test.tsx
+++ b/tests/components/widgets/SoundWidget/components/PopcornBallsView.test.tsx
@@ -1,10 +1,40 @@
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { PopcornBallsView } from '@/components/widgets/SoundWidget/components/PopcornBallsView';
 import React from 'react';
 
+// Capture the ResizeObserver callback so tests can drive a synthetic resize.
+// jsdom has no layout engine, so the component's own-container measurement
+// must be simulated by invoking the observer callback with a contentRect.
+let resizeCallback: ResizeObserverCallback | null = null;
+
+class MockResizeObserver {
+  constructor(cb: ResizeObserverCallback) {
+    resizeCallback = cb;
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+function emitResize(target: Element, width: number, height: number): void {
+  act(() => {
+    resizeCallback?.(
+      [
+        {
+          target,
+          contentRect: { width, height } as DOMRectReadOnly,
+        } as ResizeObserverEntry,
+      ],
+      {} as ResizeObserver
+    );
+  });
+}
+
 describe('PopcornBallsView', () => {
   beforeEach(() => {
+    resizeCallback = null;
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
@@ -12,22 +42,32 @@ describe('PopcornBallsView', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it('renders canvas with correct width and height', () => {
-    const { container } = render(
-      <PopcornBallsView volume={50} width={400} height={300} />
-    );
+  it('sizes the canvas from its measured container, not from props', () => {
+    const { container } = render(<PopcornBallsView volume={50} />);
     const canvas = container.querySelector('canvas');
     expect(canvas).toBeInTheDocument();
+    // Before any measurement the canvas buffer is zero-sized.
+    expect(canvas).toHaveAttribute('width', '0');
+    expect(canvas).toHaveAttribute('height', '0');
+
+    const measured = container.querySelector('div');
+    emitResize(measured as Element, 400, 300);
+
     expect(canvas).toHaveAttribute('width', '400');
     expect(canvas).toHaveAttribute('height', '300');
   });
 
-  it('starts and stops animation on mount and unmount', () => {
-    const { unmount } = render(
-      <PopcornBallsView volume={50} width={400} height={300} />
-    );
+  it('starts animation once measured and stops it on unmount', () => {
+    const { container, unmount } = render(<PopcornBallsView volume={50} />);
+    // No animation until the container has a non-zero measured size.
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+
+    const measured = container.querySelector('div');
+    emitResize(measured as Element, 400, 300);
+
     expect(window.requestAnimationFrame).toHaveBeenCalled();
     unmount();
     expect(window.cancelAnimationFrame).toHaveBeenCalled();


### PR DESCRIPTION
## Scheduled Thursday Audit — 2026-07-23

Journal updates for all five scheduled audit tasks, **plus one code fix** (see "Action" below).

## Daily Audits

**Widget Registry** — 63 WidgetTypes, all registrations clean across all maps. `pnpm type-check` and `pnpm lint` both exit 0. Zero new gaps.

**CSS Scaling** — Zero new anti-patterns during the scan. One existing MEDIUM item resolved (see Action).

**TypeScript & ESLint** — 0 errors, 0 warnings (`--max-warnings 0`, root + functions). Codebase fully type-safe and lint-clean.

## Weekly Audits

**Skill Freshness (B1)**
- Resolved: `ScheduleConfigurationPanel.tsx` LOW moved to Completed — file exists; the 2026-07-21 directory scan was incorrect.
- New LOW: `spart-new-widget` cites `QRWidget/Widget.tsx` as a "Good empty state usage" reference, but it uses hand-rolled markup instead of `ScaledEmptyState`.

**Dependency Audit (B2)**
- 141 root / 73 functions vulnerabilities (up from 139/71 on 2026-07-21).
- New MEDIUM: `protobufjs` GHSA-wcpc-wj8m-hjx6 HIGH — override must move to `^7.6.1` in both `package.json` files.
- New MEDIUM: `ws` HIGH in `functions/` — root's scoped override does not propagate to the functions workspace.
- New LOW: `fast-uri` HIGH in functions. Version drift noted for `@google/genai`, `jose`, `react`/`react-dom`.

## Action — 2026-07-23 (Thursday scheduled action run)

Resolved the highest-severity Open item across today's reading list: the **MEDIUM css-scaling** item *"SoundWidget passes raw JS-measured pixel height to PopcornBallsView, bypassing container queries."* (Daily-before-weekly tiebreak among equal MEDIUM severity; widget-registry/typescript-eslint had no open items.)

- `components/widgets/SoundWidget/components/PopcornBallsView.tsx` — dropped the `width`/`height` props (previously `width={w} height={h - 60}`, where `w`/`h` were the widget's **stored** dimensions minus a hard-coded 60px header estimate). The canvas visualizer now **self-measures its own container** via a `ResizeObserver` (SSR-guarded, rounded `contentRect`), matching the `NumberLine/Widget.tsx` idiom, so the draw buffer tracks the actual rendered content area with no magic offset. A `cqh`-CSS conversion doesn't fit here because a `<canvas>` 2D buffer needs concrete pixel dimensions.
- `components/widgets/SoundWidget/Widget.tsx` — updated the call site and removed the now-unused `const { w, h } = widget;` destructure.
- `tests/components/widgets/SoundWidget/components/PopcornBallsView.test.tsx` — rewritten to the self-measuring API (mocked `ResizeObserver` + synthetic resize).
- Journal: css-scaling item moved to Completed.

Verified: `pnpm type-check` (0 errors), `eslint --max-warnings 0` on changed files (exit 0), `prettier --check` (clean), SoundWidget + PopcornBallsView suites green (10 tests).