### PR TITLE
fix(QuizManager): unify library empty state to ScaledEmptyState (D1)

### DIFF
--- a/components/widgets/QuizWidget/components/QuizManager.tsx
+++ b/components/widgets/QuizWidget/components/QuizManager.tsx
@@ -1828,27 +1828,24 @@ const LibraryTabContent: React.FC<{
 }) => {
   const emptyState =
     totalCount === 0 ? (
-      <div className="flex flex-col items-center justify-center h-full text-brand-blue-primary/40 py-12 gap-4">
-        <div className="bg-brand-blue-lighter/50 rounded-full border-2 border-dashed border-brand-blue-primary/20 p-6">
-          <FileUp className="w-12 h-12" />
-        </div>
-        <div className="text-center">
-          <p className="font-bold text-brand-blue-primary text-base">
-            No quizzes yet
-          </p>
-          <p className="text-brand-blue-primary/60 font-medium text-sm mt-1 max-w-[220px]">
-            Import a CSV or Google Sheet to build your library.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onImport}
-          className="flex items-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl transition-all shadow-md active:scale-95 px-5 py-2.5 text-sm"
-        >
-          <Plus className="w-4 h-4" />
-          Start Importing
-        </button>
-      </div>
+      <ScaledEmptyState
+        icon={FileUp}
+        title="No Quizzes Yet"
+        subtitle="Import a CSV or Google Sheet to build your library."
+        iconClassName="text-brand-blue-primary"
+        titleClassName="text-brand-blue-primary"
+        subtitleClassName="text-brand-blue-primary/60"
+        action={
+          <button
+            type="button"
+            onClick={onImport}
+            className="flex items-center gap-2 bg-brand-blue-primary hover:bg-brand-blue-dark text-white font-bold rounded-2xl transition-all shadow-md active:scale-95 px-5 py-2.5 text-sm"
+          >
+            <Plus className="w-4 h-4" />
+            Start Importing
+          </button>
+        }
+      />
     ) : (
       <div className="text-sm font-medium text-slate-500 py-8 text-center">
         No quizzes match your search.


### PR DESCRIPTION
## Nightly Unifier — D1: Widget Empty States

**Canonical form:** `<ScaledEmptyState icon title subtitle .../>` from `components/common/ScaledEmptyState.tsx` for widget front-face missing-data states, per `docs/routines/unifier.md`.

**Instance unified:** `components/widgets/QuizWidget/components/QuizManager.tsx` — the `LibraryTabContent` "No quizzes yet" library empty state (shown when `totalCount === 0`). Replaced a hand-rolled `<div>` (dashed-border circular badge + `FileUp` icon + non-scaled title/subtitle + inline button) with `<ScaledEmptyState icon={FileUp} title="No Quizzes Yet" subtitle="Import a CSV or Google Sheet to build your library." action={<button>Start Importing</button>} />`, using `iconClassName`/`titleClassName`/`subtitleClassName` overrides to preserve the original brand-blue color theme (avoiding `ScaledEmptyState`'s light-on-dark defaults).

**Why this instance, not a novel judgment call:** `VideoActivityManager.tsx` and `GuidedLearningManager.tsx` already use `ScaledEmptyState` in the *identical* `LibraryGrid` `emptyState` slot (verified: `LibraryGrid.tsx` renders `emptyState` verbatim with no imposed wrapper), including the same icon+title+subtitle+action shape. Quiz was the one sibling still hand-rolled. The circular dashed badge behind the icon was dropped — no equivalent in `ScaledEmptyState`, and neither sibling manager has one.

**Enforcement:** N/A for this instance — the shared `ScaledEmptyState` component and `LibraryGrid` slot already exist; this closes the gap between three parallel implementations of the same UI slot.

**Behavior/visual preservation evidence:**
- Text content, color theme (brand-blue), and the "Start Importing" action button are all preserved via explicit class overrides.
- `ScaledEmptyState`'s `action` and `*ClassName` props were read directly from source to confirm support before using them.
- The `VideoActivityManager.tsx:797-812` precedent was opened and read directly (not taken on the subagent's word) to confirm the shape actually matches.

**Validation:** `pnpm run type-check` ✅, `pnpm run lint` (app + functions, `--max-warnings 0`) ✅, `pnpm run format:check` ✅, full `pnpm run test` (585 files / 7065 tests) ✅, `pnpm run build` ✅ (client + SSR + prerender). dev-paul had not moved since the worktree was cut from it, so no rebase was needed.

**Risk tag:** mechanical (drop-in component swap with an existing, verified sibling precedent; explicit color overrides preserve visual output).

**Deferred to backlog** (not touched this run, logged in `docs/routines/unifier.md`):
- `MiniApp/components/MiniAppManager.tsx` `personalEmpty`/`globalEmpty` — same library-empty-state family, needs its own review (2 variants + a third text-only state to reconcile).
- `random/ShuffleList.tsx` drag-drop empty state — `ScaledEmptyState` isn't `forwardRef`-based and doesn't cleanly support dnd-kit's droppable-ref + hover-state styling; needs a designed fix.
- `GuidedLearning/components/ScreenCaptureModal.tsx` — full-screen modal overlay outside the container-query model, same class as other blocked modal items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiuAEPdRZKcSf82RiM3RG5)_