### PR TITLE
nightly(widgets): fix ClockWidget date label dark-on-dark contrast

### DIFF
--- a/components/widgets/ClockWidget/Widget.test.tsx
+++ b/components/widgets/ClockWidget/Widget.test.tsx
@@ -204,4 +204,17 @@ describe('ClockWidget', () => {
     expect(fontSize).not.toMatch(/cqw/);
     expect(fontSize).toMatch(/cqmin/);
   });
+
+  // Regression: the date label must use the muted-text-on-dark-surface classes
+  // from CLAUDE.md (text-slate-300 body / text-slate-200 heading), never a
+  // near-black literal like text-slate-900 which is dark-on-dark on the app's
+  // slate-900 dashboard background and fails WCAG AA.
+  it('date label uses a WCAG-AA-safe muted text class on the dark dashboard surface', () => {
+    renderWidget(createWidget());
+
+    const dateLabel = screen.getByTestId('clock-date');
+    expect(dateLabel.className).not.toContain('text-slate-900');
+    expect(dateLabel.className).not.toContain('text-slate-800');
+    expect(dateLabel.className).toMatch(/text-slate-(200|300)/);
+  });
 });

--- a/components/widgets/ClockWidget/Widget.tsx
+++ b/components/widgets/ClockWidget/Widget.tsx
@@ -122,7 +122,7 @@ export const ClockWidget: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
           <div
             data-testid="clock-date"
-            className={`opacity-80 uppercase tracking-[0.2em] text-slate-900 ${getFontClass()}`}
+            className={`opacity-80 uppercase tracking-[0.2em] text-slate-300 ${getFontClass()}`}
             style={{ fontSize: '12cqmin', fontWeight: 900 }}
           >
             {time.toLocaleDateString(i18n.language, {


### PR DESCRIPTION
## Root cause
`components/widgets/ClockWidget/Widget.tsx`'s date label used `text-slate-900` (near-black) rendered directly over the app's dark `slate-900` dashboard surface — a dark-on-dark contrast failure. CLAUDE.md's design system explicitly calls for `text-slate-300` (body/label text) or `text-slate-200` (headings) for muted text on dark surfaces; `text-slate-900` is far below even the banned `text-slate-400`/`text-slate-500` tier. This is a real legibility bug for the projector/glanceable-at-distance use case this app is designed around.

## Fix
One-line class change: `text-slate-900` → `text-slate-300` on the `clock-date` element. No other logic touched.

## Band-aid rejected
None needed — this is already the minimal root-cause fix. Considered auditing/touching the ~20 other `text-slate-900` hits across other widgets, but confirmed those are all on light surfaces (settings panels, modals, light-colored cards like LunchCount) where `text-slate-900` is correct and intended — left untouched.

## Regression test
Added to `components/widgets/ClockWidget/Widget.test.tsx`, following that file's existing pattern of asserting on `className` for contrast-floor regressions:

```
it('date label uses a WCAG-AA-safe muted text class on the dark dashboard surface', () => {
  renderWidget(createWidget());
  const dateLabel = screen.getByTestId('clock-date');
  expect(dateLabel.className).not.toContain('text-slate-900');
  expect(dateLabel.className).not.toContain('text-slate-800');
  expect(dateLabel.className).toMatch(/text-slate-(200|300)/);
});
```

**Fail-before** (orchestrator-verified via file-swap against `dev-paul`'s pre-fix source, not just the subagent's own claim):
```
FAIL  components/widgets/ClockWidget/Widget.test.tsx > ClockWidget > date label uses a WCAG-AA-safe muted text class on the dark dashboard surface
AssertionError: expected 'opacity-80 uppercase tracking-[0.2em]…' not to contain 'text-slate-900'
Test Files  1 failed (1)
     Tests  1 failed | 14 passed (15)
```

**Pass-after** (orchestrator-verified):
```
Test Files  1 passed (1)
     Tests  15 passed (15)
```

## Live consumer
`clock` widget type is registered in `components/widgets/WidgetRegistry.ts` and listed in `config/tools.ts`'s `TOOLS` array — reachable from the live Dock UI.

## Validate + build
Full `pnpm run validate` and `pnpm run build` both green in the subagent's worktree (type-check, lint, format, 587 root test files / 7109 tests, 40 functions test files / 775 tests, test:counts guard, production build).

## Risk
**Contained** — single className change, additive test only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2sEXSNMrYg5yBKFCVDEe2)_