### PR TITLE
nightly(dashboard-layout): stop OverflowMenu's Escape from minimizing an unrelated widget

### DIFF
--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -90,9 +90,7 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
 
   const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
     if (e.key === 'Escape') {
-      // Stop the bubble: the menu is portalled to <body>, outside any `.widget`
-      // ancestor, so an unstopped Escape reaches DashboardView's global
-      // window-level Escape handler and minimizes the topmost widget instead.
+      // Portalled to <body> — stop Escape reaching DashboardView's global handler (see #2266 pattern).
       e.stopPropagation();
       setOpen(false);
       triggerRef.current?.focus();

--- a/components/common/sessionViews/OverflowMenu.tsx
+++ b/components/common/sessionViews/OverflowMenu.tsx
@@ -90,6 +90,10 @@ export const OverflowMenu: React.FC<OverflowMenuProps> = ({
 
   const onMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>): void => {
     if (e.key === 'Escape') {
+      // Stop the bubble: the menu is portalled to <body>, outside any `.widget`
+      // ancestor, so an unstopped Escape reaches DashboardView's global
+      // window-level Escape handler and minimizes the topmost widget instead.
+      e.stopPropagation();
       setOpen(false);
       triggerRef.current?.focus();
       return;

--- a/tests/components/common/sessionViews/OverflowMenu.test.tsx
+++ b/tests/components/common/sessionViews/OverflowMenu.test.tsx
@@ -42,6 +42,37 @@ describe('OverflowMenu', () => {
     expect(trigger).toHaveFocus();
   });
 
+  // Regression test for a missing-stopPropagation bug: the menu is portalled
+  // to document.body (outside any `.widget` DraggableWindow ancestor), so an
+  // unstopped Escape here bubbles all the way to DashboardView's global
+  // window-level Escape handler. That handler finds no `.widget` ancestor for
+  // the portalled menu item and falls back to targeting the topmost z-index
+  // widget on the board, silently minimizing an unrelated widget (e.g. a
+  // running timer) just because the user dismissed this menu. This mirrors
+  // the same bug class already fixed in ToolDockItem/RemoteControlMenu/
+  // ClassRosterMenu (#2266) and BoardNavFab/CollectionSwitcherMenu/
+  // BoardActionsFab (#2289) — see tests/components/layout/ToolDockItem.test.tsx.
+  it('does not leak the Escape keydown to window-level listeners (would otherwise let DashboardView minimize an unrelated widget)', () => {
+    render(<OverflowMenu items={[{ label: 'Export', onClick: vi.fn() }]} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    // Stand-in for DashboardView's `window.addEventListener('keydown', ...)`
+    // global handler.
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(screen.getByRole('menu'), {
+        key: 'Escape',
+        bubbles: true,
+      });
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+
   it('focuses the first item on open and navigates with Arrow keys', () => {
     render(
       <OverflowMenu


### PR DESCRIPTION
## Root cause
`components/common/sessionViews/OverflowMenu.tsx`'s `onMenuKeyDown` closed the menu on Escape but never called `stopPropagation()`. The menu is portalled to `document.body` via `createPortal`, outside any `.widget` DraggableWindow ancestor. The unstopped keydown bubbles to `DashboardView`'s global `window`-level Escape handler, which — finding no `.widget` ancestor for the portalled menu — falls back to targeting the topmost z-index widget and minimizes it. Net effect: a teacher opens this menu (live in `QuizResults.tsx`/`Results.tsx` for Video Activity) and presses Escape to dismiss it, silently minimizing an unrelated widget on their board (e.g. a running timer).

This is the same recurring bug class already fixed in `ToolDockItem`/`RemoteControlMenu`/`ClassRosterMenu` (#2266) and `BoardNavFab`/`CollectionSwitcherMenu`/`BoardActionsFab` (#2289) — `OverflowMenu` was a fresh, previously-unfixed instance.

## Live consumers
`components/widgets/QuizWidget/components/QuizResults.tsx` and `components/widgets/VideoActivityWidget/components/Results.tsx` both render `OverflowMenu` inside live dashboard widgets.

## Fix
Added `e.stopPropagation()` in the Escape branch of `onMenuKeyDown`, mirroring the established fix pattern from #2266/#2289.

## Band-aid rejected
Could have special-cased `DashboardView`'s global handler to recognize portalled dropdowns, but the codebase's established, correct pattern (per #2266/#2289) is for each Escape-to-dismiss popover to stop its own propagation at the source — not for the global fallback handler to grow more exceptions.

## Regression test
`tests/components/common/sessionViews/OverflowMenu.test.tsx` — asserts a window-level `keydown` spy (stand-in for `DashboardView`'s global handler) is never invoked when Escape is pressed inside the open menu.

**Fail-before** (orchestrator-verified via file-swap against `dev-paul`'s pre-fix source):
```
Number of calls: 1
Test Files  1 failed (1)
     Tests  1 failed | 6 passed (7)
```

**Pass-after** (orchestrator-verified):
```
Test Files  1 passed (1)
     Tests  7 passed (7)
```

## Validate + build
Full `pnpm run validate` and `pnpm run build` both green in the subagent's worktree: type-check (root + functions), lint (0 errors/warnings), format:check, 587 root test files / 7109 tests, 40 functions test files / 775 tests, test:counts guard, production build succeeded.

## Risk
**Contained** — single `stopPropagation()` call plus an additive test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2sEXSNMrYg5yBKFCVDEe2)_