### PR TITLE
fix(plcContributions): credit chronologically-first answer, matching getEarnedPoints

### DIFF
--- a/tests/utils/plcContributions.test.ts
+++ b/tests/utils/plcContributions.test.ts
@@ -235,4 +235,41 @@ describe('buildContributionDoc', () => {
     expect(docA.questionsSnapshot).toHaveLength(2);
     expect(docA.questionsSnapshot.map((q) => q.id)).toEqual(['q1', 'q2']);
   });
+
+  it('credits the chronologically-first answer when a response carries two entries for the same question (matches getEarnedPoints)', () => {
+    // A stale read-modify-write race (or a legacy/migrated doc) can leave a
+    // response's `answers` array with two entries for the same questionId.
+    // The Scoreboard/gradebook's canonical `getEarnedPoints`
+    // (components/widgets/QuizWidget/utils/quizScoreboard.ts) sorts by
+    // `answeredAt` ascending and credits the FIRST (earliest) one. The PLC
+    // contribution builder must agree, or the PLC Shared Data view can show
+    // a different score for the same student than the teacher's own Results.
+    const quiz = makeQuiz([makeMcQuestion('q1', 'Q1', 'a', 2)]);
+    const response = {
+      studentUid: 'uid-1',
+      pin: '1111',
+      classPeriod: 'Period 1',
+      answers: [
+        { questionId: 'q1', answer: 'a', answeredAt: 100 }, // correct, EARLIEST — this one should win
+        { questionId: 'q1', answer: 'x', answeredAt: 200 }, // wrong, but LAST in array order
+      ],
+      status: 'completed',
+      submittedAt: 300,
+      tabSwitchWarnings: 0,
+    } as unknown as QuizResponse;
+
+    const doc = buildContributionDoc({
+      plcId: 'plc-A',
+      teacherUid: 'teacher-1',
+      teacherName: 'Teacher One',
+      quiz,
+      responses: [response],
+    });
+
+    // Earliest answer (answeredAt: 100) is correct -> 2 points, even though a
+    // later duplicate entry in the array is wrong and naive array-order
+    // (last-wins) logic would otherwise credit that one instead.
+    expect(doc.responses[0].pointsByQuestionId.q1).toBe(2);
+    expect(doc.responses[0].pointsEarned).toBe(2);
+  });
 });

--- a/utils/plcContributions.ts
+++ b/utils/plcContributions.ts
@@ -83,9 +83,24 @@ function buildContributionResponse(
   pinToName: Record<string, string>,
   byStudentUid?: Map<string, { givenName: string; familyName: string }>
 ): PlcContributionResponse {
-  const answerByQuestionId = new Map(
-    response.answers.map((a) => [a.questionId, a.answer])
+  // Credit only the chronologically-first (earliest `answeredAt`) answer per
+  // question, mirroring `getEarnedPoints` (the Scoreboard/gradebook's
+  // canonical scoring source, `components/widgets/QuizWidget/utils/
+  // quizScoreboard.ts`). A naive `new Map(response.answers.map(...))` keeps
+  // whichever entry is LAST in array order instead — if a response ever
+  // carries two answers for the same question (a stale read-modify-write
+  // race overwriting `answers` mid-edit, or a legacy/migrated doc), the PLC
+  // Shared Data view could score a different answer than the teacher's own
+  // Results/Scoreboard, silently disagreeing on the same student's grade.
+  const sortedAnswers = [...response.answers].sort(
+    (a, b) => (a.answeredAt ?? 0) - (b.answeredAt ?? 0)
   );
+  const answerByQuestionId = new Map<string, string>();
+  for (const a of sortedAnswers) {
+    if (!answerByQuestionId.has(a.questionId)) {
+      answerByQuestionId.set(a.questionId, a.answer);
+    }
+  }
 
   const pointsByQuestionId: Record<string, number> = {};
   let pointsEarned = 0;

--- a/utils/plcContributions.ts
+++ b/utils/plcContributions.ts
@@ -83,15 +83,7 @@ function buildContributionResponse(
   pinToName: Record<string, string>,
   byStudentUid?: Map<string, { givenName: string; familyName: string }>
 ): PlcContributionResponse {
-  // Credit only the chronologically-first (earliest `answeredAt`) answer per
-  // question, mirroring `getEarnedPoints` (the Scoreboard/gradebook's
-  // canonical scoring source, `components/widgets/QuizWidget/utils/
-  // quizScoreboard.ts`). A naive `new Map(response.answers.map(...))` keeps
-  // whichever entry is LAST in array order instead — if a response ever
-  // carries two answers for the same question (a stale read-modify-write
-  // race overwriting `answers` mid-edit, or a legacy/migrated doc), the PLC
-  // Shared Data view could score a different answer than the teacher's own
-  // Results/Scoreboard, silently disagreeing on the same student's grade.
+  // Sort by answeredAt asc, keep first occurrence per questionId — matches getEarnedPoints.
   const sortedAnswers = [...response.answers].sort(
     (a, b) => (a.answeredAt ?? 0) - (b.answeredAt ?? 0)
   );


### PR DESCRIPTION
## Root cause

`buildContributionResponse()` in `utils/plcContributions.ts` built `answerByQuestionId` via `new Map(response.answers.map(a => [a.questionId, a.answer]))`. JS `Map` construction keeps whichever entry is **last** in array order when a response's `answers` array carries two entries for the same `questionId` (a stale read-modify-write race, or a legacy/migrated doc). This diverges from the codebase's canonical scoring source, `getEarnedPoints` (`components/widgets/QuizWidget/utils/quizScoreboard.ts`), which explicitly sorts by `answeredAt` ascending and credits the **first** (earliest) answer per question. The divergence means the PLC Shared Data view (fed by `publishPlcContribution`) could silently show a different score for the same student's response than the teacher's own Results/Scoreboard view — the same "duplicate-answer inflates/deflates score" bug class already fixed 9+ times elsewhere in this codebase (all using "first occurrence"/chronological-first), just never applied here.

## Fix

Sort `response.answers` by `answeredAt` ascending, then build the map keeping only the first-seen entry per `questionId` — mirroring `getEarnedPoints` exactly.

## Band-aid rejected

None needed — this directly aligns the two scoring paths rather than patching a symptom.

## Regression test

`tests/utils/plcContributions.test.ts` — "credits the chronologically-first answer when a response carries two entries for the same question (matches getEarnedPoints)". Crafted a response with a correct answer at `answeredAt: 100` and a wrong duplicate at `answeredAt: 200` (array order = chronological order, so pre-fix last-wins and post-fix first-wins genuinely differ).

## Evidence (orchestrator-verified independently)

Fail-before (file-swapped back to `dev-paul`'s pre-fix version): `expected +0 to be 2` — credits the later, wrong answer for 0 points. Pass-after (fix restored): 9/9 tests pass, `pointsEarned` = 2 (credits the earlier, correct answer).

`pnpm run validate` and `pnpm run build` both pass in an isolated worktree (585 root test files / 7066 tests, 38 functions test files / 721 tests, test-count guard green).

## Risk

**Contained** — single utility function, matches an already-established scoring convention used elsewhere in the same codebase.

---
Part of the automated nightly code-health run (`docs/routines/debugger.md`). Independently reviewed and re-verified by the orchestrator before this PR was opened.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HFt8w6JCF55A8yS82tGAfZ)_