### PR TITLE
nightly(state-data): duplicateQuiz/duplicateActivity drop authored Behavior Settings

### DIFF
--- a/hooks/useQuiz.ts
+++ b/hooks/useQuiz.ts
@@ -527,11 +527,13 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
   /**
    * Duplicate a quiz. Loads canonical content from the source's Drive
    * file, then writes a fresh quiz (new id, new Drive file, new title
-   * suffix). Preserves `folderId` when the source carries one — so a
-   * teacher who duplicates a quiz inside a folder sees the copy land
-   * in the same folder, matching their mental model. Does NOT inherit
-   * `sync` linkage (duplicates are private forks; PLC sharing is a
-   * separate explicit step).
+   * suffix). Preserves `folderId` AND `behavior` when the source carries
+   * them — so a teacher who duplicates a quiz inside a folder, or one
+   * with custom Behavior Settings (tab warnings, shuffle, result
+   * visibility, etc.), gets a copy that matches their mental model of
+   * "an independent copy of what I had," not a copy reset to defaults.
+   * Does NOT inherit `sync` linkage (duplicates are private forks; PLC
+   * sharing is a separate explicit step).
    *
    * The write is hand-rolled (not via `saveQuiz`) so we can observe the
    * freshly-created `driveFileId` and roll it back if the Firestore
@@ -569,6 +571,9 @@ export const useQuiz = (userId: string | undefined): UseQuizResult => {
           // field); reading it back yields the same shape.
           ...(sourceMeta.folderId !== undefined
             ? { folderId: sourceMeta.folderId }
+            : {}),
+          ...(sourceMeta.behavior !== undefined
+            ? { behavior: sourceMeta.behavior }
             : {}),
         };
         await setDoc(

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -396,8 +396,6 @@ export const useVideoActivity = (
           ...(source.folderId !== undefined
             ? { folderId: source.folderId }
             : {}),
-          // Preserve authored Behavior Settings on duplicate — see the
-          // function doc comment above.
           ...(source.behavior !== undefined
             ? { behavior: source.behavior }
             : {}),

--- a/hooks/useVideoActivity.ts
+++ b/hooks/useVideoActivity.ts
@@ -362,7 +362,9 @@ export const useVideoActivity = (
    * freshly-created Drive file id and roll it back on Firestore failure
    * — `saveActivity` only surfaces the id on success and would leak an
    * orphan Drive file otherwise. Mirrors the rollback path in
-   * `useQuiz.duplicateQuiz`. Reviewer flag from PR #1587.
+   * `useQuiz.duplicateQuiz`. Preserves `folderId` AND `behavior` from the
+   * source, same rationale as `useQuiz.duplicateQuiz`. Reviewer flag from
+   * PR #1587.
    */
   const duplicateActivity = useCallback(
     async (source: VideoActivityMetadata): Promise<VideoActivityMetadata> => {
@@ -393,6 +395,11 @@ export const useVideoActivity = (
           // Preserve folder placement on duplicate.
           ...(source.folderId !== undefined
             ? { folderId: source.folderId }
+            : {}),
+          // Preserve authored Behavior Settings on duplicate — see the
+          // function doc comment above.
+          ...(source.behavior !== undefined
+            ? { behavior: source.behavior }
             : {}),
         };
         await setDoc(

--- a/tests/hooks/useQuiz.behavior.test.ts
+++ b/tests/hooks/useQuiz.behavior.test.ts
@@ -302,6 +302,53 @@ describe('saveQuiz — preserve-on-omit semantics', () => {
 });
 
 // ---------------------------------------------------------------------------
+// (d2) duplicateQuiz preserves the source's behavior settings on the copy
+// ---------------------------------------------------------------------------
+
+describe('duplicateQuiz — preserves behavior on the copy', () => {
+  it('carries source.behavior onto the duplicated metadata', async () => {
+    const payloads = captureSetDocPayloads();
+
+    const { result } = renderHook(() => useQuiz(UID));
+
+    // Seed the mock Drive store with the source quiz content, then build
+    // a sourceMeta (as a manager component would hold) carrying `behavior`.
+    let saved!: QuizMetadata;
+    await act(async () => {
+      saved = await result.current.saveQuiz(QUIZ_DATA);
+    });
+    const sourceMeta: QuizMetadata = { ...saved, behavior: BEHAVIOR };
+
+    let duplicated!: QuizMetadata;
+    await act(async () => {
+      duplicated = await result.current.duplicateQuiz(sourceMeta);
+    });
+
+    expect(duplicated.behavior).toEqual(BEHAVIOR);
+    expect(payloads[payloads.length - 1]).toMatchObject({ behavior: BEHAVIOR });
+  });
+
+  it('does NOT write a behavior key when the source has none', async () => {
+    const payloads = captureSetDocPayloads();
+
+    const { result } = renderHook(() => useQuiz(UID));
+
+    let saved!: QuizMetadata;
+    await act(async () => {
+      saved = await result.current.saveQuiz(QUIZ_DATA);
+    });
+
+    let duplicated!: QuizMetadata;
+    await act(async () => {
+      duplicated = await result.current.duplicateQuiz(saved);
+    });
+
+    expect(duplicated).not.toHaveProperty('behavior');
+    expect(payloads[payloads.length - 1]).not.toHaveProperty('behavior');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (d) pullSyncedQuiz writes pulled behavior to the local metadata doc
 // ---------------------------------------------------------------------------
 

--- a/tests/hooks/useVideoActivity.behavior.test.ts
+++ b/tests/hooks/useVideoActivity.behavior.test.ts
@@ -337,6 +337,54 @@ describe('saveActivity — preserve-on-omit semantics', () => {
 });
 
 // ---------------------------------------------------------------------------
+// (d2) duplicateActivity preserves the source's behavior settings on the copy
+// ---------------------------------------------------------------------------
+
+describe('duplicateActivity — preserves behavior on the copy', () => {
+  it('carries source.behavior onto the duplicated metadata', async () => {
+    const payloads = captureSetDocPayloads();
+
+    const { result } = renderHook(() => useVideoActivity(UID));
+
+    // Seed the mock Drive store with the source activity content, then
+    // build a source meta (as a manager component would hold) carrying
+    // `behavior`.
+    let saved!: VideoActivityMetadata;
+    await act(async () => {
+      saved = await result.current.saveActivity(ACTIVITY_DATA);
+    });
+    const sourceMeta: VideoActivityMetadata = { ...saved, behavior: BEHAVIOR };
+
+    let duplicated!: VideoActivityMetadata;
+    await act(async () => {
+      duplicated = await result.current.duplicateActivity(sourceMeta);
+    });
+
+    expect(duplicated.behavior).toEqual(BEHAVIOR);
+    expect(payloads[payloads.length - 1]).toMatchObject({ behavior: BEHAVIOR });
+  });
+
+  it('does NOT write a behavior key when the source has none', async () => {
+    const payloads = captureSetDocPayloads();
+
+    const { result } = renderHook(() => useVideoActivity(UID));
+
+    let saved!: VideoActivityMetadata;
+    await act(async () => {
+      saved = await result.current.saveActivity(ACTIVITY_DATA);
+    });
+
+    let duplicated!: VideoActivityMetadata;
+    await act(async () => {
+      duplicated = await result.current.duplicateActivity(saved);
+    });
+
+    expect(duplicated).not.toHaveProperty('behavior');
+    expect(payloads[payloads.length - 1]).not.toHaveProperty('behavior');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (d) pullSyncedVideoActivity writes pulled behavior to the local metadata doc
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause
In `hooks/useQuiz.ts`'s `duplicateQuiz()` and `hooks/useVideoActivity.ts`'s `duplicateActivity()`, the hand-rolled metadata object for the newly-created copy explicitly preserved `sourceMeta.folderId` but never `sourceMeta.behavior` (the `QuizBehaviorSettings`/`VideoActivityBehaviorSettings` sub-object — tab-switch warnings, shuffle questions/answers, result/correct-answer visibility, speed bonus, attempt limit, etc.). Every other write path in these two hooks (`saveQuiz`/`saveActivity`'s preserve-on-omit fallback, `pullSyncedQuiz`/`pullSyncedVideoActivity`) carefully threads `behavior` through and is thoroughly tested for it — only the Duplicate path silently reset it to defaults. A teacher who configures Behavior Settings (e.g. turns off "show correct answer to student" for exam integrity) and then duplicates that quiz/activity for another class period gets a copy that silently reverts to defaults, with no indication anything changed.

## Fix
Added `...(sourceMeta.behavior !== undefined ? { behavior: sourceMeta.behavior } : {})` to both metadata constructions (`hooks/useQuiz.ts` ~line 572, `hooks/useVideoActivity.ts` ~line 396), mirroring the existing `folderId` pattern and `saveQuiz`'s established `!== undefined` spread convention.

## Band-aid rejected
Could have unconditionally copied `behavior` without the `undefined` guard, but that would write a `behavior: undefined` key rather than omitting it — the codebase treats "no key at all" as meaningfully different from an explicit `undefined` elsewhere in these same files (Firestore semantics), so the guard matches the established convention rather than diverging from it.

## Regression tests
Added to the existing `tests/hooks/useQuiz.behavior.test.ts` and `tests/hooks/useVideoActivity.behavior.test.ts` (established mock-Drive/mock-Firestore harness) — each seeds the mock Drive store via `saveQuiz`/`saveActivity`, builds a `sourceMeta` with `behavior` set, calls `duplicateQuiz`/`duplicateActivity`, and asserts the returned metadata + `setDoc` payload carry the same `behavior`.

**Fail-before** (orchestrator-verified via file-swap of `hooks/useQuiz.ts` and `hooks/useVideoActivity.ts` to `dev-paul`'s pre-fix source):
```
FAIL tests/hooks/useVideoActivity.behavior.test.ts > duplicateActivity — preserves behavior on the copy > carries source.behavior onto the duplicated metadata
AssertionError: expected undefined to deeply equal { sessionMode: 'auto', ... }
Test Files  2 failed (2)
     Tests  2 failed | 19 passed (21)
```

**Pass-after** (orchestrator-verified):
```
Test Files  2 passed (2)
     Tests  21 passed (21)
```

## Validate + build
Full `pnpm run validate` and `pnpm run build` both green in the subagent's worktree: type-check (root + functions), lint (0 errors/warnings), format:check, 587 root test files / 7112 tests, 40 functions test files / 775 tests, test:counts guard, production build succeeded.

## Additional issues noticed, not fixed (backlog candidates)
- `DialogContext.openNext()`'s React-18-batching risk re-traced (4th consecutive night) — mechanism still real, still unreached by any current `showPrompt()` call site.
- `useRosters.ts`'s `assignPins()` display/index drift — traced the ClassLink import path; both `assignPins` + `syncRosterPinIndex` always run together on save, so the persisted/displayed pins can't actually diverge in the traced flow. Still unconfirmed as reachable.
- `DashboardContext.updateWidget()`'s double-`JSON.stringify` diff — measured directly (50KB config, 1000 iterations, ~0.4ms/call); not a bottleneck at realistic widget config sizes. Reporting as measured-clean.
- `utils/adminBuildingConfig.ts`'s `soundboard` case concatenates sound-ID arrays without dedup, but the consuming widget filters by `.includes()`, not by iterating — confirmed harmless.

## Risk
**Contained** — additive `behavior` spread mirroring an existing pattern, plus new tests only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2sEXSNMrYg5yBKFCVDEe2)_