### PR TITLE
unify(D5): SpecialistScheduleConfigurationModal local Toast → addToast

### DIFF
--- a/components/admin/SpecialistScheduleConfigurationModal.tsx
+++ b/components/admin/SpecialistScheduleConfigurationModal.tsx
@@ -20,12 +20,12 @@ import {
 } from '@/types';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
-import { Toast } from '@/components/common/Toast';
 import { Modal } from '@/components/common/Modal';
 import { Button } from '@/components/common/Button';
 import { Card } from '@/components/common/Card';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { useDashboard } from '@/context/useDashboard';
 
 interface SpecialistScheduleConfigurationModalProps {
   isOpen: boolean;
@@ -56,16 +56,13 @@ const INTERMEDIATE_DEFAULT_OPTIONS = [
 export const SpecialistScheduleConfigurationModal: React.FC<
   SpecialistScheduleConfigurationModalProps
 > = ({ isOpen, onClose }) => {
+  const { addToast } = useDashboard();
   const BUILDINGS = useAdminBuildings();
   const [config, setConfig] = useState<SpecialistScheduleGlobalConfig>({
     buildingDefaults: {},
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState<{
-    text: string;
-    type: 'success' | 'error';
-  } | null>(null);
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
   const [currentMonth, setCurrentMonth] = useState(new Date());
@@ -116,14 +113,11 @@ export const SpecialistScheduleConfigurationModal: React.FC<
         { merge: true }
       );
       if (!updatedConfig) {
-        setMessage({
-          text: 'Specialist schedule configuration saved!',
-          type: 'success',
-        });
+        addToast('Specialist schedule configuration saved!', 'success');
       }
     } catch (err) {
       console.error('Failed to save specialist schedule config:', err);
-      setMessage({ text: 'Failed to save configuration.', type: 'error' });
+      addToast('Failed to save configuration.', 'error');
     } finally {
       setSaving(false);
     }
@@ -351,451 +345,432 @@ export const SpecialistScheduleConfigurationModal: React.FC<
   );
 
   return (
-    <>
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-        maxWidth="max-w-5xl"
-        customHeader={header}
-        footer={footer}
-        className="!p-0"
-        contentClassName=""
-        footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
-      >
-        <div className="p-6 space-y-8">
-          {loading ? (
-            <div className="flex flex-col items-center justify-center py-20 gap-4">
-              <Loader2 className="w-10 h-10 text-teal-500 animate-spin" />
-              <p className="text-sm font-bold text-slate-400 uppercase tracking-widest">
-                Loading Configuration...
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Dock Defaults */}
-              <DockDefaultsPanel
-                config={{ dockDefaults: config.dockDefaults ?? {} }}
-                onChange={(d) =>
-                  setConfig((prev) => ({ ...prev, dockDefaults: d }))
-                }
-              />
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-5xl"
+      customHeader={header}
+      footer={footer}
+      className="!p-0"
+      contentClassName=""
+      footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
+    >
+      <div className="p-6 space-y-8">
+        {loading ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-4">
+            <Loader2 className="w-10 h-10 text-teal-500 animate-spin" />
+            <p className="text-sm font-bold text-slate-400 uppercase tracking-widest">
+              Loading Configuration...
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Dock Defaults */}
+            <DockDefaultsPanel
+              config={{ dockDefaults: config.dockDefaults ?? {} }}
+              onChange={(d) =>
+                setConfig((prev) => ({ ...prev, dockDefaults: d }))
+              }
+            />
 
-              {/* Building Selector */}
-              <section className="space-y-4">
-                <div>
-                  <SettingsLabel icon={Settings2}>
-                    Select Building to Configure
-                  </SettingsLabel>
-                  <BuildingSelector
-                    selectedId={selectedBuildingId}
-                    onSelect={setSelectedBuildingId}
-                    activeClassName="bg-teal-500 text-white border-teal-500 shadow-sm"
-                  />
-                </div>
+            {/* Building Selector */}
+            <section className="space-y-4">
+              <div>
+                <SettingsLabel icon={Settings2}>
+                  Select Building to Configure
+                </SettingsLabel>
+                <BuildingSelector
+                  selectedId={selectedBuildingId}
+                  onSelect={setSelectedBuildingId}
+                  activeClassName="bg-teal-500 text-white border-teal-500 shadow-sm"
+                />
+              </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-8 animate-in fade-in slide-in-from-top-2 duration-300">
-                  {/* Left: Rotation Settings */}
-                  <div className="space-y-6">
-                    <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-6">
-                      <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                        <Settings2 className="w-4 h-4 text-teal-500" /> Rotation
-                        Settings
-                      </h4>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-8 animate-in fade-in slide-in-from-top-2 duration-300">
+                {/* Left: Rotation Settings */}
+                <div className="space-y-6">
+                  <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-6">
+                    <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                      <Settings2 className="w-4 h-4 text-teal-500" /> Rotation
+                      Settings
+                    </h4>
 
-                      <div className="flex items-center justify-between">
-                        <span className="text-sm font-medium text-slate-700">
-                          Rotation Cycle
-                        </span>
-                        <div className="flex bg-white rounded-lg p-1 border border-slate-200">
-                          <button
-                            onClick={() =>
-                              updateBuilding({
-                                cycleLength: 6,
-                                dayLabel: 'Day',
-                                blocks: [],
-                              })
-                            }
-                            className={`px-3 py-1 text-xs font-bold rounded ${currentBuildingConfig.cycleLength === 6 ? 'bg-teal-600 text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50'}`}
-                          >
-                            6-Day
-                          </button>
-                          <button
-                            onClick={() =>
-                              updateBuilding({
-                                cycleLength: 10,
-                                dayLabel: 'Block',
-                                blocks:
-                                  currentBuildingConfig.blocks?.length === 10
-                                    ? currentBuildingConfig.blocks
-                                    : Array.from({ length: 10 }, (_, i) => ({
-                                        dayNumber: i + 1,
-                                        startDate: '',
-                                        endDate: '',
-                                      })),
-                              })
-                            }
-                            className={`px-3 py-1 text-xs font-bold rounded ${currentBuildingConfig.cycleLength === 10 ? 'bg-teal-600 text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50'}`}
-                          >
-                            10-Block
-                          </button>
-                        </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-slate-700">
+                        Rotation Cycle
+                      </span>
+                      <div className="flex bg-white rounded-lg p-1 border border-slate-200">
+                        <button
+                          onClick={() =>
+                            updateBuilding({
+                              cycleLength: 6,
+                              dayLabel: 'Day',
+                              blocks: [],
+                            })
+                          }
+                          className={`px-3 py-1 text-xs font-bold rounded ${currentBuildingConfig.cycleLength === 6 ? 'bg-teal-600 text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50'}`}
+                        >
+                          6-Day
+                        </button>
+                        <button
+                          onClick={() =>
+                            updateBuilding({
+                              cycleLength: 10,
+                              dayLabel: 'Block',
+                              blocks:
+                                currentBuildingConfig.blocks?.length === 10
+                                  ? currentBuildingConfig.blocks
+                                  : Array.from({ length: 10 }, (_, i) => ({
+                                      dayNumber: i + 1,
+                                      startDate: '',
+                                      endDate: '',
+                                    })),
+                            })
+                          }
+                          className={`px-3 py-1 text-xs font-bold rounded ${currentBuildingConfig.cycleLength === 10 ? 'bg-teal-600 text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50'}`}
+                        >
+                          10-Block
+                        </button>
                       </div>
+                    </div>
 
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-slate-700">
+                        Default Day Label
+                      </span>
+                      <input
+                        type="text"
+                        value={currentBuildingConfig.dayLabel ?? ''}
+                        onChange={(e) =>
+                          updateBuilding({ dayLabel: e.target.value })
+                        }
+                        className="w-24 px-2 py-1 text-sm border border-slate-200 rounded-lg text-right font-bold text-teal-700 focus:ring-2 focus:ring-teal-500 outline-none"
+                        placeholder="e.g. Day"
+                      />
+                    </div>
+
+                    {currentBuildingConfig.cycleLength === 6 && (
                       <div className="flex items-center justify-between">
                         <span className="text-sm font-medium text-slate-700">
-                          Default Day Label
+                          Start Date
                         </span>
                         <input
-                          type="text"
-                          value={currentBuildingConfig.dayLabel ?? ''}
+                          type="date"
+                          value={currentBuildingConfig.startDate}
                           onChange={(e) =>
-                            updateBuilding({ dayLabel: e.target.value })
+                            updateBuilding({ startDate: e.target.value })
                           }
-                          className="w-24 px-2 py-1 text-sm border border-slate-200 rounded-lg text-right font-bold text-teal-700 focus:ring-2 focus:ring-teal-500 outline-none"
-                          placeholder="e.g. Day"
+                          className="px-2 py-1 text-sm border border-slate-200 rounded-lg font-bold text-teal-700 focus:ring-2 focus:ring-teal-500 outline-none"
                         />
                       </div>
+                    )}
+                  </div>
 
-                      {currentBuildingConfig.cycleLength === 6 && (
-                        <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium text-slate-700">
-                            Start Date
+                  {/* Custom Day Names */}
+                  <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
+                    <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                      <Settings2 className="w-4 h-4 text-teal-500" /> Custom Day
+                      Names
+                    </h4>
+                    <div className="grid grid-cols-2 gap-2">
+                      {Array.from(
+                        { length: currentBuildingConfig.cycleLength },
+                        (_, i) => i + 1
+                      ).map((num) => (
+                        <div
+                          key={num}
+                          className="flex items-center gap-2 bg-white p-2 rounded-xl border border-slate-100"
+                        >
+                          <span className="text-xxs font-black text-slate-400 w-4">
+                            {num}
                           </span>
                           <input
-                            type="date"
-                            value={currentBuildingConfig.startDate}
-                            onChange={(e) =>
-                              updateBuilding({ startDate: e.target.value })
+                            type="text"
+                            value={
+                              currentBuildingConfig.customDayNames?.[num] ?? ''
                             }
-                            className="px-2 py-1 text-sm border border-slate-200 rounded-lg font-bold text-teal-700 focus:ring-2 focus:ring-teal-500 outline-none"
+                            onChange={(e) => updateDayName(num, e.target.value)}
+                            placeholder={`${currentBuildingConfig.dayLabel ?? 'Day'} ${num}`}
+                            className="flex-1 text-xs font-bold text-slate-700 focus:outline-none"
                           />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Middle: Specialist Options */}
+                <div className="space-y-6">
+                  <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4 h-full flex flex-col">
+                    <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                      <Settings2 className="w-4 h-4 text-teal-500" /> Specialist
+                      Classes
+                    </h4>
+                    <p className="text-xxs text-slate-400 font-bold uppercase">
+                      Predefined options for teachers
+                    </p>
+
+                    <div className="flex gap-2">
+                      <input
+                        type="text"
+                        value={newOption}
+                        onChange={(e) => setNewOption(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && addOption()}
+                        placeholder="e.g. 🎨 Art"
+                        className="flex-1 px-3 py-1.5 text-xs border border-slate-200 rounded-xl focus:ring-2 focus:ring-teal-500 outline-none font-bold"
+                      />
+                      <button
+                        onClick={addOption}
+                        className="p-1.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700"
+                      >
+                        <Plus className="w-4 h-4" />
+                      </button>
+                    </div>
+
+                    <div className="flex-1 overflow-y-auto space-y-2 custom-scrollbar pr-1 min-h-[200px]">
+                      {(currentBuildingConfig.specialistOptions ?? []).map(
+                        (option) => (
+                          <div
+                            key={option}
+                            className="flex items-center justify-between bg-white p-2 rounded-xl border border-slate-100 group"
+                          >
+                            <span className="text-xs font-bold text-slate-700">
+                              {option}
+                            </span>
+                            <button
+                              onClick={() => removeOption(option)}
+                              className="p-1 text-slate-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </button>
+                          </div>
+                        )
+                      )}
+                      {(currentBuildingConfig.specialistOptions ?? [])
+                        .length === 0 && (
+                        <div className="text-center py-8 text-slate-300 italic text-xs">
+                          No options added.
                         </div>
                       )}
                     </div>
 
-                    {/* Custom Day Names */}
-                    <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
-                      <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                        <Settings2 className="w-4 h-4 text-teal-500" /> Custom
-                        Day Names
+                    <div className="bg-teal-50 p-4 rounded-xl border border-teal-100 space-y-2 shrink-0">
+                      <h4 className="text-xs font-black text-teal-800 uppercase tracking-widest">
+                        Current Summary
                       </h4>
-                      <div className="grid grid-cols-2 gap-2">
-                        {Array.from(
-                          { length: currentBuildingConfig.cycleLength },
-                          (_, i) => i + 1
-                        ).map((num) => (
-                          <div
-                            key={num}
-                            className="flex items-center gap-2 bg-white p-2 rounded-xl border border-slate-100"
-                          >
-                            <span className="text-xxs font-black text-slate-400 w-4">
-                              {num}
-                            </span>
-                            <input
-                              type="text"
-                              value={
-                                currentBuildingConfig.customDayNames?.[num] ??
-                                ''
-                              }
-                              onChange={(e) =>
-                                updateDayName(num, e.target.value)
-                              }
-                              placeholder={`${currentBuildingConfig.dayLabel ?? 'Day'} ${num}`}
-                              className="flex-1 text-xs font-bold text-slate-700 focus:outline-none"
-                            />
-                          </div>
-                        ))}
-                      </div>
+                      <p className="text-xs text-teal-700/70">
+                        {BUILDINGS.find((b) => b.id === selectedBuildingId)
+                          ?.name ?? 'Selected Building'}{' '}
+                        is currently using a{' '}
+                        <strong>
+                          {currentBuildingConfig.cycleLength}-
+                          {currentBuildingConfig.dayLabel}
+                        </strong>{' '}
+                        rotation.
+                      </p>
+                      {currentPreviewDay && (
+                        <div className="pt-1 flex items-center gap-2">
+                          <span className="text-xxs font-bold text-teal-600 uppercase tracking-widest">
+                            Today is:
+                          </span>
+                          <span className="bg-white px-2 py-0.5 rounded-lg border border-teal-200 text-teal-700 font-black text-xs">
+                            {currentPreviewDay === 'No School'
+                              ? 'Non-School Day'
+                              : currentPreviewDay}
+                          </span>
+                        </div>
+                      )}
                     </div>
                   </div>
+                </div>
 
-                  {/* Middle: Specialist Options */}
-                  <div className="space-y-6">
-                    <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4 h-full flex flex-col">
-                      <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                        <Settings2 className="w-4 h-4 text-teal-500" />{' '}
-                        Specialist Classes
-                      </h4>
-                      <p className="text-xxs text-slate-400 font-bold uppercase">
-                        Predefined options for teachers
-                      </p>
-
-                      <div className="flex gap-2">
-                        <input
-                          type="text"
-                          value={newOption}
-                          onChange={(e) => setNewOption(e.target.value)}
-                          onKeyDown={(e) => e.key === 'Enter' && addOption()}
-                          placeholder="e.g. 🎨 Art"
-                          className="flex-1 px-3 py-1.5 text-xs border border-slate-200 rounded-xl focus:ring-2 focus:ring-teal-500 outline-none font-bold"
-                        />
-                        <button
-                          onClick={addOption}
-                          className="p-1.5 bg-teal-600 text-white rounded-lg hover:bg-teal-700"
-                        >
-                          <Plus className="w-4 h-4" />
-                        </button>
+                {/* Right: Calendar Marking or Block Selection */}
+                <div className="space-y-4">
+                  {currentBuildingConfig.cycleLength === 10 ? (
+                    <Card
+                      rounded="2xl"
+                      padding="none"
+                      className="overflow-hidden flex flex-col h-full max-h-[500px]"
+                    >
+                      <div className="bg-slate-50 p-4 border-b border-slate-200">
+                        <h4 className="font-black text-slate-700 uppercase tracking-widest text-xs flex items-center gap-2">
+                          <CalendarDays className="w-4 h-4 text-teal-500" />{' '}
+                          Block Date Ranges
+                        </h4>
+                        <p className="text-xxs text-slate-400 font-bold mt-1 uppercase">
+                          Configure explicit windows for each block
+                        </p>
                       </div>
-
-                      <div className="flex-1 overflow-y-auto space-y-2 custom-scrollbar pr-1 min-h-[200px]">
-                        {(currentBuildingConfig.specialistOptions ?? []).map(
-                          (option) => (
+                      <div className="flex-1 overflow-y-auto p-4 space-y-3 custom-scrollbar">
+                        {Array.from({ length: 10 }, (_, i) => i + 1).map(
+                          (num, i) => (
                             <div
-                              key={option}
-                              className="flex items-center justify-between bg-white p-2 rounded-xl border border-slate-100 group"
+                              key={num}
+                              className="flex flex-col gap-2 p-3 bg-slate-50 rounded-xl border border-slate-100"
                             >
-                              <span className="text-xs font-bold text-slate-700">
-                                {option}
-                              </span>
-                              <button
-                                onClick={() => removeOption(option)}
-                                className="p-1 text-slate-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                              >
-                                <Trash2 className="w-3.5 h-3.5" />
-                              </button>
+                              <div className="flex items-center justify-between">
+                                <span className="text-xs font-black text-teal-700 uppercase tracking-widest">
+                                  {currentBuildingConfig.customDayNames?.[
+                                    num
+                                  ] ?? `Block ${num}`}
+                                </span>
+                              </div>
+                              <div className="grid grid-cols-2 gap-2">
+                                <div className="space-y-1">
+                                  <label className="text-xxxs font-black text-slate-400 uppercase tracking-widest">
+                                    Start Date
+                                  </label>
+                                  <input
+                                    type="date"
+                                    value={
+                                      currentBuildingConfig.blocks?.[i]
+                                        ?.startDate ?? ''
+                                    }
+                                    onChange={(e) =>
+                                      updateBlock(
+                                        i,
+                                        'startDate',
+                                        e.target.value
+                                      )
+                                    }
+                                    className="w-full px-2 py-1 text-xs border border-slate-200 rounded font-bold text-slate-600 focus:ring-1 focus:ring-teal-500 outline-none"
+                                  />
+                                </div>
+                                <div className="space-y-1">
+                                  <label className="text-xxxs font-black text-slate-400 uppercase tracking-widest">
+                                    End Date
+                                  </label>
+                                  <input
+                                    type="date"
+                                    value={
+                                      currentBuildingConfig.blocks?.[i]
+                                        ?.endDate ?? ''
+                                    }
+                                    onChange={(e) =>
+                                      updateBlock(i, 'endDate', e.target.value)
+                                    }
+                                    className="w-full px-2 py-1 text-xs border border-slate-200 rounded font-bold text-slate-600 focus:ring-1 focus:ring-teal-500 outline-none"
+                                  />
+                                </div>
+                              </div>
                             </div>
                           )
                         )}
-                        {(currentBuildingConfig.specialistOptions ?? [])
-                          .length === 0 && (
-                          <div className="text-center py-8 text-slate-300 italic text-xs">
-                            No options added.
-                          </div>
-                        )}
                       </div>
-
-                      <div className="bg-teal-50 p-4 rounded-xl border border-teal-100 space-y-2 shrink-0">
-                        <h4 className="text-xs font-black text-teal-800 uppercase tracking-widest">
-                          Current Summary
-                        </h4>
-                        <p className="text-xs text-teal-700/70">
-                          {BUILDINGS.find((b) => b.id === selectedBuildingId)
-                            ?.name ?? 'Selected Building'}{' '}
-                          is currently using a{' '}
-                          <strong>
-                            {currentBuildingConfig.cycleLength}-
-                            {currentBuildingConfig.dayLabel}
-                          </strong>{' '}
-                          rotation.
-                        </p>
-                        {currentPreviewDay && (
-                          <div className="pt-1 flex items-center gap-2">
-                            <span className="text-xxs font-bold text-teal-600 uppercase tracking-widest">
-                              Today is:
-                            </span>
-                            <span className="bg-white px-2 py-0.5 rounded-lg border border-teal-200 text-teal-700 font-black text-xs">
-                              {currentPreviewDay === 'No School'
-                                ? 'Non-School Day'
-                                : currentPreviewDay}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Right: Calendar Marking or Block Selection */}
-                  <div className="space-y-4">
-                    {currentBuildingConfig.cycleLength === 10 ? (
-                      <Card
-                        rounded="2xl"
-                        padding="none"
-                        className="overflow-hidden flex flex-col h-full max-h-[500px]"
-                      >
-                        <div className="bg-slate-50 p-4 border-b border-slate-200">
-                          <h4 className="font-black text-slate-700 uppercase tracking-widest text-xs flex items-center gap-2">
-                            <CalendarDays className="w-4 h-4 text-teal-500" />{' '}
-                            Block Date Ranges
-                          </h4>
-                          <p className="text-xxs text-slate-400 font-bold mt-1 uppercase">
-                            Configure explicit windows for each block
-                          </p>
-                        </div>
-                        <div className="flex-1 overflow-y-auto p-4 space-y-3 custom-scrollbar">
-                          {Array.from({ length: 10 }, (_, i) => i + 1).map(
-                            (num, i) => (
-                              <div
-                                key={num}
-                                className="flex flex-col gap-2 p-3 bg-slate-50 rounded-xl border border-slate-100"
-                              >
-                                <div className="flex items-center justify-between">
-                                  <span className="text-xs font-black text-teal-700 uppercase tracking-widest">
-                                    {currentBuildingConfig.customDayNames?.[
-                                      num
-                                    ] ?? `Block ${num}`}
-                                  </span>
-                                </div>
-                                <div className="grid grid-cols-2 gap-2">
-                                  <div className="space-y-1">
-                                    <label className="text-xxxs font-black text-slate-400 uppercase tracking-widest">
-                                      Start Date
-                                    </label>
-                                    <input
-                                      type="date"
-                                      value={
-                                        currentBuildingConfig.blocks?.[i]
-                                          ?.startDate ?? ''
-                                      }
-                                      onChange={(e) =>
-                                        updateBlock(
-                                          i,
-                                          'startDate',
-                                          e.target.value
-                                        )
-                                      }
-                                      className="w-full px-2 py-1 text-xs border border-slate-200 rounded font-bold text-slate-600 focus:ring-1 focus:ring-teal-500 outline-none"
-                                    />
-                                  </div>
-                                  <div className="space-y-1">
-                                    <label className="text-xxxs font-black text-slate-400 uppercase tracking-widest">
-                                      End Date
-                                    </label>
-                                    <input
-                                      type="date"
-                                      value={
-                                        currentBuildingConfig.blocks?.[i]
-                                          ?.endDate ?? ''
-                                      }
-                                      onChange={(e) =>
-                                        updateBlock(
-                                          i,
-                                          'endDate',
-                                          e.target.value
-                                        )
-                                      }
-                                      className="w-full px-2 py-1 text-xs border border-slate-200 rounded font-bold text-slate-600 focus:ring-1 focus:ring-teal-500 outline-none"
-                                    />
-                                  </div>
-                                </div>
-                              </div>
+                    </Card>
+                  ) : (
+                    <Card
+                      rounded="2xl"
+                      padding="none"
+                      className="overflow-hidden"
+                    >
+                      <div className="bg-slate-50 p-3 flex items-center justify-between border-b border-slate-200">
+                        <button
+                          onClick={() =>
+                            setCurrentMonth(
+                              new Date(
+                                currentMonth.getFullYear(),
+                                currentMonth.getMonth() - 1,
+                                1
+                              )
                             )
-                          )}
-                        </div>
-                      </Card>
-                    ) : (
-                      <Card
-                        rounded="2xl"
-                        padding="none"
-                        className="overflow-hidden"
-                      >
-                        <div className="bg-slate-50 p-3 flex items-center justify-between border-b border-slate-200">
-                          <button
-                            onClick={() =>
-                              setCurrentMonth(
-                                new Date(
-                                  currentMonth.getFullYear(),
-                                  currentMonth.getMonth() - 1,
-                                  1
-                                )
+                          }
+                          className="p-1 hover:bg-slate-200 rounded-lg transition-colors"
+                        >
+                          <ChevronLeft className="w-5 h-5 text-slate-600" />
+                        </button>
+                        <h4 className="font-bold text-slate-700">
+                          {currentMonth.toLocaleDateString(undefined, {
+                            month: 'long',
+                            year: 'numeric',
+                          })}
+                        </h4>
+                        <button
+                          onClick={() =>
+                            setCurrentMonth(
+                              new Date(
+                                currentMonth.getFullYear(),
+                                currentMonth.getMonth() + 1,
+                                1
                               )
-                            }
-                            className="p-1 hover:bg-slate-200 rounded-lg transition-colors"
-                          >
-                            <ChevronLeft className="w-5 h-5 text-slate-600" />
-                          </button>
-                          <h4 className="font-bold text-slate-700">
-                            {currentMonth.toLocaleDateString(undefined, {
-                              month: 'long',
-                              year: 'numeric',
-                            })}
-                          </h4>
-                          <button
-                            onClick={() =>
-                              setCurrentMonth(
-                                new Date(
-                                  currentMonth.getFullYear(),
-                                  currentMonth.getMonth() + 1,
-                                  1
-                                )
-                              )
-                            }
-                            className="p-1 hover:bg-slate-200 rounded-lg transition-colors"
-                          >
-                            <ChevronRight className="w-5 h-5 text-slate-600" />
-                          </button>
-                        </div>
+                            )
+                          }
+                          className="p-1 hover:bg-slate-200 rounded-lg transition-colors"
+                        >
+                          <ChevronRight className="w-5 h-5 text-slate-600" />
+                        </button>
+                      </div>
 
-                        <div className="p-3">
-                          <div className="grid grid-cols-7 mb-2">
-                            {['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'].map(
-                              (d) => (
-                                <div
-                                  key={d}
-                                  className="text-center text-xxs font-black text-slate-400 uppercase"
-                                >
-                                  {d}
-                                </div>
-                              )
-                            )}
-                          </div>
-                          <div className="grid grid-cols-7 gap-1">
-                            {daysInMonth.map((date, i) => {
-                              if (!date) return <div key={`pad-${i}`} />;
-                              const dateStr = toDateStr(date);
-                              const isSelected =
-                                currentBuildingConfig.schoolDays.includes(
-                                  dateStr
-                                );
-                              const isToday = dateStr === toDateStr(new Date());
+                      <div className="p-3">
+                        <div className="grid grid-cols-7 mb-2">
+                          {['Su', 'M', 'Tu', 'W', 'Th', 'F', 'Sa'].map((d) => (
+                            <div
+                              key={d}
+                              className="text-center text-xxs font-black text-slate-400 uppercase"
+                            >
+                              {d}
+                            </div>
+                          ))}
+                        </div>
+                        <div className="grid grid-cols-7 gap-1">
+                          {daysInMonth.map((date, i) => {
+                            if (!date) return <div key={`pad-${i}`} />;
+                            const dateStr = toDateStr(date);
+                            const isSelected =
+                              currentBuildingConfig.schoolDays.includes(
+                                dateStr
+                              );
+                            const isToday = dateStr === toDateStr(new Date());
 
-                              return (
-                                <button
-                                  key={dateStr}
-                                  onClick={() => toggleSchoolDay(date)}
-                                  className={`
+                            return (
+                              <button
+                                key={dateStr}
+                                onClick={() => toggleSchoolDay(date)}
+                                className={`
                                   aspect-square flex items-center justify-center text-xs rounded-lg font-bold transition-all
                                   ${isSelected ? 'bg-teal-600 text-white shadow-sm scale-105' : 'hover:bg-slate-100 text-slate-600'}
                                   ${isToday ? 'ring-2 ring-teal-200' : ''}
                                 `}
-                                >
-                                  {date.getDate()}
-                                </button>
-                              );
-                            })}
-                          </div>
+                              >
+                                {date.getDate()}
+                              </button>
+                            );
+                          })}
                         </div>
-                      </Card>
-                    )}
-
-                    {currentBuildingConfig.cycleLength !== 10 && (
-                      <div className="flex gap-2">
-                        <Button
-                          variant="secondary"
-                          className="flex-1 text-xxs"
-                          onClick={selectAllWeekdays}
-                        >
-                          Select M-F
-                        </Button>
-                        <Button
-                          variant="secondary"
-                          className="flex-1 text-xxs"
-                          onClick={clearMonth}
-                        >
-                          Clear Month
-                        </Button>
                       </div>
-                    )}
+                    </Card>
+                  )}
 
-                    <p className="text-xs text-slate-400 italic text-center px-4 leading-tight">
-                      {currentBuildingConfig.cycleLength === 10
-                        ? 'Set explicit date ranges for each of the 10 rotation blocks.'
-                        : 'Click dates to mark them as school days. The rotation only advances on marked days.'}
-                    </p>
-                  </div>
+                  {currentBuildingConfig.cycleLength !== 10 && (
+                    <div className="flex gap-2">
+                      <Button
+                        variant="secondary"
+                        className="flex-1 text-xxs"
+                        onClick={selectAllWeekdays}
+                      >
+                        Select M-F
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        className="flex-1 text-xxs"
+                        onClick={clearMonth}
+                      >
+                        Clear Month
+                      </Button>
+                    </div>
+                  )}
+
+                  <p className="text-xs text-slate-400 italic text-center px-4 leading-tight">
+                    {currentBuildingConfig.cycleLength === 10
+                      ? 'Set explicit date ranges for each of the 10 rotation blocks.'
+                      : 'Click dates to mark them as school days. The rotation only advances on marked days.'}
+                  </p>
                 </div>
-              </section>
-            </>
-          )}
-        </div>
-      </Modal>
-
-      {message && (
-        <Toast
-          message={message.text}
-          type={message.type}
-          onClose={() => setMessage(null)}
-        />
-      )}
-    </>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </Modal>
   );
 };


### PR DESCRIPTION
## Nightly consistency routine — Dimension D5 (Toast Architecture)

**Canonical form:** `addToast(message, type)` via `useDashboard()` — the centralized toast queue rendered by `DashboardView`'s `ToastContainer`.

**Instance unified:** `components/admin/SpecialistScheduleConfigurationModal.tsx`
- Removed local `message` `useState<{ text; type }>` + a sibling `<Toast>` rendered *outside* the `<Modal>` (via an outer `<>...</>` fragment) on save success/failure.
- Wired `const { addToast } = useDashboard();` and replaced both `setMessage(...)` call sites with `addToast('...', 'success' | 'error')`.
- Removed the now-unnecessary outer fragment since `<Modal>` is the sole root again — this reindents the entire JSX body one level, which accounts for most of the diff size; there is no logic/markup change beyond the toast wiring itself.

This modal is mounted from `FeaturePermissionsManager.tsx`, itself part of the teacher `AdminSettings` tree — `DashboardProvider` (and therefore `useDashboard()`/`addToast`) is reachable, and the original `<Toast>` was rendered as an independent overlay (not inline within the modal body), so this doesn't match any of the "acceptable local Toast" exception shapes (D5-E1–E22) — it was a straightforward accidental drift instance.

**Enforcement:** None added — this dimension already has an established canon (`addToast` via `useDashboard()`) and a well-documented set of legitimate exceptions; no additional lint rule was judged necessary for a single one-off admin modal.

**Behavior-preservation evidence:**
- Same two messages ("Specialist schedule configuration saved!" / "Failed to save configuration."), same success/error types, same trigger points (post-`setDoc` success path, catch block).
- `pnpm run validate` — green: type-check, lint, format-check, 585/585 root test files (7059 tests), 38/38 functions test files (721 tests), test-count guard passed.
- `pnpm run build` — green (app + SSR prerender build, exit 0).

**Risk tag:** `mechanical` (pure equivalence — same messages/triggers, only the toast delivery mechanism changed to match the established app-wide pattern).

---
_Generated by [Claude Code](https://claude.ai/code/session_014hfKMidAQDV3uCTtHyJh1Q)_