### PR TITLE
fix(Classes/rosterUtils): stop reattaching student IDs by raw list position

### DIFF
--- a/components/widgets/Classes/rosterUtils.test.ts
+++ b/components/widgets/Classes/rosterUtils.test.ts
@@ -153,6 +153,56 @@ describe('rosterUtils', () => {
       expect(result[0].pin).toBe('05');
     });
 
+    it("keeps each student's identity attached to their own name when the list is reordered", () => {
+      // Regression for a bug where matching was done by raw array index:
+      // alphabetizing (or any reorder) of an existing roster silently
+      // swapped which ID/pin/ClassLink link attached to which student.
+      const existing = [
+        { id: 'a1', firstName: 'Bob', lastName: 'Baker', pin: '01' },
+        { id: 'b2', firstName: 'Alice', lastName: 'Ackerman', pin: '02' },
+      ];
+      // Same two students, now alphabetized (Alice first).
+      const result = generateStudentsList(
+        'Alice\nBob',
+        'Ackerman\nBaker',
+        existing
+      );
+
+      expect(result[0].firstName).toBe('Alice');
+      expect(result[0].id).toBe('b2');
+      expect(result[0].pin).toBe('02');
+
+      expect(result[1].firstName).toBe('Bob');
+      expect(result[1].id).toBe('a1');
+      expect(result[1].pin).toBe('01');
+    });
+
+    it("does not reattach an existing student's ID to a different student inserted above them", () => {
+      // Regression: inserting a new name above existing rows used to shift
+      // every subsequent existing[i] lookup by one, reassigning IDs/pins to
+      // the wrong students.
+      const existing = [
+        { id: 'a1', firstName: 'Alice', lastName: 'Ann', pin: '11' },
+        { id: 'b2', firstName: 'Bob', lastName: 'Ben', pin: '22' },
+      ];
+      const result = generateStudentsList(
+        'Zoe\nAlice\nBob',
+        'Zed\nAnn\nBen',
+        existing
+      );
+
+      const zoe = result.find((s) => s.firstName === 'Zoe');
+      const alice = result.find((s) => s.firstName === 'Alice');
+      const bob = result.find((s) => s.firstName === 'Bob');
+
+      expect(alice?.id).toBe('a1');
+      expect(alice?.pin).toBe('11');
+      expect(bob?.id).toBe('b2');
+      expect(bob?.pin).toBe('22');
+      expect(zoe?.id).not.toBe('a1');
+      expect(zoe?.id).not.toBe('b2');
+    });
+
     it('preserves classLinkSourcedId on existing rows so re-sync stays stable', () => {
       const existing = [
         {

--- a/components/widgets/Classes/rosterUtils.test.ts
+++ b/components/widgets/Classes/rosterUtils.test.ts
@@ -195,6 +195,9 @@ describe('rosterUtils', () => {
       const alice = result.find((s) => s.firstName === 'Alice');
       const bob = result.find((s) => s.firstName === 'Bob');
 
+      expect(zoe).toBeDefined();
+      expect(alice).toBeDefined();
+      expect(bob).toBeDefined();
       expect(alice?.id).toBe('a1');
       expect(alice?.pin).toBe('11');
       expect(bob?.id).toBe('b2');

--- a/components/widgets/Classes/rosterUtils.ts
+++ b/components/widgets/Classes/rosterUtils.ts
@@ -57,6 +57,14 @@ export const mergeNames = (firsts: string, lasts: string): string[] => {
 /**
  * Generates a list of Student objects from first and last names,
  * preserving IDs (and `classLinkSourcedId`) from an existing list if possible.
+ *
+ * Matching is two-phase, not raw array-index lookup: (1) an unchanged name
+ * is matched to the existing student with that exact name first, so
+ * reordering/inserting lines above it can't reattach its ID to someone else;
+ * (2) any names left over (a genuine rename) are paired with any existing
+ * students left over, in the order each side appears, so a same-position
+ * rename still keeps its ID/pin/ClassLink link — matching the previous
+ * position-based behavior for that case only.
  */
 export const generateStudentsList = (
   firsts: string,
@@ -68,27 +76,59 @@ export const generateStudentsList = (
   const lList = lasts.split('\n');
   const pList = pins?.split('\n');
 
-  return fList
-    .map((f, i) => {
+  const parsed = fList
+    .map((f, lineIndex) => {
       const first = f.trim();
-      const last = lList[i] ? lList[i].trim() : '';
-      if (!first && !last) return null;
-
-      // Try to find an existing student at this position to preserve ID,
-      // pin, and ClassLink link (keeps re-sync stable after manual edits).
-      const existing = existingStudents[i];
-      const id = existing ? existing.id : crypto.randomUUID();
-      const pin = pList
-        ? (pList[i]?.trim() ?? existing?.pin ?? '')
-        : (existing?.pin ?? '');
-
-      const student: Student = { id, firstName: first, lastName: last, pin };
-      if (existing?.classLinkSourcedId !== undefined) {
-        student.classLinkSourcedId = existing.classLinkSourcedId;
-      }
-      return student;
+      const last = lList[lineIndex] ? lList[lineIndex].trim() : '';
+      return { first, last, lineIndex };
     })
-    .filter((s): s is Student => s !== null);
+    .filter((entry) => entry.first || entry.last);
+
+  const byName = new Map<string, Student[]>();
+  for (const s of existingStudents) {
+    const key = `${s.firstName} ${s.lastName}`;
+    const bucket = byName.get(key);
+    if (bucket) bucket.push(s);
+    else byName.set(key, [s]);
+  }
+
+  const matched = new Array<Student | undefined>(parsed.length);
+  const consumed = new Set<Student>();
+  parsed.forEach((entry, idx) => {
+    const key = `${entry.first} ${entry.last}`;
+    const candidate = byName.get(key)?.shift();
+    if (candidate) {
+      matched[idx] = candidate;
+      consumed.add(candidate);
+    }
+  });
+
+  const leftoverExisting = existingStudents.filter((s) => !consumed.has(s));
+  let leftoverCursor = 0;
+  parsed.forEach((entry, idx) => {
+    if (matched[idx] !== undefined) return;
+    matched[idx] = leftoverExisting[leftoverCursor];
+    leftoverCursor++;
+  });
+
+  return parsed.map((entry, idx) => {
+    const existing = matched[idx];
+    const id = existing ? existing.id : crypto.randomUUID();
+    const pin = pList
+      ? (pList[entry.lineIndex]?.trim() ?? existing?.pin ?? '')
+      : (existing?.pin ?? '');
+
+    const student: Student = {
+      id,
+      firstName: entry.first,
+      lastName: entry.last,
+      pin,
+    };
+    if (existing?.classLinkSourcedId !== undefined) {
+      student.classLinkSourcedId = existing.classLinkSourcedId;
+    }
+    return student;
+  });
 };
 
 /**

--- a/components/widgets/Classes/rosterUtils.ts
+++ b/components/widgets/Classes/rosterUtils.ts
@@ -92,7 +92,7 @@ export const generateStudentsList = (
     else byName.set(key, [s]);
   }
 
-  const matched = new Array<Student | undefined>(parsed.length);
+  const matched = new Array<Student | undefined>(parsed.length).fill(undefined);
   const consumed = new Set<Student>();
   parsed.forEach((entry, idx) => {
     const key = `${entry.first} ${entry.last}`;


### PR DESCRIPTION
## Root cause

`generateStudentsList()` in `components/widgets/Classes/rosterUtils.ts` matched existing students to typed roster lines by raw array index (`existingStudents[i]`). Any edit that reordered or inserted a line above an existing student — alphabetizing the roster, adding a new student mid-list — shifted every subsequent index-based lookup by one, silently reattaching another student's `id`/`pin`/`classLinkSourcedId` to the wrong name. `student.id` is the anchor for attendance, pins, and ClassLink sync elsewhere in the app, so this was a data-integrity bug, not a cosmetic one.

## Fix

Two-phase matching:
1. Match unchanged names exactly first (consumed FIFO per name-key), so reordering/insertion can't steal another student's ID.
2. Pair only the genuine leftovers (renames) positionally within the unmatched remainder — preserving the existing, intentionally-tested "rename in place keeps the same ID" behavior.

## Band-aid rejected

Matching purely by exact name (a simple Map lookup) would break the intentional "rename in place" behavior (fixing a typo in a name must keep the same student ID). A pure diff/LCS approach can't reconcile "rename" vs. "reorder" either, since a rename changes the string entirely — hence the two-phase approach above.

## Regression test

`components/widgets/Classes/rosterUtils.test.ts` — two new cases:
- "keeps each student's identity attached to their own name when the list is reordered"
- "does not reattach an existing student's ID to a different student inserted above them"

## Evidence (orchestrator-verified independently, not just subagent-reported)

Fail-before (old index-based matching):
```
FAIL: expected 'a1' to be 'b2' (reorder swapped IDs)
FAIL: expected 'b2' to be 'a1' (insertion reassigned IDs)
```
Pass-after: `22 passed (22)` — including all 8 pre-existing tests (rename-in-place case still passes).

`pnpm run validate` and `pnpm run build` both pass in an isolated worktree (585 root test files / 7067 tests, 38 functions test files / 721 tests, test-count guard green).

## Risk

**Contained** — single file, additive matching-logic change, full existing test coverage preserved.

---
Part of the automated nightly code-health run (`docs/routines/debugger.md`). Independently reviewed and re-verified by the orchestrator (fail-before/pass-after re-run from a clean worktree, isolated `pnpm run validate` re-run after subagent contention settled) before this PR was opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFt8w6JCF55A8yS82tGAfZ)_