### PR TITLE
fix(layout): stop Escape in board-nav FAB menus from minimizing an unrelated widget

### DIFF
--- a/components/layout/BoardActionsFab.tsx
+++ b/components/layout/BoardActionsFab.tsx
@@ -92,6 +92,12 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
   const handlePopupKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
+      // This popup lives outside any `.widget` DraggableWindow, so without
+      // stopping propagation an unhandled Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget on the board — a completely
+      // unrelated widget disappearing just because this popup was dismissed.
+      e.stopPropagation();
       closeSlider();
       return;
     }

--- a/components/layout/BoardActionsFab.tsx
+++ b/components/layout/BoardActionsFab.tsx
@@ -92,11 +92,7 @@ export const BoardActionsFab: FC<BoardActionsFabProps> = ({
   const handlePopupKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      // This popup lives outside any `.widget` DraggableWindow, so without
-      // stopping propagation an unhandled Escape here also bubbles up to
-      // DashboardView's global window-level Escape handler, which falls
-      // back to minimizing the topmost widget on the board — a completely
-      // unrelated widget disappearing just because this popup was dismissed.
+      // Stop the bubble to DashboardView's global Escape handler, which would otherwise minimize an unrelated widget.
       e.stopPropagation();
       closeSlider();
       return;

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -156,6 +156,12 @@ export const BoardNavFab: FC = () => {
     switch (e.key) {
       case 'Escape':
         e.preventDefault();
+        // This menu lives outside any `.widget` DraggableWindow, so without
+        // stopping propagation an unhandled Escape here also bubbles up to
+        // DashboardView's global window-level Escape handler, which falls
+        // back to minimizing the topmost widget on the board — a completely
+        // unrelated widget disappearing just because this menu was dismissed.
+        e.stopPropagation();
         closeBoardsMenu();
         break;
       case 'ArrowDown':

--- a/components/layout/BoardNavFab.tsx
+++ b/components/layout/BoardNavFab.tsx
@@ -156,11 +156,7 @@ export const BoardNavFab: FC = () => {
     switch (e.key) {
       case 'Escape':
         e.preventDefault();
-        // This menu lives outside any `.widget` DraggableWindow, so without
-        // stopping propagation an unhandled Escape here also bubbles up to
-        // DashboardView's global window-level Escape handler, which falls
-        // back to minimizing the topmost widget on the board — a completely
-        // unrelated widget disappearing just because this menu was dismissed.
+        // Stop the bubble to DashboardView's global Escape handler, which would otherwise minimize an unrelated widget.
         e.stopPropagation();
         closeBoardsMenu();
         break;

--- a/components/layout/CollectionSwitcherMenu.tsx
+++ b/components/layout/CollectionSwitcherMenu.tsx
@@ -87,6 +87,12 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
     switch (e.key) {
       case 'Escape':
         e.preventDefault();
+        // This menu lives outside any `.widget` DraggableWindow, so without
+        // stopping propagation an unhandled Escape here also bubbles up to
+        // DashboardView's global window-level Escape handler, which falls
+        // back to minimizing the topmost widget on the board — a completely
+        // unrelated widget disappearing just because this menu was dismissed.
+        e.stopPropagation();
         onClose();
         break;
       case 'ArrowDown':

--- a/components/layout/CollectionSwitcherMenu.tsx
+++ b/components/layout/CollectionSwitcherMenu.tsx
@@ -87,11 +87,7 @@ export const CollectionSwitcherMenu: FC<CollectionSwitcherMenuProps> = ({
     switch (e.key) {
       case 'Escape':
         e.preventDefault();
-        // This menu lives outside any `.widget` DraggableWindow, so without
-        // stopping propagation an unhandled Escape here also bubbles up to
-        // DashboardView's global window-level Escape handler, which falls
-        // back to minimizing the topmost widget on the board — a completely
-        // unrelated widget disappearing just because this menu was dismissed.
+        // Stop the bubble to DashboardView's global Escape handler, which would otherwise minimize an unrelated widget.
         e.stopPropagation();
         onClose();
         break;

--- a/tests/components/layout/BoardActionsFab.test.tsx
+++ b/tests/components/layout/BoardActionsFab.test.tsx
@@ -95,4 +95,31 @@ describe('BoardActionsFab', () => {
     expect(root?.className).toContain('right-4');
     expect(root?.className).not.toContain('left-14');
   });
+
+  // Regression test: the zoom popup lives outside any `.widget`
+  // DraggableWindow. Pressing Escape while a preset chip (not the range
+  // input) has focus previously bubbled the keydown past the popup, all the
+  // way to DashboardView's global window-level Escape handler — which finds
+  // no typing field and no `.widget` ancestor for the focused chip, so it
+  // falls back to minimizing the topmost widget on the board. Simulates that
+  // window-level listener directly rather than mounting the full
+  // DashboardView, mirroring the pattern in ToolDockItem.test.tsx (#2266).
+  it('does not leak the Escape keydown to window-level listeners when a preset chip has focus', () => {
+    setupContexts(2);
+    render(<BoardActionsFab onOpenCheatSheet={noop} />);
+    fireEvent.click(screen.getByLabelText('Zoom level'));
+    const presetButton = screen.getByRole('button', { name: '200%' });
+    presetButton.focus();
+    expect(document.activeElement).toBe(presetButton);
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+    try {
+      fireEvent.keyDown(presetButton, { key: 'Escape', bubbles: true });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
 });

--- a/tests/components/layout/BoardNavFab.test.tsx
+++ b/tests/components/layout/BoardNavFab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BoardNavFab } from '@/components/layout/BoardNavFab';
 import type { useDashboard } from '@/context/useDashboard';
@@ -242,6 +242,36 @@ describe('BoardNavFab', () => {
       await userEvent.keyboard('{Escape}');
       expect(screen.queryByRole('menu')).not.toBeInTheDocument();
       expect(document.activeElement).toBe(trigger);
+    });
+
+    // Regression test: this menu lives outside any `.widget` DraggableWindow.
+    // Pressing Escape while a board item has focus previously bubbled the
+    // keydown past the menu, all the way to DashboardView's global
+    // window-level Escape handler — which finds no typing field and no
+    // `.widget` ancestor for the focused item, so it falls back to
+    // minimizing the topmost widget on the board. Simulates that
+    // window-level listener directly rather than mounting the full
+    // DashboardView, mirroring the pattern in ToolDockItem.test.tsx (#2266).
+    it('does not leak the Escape keydown to window-level listeners', async () => {
+      mockContext({
+        dashboards: [dashboard('d1', 'A'), dashboard('d2', 'B')],
+        collections: [],
+      });
+      render(<BoardNavFab />);
+      await userEvent.click(
+        screen.getByRole('button', { name: /select board/i })
+      );
+      const item = screen.getByRole('menuitem', { name: /A/ });
+      expect(document.activeElement).toBe(item);
+
+      const windowKeydownSpy = vi.fn();
+      window.addEventListener('keydown', windowKeydownSpy);
+      try {
+        fireEvent.keyDown(item, { key: 'Escape', bubbles: true });
+        expect(windowKeydownSpy).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('keydown', windowKeydownSpy);
+      }
     });
   });
 

--- a/tests/components/layout/CollectionSwitcherMenu.test.tsx
+++ b/tests/components/layout/CollectionSwitcherMenu.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CollectionSwitcherMenu } from '@/components/layout/CollectionSwitcherMenu';
 import type { Collection } from '@/types';
@@ -102,5 +102,36 @@ describe('CollectionSwitcherMenu', () => {
       screen.getByRole('menuitem', { name: /no collection/i })
     );
     expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  // Regression test: this menu lives outside any `.widget` DraggableWindow.
+  // Pressing Escape while a menu item has focus previously bubbled the
+  // keydown past the menu, all the way to DashboardView's global
+  // window-level Escape handler — which finds no typing field and no
+  // `.widget` ancestor for the focused item, so it falls back to minimizing
+  // the topmost widget on the board. Simulates that window-level listener
+  // directly rather than mounting the full DashboardView, mirroring the
+  // pattern in ToolDockItem.test.tsx (#2266).
+  it('does not leak the Escape keydown to window-level listeners', () => {
+    render(
+      <CollectionSwitcherMenu
+        collections={[coll('a', null, 0, 'A')]}
+        activeCollectionId={null}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const item = screen.getByRole('menuitem', { name: 'A' });
+    item.focus();
+    expect(document.activeElement).toBe(item);
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+    try {
+      fireEvent.keyDown(item, { key: 'Escape', bubbles: true });
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
   });
 });


### PR DESCRIPTION
## Root cause

Three sibling FAB menus — `BoardNavFab.tsx`'s boards menu, `CollectionSwitcherMenu.tsx`, and `BoardActionsFab.tsx`'s zoom popup — handle Escape via a React `onKeyDown` that never calls `stopPropagation()`. All three render outside any `.widget` DraggableWindow ancestor. Since React's synthetic dispatch doesn't stop the native DOM event from continuing to bubble, an unhandled Escape reaches `DashboardView`'s global `window`-level Escape handler, which finds no typing field and no `.widget` ancestor for the focused menu item and falls back to dispatching a `widget-keyboard-action` Escape event at the topmost z-index widget — silently minimizing an unrelated widget (e.g. a running timer) whenever a teacher presses Escape to dismiss the zoom popup, boards menu, or collection switcher.

This is the same bug class already fixed for `ToolDockItem`/`RemoteControlMenu`/`ClassRosterMenu` in #2266 — these three sibling FAB components were added later and never got the same treatment.

## Fix

Added `e.stopPropagation()` in each component's Escape branch, matching the established pattern from #2266.

## Band-aid rejected

Adding an `isEscapeFromWidgetInput` guard instead was considered and rejected — unnecessary here since focus in these menus is never a widget input; the missing piece is purely the propagation stop.

## Regression tests

- `tests/components/layout/BoardActionsFab.test.tsx`
- `tests/components/layout/CollectionSwitcherMenu.test.tsx`
- `tests/components/layout/BoardNavFab.test.tsx`

Each mounts the component, opens its menu/popup, focuses a non-input menu item, fires Escape, and asserts a `window`-level keydown spy is not invoked.

## Evidence (orchestrator-verified independently)

Fail-before (file-swapped back to `dev-paul`'s pre-fix versions): all 3 new tests fail (window spy called once each). Pass-after (fix restored): 33/33 tests across the three files pass.

`pnpm run validate` and `pnpm run build` both pass in an isolated worktree (585 root test files / 7068 tests, 38 functions test files / 721 tests, test-count guard green).

## Risk

**Contained** — mirrors an already-shipped, already-reviewed fix pattern (#2266) applied to three sibling components.

---
Part of the automated nightly code-health run (`docs/routines/debugger.md`). Independently reviewed and re-verified by the orchestrator before this PR was opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFt8w6JCF55A8yS82tGAfZ)_