### PR TITLE
unify(D3): NumberLine/Settings compact add-form labels → SettingsLabel

### DIFF
--- a/components/widgets/NumberLine/Settings.tsx
+++ b/components/widgets/NumberLine/Settings.tsx
@@ -266,12 +266,7 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
         {/* Add Marker Form */}
         <div className="flex gap-2 items-end mb-4 bg-slate-50 p-3 rounded-xl border border-slate-100">
           <div className="flex-1">
-            <label
-              htmlFor={markerValueId}
-              className="block text-xxs font-bold uppercase text-slate-400 mb-1"
-            >
-              Value
-            </label>
+            <SettingsLabel htmlFor={markerValueId}>Value</SettingsLabel>
             <input
               id={markerValueId}
               type="number"
@@ -281,12 +276,7 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div className="flex-1">
-            <label
-              htmlFor={markerLabelId}
-              className="block text-xxs font-bold uppercase text-slate-400 mb-1"
-            >
-              Label
-            </label>
+            <SettingsLabel htmlFor={markerLabelId}>Label</SettingsLabel>
             <input
               id={markerLabelId}
               type="text"
@@ -357,12 +347,7 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
         {/* Add Jump Form */}
         <div className="flex gap-2 items-end mb-4 bg-slate-50 p-3 rounded-xl border border-slate-100">
           <div className="w-16">
-            <label
-              htmlFor={jumpStartId}
-              className="block text-xxs font-bold uppercase text-slate-400 mb-1"
-            >
-              Start
-            </label>
+            <SettingsLabel htmlFor={jumpStartId}>Start</SettingsLabel>
             <input
               id={jumpStartId}
               type="number"
@@ -372,12 +357,7 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div className="w-16">
-            <label
-              htmlFor={jumpEndId}
-              className="block text-xxs font-bold uppercase text-slate-400 mb-1"
-            >
-              End
-            </label>
+            <SettingsLabel htmlFor={jumpEndId}>End</SettingsLabel>
             <input
               id={jumpEndId}
               type="number"
@@ -387,12 +367,7 @@ export const NumberLineSettings: React.FC<{ widget: WidgetData }> = ({
             />
           </div>
           <div className="flex-1">
-            <label
-              htmlFor={jumpLabelId}
-              className="block text-xxs font-bold uppercase text-slate-400 mb-1"
-            >
-              Label
-            </label>
+            <SettingsLabel htmlFor={jumpLabelId}>Label</SettingsLabel>
             <input
               id={jumpLabelId}
               type="text"


### PR DESCRIPTION
Nightly unifier run 43 — dimension D3 (Settings Panel Label Primitives).

**Canonical form:** `<SettingsLabel htmlFor={id}>Label</SettingsLabel>` from `components/common/SettingsLabel.tsx` — `text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2`.

**Background:** `NumberLine/Settings.tsx`'s 5 compact add-form labels (`text-xxs font-bold uppercase text-slate-400 mb-1`) sat in the D3 backlog as a long-standing NEEDS REVIEW item — close to, but not matching, the canonical string (font-bold not font-black, missing `tracking-widest`, `mb-1` not `mb-2`). Last night's run (42) investigated this cluster alongside several siblings and resolved most of it into new deliberate-tier Intentional Exceptions (D3-E24–E27), but left NumberLine open, concluding it was "likely genuine drift... but unsafe to convert as a single isolated instance (would create a within-row visual mismatch with untouched siblings)."

**Tonight's investigation:** re-verified the classification from scratch — an exact-string repo-wide grep for `text-xxs font-bold uppercase text-slate-400 mb-1` returns *only* this one file (all 5 hits), and a structural comparison against the file's own sibling compact-add-form containers (Schedule/Settings.tsx, Calendar/Settings.tsx, RevealGrid/Settings.tsx) found no corroborating reuse of this exact combination anywhere else. The file already imports and uses real `SettingsLabel` correctly for its own section headers, confirming this is a self-contained copy-paste (Marker form → Jump form), not an intentional secondary tier. Conclusion: accidental drift, not a new exception.

**Instances unified (all 5, in one commit — resolving last night's "isolated single instance" objection):**
- `Value` / `Label` labels in the "Add Marker" form
- `Start` / `End` / `Label` labels in the "Add Jump" form

Each was already paired 1:1 with exactly one input via a pre-existing `useId()` + `htmlFor`, so the swap to `<SettingsLabel htmlFor={id}>` is a direct drop-in with no id/pairing changes needed.

**Enforcement:** none added — this is a single self-contained file, not a recurring bug class across multiple files (unlike the D4 ESLint-rule precedent), so a manual conversion is the appropriate fix.

**Behavior-preservation evidence:**
- Visual delta: `font-bold`→`font-black`, adds `tracking-widest`, `mb-1`→`mb-2`. This is the same small, accepted "canonical alignment" delta shipped in numerous prior D3 PRs (e.g. runs 6, 8) — not a functional change, and consistent within the diff (all 5 labels converted together, so no partial-row mismatch).
- `pnpm run type-check:all`, `pnpm run lint` (app + functions), `pnpm run format:check` — all green.
- `pnpm run test` (root, 585 files / 7065 tests) and `pnpm -C functions test` (38 files / 721 tests) — all green, `test:counts` guard passed.
- `pnpm run build` — succeeded (app + SSR prerender).
- Orchestrator independently re-verified: read `SettingsLabel.tsx` source directly to confirm the `htmlFor` pairing renders identically to the original hand-rolled `<label htmlFor>`, and spot-checked `eslint`/`tsc --noEmit` against the changed file directly.

**Risk tag:** mechanical (pure equivalence + accepted canonical-alignment delta).

---
_Generated by [Claude Code](https://claude.ai/code/session_018zo65ZQBSEF1X7xWBc7mE1)_