### PR TITLE
unifier(D3): SettingsLabel group-heading retrofits — Checklist, MathToolInstance

### DIFF
--- a/components/widgets/Checklist/Settings.tsx
+++ b/components/widgets/Checklist/Settings.tsx
@@ -244,8 +244,17 @@ export const ChecklistSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Mode Toggle */}
       <div>
-        <SettingsLabel>List Source</SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <SettingsLabel
+          as="span"
+          id={`checklist-list-source-label-${widget.id}`}
+        >
+          List Source
+        </SettingsLabel>
+        <div
+          className="flex bg-slate-100 p-1 rounded-xl"
+          role="group"
+          aria-labelledby={`checklist-list-source-label-${widget.id}`}
+        >
           <button
             onClick={() =>
               updateWidget(widget.id, { config: { ...config, mode: 'manual' } })

--- a/components/widgets/MathToolInstance/Settings.tsx
+++ b/components/widgets/MathToolInstance/Settings.tsx
@@ -31,8 +31,17 @@ export const MathToolInstanceSettings: React.FC<{ widget: WidgetData }> = ({
     <div className="space-y-5 p-1">
       {/* Tool type selector */}
       <div className="space-y-2">
-        <SettingsLabel>Tool Type</SettingsLabel>
-        <div className="grid grid-cols-2 gap-1">
+        <SettingsLabel
+          as="span"
+          id={`mathtoolinstance-tooltype-label-${widget.id}`}
+        >
+          Tool Type
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-2 gap-1"
+          role="group"
+          aria-labelledby={`mathtoolinstance-tooltype-label-${widget.id}`}
+        >
           {TOOL_TYPES.map(({ type, label, emoji }) => (
             <button
               key={type}
@@ -105,8 +114,17 @@ export const MathToolInstanceSettings: React.FC<{ widget: WidgetData }> = ({
       {config.toolType === 'number-line' && (
         <div className="space-y-3">
           <div className="space-y-1">
-            <SettingsLabel>Mode</SettingsLabel>
-            <div className="flex gap-1">
+            <SettingsLabel
+              as="span"
+              id={`mathtoolinstance-mode-label-${widget.id}`}
+            >
+              Mode
+            </SettingsLabel>
+            <div
+              className="flex gap-1"
+              role="group"
+              aria-labelledby={`mathtoolinstance-mode-label-${widget.id}`}
+            >
               {numberLineModes.map((m) => (
                 <button
                   key={m}
@@ -172,8 +190,17 @@ export const MathToolInstanceSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Ruler units (for ruler types) */}
       {(config.toolType === 'ruler-in' || config.toolType === 'ruler-cm') && (
         <div className="space-y-1">
-          <SettingsLabel>Units Displayed</SettingsLabel>
-          <div className="flex gap-1">
+          <SettingsLabel
+            as="span"
+            id={`mathtoolinstance-units-label-${widget.id}`}
+          >
+            Units Displayed
+          </SettingsLabel>
+          <div
+            className="flex gap-1"
+            role="group"
+            aria-labelledby={`mathtoolinstance-units-label-${widget.id}`}
+          >
             {(['in', 'cm', 'both'] as const).map((u) => (
               <button
                 key={u}


### PR DESCRIPTION
## Summary

Nightly unifier routine (run 46), dimension D3 — Settings Panel Label Primitives.

**Canonical form:** `<SettingsLabel as="span" id="...">Heading</SettingsLabel>` + `role="group" aria-labelledby="..."` on the sibling-controls container, for a `SettingsLabel` that heads a *group* of controls (button/chip groups) rather than pairing 1:1 with one control — a bare `<label>` in that case is semantically orphaned (no single control to associate with). This variant (added via PR #2141, formalized as canon in run 30) was previously retrofitted across a named series (DrawingWidget → RevealGrid ×2 → RandomSettings → MusicWidget ×2 → SyntaxFramer ×2, runs 32–41), which the memory doc had marked closed ("no further candidates found"). A fresh sweep of `Settings.tsx` files outside that named series turned up 4 more genuine instances.

## Instances unified

- `components/widgets/Checklist/Settings.tsx` — "List Source" (manual/roster 2-button toggle)
- `components/widgets/MathToolInstance/Settings.tsx` — "Tool Type" (button grid), "Mode" (number-line mode buttons), "Units Displayed" (in/cm/both buttons)

All four are genuine group-heading shapes: a `SettingsLabel` immediately above a `<div>` containing multiple sibling `<button>` elements, no single associated control. Used `widget.id`-interpolated ids (e.g. `` `mathtoolinstance-tooltype-label-${widget.id}` ``) matching the established convention for per-widget-instance components (DrawingWidget/RevealGrid/MusicWidget precedent) — both `ChecklistSettings` and `MathToolInstanceSettings` render per-widget-instance via `DraggableWindow`, so a static id would collide with 2+ simultaneous instances of the same widget on one dashboard.

## Behavior-preservation evidence

- `SettingsLabel.tsx`'s `combinedClasses` is computed identically regardless of the `as` prop — confirmed by reading the component source directly. `as="span"` renders the exact same class string as the default `as="label"`, just a different tag. Zero visual delta.
- Orchestrator independently re-diffed both files against `origin/dev-paul` — the changes are exactly the label-wrapper + `role="group"`/`aria-labelledby` additions, no other JSX/logic touched.
- `pnpm run type-check:all` (root + functions) — clean
- `pnpm run lint` — clean, 0 errors/warnings
- `pnpm run format:check` — clean
- `pnpm run test` — 587 files / 7108 tests passed (root), 40 files / 775 tests passed (functions)
- `pnpm run build` — succeeded (app + SSR prerender)
- No dedicated test files reference `ChecklistSettings`/`MathToolInstanceSettings` by name, so no test updates needed.

**Risk tag: mechanical** (zero visual delta, accessibility-only semantic fix — same rendered classes, corrected DOM semantics).

## Test plan

- [x] `pnpm run validate` — green
- [x] `pnpm run build` — green
- [ ] Manual: flip Checklist and MathToolInstance widgets to settings, confirm the button-group labels render identically and screen-reader group semantics work as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTGmYNjKRWf2xsY6cJTSyC)_