### PR TITLE
unifier(D5): Toast architecture — StarterPackConfigurationModal

### DIFF
--- a/components/admin/StarterPackConfigurationModal.tsx
+++ b/components/admin/StarterPackConfigurationModal.tsx
@@ -37,7 +37,6 @@ import { WIDGET_DEFAULTS } from '@/config/widgetDefaults';
 import { useDashboard } from '@/context/useDashboard';
 import { createBoardSnapshot } from '@/utils/widgetHelpers';
 import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
-import { Toast } from '@/components/common/Toast';
 import { Modal } from '@/components/common/Modal';
 import { useDialog } from '@/context/useDialog';
 import { DockDefaultsPanel } from './DockDefaultsPanel';
@@ -258,17 +257,13 @@ const SnapZonePicker: React.FC<SnapZonePickerProps> = ({
 export const StarterPackConfigurationModal: React.FC<
   StarterPackConfigurationModalProps
 > = ({ isOpen, onClose, permission, onSave }) => {
-  const { activeDashboard } = useDashboard();
+  const { activeDashboard, addToast } = useDashboard();
   const { showConfirm } = useDialog();
 
   const [globalConfig, setGlobalConfig] = useState<StarterPackGlobalConfig>({});
   const [packs, setPacks] = useState<StarterPack[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState<{
-    text: string;
-    type: 'success' | 'error';
-  } | null>(null);
 
   // View: 'list' shows all packs, 'editor' shows the pack form
   const [view, setView] = useState<'list' | 'editor'>('list');
@@ -300,8 +295,7 @@ export const StarterPackConfigurationModal: React.FC<
   );
 
   const showMessage = (type: 'success' | 'error', text: string) => {
-    setMessage({ type, text });
-    setTimeout(() => setMessage(null), 3000);
+    addToast(text, type);
   };
 
   useEffect(() => {
@@ -611,643 +605,629 @@ export const StarterPackConfigurationModal: React.FC<
     ) : undefined;
 
   return (
-    <>
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-        maxWidth="max-w-5xl"
-        customHeader={header}
-        footer={footer}
-        className="!p-0 !bg-slate-50"
-        contentClassName="bg-slate-50"
-        footerClassName="px-6 py-4 border-t border-slate-100 bg-white flex items-center justify-between w-full shrink-0"
-      >
-        {view === 'list' ? (
-          /* ── Pack List ── */
-          <div className="p-6 space-y-6">
-            {onSave && (
-              <div className="bg-white p-4 rounded-xl border border-slate-200 space-y-4 mb-2">
-                <DockDefaultsPanel
-                  config={{ dockDefaults: globalConfig.dockDefaults ?? {} }}
-                  onChange={(d) =>
-                    setGlobalConfig((prev) => ({ ...prev, dockDefaults: d }))
-                  }
-                />
-                <div className="flex justify-end border-t border-slate-50 pt-3">
-                  <button
-                    onClick={() => {
-                      onSave({
-                        config: globalConfig as unknown as Record<
-                          string,
-                          unknown
-                        >,
-                      });
-                      showMessage('success', 'Dock defaults saved');
-                    }}
-                    className="flex items-center gap-2 px-4 py-1.5 bg-indigo-600 text-white rounded-xl text-xs font-bold hover:bg-indigo-700 transition-colors shadow-sm"
-                  >
-                    <Save className="w-3.5 h-3.5" />
-                    Save Dock Defaults
-                  </button>
-                </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-5xl"
+      customHeader={header}
+      footer={footer}
+      className="!p-0 !bg-slate-50"
+      contentClassName="bg-slate-50"
+      footerClassName="px-6 py-4 border-t border-slate-100 bg-white flex items-center justify-between w-full shrink-0"
+    >
+      {view === 'list' ? (
+        /* ── Pack List ── */
+        <div className="p-6 space-y-6">
+          {onSave && (
+            <div className="bg-white p-4 rounded-xl border border-slate-200 space-y-4 mb-2">
+              <DockDefaultsPanel
+                config={{ dockDefaults: globalConfig.dockDefaults ?? {} }}
+                onChange={(d) =>
+                  setGlobalConfig((prev) => ({ ...prev, dockDefaults: d }))
+                }
+              />
+              <div className="flex justify-end border-t border-slate-50 pt-3">
+                <button
+                  onClick={() => {
+                    onSave({
+                      config: globalConfig as unknown as Record<
+                        string,
+                        unknown
+                      >,
+                    });
+                    showMessage('success', 'Dock defaults saved');
+                  }}
+                  className="flex items-center gap-2 px-4 py-1.5 bg-indigo-600 text-white rounded-xl text-xs font-bold hover:bg-indigo-700 transition-colors shadow-sm"
+                >
+                  <Save className="w-3.5 h-3.5" />
+                  Save Dock Defaults
+                </button>
               </div>
-            )}
+            </div>
+          )}
 
-            <div className="flex items-center justify-between">
-              <p className="text-sm text-slate-600">
-                {loading
-                  ? 'Loading...'
-                  : `${packs.length} pack${packs.length === 1 ? '' : 's'} available building-wide`}
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-slate-600">
+              {loading
+                ? 'Loading...'
+                : `${packs.length} pack${packs.length === 1 ? '' : 's'} available building-wide`}
+            </p>
+            <button
+              onClick={handleNewPack}
+              className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              New Pack
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-12 text-slate-400">
+              <Loader2 className="w-6 h-6 animate-spin mr-2" />
+              Loading packs...
+            </div>
+          ) : packs.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-slate-400 text-center gap-3">
+              <Wand2 className="w-10 h-10 opacity-40" />
+              <p className="font-medium">No building-wide packs yet.</p>
+              <p className="text-sm">
+                Create one to give teachers instant workspace setups.
               </p>
               <button
                 onClick={handleNewPack}
-                className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors"
+                className="mt-2 flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors"
               >
                 <Plus className="w-4 h-4" />
-                New Pack
+                Create First Pack
+              </button>
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {packs.map((pack) => {
+                const PackIcon =
+                  (LucideIcons as unknown as Record<string, LucideIcon>)[
+                    pack.icon
+                  ] ?? LucideIcons.Wand2;
+                return (
+                  <div
+                    key={pack.id}
+                    className="bg-white border border-slate-200 rounded-2xl p-4 flex items-center gap-4 hover:border-indigo-200 transition-colors"
+                  >
+                    <div
+                      className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
+                      style={{
+                        backgroundColor: COLOR_MAP[pack.color] + '20',
+                        color: COLOR_MAP[pack.color],
+                      }}
+                    >
+                      <PackIcon className="w-6 h-6" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h4 className="font-bold text-slate-800">
+                          {pack.name}
+                        </h4>
+                        {pack.isLocked && (
+                          <span className="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded-full border border-slate-200 font-medium">
+                            Locked
+                          </span>
+                        )}
+                      </div>
+                      {pack.description && (
+                        <p className="text-sm text-slate-500 truncate">
+                          {pack.description}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                        <span className="text-xs text-slate-400 flex items-center gap-1">
+                          <LayoutGrid className="w-3 h-3" />
+                          {pack.widgets.length} widget
+                          {pack.widgets.length === 1 ? '' : 's'}
+                        </span>
+                        {pack.gradeLevels.map((level) => (
+                          <span
+                            key={level}
+                            className="text-xs bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded-full border border-indigo-100 font-medium"
+                          >
+                            {level.toUpperCase()}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => handleEdit(pack)}
+                        className="p-2 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+                        title="Edit pack"
+                      >
+                        <Edit2 className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => void handleDelete(pack.id)}
+                        className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
+                        title="Delete pack"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : (
+        /* ── Pack Editor ── */
+        <div className="p-6 space-y-6">
+          {/* Metadata */}
+          <section className="bg-white rounded-2xl border border-slate-200 p-5 space-y-4">
+            <h3 className="font-bold text-slate-700 text-sm uppercase tracking-wider">
+              Pack Details
+            </h3>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="col-span-2 sm:col-span-1">
+                <label className="text-sm font-semibold text-slate-600 block mb-1.5">
+                  Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) =>
+                    setFormData((p) => ({ ...p, name: e.target.value }))
+                  }
+                  placeholder="e.g. Reading Workshop"
+                  className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
+                />
+              </div>
+
+              <div className="col-span-2 sm:col-span-1">
+                <label className="text-sm font-semibold text-slate-600 block mb-1.5">
+                  Description
+                </label>
+                <input
+                  type="text"
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData((p) => ({
+                      ...p,
+                      description: e.target.value,
+                    }))
+                  }
+                  placeholder="Brief description of the pack"
+                  className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
+                />
+              </div>
+            </div>
+
+            {/* Icon & Color */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {/* Icon Selection */}
+              <div>
+                <label className="text-sm font-semibold text-slate-600 block mb-2">
+                  Icon
+                </label>
+                <div className="relative">
+                  <button
+                    type="button"
+                    onClick={() => setShowIconPicker(!showIconPicker)}
+                    className="flex items-center gap-3 px-3 py-2 border-2 border-slate-200 rounded-xl hover:border-indigo-500 transition-colors bg-white w-full sm:w-auto"
+                  >
+                    <div
+                      className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0 shadow-sm"
+                      style={{
+                        backgroundColor: COLOR_MAP[formData.color] + '20', // 12.5% opacity
+                        color: COLOR_MAP[formData.color],
+                      }}
+                    >
+                      <PreviewIcon className="w-6 h-6" />
+                    </div>
+                    <span className="text-sm font-medium text-slate-700">
+                      {formData.icon}
+                    </span>
+                    <ChevronDown className="w-4 h-4 text-slate-400 ml-auto" />
+                  </button>
+
+                  {showIconPicker && (
+                    <div className="absolute top-full left-0 mt-2 p-3 bg-white rounded-2xl shadow-xl border border-slate-200 z-popover w-full sm:w-[320px]">
+                      <div className="grid grid-cols-6 gap-2 max-h-[240px] overflow-y-auto p-1 custom-scrollbar">
+                        {ICON_OPTIONS.map((name) => {
+                          const IconComp = (
+                            LucideIcons as unknown as Record<string, LucideIcon>
+                          )[name];
+                          if (!IconComp) return null;
+                          return (
+                            <button
+                              key={name}
+                              type="button"
+                              onClick={() => {
+                                setFormData((p) => ({ ...p, icon: name }));
+                                setShowIconPicker(false);
+                              }}
+                              className={`p-2 rounded-lg flex items-center justify-center transition-colors ${
+                                formData.icon === name
+                                  ? 'bg-indigo-100 text-indigo-600'
+                                  : 'text-slate-500 hover:bg-slate-100'
+                              }`}
+                              title={name}
+                            >
+                              <IconComp className="w-5 h-5" />
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Color Selection */}
+              <div>
+                <label className="text-sm font-semibold text-slate-600 block mb-2">
+                  Brand Color
+                </label>
+                <div className="grid grid-cols-11 gap-1.5 p-1 bg-slate-50 rounded-xl border border-slate-200">
+                  {COLOR_OPTIONS.map(({ value, label }) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() =>
+                        setFormData((p) => ({ ...p, color: value }))
+                      }
+                      className={`w-6 h-6 rounded-full border-2 transition-all flex items-center justify-center ${
+                        formData.color === value
+                          ? 'border-slate-800 scale-110 shadow-sm'
+                          : 'border-transparent hover:scale-110'
+                      }`}
+                      style={{
+                        backgroundColor: COLOR_MAP[value],
+                      }}
+                      title={label}
+                    >
+                      {formData.color === value && (
+                        <div className="w-1.5 h-1.5 bg-white rounded-full" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* Grade Levels */}
+            <div>
+              <label className="text-sm font-semibold text-slate-600 block mb-2">
+                Grade Levels
+              </label>
+              <div className="flex gap-2 flex-wrap">
+                {ALL_GRADE_LEVELS.map((level) => {
+                  const selected = formData.gradeLevels.includes(level);
+                  return (
+                    <button
+                      key={level}
+                      onClick={() => {
+                        const current = formData.gradeLevels;
+                        setFormData((p) => ({
+                          ...p,
+                          gradeLevels: selected
+                            ? current.filter((l) => l !== level)
+                            : [...current, level],
+                        }));
+                      }}
+                      className={`px-3 py-1 text-xs font-bold rounded-full border-2 transition-all ${
+                        selected
+                          ? 'bg-brand-blue-primary text-white border-brand-blue-primary'
+                          : 'bg-white text-slate-500 border-slate-200 hover:border-slate-400'
+                      }`}
+                    >
+                      {level.toUpperCase()}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Locked toggle */}
+            <div className="flex items-center justify-between pt-1">
+              <div>
+                <p className="text-sm font-semibold text-slate-700">
+                  Lock Pack
+                </p>
+                <p className="text-xs text-slate-500">
+                  Locked packs cannot be edited or deleted by teachers
+                </p>
+              </div>
+              <button
+                onClick={() =>
+                  setFormData((p) => ({ ...p, isLocked: !p.isLocked }))
+                }
+                className={`relative w-11 h-6 rounded-full transition-colors ${
+                  formData.isLocked ? 'bg-brand-blue-primary' : 'bg-slate-200'
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
+                    formData.isLocked ? 'translate-x-5' : 'translate-x-0'
+                  }`}
+                />
+              </button>
+            </div>
+          </section>
+
+          {/* Widget Layout */}
+          <section className="bg-white rounded-2xl border border-slate-200 p-5 space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-bold text-slate-700 text-sm uppercase tracking-wider">
+                  Widget Layout
+                </h3>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  {formData.widgets.length} widget
+                  {formData.widgets.length === 1 ? '' : 's'} in this pack
+                </p>
+              </div>
+              <button
+                onClick={handleCaptureBoard}
+                className="flex items-center gap-2 px-3 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-bold rounded-xl transition-colors"
+                title="Capture all widgets from your current board (positions and sizes included)"
+              >
+                <Camera className="w-4 h-4" />
+                Capture Current Board
               </button>
             </div>
 
-            {loading ? (
-              <div className="flex items-center justify-center py-12 text-slate-400">
-                <Loader2 className="w-6 h-6 animate-spin mr-2" />
-                Loading packs...
-              </div>
-            ) : packs.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-16 text-slate-400 text-center gap-3">
-                <Wand2 className="w-10 h-10 opacity-40" />
-                <p className="font-medium">No building-wide packs yet.</p>
-                <p className="text-sm">
-                  Create one to give teachers instant workspace setups.
-                </p>
-                <button
-                  onClick={handleNewPack}
-                  className="mt-2 flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors"
-                >
-                  <Plus className="w-4 h-4" />
-                  Create First Pack
-                </button>
-              </div>
-            ) : (
-              <div className="grid gap-3">
-                {packs.map((pack) => {
-                  const PackIcon =
-                    (LucideIcons as unknown as Record<string, LucideIcon>)[
-                      pack.icon
-                    ] ?? LucideIcons.Wand2;
+            {/* Existing widgets */}
+            {formData.widgets.length > 0 ? (
+              <div className="space-y-2">
+                {formData.widgets.map((widget, index) => {
+                  const toolMeta = TOOLS.find((t) => t.type === widget.type);
+                  const WidgetIcon = toolMeta?.icon ?? Package;
+                  const isSnapOpen = snappingWidgetIndex === index;
                   return (
                     <div
-                      key={pack.id}
-                      className="bg-white border border-slate-200 rounded-2xl p-4 flex items-center gap-4 hover:border-indigo-200 transition-colors"
+                      key={index}
+                      className="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden"
                     >
-                      <div
-                        className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0"
-                        style={{
-                          backgroundColor: COLOR_MAP[pack.color] + '20',
-                          color: COLOR_MAP[pack.color],
-                        }}
-                      >
-                        <PackIcon className="w-6 h-6" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 flex-wrap">
-                          <h4 className="font-bold text-slate-800">
-                            {pack.name}
-                          </h4>
-                          {pack.isLocked && (
-                            <span className="text-xs bg-slate-100 text-slate-500 px-2 py-0.5 rounded-full border border-slate-200 font-medium">
-                              Locked
-                            </span>
+                      <div className="flex items-center gap-3 p-3">
+                        <div
+                          className={`w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 ${toolMeta?.color ?? 'bg-slate-400'}`}
+                        >
+                          <WidgetIcon className="w-4 h-4" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-slate-700 truncate">
+                            {toolMeta?.label ?? widget.type}
+                          </p>
+                          {showWidgetManualPositioning[index] && (
+                            <div className="flex gap-3 mt-1 flex-wrap animate-in fade-in slide-in-from-top-1 duration-200">
+                              {(
+                                [
+                                  ['x', 'X'],
+                                  ['y', 'Y'],
+                                  ['w', 'W'],
+                                  ['h', 'H'],
+                                ] as [
+                                  keyof typeof widget & ('x' | 'y' | 'w' | 'h'),
+                                  string,
+                                ][]
+                              ).map(([field, label]) => (
+                                <label
+                                  key={field}
+                                  className="flex items-center gap-1 text-xs text-slate-500"
+                                >
+                                  <span className="font-bold text-slate-400 uppercase">
+                                    {label}
+                                  </span>
+                                  <input
+                                    type="number"
+                                    value={widget[field]}
+                                    onChange={(e) => {
+                                      const next =
+                                        e.currentTarget.valueAsNumber;
+                                      if (!Number.isFinite(next)) return;
+                                      handleUpdateWidget(index, field, next);
+                                      setWidgetSnapKeys((prev) => {
+                                        if (!prev[index]) return prev;
+                                        const { [index]: _, ...rest } = prev;
+                                        return rest;
+                                      });
+                                    }}
+                                    className="w-16 px-1.5 py-0.5 border border-slate-200 rounded-md text-xs text-center focus:border-indigo-400 focus:outline-none"
+                                  />
+                                </label>
+                              ))}
+                            </div>
                           )}
                         </div>
-                        {pack.description && (
-                          <p className="text-sm text-slate-500 truncate">
-                            {pack.description}
-                          </p>
-                        )}
-                        <div className="flex items-center gap-2 mt-1.5 flex-wrap">
-                          <span className="text-xs text-slate-400 flex items-center gap-1">
-                            <LayoutGrid className="w-3 h-3" />
-                            {pack.widgets.length} widget
-                            {pack.widgets.length === 1 ? '' : 's'}
-                          </span>
-                          {pack.gradeLevels.map((level) => (
-                            <span
-                              key={level}
-                              className="text-xs bg-indigo-50 text-indigo-600 px-2 py-0.5 rounded-full border border-indigo-100 font-medium"
-                            >
-                              {level.toUpperCase()}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1 shrink-0">
                         <button
-                          onClick={() => handleEdit(pack)}
-                          className="p-2 text-slate-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
-                          title="Edit pack"
+                          onClick={() =>
+                            setShowWidgetManualPositioning((prev) => ({
+                              ...prev,
+                              [index]: !prev[index],
+                            }))
+                          }
+                          className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                            showWidgetManualPositioning[index]
+                              ? 'bg-slate-200 text-slate-700'
+                              : 'text-slate-400 hover:text-slate-600 hover:bg-slate-100'
+                          }`}
+                          title="Toggle manual coordinates"
                         >
                           <Edit2 className="w-4 h-4" />
                         </button>
                         <button
-                          onClick={() => void handleDelete(pack.id)}
-                          className="p-2 text-slate-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                          title="Delete pack"
+                          onClick={() =>
+                            setSnappingWidgetIndex(isSnapOpen ? null : index)
+                          }
+                          className={`p-1.5 rounded-lg transition-colors shrink-0 ${
+                            isSnapOpen
+                              ? 'bg-indigo-100 text-indigo-600'
+                              : 'text-slate-400 hover:text-indigo-600 hover:bg-indigo-50'
+                          }`}
+                          title="Snap to layout position"
+                          aria-label="Snap to layout position"
+                          aria-expanded={isSnapOpen}
+                        >
+                          <LayoutTemplate className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => handleRemoveWidget(index)}
+                          className="p-1.5 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors shrink-0"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
+                      {isSnapOpen && (
+                        <div className="px-3 pb-3 border-t border-slate-200">
+                          <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mt-2 mb-1.5">
+                            Snap to Layout Position
+                          </p>
+                          <SnapZonePicker
+                            selectedKey={widgetSnapKeys[index] ?? null}
+                            onSelect={(key, bounds) => {
+                              setFormData((prev) => ({
+                                ...prev,
+                                widgets: prev.widgets.map((w, i) =>
+                                  i === index ? { ...w, ...bounds } : w
+                                ),
+                              }));
+                              setWidgetSnapKeys((prev) => ({
+                                ...prev,
+                                [index]: key,
+                              }));
+                            }}
+                          />
+                        </div>
+                      )}
                     </div>
                   );
                 })}
               </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-8 text-slate-400 text-center gap-2 bg-slate-50 rounded-xl border-2 border-dashed border-slate-200">
+                <LayoutGrid className="w-8 h-8 opacity-40" />
+                <p className="text-sm font-medium">No widgets yet</p>
+                <p className="text-xs">
+                  Capture your current board or add widgets individually below
+                </p>
+              </div>
             )}
-          </div>
-        ) : (
-          /* ── Pack Editor ── */
-          <div className="p-6 space-y-6">
-            {/* Metadata */}
-            <section className="bg-white rounded-2xl border border-slate-200 p-5 space-y-4">
-              <h3 className="font-bold text-slate-700 text-sm uppercase tracking-wider">
-                Pack Details
-              </h3>
 
-              <div className="grid grid-cols-2 gap-4">
-                <div className="col-span-2 sm:col-span-1">
-                  <label className="text-sm font-semibold text-slate-600 block mb-1.5">
-                    Name <span className="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData((p) => ({ ...p, name: e.target.value }))
-                    }
-                    placeholder="e.g. Reading Workshop"
-                    className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
-                  />
-                </div>
-
-                <div className="col-span-2 sm:col-span-1">
-                  <label className="text-sm font-semibold text-slate-600 block mb-1.5">
-                    Description
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.description}
-                    onChange={(e) =>
-                      setFormData((p) => ({
-                        ...p,
-                        description: e.target.value,
-                      }))
-                    }
-                    placeholder="Brief description of the pack"
-                    className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
-                  />
-                </div>
-              </div>
-
-              {/* Icon & Color */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-                {/* Icon Selection */}
-                <div>
-                  <label className="text-sm font-semibold text-slate-600 block mb-2">
-                    Icon
-                  </label>
-                  <div className="relative">
-                    <button
-                      type="button"
-                      onClick={() => setShowIconPicker(!showIconPicker)}
-                      className="flex items-center gap-3 px-3 py-2 border-2 border-slate-200 rounded-xl hover:border-indigo-500 transition-colors bg-white w-full sm:w-auto"
-                    >
-                      <div
-                        className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0 shadow-sm"
-                        style={{
-                          backgroundColor: COLOR_MAP[formData.color] + '20', // 12.5% opacity
-                          color: COLOR_MAP[formData.color],
-                        }}
-                      >
-                        <PreviewIcon className="w-6 h-6" />
-                      </div>
-                      <span className="text-sm font-medium text-slate-700">
-                        {formData.icon}
-                      </span>
-                      <ChevronDown className="w-4 h-4 text-slate-400 ml-auto" />
-                    </button>
-
-                    {showIconPicker && (
-                      <div className="absolute top-full left-0 mt-2 p-3 bg-white rounded-2xl shadow-xl border border-slate-200 z-popover w-full sm:w-[320px]">
-                        <div className="grid grid-cols-6 gap-2 max-h-[240px] overflow-y-auto p-1 custom-scrollbar">
-                          {ICON_OPTIONS.map((name) => {
-                            const IconComp = (
-                              LucideIcons as unknown as Record<
-                                string,
-                                LucideIcon
-                              >
-                            )[name];
-                            if (!IconComp) return null;
-                            return (
-                              <button
-                                key={name}
-                                type="button"
-                                onClick={() => {
-                                  setFormData((p) => ({ ...p, icon: name }));
-                                  setShowIconPicker(false);
-                                }}
-                                className={`p-2 rounded-lg flex items-center justify-center transition-colors ${
-                                  formData.icon === name
-                                    ? 'bg-indigo-100 text-indigo-600'
-                                    : 'text-slate-500 hover:bg-slate-100'
-                                }`}
-                                title={name}
-                              >
-                                <IconComp className="w-5 h-5" />
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Color Selection */}
-                <div>
-                  <label className="text-sm font-semibold text-slate-600 block mb-2">
-                    Brand Color
-                  </label>
-                  <div className="grid grid-cols-11 gap-1.5 p-1 bg-slate-50 rounded-xl border border-slate-200">
-                    {COLOR_OPTIONS.map(({ value, label }) => (
-                      <button
-                        key={value}
-                        type="button"
-                        onClick={() =>
-                          setFormData((p) => ({ ...p, color: value }))
-                        }
-                        className={`w-6 h-6 rounded-full border-2 transition-all flex items-center justify-center ${
-                          formData.color === value
-                            ? 'border-slate-800 scale-110 shadow-sm'
-                            : 'border-transparent hover:scale-110'
-                        }`}
-                        style={{
-                          backgroundColor: COLOR_MAP[value],
-                        }}
-                        title={label}
-                      >
-                        {formData.color === value && (
-                          <div className="w-1.5 h-1.5 bg-white rounded-full" />
-                        )}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-
-              {/* Grade Levels */}
-              <div>
-                <label className="text-sm font-semibold text-slate-600 block mb-2">
-                  Grade Levels
-                </label>
-                <div className="flex gap-2 flex-wrap">
-                  {ALL_GRADE_LEVELS.map((level) => {
-                    const selected = formData.gradeLevels.includes(level);
-                    return (
-                      <button
-                        key={level}
-                        onClick={() => {
-                          const current = formData.gradeLevels;
-                          setFormData((p) => ({
-                            ...p,
-                            gradeLevels: selected
-                              ? current.filter((l) => l !== level)
-                              : [...current, level],
-                          }));
-                        }}
-                        className={`px-3 py-1 text-xs font-bold rounded-full border-2 transition-all ${
-                          selected
-                            ? 'bg-brand-blue-primary text-white border-brand-blue-primary'
-                            : 'bg-white text-slate-500 border-slate-200 hover:border-slate-400'
-                        }`}
-                      >
-                        {level.toUpperCase()}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Locked toggle */}
-              <div className="flex items-center justify-between pt-1">
-                <div>
-                  <p className="text-sm font-semibold text-slate-700">
-                    Lock Pack
-                  </p>
-                  <p className="text-xs text-slate-500">
-                    Locked packs cannot be edited or deleted by teachers
-                  </p>
-                </div>
+            {/* Add individual widget */}
+            <div className="border-t border-slate-100 pt-4">
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                  Add New Widget
+                </p>
                 <button
+                  type="button"
                   onClick={() =>
-                    setFormData((p) => ({ ...p, isLocked: !p.isLocked }))
+                    setShowManualPositioning(!showManualPositioning)
                   }
-                  className={`relative w-11 h-6 rounded-full transition-colors ${
-                    formData.isLocked ? 'bg-brand-blue-primary' : 'bg-slate-200'
+                  className={`text-xxs font-black uppercase tracking-widest px-2 py-1 rounded-md transition-colors ${
+                    showManualPositioning
+                      ? 'bg-slate-200 text-slate-600'
+                      : 'bg-slate-100 text-slate-400 hover:text-slate-600'
                   }`}
                 >
-                  <span
-                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${
-                      formData.isLocked ? 'translate-x-5' : 'translate-x-0'
-                    }`}
-                  />
-                </button>
-              </div>
-            </section>
-
-            {/* Widget Layout */}
-            <section className="bg-white rounded-2xl border border-slate-200 p-5 space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="font-bold text-slate-700 text-sm uppercase tracking-wider">
-                    Widget Layout
-                  </h3>
-                  <p className="text-xs text-slate-500 mt-0.5">
-                    {formData.widgets.length} widget
-                    {formData.widgets.length === 1 ? '' : 's'} in this pack
-                  </p>
-                </div>
-                <button
-                  onClick={handleCaptureBoard}
-                  className="flex items-center gap-2 px-3 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-bold rounded-xl transition-colors"
-                  title="Capture all widgets from your current board (positions and sizes included)"
-                >
-                  <Camera className="w-4 h-4" />
-                  Capture Current Board
+                  {showManualPositioning ? 'Hide Manual' : 'Show Manual'}
                 </button>
               </div>
 
-              {/* Existing widgets */}
-              {formData.widgets.length > 0 ? (
-                <div className="space-y-2">
-                  {formData.widgets.map((widget, index) => {
-                    const toolMeta = TOOLS.find((t) => t.type === widget.type);
-                    const WidgetIcon = toolMeta?.icon ?? Package;
-                    const isSnapOpen = snappingWidgetIndex === index;
-                    return (
-                      <div
-                        key={index}
-                        className="bg-slate-50 rounded-xl border border-slate-200 overflow-hidden"
-                      >
-                        <div className="flex items-center gap-3 p-3">
-                          <div
-                            className={`w-8 h-8 rounded-lg flex items-center justify-center text-white shrink-0 ${toolMeta?.color ?? 'bg-slate-400'}`}
-                          >
-                            <WidgetIcon className="w-4 h-4" />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-semibold text-slate-700 truncate">
-                              {toolMeta?.label ?? widget.type}
-                            </p>
-                            {showWidgetManualPositioning[index] && (
-                              <div className="flex gap-3 mt-1 flex-wrap animate-in fade-in slide-in-from-top-1 duration-200">
-                                {(
-                                  [
-                                    ['x', 'X'],
-                                    ['y', 'Y'],
-                                    ['w', 'W'],
-                                    ['h', 'H'],
-                                  ] as [
-                                    keyof typeof widget &
-                                      ('x' | 'y' | 'w' | 'h'),
-                                    string,
-                                  ][]
-                                ).map(([field, label]) => (
-                                  <label
-                                    key={field}
-                                    className="flex items-center gap-1 text-xs text-slate-500"
-                                  >
-                                    <span className="font-bold text-slate-400 uppercase">
-                                      {label}
-                                    </span>
-                                    <input
-                                      type="number"
-                                      value={widget[field]}
-                                      onChange={(e) => {
-                                        const next =
-                                          e.currentTarget.valueAsNumber;
-                                        if (!Number.isFinite(next)) return;
-                                        handleUpdateWidget(index, field, next);
-                                        setWidgetSnapKeys((prev) => {
-                                          if (!prev[index]) return prev;
-                                          const { [index]: _, ...rest } = prev;
-                                          return rest;
-                                        });
-                                      }}
-                                      className="w-16 px-1.5 py-0.5 border border-slate-200 rounded-md text-xs text-center focus:border-indigo-400 focus:outline-none"
-                                    />
-                                  </label>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                          <button
-                            onClick={() =>
-                              setShowWidgetManualPositioning((prev) => ({
-                                ...prev,
-                                [index]: !prev[index],
-                              }))
-                            }
-                            className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                              showWidgetManualPositioning[index]
-                                ? 'bg-slate-200 text-slate-700'
-                                : 'text-slate-400 hover:text-slate-600 hover:bg-slate-100'
-                            }`}
-                            title="Toggle manual coordinates"
-                          >
-                            <Edit2 className="w-4 h-4" />
-                          </button>
-                          <button
-                            onClick={() =>
-                              setSnappingWidgetIndex(isSnapOpen ? null : index)
-                            }
-                            className={`p-1.5 rounded-lg transition-colors shrink-0 ${
-                              isSnapOpen
-                                ? 'bg-indigo-100 text-indigo-600'
-                                : 'text-slate-400 hover:text-indigo-600 hover:bg-indigo-50'
-                            }`}
-                            title="Snap to layout position"
-                            aria-label="Snap to layout position"
-                            aria-expanded={isSnapOpen}
-                          >
-                            <LayoutTemplate className="w-4 h-4" />
-                          </button>
-                          <button
-                            onClick={() => handleRemoveWidget(index)}
-                            className="p-1.5 text-slate-300 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors shrink-0"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </div>
-                        {isSnapOpen && (
-                          <div className="px-3 pb-3 border-t border-slate-200">
-                            <p className="text-xs font-bold text-slate-500 uppercase tracking-wider mt-2 mb-1.5">
-                              Snap to Layout Position
-                            </p>
-                            <SnapZonePicker
-                              selectedKey={widgetSnapKeys[index] ?? null}
-                              onSelect={(key, bounds) => {
-                                setFormData((prev) => ({
-                                  ...prev,
-                                  widgets: prev.widgets.map((w, i) =>
-                                    i === index ? { ...w, ...bounds } : w
-                                  ),
-                                }));
-                                setWidgetSnapKeys((prev) => ({
-                                  ...prev,
-                                  [index]: key,
-                                }));
-                              }}
-                            />
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="flex flex-col items-center justify-center py-8 text-slate-400 text-center gap-2 bg-slate-50 rounded-xl border-2 border-dashed border-slate-200">
-                  <LayoutGrid className="w-8 h-8 opacity-40" />
-                  <p className="text-sm font-medium">No widgets yet</p>
-                  <p className="text-xs">
-                    Capture your current board or add widgets individually below
-                  </p>
-                </div>
-              )}
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-end">
+                  <div>
+                    <label className="text-xs font-semibold text-slate-600 block mb-1">
+                      Widget Type
+                    </label>
+                    <select
+                      value={newWidgetType}
+                      onChange={(e) =>
+                        handleWidgetTypeChange(e.target.value as WidgetType)
+                      }
+                      className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
+                    >
+                      {ADDABLE_TOOLS.map((t) => (
+                        <option key={t.type} value={t.type}>
+                          {t.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
 
-              {/* Add individual widget */}
-              <div className="border-t border-slate-100 pt-4">
-                <div className="flex items-center justify-between mb-4">
-                  <p className="text-xs font-bold text-slate-500 uppercase tracking-wider">
-                    Add New Widget
-                  </p>
                   <button
-                    type="button"
-                    onClick={() =>
-                      setShowManualPositioning(!showManualPositioning)
-                    }
-                    className={`text-xxs font-black uppercase tracking-widest px-2 py-1 rounded-md transition-colors ${
-                      showManualPositioning
-                        ? 'bg-slate-200 text-slate-600'
-                        : 'bg-slate-100 text-slate-400 hover:text-slate-600'
-                    }`}
+                    onClick={handleAddWidget}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors h-[42px]"
                   >
-                    {showManualPositioning ? 'Hide Manual' : 'Show Manual'}
+                    <Plus className="w-4 h-4" />
+                    Add to Pack
                   </button>
                 </div>
 
-                <div className="space-y-4">
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-end">
-                    <div>
-                      <label className="text-xs font-semibold text-slate-600 block mb-1">
-                        Widget Type
-                      </label>
-                      <select
-                        value={newWidgetType}
-                        onChange={(e) =>
-                          handleWidgetTypeChange(e.target.value as WidgetType)
-                        }
-                        className="w-full px-3 py-2 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
-                      >
-                        {ADDABLE_TOOLS.map((t) => (
-                          <option key={t.type} value={t.type}>
-                            {t.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-
-                    <button
-                      onClick={handleAddWidget}
-                      className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-xl transition-colors h-[42px]"
-                    >
-                      <Plus className="w-4 h-4" />
-                      Add to Pack
-                    </button>
+                {showManualPositioning && (
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 animate-in fade-in slide-in-from-top-1 duration-200">
+                    {(
+                      [
+                        ['X', newWidgetX, setNewWidgetX],
+                        ['Y', newWidgetY, setNewWidgetY],
+                        ['W', newWidgetW, setNewWidgetW],
+                        ['H', newWidgetH, setNewWidgetH],
+                      ] as [
+                        string,
+                        number,
+                        React.Dispatch<React.SetStateAction<number>>,
+                      ][]
+                    ).map(([label, val, setter]) => (
+                      <div key={label}>
+                        <label className="text-xxs font-bold text-slate-400 uppercase tracking-wider block mb-1">
+                          {label === 'X' || label === 'Y'
+                            ? `${label} Position`
+                            : label === 'W'
+                              ? 'Width'
+                              : 'Height'}
+                        </label>
+                        <input
+                          type="number"
+                          value={val}
+                          onChange={(e) => {
+                            const next = e.currentTarget.valueAsNumber;
+                            if (!Number.isFinite(next)) return;
+                            setter(next);
+                            setNewWidgetSnapKey(null);
+                          }}
+                          className="w-full px-3 py-1.5 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
+                        />
+                      </div>
+                    ))}
                   </div>
+                )}
 
-                  {showManualPositioning && (
-                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 animate-in fade-in slide-in-from-top-1 duration-200">
-                      {(
-                        [
-                          ['X', newWidgetX, setNewWidgetX],
-                          ['Y', newWidgetY, setNewWidgetY],
-                          ['W', newWidgetW, setNewWidgetW],
-                          ['H', newWidgetH, setNewWidgetH],
-                        ] as [
-                          string,
-                          number,
-                          React.Dispatch<React.SetStateAction<number>>,
-                        ][]
-                      ).map(([label, val, setter]) => (
-                        <div key={label}>
-                          <label className="text-xxs font-bold text-slate-400 uppercase tracking-wider block mb-1">
-                            {label === 'X' || label === 'Y'
-                              ? `${label} Position`
-                              : label === 'W'
-                                ? 'Width'
-                                : 'Height'}
-                          </label>
-                          <input
-                            type="number"
-                            value={val}
-                            onChange={(e) => {
-                              const next = e.currentTarget.valueAsNumber;
-                              if (!Number.isFinite(next)) return;
-                              setter(next);
-                              setNewWidgetSnapKey(null);
-                            }}
-                            className="w-full px-3 py-1.5 border-2 border-slate-200 rounded-xl focus:border-indigo-500 focus:outline-none transition-colors text-sm"
-                          />
-                        </div>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Snap to Layout Position picker - Always open for new widgets as it is priority */}
-                  <div className="bg-white rounded-2xl border border-slate-200 p-4 shadow-sm">
-                    <div className="flex items-center gap-1.5 text-xs font-bold text-slate-700 uppercase tracking-widest mb-3">
-                      <LayoutTemplate className="w-3.5 h-3.5" />
-                      Snap to Layout Position
-                      {newWidgetSnapKey && (
-                        <span className="ml-1 normal-case font-normal text-indigo-500 tracking-normal">
-                          — position selected
-                        </span>
-                      )}
-                    </div>
-                    <SnapZonePicker
-                      selectedKey={newWidgetSnapKey}
-                      onSelect={(key, bounds) => {
-                        setNewWidgetX(bounds.x);
-                        setNewWidgetY(bounds.y);
-                        setNewWidgetW(bounds.w);
-                        setNewWidgetH(bounds.h);
-                        setNewWidgetSnapKey(key);
-                      }}
-                    />
+                {/* Snap to Layout Position picker - Always open for new widgets as it is priority */}
+                <div className="bg-white rounded-2xl border border-slate-200 p-4 shadow-sm">
+                  <div className="flex items-center gap-1.5 text-xs font-bold text-slate-700 uppercase tracking-widest mb-3">
+                    <LayoutTemplate className="w-3.5 h-3.5" />
+                    Snap to Layout Position
+                    {newWidgetSnapKey && (
+                      <span className="ml-1 normal-case font-normal text-indigo-500 tracking-normal">
+                        — position selected
+                      </span>
+                    )}
                   </div>
+                  <SnapZonePicker
+                    selectedKey={newWidgetSnapKey}
+                    onSelect={(key, bounds) => {
+                      setNewWidgetX(bounds.x);
+                      setNewWidgetY(bounds.y);
+                      setNewWidgetW(bounds.w);
+                      setNewWidgetH(bounds.h);
+                      setNewWidgetSnapKey(key);
+                    }}
+                  />
                 </div>
               </div>
-            </section>
-          </div>
-        )}
-      </Modal>
-
-      {message && (
-        <Toast
-          message={message.text}
-          type={message.type}
-          onClose={() => setMessage(null)}
-        />
+            </div>
+          </section>
+        </div>
       )}
-    </>
+    </Modal>
   );
 };


### PR DESCRIPTION
## Summary

Nightly unifier routine (run 46), dimension D5 — Toast Architecture in Admin Components.

**Canonical form:** `addToast(message, type)` via `useDashboard()` — the centralized toast queue rendered by DashboardView's `ToastContainer`. A local `useState` + `<Toast />` rendered as a JSX sibling *outside* the modal (imitating a global overlay) is the anti-pattern this dimension unifies, per `docs/routines/unifier.md`.

## Instance unified

`components/admin/StarterPackConfigurationModal.tsx`:
- Removed local `message` `useState` and the `<Toast>` import.
- `showMessage(type, text)` now calls `addToast(text, type)` (added `addToast` to the existing `useDashboard()` destructure — `activeDashboard` was already pulled from the same hook, confirming `DashboardProvider` is reachable in this component's render tree; it's mounted from `FeaturePermissionsManager.tsx`, same as the two prior fixes of this exact shape).
- Removed the now-unneeded `<>...</>` Fragment wrapper (the `<Toast>` sibling that required it is gone, so `<Modal>` is the direct return value again) — this accounts for most of the diff stat as a pure one-level reindent, not a logic change.

Same shape as the two most recent D5 fixes in this routine (`CalendarConfigurationModal.tsx`, `SpecialistScheduleConfigurationModal.tsx`).

## Enforcement

No new lint rule added — this pattern isn't mechanically detectable without false positives (the acceptable inline-Toast exception uses the identical `<Toast>` import). Relying on the routine's per-run grep sweep, as prior D5 fixes have.

## Behavior-preservation evidence

- Diff is exactly: import/state removal, `showMessage` body swapped to `addToast`, Fragment de-nesting. No other JSX/logic touched — orchestrator independently re-diffed against `origin/dev-paul` and confirmed no stray changes.
- No leftover references to `Toast`/`message`/`setMessage` in the file (grepped post-change).
- `pnpm run type-check` — clean
- `pnpm exec eslint components/admin/StarterPackConfigurationModal.tsx --max-warnings 0` — clean
- `pnpm exec prettier --check` on the file — clean
- `pnpm run lint` (full) — clean
- `pnpm run format:check` (full) — clean
- `pnpm run test` — 587 files / 7108 tests passed
- `pnpm run build` — succeeded (app + SSR prerender)
- No dedicated test file exists for this component, so no mocks needed updating.

**Risk tag: mechanical** (pure architectural equivalence — same notification content/timing/styling, different plumbing).

## Test plan

- [x] `pnpm run validate` — green
- [x] `pnpm run build` — green
- [ ] Manual: open Admin Settings → Feature Permissions → Starter Packs config, trigger a save/error toast, confirm it renders via the global toast queue identically to before

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTGmYNjKRWf2xsY6cJTSyC)_