### PR TITLE
fix(RosterModeControl): unify roster-mode toggle label to SettingsLabel (D3)

### DIFF
--- a/components/common/RosterModeControl.tsx
+++ b/components/common/RosterModeControl.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useDashboard } from '@/context/useDashboard';
+import { SettingsLabel } from '@/components/common/SettingsLabel';
 
 interface RosterModeControlProps {
   rosterMode: 'class' | 'custom';
@@ -12,14 +13,19 @@ export const RosterModeControl: React.FC<RosterModeControlProps> = ({
 }) => {
   const { activeRosterId, rosters } = useDashboard();
   const activeRoster = rosters.find((r) => r.id === activeRosterId);
+  const rosterModeLabelId = useId();
 
   return (
     <div className="space-y-2 mb-4">
       <div className="flex items-center justify-between p-2 bg-slate-50 rounded-xl border border-slate-100">
-        <span className="text-xxs font-black text-slate-400 uppercase tracking-widest">
+        <SettingsLabel as="span" id={rosterModeLabelId} className="mb-0">
           Roster Selection
-        </span>
-        <div className="flex bg-slate-200/50 p-0.5 rounded-lg">
+        </SettingsLabel>
+        <div
+          role="group"
+          aria-labelledby={rosterModeLabelId}
+          className="flex bg-slate-200/50 p-0.5 rounded-lg"
+        >
           <button
             type="button"
             onClick={() => onModeChange('class')}


### PR DESCRIPTION
## Nightly Unifier — D3: Settings Panel Label Primitives

**Canonical form:** `<SettingsLabel>...</SettingsLabel>` from `components/common/SettingsLabel.tsx`; for a label heading a group of sibling controls (not one associated input), `<SettingsLabel as="span" id="...">` paired with `role="group" aria-labelledby="..."` on the group container.

**Instance unified:** `components/common/RosterModeControl.tsx` — the "Roster Selection" label heading a 2-button Auto/Custom toggle group, shared across 4 widgets' Settings back-faces (`Checklist`, `SeatingChart`, `random/RandomSettings`, `LunchCount`). Converted the bare `<span className="text-xxs font-black text-slate-400 uppercase tracking-widest">` to `<SettingsLabel as="span" id={rosterModeLabelId} className="mb-0">`, with `role="group" aria-labelledby={rosterModeLabelId}` added to the button-group container. `id` is scoped via `useId()` since this component can render simultaneously across multiple widget instances.

**Note for reviewers:** this exact file/line was previously catalogued in `docs/routines/unifier.md` as intentional exception D3-E5, on the rationale that `SettingsLabel`'s default `mb-2` would cause vertical misalignment in the component's `flex items-center justify-between` row. That specific concern is what the `className="mb-0"` override neutralizes — a pattern already established elsewhere in the repo (`MaterialsWidget/Settings.tsx:168`, `Calendar/Settings.tsx:193`, `BreathingConfigurationPanel.tsx:137`, `PollWidget/Settings.tsx:196`), independently confirmed by reading `SettingsLabel.tsx` source. `docs/routines/unifier.md` is being updated separately to retire D3-E5 as resolved.

**Behavior/visual preservation evidence:**
- Text styling classes (`text-xxs font-black text-slate-400 uppercase tracking-widest`) are byte-identical between the old span and `SettingsLabel`'s base classes.
- `block` (part of `SettingsLabel`'s base classes) is a no-op here — flex items are always blockified regardless of declared `display`, so it doesn't affect layout.
- The only meaningful diff (`mb-2`) is neutralized via `className="mb-0"`, following an established repo convention verified in 3+ other files.
- Two themed "Active: {class}" spans elsewhere in the same file were correctly left untouched (out of scope).

**Enforcement:** N/A — existing shared component, no new lint rule needed for a single shared file.

**Validation:** `pnpm run type-check:all` ✅, `pnpm run lint` ✅, `pnpm run format:check` ✅, full `pnpm run test` (585 files / 7065 tests) ✅, `pnpm run build` ✅. dev-paul had not moved since the worktree was cut, so no rebase was needed.

**Risk tag:** mechanical (drop-in primitive swap; margin-override pattern independently verified against 3 existing production usages; full validate+build green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiuAEPdRZKcSf82RiM3RG5)_