### PR TITLE
unify(D1): MiniAppManager library empty states → ScaledEmptyState

### DIFF
--- a/components/widgets/MiniApp/components/MiniAppManager.tsx
+++ b/components/widgets/MiniApp/components/MiniAppManager.tsx
@@ -51,6 +51,7 @@ import type {
   GlobalMiniAppItem,
   MiniAppAssignment,
 } from '@/types';
+import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
 import { LibraryShell } from '@/components/common/library/LibraryShell';
 import { LibraryToolbar } from '@/components/common/library/LibraryToolbar';
 import { LibraryGrid } from '@/components/common/library/LibraryGrid';
@@ -851,35 +852,25 @@ export const MiniAppManager: React.FC<MiniAppManagerProps> = ({
   /* ── Empty states ─────────────────────────────────────────────────────── */
 
   const personalEmpty = (
-    <div className="flex flex-col items-center justify-center gap-3 text-center py-10 text-slate-400">
-      <div className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 backdrop-blur-sm p-5">
-        <Box className="h-8 w-8 stroke-slate-300" />
-      </div>
-      <div>
-        <p className="text-sm font-black uppercase tracking-widest text-slate-500">
-          No apps saved yet
-        </p>
-        <p className="text-xs font-medium text-slate-400">
-          Import a file or create your first mini-app.
-        </p>
-      </div>
-    </div>
+    <ScaledEmptyState
+      icon={Box}
+      title="No apps saved yet"
+      subtitle="Import a file or create your first mini-app."
+      iconClassName="text-slate-300"
+      titleClassName="text-slate-500"
+      subtitleClassName="text-slate-400"
+    />
   );
 
   const globalEmpty = (
-    <div className="flex flex-col items-center justify-center gap-3 text-center py-10 text-slate-400">
-      <div className="rounded-2xl border border-dashed border-slate-300/70 bg-white/60 backdrop-blur-sm p-5">
-        <Globe className="h-8 w-8 stroke-slate-300" />
-      </div>
-      <div>
-        <p className="text-sm font-black uppercase tracking-widest text-slate-500">
-          No shared apps yet
-        </p>
-        <p className="text-xs font-medium text-slate-400">
-          Your admin has not published any apps yet.
-        </p>
-      </div>
-    </div>
+    <ScaledEmptyState
+      icon={Globe}
+      title="No shared apps yet"
+      subtitle="Your admin has not published any apps yet."
+      iconClassName="text-slate-300"
+      titleClassName="text-slate-500"
+      subtitleClassName="text-slate-400"
+    />
   );
 
   const activeEmpty = (


### PR DESCRIPTION
## Nightly Unifier — D1: Widget Empty States

**Canonical form:** `<ScaledEmptyState icon={...} title="..." subtitle="..." />` from `components/common/ScaledEmptyState.tsx`.

**Instances unified** in `components/widgets/MiniApp/components/MiniAppManager.tsx`:
- `personalEmpty` — hand-rolled dashed-badge (`rounded-2xl border-dashed bg-white/60`) + `Box` icon → `ScaledEmptyState`
- `globalEmpty` — same shape + `Globe` icon → `ScaledEmptyState`

Both use `iconClassName="text-slate-300"` / `titleClassName="text-slate-500"` / `subtitleClassName="text-slate-400"` overrides to preserve the original color scheme (this manager's surrounding UI is light-surface — `bg-white/60`/`text-slate-800` — so `ScaledEmptyState`'s dark-widget default colors would be low-contrast if used unmodified).

**Deliberately left alone:** `activeEmpty` and `archiveEmpty` in the same file are text-only, no-icon states — converting them would force in a new icon plus `ScaledEmptyState`'s hardcoded uppercase title styling, a real visual change rather than a preserved one. This matches the established D1 "no-icon exception family" (D1-E9/E15/E16/E17/E23).

**Direct precedent (read, not just cited):** `QuizWidget/components/QuizManager.tsx` (PR #2284) already converted the identical dashed-badge+icon shape in the same `LibraryGrid`/`emptyState` slot, dropping the dashed circular badge (no `ScaledEmptyState` equivalent exists for it) — same approach applied here. `LibraryGrid.tsx` confirmed to render the `emptyState` node verbatim with no imposed wrapper.

**Behavior/visual-preservation evidence:**
- Title: original `text-sm font-black uppercase tracking-widest text-slate-500` (14px) → `ScaledEmptyState`'s `font-black uppercase tracking-widest` + `min(14px, 4cqmin)` (14px cap) + `text-slate-500` override — casing/weight/color preserved, size cap matches.
- Subtitle: original `text-xs font-medium text-slate-400` (12px) → `leading-tight` + `min(12px, 3cqmin)` (12px cap) + `text-slate-400` override — color/size cap preserved; `font-medium` (500) isn't reproducible via `ScaledEmptyState`'s fixed markup, so subtitle renders at the default weight (400) — a minor, established delta consistent with the already-shipped QuizManager conversion, not something introduced here.
- Icon: dashed-badge wrapper dropped (no equivalent prop, matches precedent); `stroke-slate-300` → `iconClassName="text-slate-300"` (Lucide icons use `currentColor` for stroke by default, so this is equivalent).
- `WidgetRegistry.ts` confirms `miniApp` is `skipScaling: true` (container-query model), consistent with `cqmin` scaling being valid here, same as the already-shipped Quiz/VideoActivity conversions.

**Verification:** `pnpm run validate` (type-check, lint, format-check, root + functions tests — 587/587 root files + 39/39 functions files, all passing) and `pnpm run build` both green in the subagent's worktree. Orchestrator independently re-ran `eslint --max-warnings 0`, `prettier --check`, and `tsc --noEmit` on the changed file directly — all clean. `dev-paul` had not moved since the worktree was cut, so no rebase was needed.

**Risk tag:** mechanical (pure equivalence conversion, same shape as an already-merged sibling PR).

**Backlog note for next run:** `archiveEmpty` (~line 898, same file) is a second text-only/no-icon empty state alongside `activeEmpty` — recorded as its own no-icon-exception candidate in the memory doc so a future run doesn't re-litigate it.

---
Part of the nightly consistency-unifier routine (`docs/routines/unifier.md`, run 45).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ESkYWQQPqecXfJ1eE3RY9g)_