### PR TITLE
unify(D5): CalendarConfigurationModal local Toast → addToast

### DIFF
--- a/components/admin/CalendarConfigurationModal.tsx
+++ b/components/admin/CalendarConfigurationModal.tsx
@@ -24,12 +24,12 @@ import {
 } from '@/types';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
-import { Toast } from '@/components/common/Toast';
 import { Modal } from '@/components/common/Modal';
 import { useAuth } from '@/context/useAuth';
 import { GoogleCalendarService } from '@/utils/googleCalendarService';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { useDashboard } from '@/context/useDashboard';
 
 interface CalendarConfigurationModalProps {
   isOpen: boolean;
@@ -39,6 +39,7 @@ interface CalendarConfigurationModalProps {
 export const CalendarConfigurationModal: React.FC<
   CalendarConfigurationModalProps
 > = ({ isOpen, onClose }) => {
+  const { addToast } = useDashboard();
   const BUILDINGS = useAdminBuildings();
   // Path B: calendar sync needs the `calendar.readonly` scope, acquired on
   // demand (not at login). Probe SILENTLY on open to reflect already-granted
@@ -59,10 +60,6 @@ export const CalendarConfigurationModal: React.FC<
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [syncing, setSyncing] = useState(false);
-  const [message, setMessage] = useState<{
-    text: string;
-    type: 'success' | 'error';
-  } | null>(null);
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
 
@@ -134,11 +131,11 @@ export const CalendarConfigurationModal: React.FC<
         { merge: true }
       );
       if (!updatedConfig) {
-        setMessage({ text: 'Calendar configuration saved!', type: 'success' });
+        addToast('Calendar configuration saved!', 'success');
       }
     } catch (err) {
       console.error('Failed to save calendar config:', err);
-      setMessage({ text: 'Failed to save configuration.', type: 'error' });
+      addToast('Failed to save configuration.', 'error');
     } finally {
       setSaving(false);
     }
@@ -154,10 +151,7 @@ export const CalendarConfigurationModal: React.FC<
       interactive: true,
     });
     if (!token) {
-      setMessage({
-        text: 'Please sign in with Google to sync calendars.',
-        type: 'error',
-      });
+      addToast('Please sign in with Google to sync calendars.', 'error');
       return;
     }
     setIsCalendarConnected(true);
@@ -202,10 +196,10 @@ export const CalendarConfigurationModal: React.FC<
       };
       setConfig(nextConfig);
       await handleSave(nextConfig);
-      setMessage({ text: 'All building calendars synced!', type: 'success' });
+      addToast('All building calendars synced!', 'success');
     } catch (err) {
       console.error('Global sync failed:', err);
-      setMessage({ text: 'Failed to sync all calendars.', type: 'error' });
+      addToast('Failed to sync all calendars.', 'error');
     } finally {
       setSyncing(false);
     }
@@ -327,390 +321,375 @@ export const CalendarConfigurationModal: React.FC<
   );
 
   return (
-    <>
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-        maxWidth="max-w-4xl"
-        customHeader={header}
-        footer={footer}
-        className="!p-0"
-        contentClassName=""
-        footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
-      >
-        <div className="p-6 space-y-8">
-          {loading ? (
-            <div className="flex flex-col items-center justify-center py-20 gap-4">
-              <Loader2 className="w-10 h-10 text-rose-500 animate-spin" />
-              <p className="text-sm font-bold text-slate-400 uppercase tracking-widest">
-                Loading Configuration...
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Dock Defaults */}
-              <DockDefaultsPanel
-                config={{ dockDefaults: config.dockDefaults ?? {} }}
-                onChange={(d) =>
-                  setConfig((prev) => ({ ...prev, dockDefaults: d }))
-                }
-              />
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-4xl"
+      customHeader={header}
+      footer={footer}
+      className="!p-0"
+      contentClassName=""
+      footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
+    >
+      <div className="p-6 space-y-8">
+        {loading ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-4">
+            <Loader2 className="w-10 h-10 text-rose-500 animate-spin" />
+            <p className="text-sm font-bold text-slate-400 uppercase tracking-widest">
+              Loading Configuration...
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Dock Defaults */}
+            <DockDefaultsPanel
+              config={{ dockDefaults: config.dockDefaults ?? {} }}
+              onChange={(d) =>
+                setConfig((prev) => ({ ...prev, dockDefaults: d }))
+              }
+            />
 
-              {/* Proxy Sync Controls */}
-              <section className="bg-blue-50 border border-blue-100 rounded-2xl p-5">
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h3 className="text-sm font-black text-blue-700 uppercase tracking-widest flex items-center gap-2">
-                      <RefreshCw className="w-4 h-4" /> Managed Proxy Sync
-                    </h3>
-                    <p className="text-xxs text-blue-600/70 font-medium mt-1 uppercase tracking-wider">
-                      Pull events centrally so users don&apos;t need individual
-                      auth
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center gap-2 bg-white px-3 py-1.5 rounded-xl border border-blue-200">
-                      <Clock className="w-3.5 h-3.5 text-blue-400" />
-                      <span className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
-                        Every
-                      </span>
-                      <input
-                        type="number"
-                        min="1"
-                        max="24"
-                        value={config.updateFrequencyHours ?? 4}
-                        onChange={(e) =>
-                          updateGlobal({
-                            updateFrequencyHours: parseInt(e.target.value, 10),
-                          })
-                        }
-                        className="w-10 text-xs font-black text-blue-700 text-center bg-transparent outline-none"
-                      />
-                      <span className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
-                        Hours
-                      </span>
-                    </div>
-                    <button
-                      onClick={handleSyncAll}
-                      // Disabled until the silent probe resolves to a REAL
-                      // connection (true). While the probe is pending (null) or
-                      // the admin hasn't granted the scope (false), clicking
-                      // would fire an interactive ensureGoogleScope and pop an
-                      // unexpected OAuth dialog. Disconnected admins use the
-                      // "Reconnect Google" button (gated on === false) to grant
-                      // consent first; that flips this to enabled.
-                      disabled={syncing || isCalendarConnected !== true}
-                      className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary text-white rounded-xl text-xs font-black hover:bg-brand-blue-dark transition-all shadow-md disabled:opacity-50"
-                    >
-                      {syncing ? (
-                        <>
-                          <Loader2 className="w-3.5 h-3.5 animate-spin" />{' '}
-                          Syncing...
-                        </>
-                      ) : (
-                        <>
-                          <RefreshCw className="w-3.5 h-3.5" /> Sync All Now
-                        </>
-                      )}
-                    </button>
-                  </div>
+            {/* Proxy Sync Controls */}
+            <section className="bg-blue-50 border border-blue-100 rounded-2xl p-5">
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <h3 className="text-sm font-black text-blue-700 uppercase tracking-widest flex items-center gap-2">
+                    <RefreshCw className="w-4 h-4" /> Managed Proxy Sync
+                  </h3>
+                  <p className="text-xxs text-blue-600/70 font-medium mt-1 uppercase tracking-wider">
+                    Pull events centrally so users don&apos;t need individual
+                    auth
+                  </p>
                 </div>
-
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-                  {BUILDINGS.map((b) => {
-                    const bConfig = config.buildingDefaults?.[b.id];
-                    const lastSync = bConfig?.lastProxySync;
-                    const eventCount = bConfig?.cachedEvents?.length ?? 0;
-                    return (
-                      <div
-                        key={b.id}
-                        className="bg-white/50 border border-blue-100 p-2 rounded-xl flex flex-col gap-1"
-                      >
-                        <span className="text-xxs font-black text-slate-700 truncate">
-                          {b.name}
-                        </span>
-                        <div className="flex items-center justify-between">
-                          <span className="text-xxs font-medium text-blue-600/70">
-                            {eventCount} events
-                          </span>
-                          {lastSync && (
-                            <span
-                              className="text-xxxs font-bold text-slate-400 uppercase"
-                              title={new Date(lastSync).toLocaleString()}
-                            >
-                              {new Date(lastSync).toLocaleTimeString([], {
-                                hour: '2-digit',
-                                minute: '2-digit',
-                              })}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </section>
-
-              {/* Global Blocked Dates */}
-              <section className="bg-red-50 border border-red-100 rounded-2xl p-5">
-                <div className="flex items-center justify-between mb-4">
-                  <div>
-                    <h3 className="text-sm font-black text-red-700 uppercase tracking-widest flex items-center gap-2">
-                      <Ban className="w-4 h-4" /> District Blocked Dates
-                    </h3>
-                    <p className="text-xxs text-red-600/70 font-medium mt-1 uppercase tracking-wider">
-                      Hidden from ALL teacher widgets district-wide
-                    </p>
+                <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2 bg-white px-3 py-1.5 rounded-xl border border-blue-200">
+                    <Clock className="w-3.5 h-3.5 text-blue-400" />
+                    <span className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
+                      Every
+                    </span>
+                    <input
+                      type="number"
+                      min="1"
+                      max="24"
+                      value={config.updateFrequencyHours ?? 4}
+                      onChange={(e) =>
+                        updateGlobal({
+                          updateFrequencyHours: parseInt(e.target.value, 10),
+                        })
+                      }
+                      className="w-10 text-xs font-black text-blue-700 text-center bg-transparent outline-none"
+                    />
+                    <span className="text-xxs font-bold text-slate-500 uppercase tracking-widest">
+                      Hours
+                    </span>
                   </div>
                   <button
-                    onClick={addBlockedDate}
-                    className="flex items-center gap-2 px-3 py-1.5 bg-white text-red-600 border border-red-200 rounded-xl text-xs font-black hover:bg-red-100 transition-colors shadow-sm"
+                    onClick={handleSyncAll}
+                    // Disabled until the silent probe resolves to a REAL
+                    // connection (true). While the probe is pending (null) or
+                    // the admin hasn't granted the scope (false), clicking
+                    // would fire an interactive ensureGoogleScope and pop an
+                    // unexpected OAuth dialog. Disconnected admins use the
+                    // "Reconnect Google" button (gated on === false) to grant
+                    // consent first; that flips this to enabled.
+                    disabled={syncing || isCalendarConnected !== true}
+                    className="flex items-center gap-2 px-4 py-2 bg-brand-blue-primary text-white rounded-xl text-xs font-black hover:bg-brand-blue-dark transition-all shadow-md disabled:opacity-50"
                   >
-                    <Plus className="w-3.5 h-3.5" /> Add Date
+                    {syncing ? (
+                      <>
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />{' '}
+                        Syncing...
+                      </>
+                    ) : (
+                      <>
+                        <RefreshCw className="w-3.5 h-3.5" /> Sync All Now
+                      </>
+                    )}
                   </button>
                 </div>
+              </div>
 
-                <div className="flex flex-wrap gap-2">
-                  {config.blockedDates.map((date, idx) => (
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                {BUILDINGS.map((b) => {
+                  const bConfig = config.buildingDefaults?.[b.id];
+                  const lastSync = bConfig?.lastProxySync;
+                  const eventCount = bConfig?.cachedEvents?.length ?? 0;
+                  return (
                     <div
-                      key={idx}
-                      className="flex items-center gap-2 bg-white border border-red-200 px-2 py-1.5 rounded-xl shadow-sm group animate-in zoom-in-95"
+                      key={b.id}
+                      className="bg-white/50 border border-blue-100 p-2 rounded-xl flex flex-col gap-1"
                     >
-                      <input
-                        type="date"
-                        value={date}
-                        onChange={(e) => {
-                          const next = [...config.blockedDates];
-                          next[idx] = e.target.value;
-                          updateGlobal({ blockedDates: next });
-                        }}
-                        className="text-xs font-black text-red-700 outline-none bg-transparent"
-                      />
+                      <span className="text-xxs font-black text-slate-700 truncate">
+                        {b.name}
+                      </span>
+                      <div className="flex items-center justify-between">
+                        <span className="text-xxs font-medium text-blue-600/70">
+                          {eventCount} events
+                        </span>
+                        {lastSync && (
+                          <span
+                            className="text-xxxs font-bold text-slate-400 uppercase"
+                            title={new Date(lastSync).toLocaleString()}
+                          >
+                            {new Date(lastSync).toLocaleTimeString([], {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            {/* Global Blocked Dates */}
+            <section className="bg-red-50 border border-red-100 rounded-2xl p-5">
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <h3 className="text-sm font-black text-red-700 uppercase tracking-widest flex items-center gap-2">
+                    <Ban className="w-4 h-4" /> District Blocked Dates
+                  </h3>
+                  <p className="text-xxs text-red-600/70 font-medium mt-1 uppercase tracking-wider">
+                    Hidden from ALL teacher widgets district-wide
+                  </p>
+                </div>
+                <button
+                  onClick={addBlockedDate}
+                  className="flex items-center gap-2 px-3 py-1.5 bg-white text-red-600 border border-red-200 rounded-xl text-xs font-black hover:bg-red-100 transition-colors shadow-sm"
+                >
+                  <Plus className="w-3.5 h-3.5" /> Add Date
+                </button>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {config.blockedDates.map((date, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-2 bg-white border border-red-200 px-2 py-1.5 rounded-xl shadow-sm group animate-in zoom-in-95"
+                  >
+                    <input
+                      type="date"
+                      value={date}
+                      onChange={(e) => {
+                        const next = [...config.blockedDates];
+                        next[idx] = e.target.value;
+                        updateGlobal({ blockedDates: next });
+                      }}
+                      className="text-xs font-black text-red-700 outline-none bg-transparent"
+                    />
+                    <button
+                      onClick={() => {
+                        const next = config.blockedDates.filter(
+                          (_, i) => i !== idx
+                        );
+                        updateGlobal({ blockedDates: next });
+                      }}
+                      className="text-red-300 hover:text-red-600 transition-colors"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+                {config.blockedDates.length === 0 && (
+                  <div className="w-full text-center py-4 text-red-400 text-xs italic font-medium">
+                    No blocked dates configured.
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <hr className="border-slate-100" />
+
+            {/* Building Specific Config */}
+            <section className="space-y-6">
+              <div>
+                <SettingsLabel icon={Settings2}>
+                  Select Building to Configure
+                </SettingsLabel>
+                <BuildingSelector
+                  selectedId={selectedBuildingId}
+                  onSelect={setSelectedBuildingId}
+                />
+              </div>
+
+              <div className="bg-slate-50 rounded-2xl border border-slate-200 p-6 space-y-8 animate-in fade-in slide-in-from-top-2 duration-300">
+                {/* Building Defaults */}
+                <div>
+                  <div className="flex items-center justify-between mb-4">
+                    <div>
+                      <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                        <CalendarIcon className="w-4 h-4 text-rose-500" />{' '}
+                        Default Building Events
+                      </h4>
+                      <p className="text-xxs text-slate-500 font-medium mt-1 uppercase tracking-wider">
+                        A/B schedule, block rotation, or fixed dates
+                      </p>
+                    </div>
+                    <button
+                      onClick={addDefaultEvent}
+                      className="flex items-center gap-2 px-3 py-1.5 bg-white text-brand-blue-primary border border-slate-200 rounded-xl text-xs font-black hover:bg-blue-50 transition-colors shadow-sm"
+                    >
+                      <Plus className="w-3.5 h-3.5" /> Add Event
+                    </button>
+                  </div>
+
+                  <div className="space-y-2">
+                    {currentBuildingConfig.events.map((event, idx) => (
+                      <div
+                        key={idx}
+                        className="bg-white border border-slate-200 rounded-xl p-3 flex items-center gap-4 shadow-sm group animate-in zoom-in-95"
+                      >
+                        <div className="flex-1 grid grid-cols-12 gap-3">
+                          <div className="col-span-4">
+                            <input
+                              type="date"
+                              value={event.date}
+                              onChange={(e) => {
+                                const next = [...currentBuildingConfig.events];
+                                next[idx] = {
+                                  ...next[idx],
+                                  date: e.target.value,
+                                };
+                                updateBuilding({ events: next });
+                              }}
+                              className="w-full px-3 py-2 text-xs font-bold border border-slate-100 rounded-lg focus:border-rose-400 outline-none bg-slate-50/50"
+                            />
+                          </div>
+                          <div className="col-span-8">
+                            <input
+                              type="text"
+                              value={event.title}
+                              onChange={(e) => {
+                                const next = [...currentBuildingConfig.events];
+                                next[idx] = {
+                                  ...next[idx],
+                                  title: e.target.value,
+                                };
+                                updateBuilding({ events: next });
+                              }}
+                              placeholder="Event Title (e.g. Day A)"
+                              className="w-full px-3 py-2 text-xs font-bold border border-slate-100 rounded-lg focus:border-rose-400 outline-none bg-slate-50/50"
+                            />
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => {
+                            const next = currentBuildingConfig.events.filter(
+                              (_, i) => i !== idx
+                            );
+                            updateBuilding({ events: next });
+                          }}
+                          className="text-slate-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    ))}
+                    {currentBuildingConfig.events.length === 0 && (
+                      <div className="text-center py-10 border-2 border-dashed border-slate-200 rounded-2xl text-slate-400 text-xs italic font-medium">
+                        No default events configured for this building.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <hr className="border-slate-200" />
+
+                {/* Google Calendar Sync */}
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                        <Settings2 className="w-4 h-4 text-blue-500" /> Google
+                        Calendar IDs
+                      </h4>
+                      <p className="text-xxs text-slate-500 font-medium mt-1 uppercase tracking-wider">
+                        District or building-wide synced calendars
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      {currentBuildingConfig.lastProxySync && (
+                        <div className="flex items-center gap-1 bg-green-50 px-2 py-1 rounded-lg border border-green-100">
+                          <CheckCircle2 className="w-3 h-3 text-green-500" />
+                          <span className="text-xxs font-black text-green-600 uppercase tracking-tighter">
+                            Proxied
+                          </span>
+                        </div>
+                      )}
                       <button
                         onClick={() => {
-                          const next = config.blockedDates.filter(
-                            (_, i) => i !== idx
-                          );
-                          updateGlobal({ blockedDates: next });
+                          const nextIds = [
+                            ...(currentBuildingConfig.googleCalendarIds ?? []),
+                            '',
+                          ];
+                          updateBuilding({ googleCalendarIds: nextIds });
                         }}
-                        className="text-red-300 hover:text-red-600 transition-colors"
-                      >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </button>
-                    </div>
-                  ))}
-                  {config.blockedDates.length === 0 && (
-                    <div className="w-full text-center py-4 text-red-400 text-xs italic font-medium">
-                      No blocked dates configured.
-                    </div>
-                  )}
-                </div>
-              </section>
-
-              <hr className="border-slate-100" />
-
-              {/* Building Specific Config */}
-              <section className="space-y-6">
-                <div>
-                  <SettingsLabel icon={Settings2}>
-                    Select Building to Configure
-                  </SettingsLabel>
-                  <BuildingSelector
-                    selectedId={selectedBuildingId}
-                    onSelect={setSelectedBuildingId}
-                  />
-                </div>
-
-                <div className="bg-slate-50 rounded-2xl border border-slate-200 p-6 space-y-8 animate-in fade-in slide-in-from-top-2 duration-300">
-                  {/* Building Defaults */}
-                  <div>
-                    <div className="flex items-center justify-between mb-4">
-                      <div>
-                        <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                          <CalendarIcon className="w-4 h-4 text-rose-500" />{' '}
-                          Default Building Events
-                        </h4>
-                        <p className="text-xxs text-slate-500 font-medium mt-1 uppercase tracking-wider">
-                          A/B schedule, block rotation, or fixed dates
-                        </p>
-                      </div>
-                      <button
-                        onClick={addDefaultEvent}
                         className="flex items-center gap-2 px-3 py-1.5 bg-white text-brand-blue-primary border border-slate-200 rounded-xl text-xs font-black hover:bg-blue-50 transition-colors shadow-sm"
                       >
-                        <Plus className="w-3.5 h-3.5" /> Add Event
+                        <Plus className="w-3.5 h-3.5" /> Add ID
                       </button>
                     </div>
+                  </div>
 
-                    <div className="space-y-2">
-                      {currentBuildingConfig.events.map((event, idx) => (
+                  <div className="space-y-3">
+                    {(currentBuildingConfig.googleCalendarIds ?? []).map(
+                      (id, idx) => (
                         <div
                           key={idx}
-                          className="bg-white border border-slate-200 rounded-xl p-3 flex items-center gap-4 shadow-sm group animate-in zoom-in-95"
+                          className="bg-white border border-slate-200 rounded-xl p-2 flex items-center gap-2 group animate-in zoom-in-95"
                         >
-                          <div className="flex-1 grid grid-cols-12 gap-3">
-                            <div className="col-span-4">
-                              <input
-                                type="date"
-                                value={event.date}
-                                onChange={(e) => {
-                                  const next = [
-                                    ...currentBuildingConfig.events,
-                                  ];
-                                  next[idx] = {
-                                    ...next[idx],
-                                    date: e.target.value,
-                                  };
-                                  updateBuilding({ events: next });
-                                }}
-                                className="w-full px-3 py-2 text-xs font-bold border border-slate-100 rounded-lg focus:border-rose-400 outline-none bg-slate-50/50"
-                              />
-                            </div>
-                            <div className="col-span-8">
-                              <input
-                                type="text"
-                                value={event.title}
-                                onChange={(e) => {
-                                  const next = [
-                                    ...currentBuildingConfig.events,
-                                  ];
-                                  next[idx] = {
-                                    ...next[idx],
-                                    title: e.target.value,
-                                  };
-                                  updateBuilding({ events: next });
-                                }}
-                                placeholder="Event Title (e.g. Day A)"
-                                className="w-full px-3 py-2 text-xs font-bold border border-slate-100 rounded-lg focus:border-rose-400 outline-none bg-slate-50/50"
-                              />
-                            </div>
-                          </div>
+                          <input
+                            type="text"
+                            value={id}
+                            onChange={(e) => {
+                              const next = [
+                                ...(currentBuildingConfig.googleCalendarIds ??
+                                  []),
+                              ];
+                              next[idx] = e.target.value;
+                              updateBuilding({ googleCalendarIds: next });
+                            }}
+                            placeholder="email@group.calendar.google.com"
+                            className="flex-1 px-3 py-2 text-xs font-mono border border-slate-100 rounded-lg focus:border-blue-400 outline-none bg-slate-50/50"
+                          />
+                          <a
+                            href={`https://calendar.google.com/calendar/u/0/embed?src=${id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="p-2 text-slate-400 hover:text-blue-500 transition-colors"
+                            title="Verify Calendar ID"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                          </a>
                           <button
                             onClick={() => {
-                              const next = currentBuildingConfig.events.filter(
-                                (_, i) => i !== idx
-                              );
-                              updateBuilding({ events: next });
+                              const next = (
+                                currentBuildingConfig.googleCalendarIds ?? []
+                              ).filter((_, i) => i !== idx);
+                              updateBuilding({ googleCalendarIds: next });
                             }}
-                            className="text-slate-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                            className="p-2 text-slate-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
                           >
                             <Trash2 className="w-4 h-4" />
                           </button>
                         </div>
-                      ))}
-                      {currentBuildingConfig.events.length === 0 && (
-                        <div className="text-center py-10 border-2 border-dashed border-slate-200 rounded-2xl text-slate-400 text-xs italic font-medium">
-                          No default events configured for this building.
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  <hr className="border-slate-200" />
-
-                  {/* Google Calendar Sync */}
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                          <Settings2 className="w-4 h-4 text-blue-500" /> Google
-                          Calendar IDs
-                        </h4>
-                        <p className="text-xxs text-slate-500 font-medium mt-1 uppercase tracking-wider">
-                          District or building-wide synced calendars
-                        </p>
+                      )
+                    )}
+                    {(currentBuildingConfig.googleCalendarIds ?? []).length ===
+                      0 && (
+                      <div className="text-center py-8 border-2 border-dashed border-slate-200 rounded-2xl text-slate-400 text-xs italic font-medium">
+                        No Google Calendars synced for this building.
                       </div>
-                      <div className="flex gap-2">
-                        {currentBuildingConfig.lastProxySync && (
-                          <div className="flex items-center gap-1 bg-green-50 px-2 py-1 rounded-lg border border-green-100">
-                            <CheckCircle2 className="w-3 h-3 text-green-500" />
-                            <span className="text-xxs font-black text-green-600 uppercase tracking-tighter">
-                              Proxied
-                            </span>
-                          </div>
-                        )}
-                        <button
-                          onClick={() => {
-                            const nextIds = [
-                              ...(currentBuildingConfig.googleCalendarIds ??
-                                []),
-                              '',
-                            ];
-                            updateBuilding({ googleCalendarIds: nextIds });
-                          }}
-                          className="flex items-center gap-2 px-3 py-1.5 bg-white text-brand-blue-primary border border-slate-200 rounded-xl text-xs font-black hover:bg-blue-50 transition-colors shadow-sm"
-                        >
-                          <Plus className="w-3.5 h-3.5" /> Add ID
-                        </button>
-                      </div>
-                    </div>
-
-                    <div className="space-y-3">
-                      {(currentBuildingConfig.googleCalendarIds ?? []).map(
-                        (id, idx) => (
-                          <div
-                            key={idx}
-                            className="bg-white border border-slate-200 rounded-xl p-2 flex items-center gap-2 group animate-in zoom-in-95"
-                          >
-                            <input
-                              type="text"
-                              value={id}
-                              onChange={(e) => {
-                                const next = [
-                                  ...(currentBuildingConfig.googleCalendarIds ??
-                                    []),
-                                ];
-                                next[idx] = e.target.value;
-                                updateBuilding({ googleCalendarIds: next });
-                              }}
-                              placeholder="email@group.calendar.google.com"
-                              className="flex-1 px-3 py-2 text-xs font-mono border border-slate-100 rounded-lg focus:border-blue-400 outline-none bg-slate-50/50"
-                            />
-                            <a
-                              href={`https://calendar.google.com/calendar/u/0/embed?src=${id}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="p-2 text-slate-400 hover:text-blue-500 transition-colors"
-                              title="Verify Calendar ID"
-                            >
-                              <ExternalLink className="w-4 h-4" />
-                            </a>
-                            <button
-                              onClick={() => {
-                                const next = (
-                                  currentBuildingConfig.googleCalendarIds ?? []
-                                ).filter((_, i) => i !== idx);
-                                updateBuilding({ googleCalendarIds: next });
-                              }}
-                              className="p-2 text-slate-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </button>
-                          </div>
-                        )
-                      )}
-                      {(currentBuildingConfig.googleCalendarIds ?? [])
-                        .length === 0 && (
-                        <div className="text-center py-8 border-2 border-dashed border-slate-200 rounded-2xl text-slate-400 text-xs italic font-medium">
-                          No Google Calendars synced for this building.
-                        </div>
-                      )}
-                    </div>
+                    )}
                   </div>
                 </div>
-              </section>
-            </>
-          )}
-        </div>
-      </Modal>
-
-      {message && (
-        <Toast
-          message={message.text}
-          type={message.type}
-          onClose={() => setMessage(null)}
-        />
-      )}
-    </>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </Modal>
   );
 };

--- a/tests/components/admin/CalendarConfigurationModal.syncButton.test.tsx
+++ b/tests/components/admin/CalendarConfigurationModal.syncButton.test.tsx
@@ -23,6 +23,11 @@ vi.mock('@/context/useAuth', () => ({
   useAuth: () => ({ ensureGoogleScope: ensureGoogleScopeMock }),
 }));
 
+const mockAddToast = vi.fn();
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ addToast: mockAddToast }),
+}));
+
 const STABLE_BUILDINGS = [{ id: 'b1', name: 'Building One' }];
 vi.mock('@/hooks/useAdminBuildings', () => ({
   useAdminBuildings: () => STABLE_BUILDINGS,
@@ -52,6 +57,7 @@ function getSyncButton(): HTMLButtonElement {
 
 beforeEach(() => {
   ensureGoogleScopeMock.mockClear();
+  mockAddToast.mockClear();
   resolveProbe = () => undefined;
 });
 


### PR DESCRIPTION
## Summary

Nightly consistency-unifier run (dimension D5 — Toast Architecture in Admin Components).

- **Canonical form:** `addToast(message, type)` via `useDashboard()` — the centralized toast queue rendered by `DashboardView`'s `ToastContainer`.
- **Anti-pattern found:** `CalendarConfigurationModal.tsx` rendered a local `Toast` component as a JSX sibling *outside* the closing `</Modal>` tag (wrapped in a fragment), imitating a global-overlay toast with local `useState` instead of using the app's real global toast queue. `useDashboard()`/`addToast` is reachable in this component's tree (mounted via `FeaturePermissionsManager.tsx` → `AdminSettings`, inside the teacher app's `DashboardProvider`) — the exact same shape fixed in `SpecialistScheduleConfigurationModal` in a prior nightly run (#2273).
- **Instances unified:** `components/admin/CalendarConfigurationModal.tsx` — removed the local `message` state, the `Toast` import, and the wrapping fragment (the `Modal` is now the direct return value, since it no longer needs a sibling). Replaced all 5 `setMessage(...)` call sites with `addToast(text, type)`, preserving identical copy and success/error types:
  - "Calendar configuration saved!" (success)
  - "Failed to save configuration." (error)
  - "Please sign in with Google to sync calendars." (error)
  - "All building calendars synced!" (success)
  - "Failed to sync all calendars." (error)
- **Test updated:** `tests/components/admin/CalendarConfigurationModal.syncButton.test.tsx` now mocks `@/context/useDashboard` (`{ addToast: mockAddToast }`), matching the existing project pattern (e.g. `tests/components/admin/PlcRecoveryPanel.test.tsx`). No assertions changed — same 3 tests, same behavior.
- **Enforcement:** none added — this is an isolated single-file drift instance, not a recurring bug class warranting a lint rule (consistent with how the prior sibling fix was handled).

## Behavior-preservation evidence

Same copy, same success/error semantics, same UX (both are user-visible toast notifications — this only moves the delivery mechanism from a local overlay to the app's centralized toast queue). The JSX diff outside the toast logic is a pure reindent (removing the now-unnecessary wrapping fragment), not a markup/logic change.

- `pnpm run type-check:all` — exit 0
- `pnpm run lint` — exit 0 (0 errors, 0 warnings)
- `pnpm run format:check` — exit 0
- `pnpm run test` — exit 0, 585/585 files, 7065/7065 tests
- `pnpm -C functions run test` — exit 0, 38/38 files, 721/721 tests
- `pnpm run test:counts` — exit 0, guard passed
- `pnpm run build` — exit 0 (build + SSR prerender)

Orchestrator independently reviewed the full diff and ran a targeted `eslint --max-warnings 0` on both changed files (clean) before opening this PR.

## Risk tag

**mechanical** — pure equivalence swap of one notification mechanism for another, no behavior or visual change beyond toast delivery (global queue vs. local overlay), following an established precedent from a prior nightly run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqzMPx9dBvkPtZWW6XrTWa)_