### PR TITLE
nightly: unify D5 toast architecture — BloomsTaxonomyConfigurationModal

### DIFF
--- a/components/admin/BloomsTaxonomyConfigurationModal.tsx
+++ b/components/admin/BloomsTaxonomyConfigurationModal.tsx
@@ -16,7 +16,6 @@ import {
   BloomsTaxonomyBuildingConfig,
   FeaturePermission,
 } from '@/types';
-import { Toast } from '@/components/common/Toast';
 import { Modal } from '@/components/common/Modal';
 import {
   BLOOMS_LEVELS,
@@ -29,6 +28,7 @@ import {
 } from '@/components/widgets/BloomsTaxonomy/constants';
 import { DEFAULT_BLOOMS_CONTENT } from '@/components/widgets/BloomsTaxonomy/defaultContent';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
+import { useDashboard } from '@/context/useDashboard';
 
 const normalizeConfig = (raw: unknown): BloomsTaxonomyGlobalConfig => {
   const config = raw as BloomsTaxonomyGlobalConfig | undefined;
@@ -45,15 +45,12 @@ interface BloomsTaxonomyConfigurationModalProps {
 export const BloomsTaxonomyConfigurationModal: React.FC<
   BloomsTaxonomyConfigurationModalProps
 > = ({ isOpen, onClose, permission, onSave }) => {
+  const { addToast } = useDashboard();
   const BUILDINGS = useAdminBuildings();
   const [config, setConfig] = useState<BloomsTaxonomyGlobalConfig>(() =>
     normalizeConfig(permission.config)
   );
   const [saving, setSaving] = useState(false);
-  const [message, setMessage] = useState<{
-    text: string;
-    type: 'success' | 'error';
-  } | null>(null);
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
   const [selectedLevel, setSelectedLevel] = useState<BloomsLevel>('remember');
@@ -71,14 +68,11 @@ export const BloomsTaxonomyConfigurationModal: React.FC<
       onSave({
         config: config as unknown as Record<string, unknown>,
       });
-      setMessage({
-        text: "Bloom's Taxonomy configuration saved!",
-        type: 'success',
-      });
+      addToast("Bloom's Taxonomy configuration saved!", 'success');
       onClose();
     } catch (err) {
       console.error("Failed to save Bloom's Taxonomy config:", err);
-      setMessage({ text: 'Failed to save configuration.', type: 'error' });
+      addToast('Failed to save configuration.', 'error');
     } finally {
       setSaving(false);
     }
@@ -248,230 +242,218 @@ export const BloomsTaxonomyConfigurationModal: React.FC<
   );
 
   return (
-    <>
-      <Modal
-        isOpen={isOpen}
-        onClose={onClose}
-        maxWidth="max-w-5xl"
-        customHeader={header}
-        footer={footer}
-        className="!p-0"
-        contentClassName=""
-        footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
-      >
-        <div className="p-6 space-y-8">
-          {/* Building Selector */}
-          <section className="space-y-4">
-            <div>
-              <SettingsLabel icon={Settings2}>
-                Select Building to Configure
-              </SettingsLabel>
-              <BuildingSelector
-                selectedId={selectedBuildingId}
-                onSelect={setSelectedBuildingId}
-                activeClassName="bg-indigo-500 text-white border-indigo-500 shadow-sm"
-              />
-            </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      maxWidth="max-w-5xl"
+      customHeader={header}
+      footer={footer}
+      className="!p-0"
+      contentClassName=""
+      footerClassName="px-6 py-4 border-t border-slate-100 bg-slate-50 flex items-center justify-between w-full shrink-0"
+    >
+      <div className="p-6 space-y-8">
+        {/* Building Selector */}
+        <section className="space-y-4">
+          <div>
+            <SettingsLabel icon={Settings2}>
+              Select Building to Configure
+            </SettingsLabel>
+            <BuildingSelector
+              selectedId={selectedBuildingId}
+              onSelect={setSelectedBuildingId}
+              activeClassName="bg-indigo-500 text-white border-indigo-500 shadow-sm"
+            />
+          </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 animate-in fade-in slide-in-from-top-2 duration-300">
-              {/* Left: Category & AI settings */}
-              <div className="space-y-6">
-                {/* Available Categories */}
-                <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
-                  <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                    <Settings2 className="w-4 h-4 text-indigo-500" /> Available
-                    Categories
-                  </h4>
-                  <p className="text-xs text-slate-500">
-                    Which categories teachers can see in this building.
-                  </p>
-                  <div className="space-y-2">
-                    {(CONTENT_CATEGORIES as readonly ContentCategory[]).map(
-                      (cat) => (
-                        <label
-                          key={cat}
-                          className="flex items-center gap-2 cursor-pointer text-sm text-slate-700"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={availableCategories.includes(cat)}
-                            onChange={() => toggleAvailable(cat)}
-                            className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500"
-                          />
-                          {CATEGORY_LABELS[cat]}
-                        </label>
-                      )
-                    )}
-                  </div>
-                </div>
-
-                {/* Default Enabled Categories */}
-                <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
-                  <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest">
-                    Default Enabled Categories
-                  </h4>
-                  <p className="text-xs text-slate-500">
-                    Pre-selected when a teacher first adds the widget.
-                  </p>
-                  <div className="space-y-2">
-                    {availableCategories.map((cat) => (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 animate-in fade-in slide-in-from-top-2 duration-300">
+            {/* Left: Category & AI settings */}
+            <div className="space-y-6">
+              {/* Available Categories */}
+              <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
+                <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                  <Settings2 className="w-4 h-4 text-indigo-500" /> Available
+                  Categories
+                </h4>
+                <p className="text-xs text-slate-500">
+                  Which categories teachers can see in this building.
+                </p>
+                <div className="space-y-2">
+                  {(CONTENT_CATEGORIES as readonly ContentCategory[]).map(
+                    (cat) => (
                       <label
                         key={cat}
                         className="flex items-center gap-2 cursor-pointer text-sm text-slate-700"
                       >
                         <input
                           type="checkbox"
-                          checked={defaultEnabled.includes(cat)}
-                          onChange={() => toggleDefaultEnabled(cat)}
+                          checked={availableCategories.includes(cat)}
+                          onChange={() => toggleAvailable(cat)}
                           className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500"
                         />
                         {CATEGORY_LABELS[cat]}
                       </label>
-                    ))}
-                  </div>
-                </div>
-
-                {/* AI Toggle */}
-                <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
-                  <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest">
-                    AI Generation
-                  </h4>
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={currentBuildingConfig.aiEnabled ?? false}
-                      onChange={(e) =>
-                        updateBuilding({ aiEnabled: e.target.checked })
-                      }
-                      className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500 w-5 h-5"
-                    />
-                    <div>
-                      <p className="text-sm font-semibold text-slate-700">
-                        Enable AI content generation
-                      </p>
-                      <p className="text-xs text-slate-500">
-                        Teachers can type a topic and generate Bloom&apos;s
-                        content with AI.
-                      </p>
-                    </div>
-                  </label>
+                    )
+                  )}
                 </div>
               </div>
 
-              {/* Right: Content Editor */}
-              <div className="space-y-4">
-                <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
-                  <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
-                    <Settings2 className="w-4 h-4 text-indigo-500" /> Content
-                    Editor
-                  </h4>
-                  <p className="text-xs text-slate-500">
-                    Customize items per level and category. Changes override
-                    defaults.
-                  </p>
+              {/* Default Enabled Categories */}
+              <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
+                <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest">
+                  Default Enabled Categories
+                </h4>
+                <p className="text-xs text-slate-500">
+                  Pre-selected when a teacher first adds the widget.
+                </p>
+                <div className="space-y-2">
+                  {availableCategories.map((cat) => (
+                    <label
+                      key={cat}
+                      className="flex items-center gap-2 cursor-pointer text-sm text-slate-700"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={defaultEnabled.includes(cat)}
+                        onChange={() => toggleDefaultEnabled(cat)}
+                        className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500"
+                      />
+                      {CATEGORY_LABELS[cat]}
+                    </label>
+                  ))}
+                </div>
+              </div>
 
-                  {/* Level tabs */}
-                  <div className="flex flex-wrap gap-1">
-                    {BLOOMS_LEVELS.map((level) => (
-                      <button
-                        key={level}
-                        onClick={() => setSelectedLevel(level)}
-                        className="px-3 py-1.5 rounded-lg text-xs font-bold transition-all"
-                        style={
-                          selectedLevel === level
-                            ? {
-                                backgroundColor: BLOOMS_COLORS[level],
-                                color: 'white',
-                              }
-                            : {
-                                backgroundColor: 'transparent',
-                                color: BLOOMS_COLORS[level],
-                                border: `1px solid ${BLOOMS_COLORS[level]}40`,
-                              }
-                        }
-                      >
-                        {BLOOMS_LABELS[level]}
-                      </button>
-                    ))}
+              {/* AI Toggle */}
+              <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
+                <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest">
+                  AI Generation
+                </h4>
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={currentBuildingConfig.aiEnabled ?? false}
+                    onChange={(e) =>
+                      updateBuilding({ aiEnabled: e.target.checked })
+                    }
+                    className="rounded border-slate-300 text-indigo-500 focus:ring-indigo-500 w-5 h-5"
+                  />
+                  <div>
+                    <p className="text-sm font-semibold text-slate-700">
+                      Enable AI content generation
+                    </p>
+                    <p className="text-xs text-slate-500">
+                      Teachers can type a topic and generate Bloom&apos;s
+                      content with AI.
+                    </p>
                   </div>
+                </label>
+              </div>
+            </div>
 
-                  {/* Category content for selected level */}
-                  <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
-                    {(CONTENT_CATEGORIES as readonly ContentCategory[]).map(
-                      (cat) => {
-                        const items = getItemsForLevelCategory(
-                          selectedLevel,
-                          cat
-                        );
-                        return (
-                          <div
-                            key={cat}
-                            className="bg-white p-3 rounded-xl border border-slate-200 space-y-2"
-                          >
-                            <div className="flex items-center justify-between">
-                              <h5 className="text-xs font-bold text-slate-600 uppercase tracking-wider">
-                                {CATEGORY_LABELS[cat]}
-                              </h5>
+            {/* Right: Content Editor */}
+            <div className="space-y-4">
+              <div className="bg-slate-50 p-5 rounded-2xl border border-slate-200 space-y-4">
+                <h4 className="text-sm font-black text-slate-700 uppercase tracking-widest flex items-center gap-2">
+                  <Settings2 className="w-4 h-4 text-indigo-500" /> Content
+                  Editor
+                </h4>
+                <p className="text-xs text-slate-500">
+                  Customize items per level and category. Changes override
+                  defaults.
+                </p>
+
+                {/* Level tabs */}
+                <div className="flex flex-wrap gap-1">
+                  {BLOOMS_LEVELS.map((level) => (
+                    <button
+                      key={level}
+                      onClick={() => setSelectedLevel(level)}
+                      className="px-3 py-1.5 rounded-lg text-xs font-bold transition-all"
+                      style={
+                        selectedLevel === level
+                          ? {
+                              backgroundColor: BLOOMS_COLORS[level],
+                              color: 'white',
+                            }
+                          : {
+                              backgroundColor: 'transparent',
+                              color: BLOOMS_COLORS[level],
+                              border: `1px solid ${BLOOMS_COLORS[level]}40`,
+                            }
+                      }
+                    >
+                      {BLOOMS_LABELS[level]}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Category content for selected level */}
+                <div className="space-y-4 max-h-[400px] overflow-y-auto pr-1">
+                  {(CONTENT_CATEGORIES as readonly ContentCategory[]).map(
+                    (cat) => {
+                      const items = getItemsForLevelCategory(
+                        selectedLevel,
+                        cat
+                      );
+                      return (
+                        <div
+                          key={cat}
+                          className="bg-white p-3 rounded-xl border border-slate-200 space-y-2"
+                        >
+                          <div className="flex items-center justify-between">
+                            <h5 className="text-xs font-bold text-slate-600 uppercase tracking-wider">
+                              {CATEGORY_LABELS[cat]}
+                            </h5>
+                            <button
+                              onClick={() => addItem(selectedLevel, cat)}
+                              className="p-1 text-indigo-500 hover:bg-indigo-50 rounded transition-colors"
+                              title="Add item"
+                            >
+                              <Plus className="w-3.5 h-3.5" />
+                            </button>
+                          </div>
+                          {items.map((item, idx) => (
+                            <div key={idx} className="flex items-center gap-1">
+                              <input
+                                type="text"
+                                value={item}
+                                onChange={(e) =>
+                                  updateItem(
+                                    selectedLevel,
+                                    cat,
+                                    idx,
+                                    e.target.value
+                                  )
+                                }
+                                className="flex-1 text-xs border border-slate-200 rounded px-2 py-1 text-slate-700 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 outline-none"
+                              />
                               <button
-                                onClick={() => addItem(selectedLevel, cat)}
-                                className="p-1 text-indigo-500 hover:bg-indigo-50 rounded transition-colors"
-                                title="Add item"
+                                onClick={() =>
+                                  removeItem(selectedLevel, cat, idx)
+                                }
+                                className="p-1 text-red-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+                                title="Remove item"
                               >
-                                <Plus className="w-3.5 h-3.5" />
+                                <Trash2 className="w-3 h-3" />
                               </button>
                             </div>
-                            {items.map((item, idx) => (
-                              <div
-                                key={idx}
-                                className="flex items-center gap-1"
-                              >
-                                <input
-                                  type="text"
-                                  value={item}
-                                  onChange={(e) =>
-                                    updateItem(
-                                      selectedLevel,
-                                      cat,
-                                      idx,
-                                      e.target.value
-                                    )
-                                  }
-                                  className="flex-1 text-xs border border-slate-200 rounded px-2 py-1 text-slate-700 focus:border-indigo-400 focus:ring-1 focus:ring-indigo-400 outline-none"
-                                />
-                                <button
-                                  onClick={() =>
-                                    removeItem(selectedLevel, cat, idx)
-                                  }
-                                  className="p-1 text-red-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
-                                  title="Remove item"
-                                >
-                                  <Trash2 className="w-3 h-3" />
-                                </button>
-                              </div>
-                            ))}
-                            {items.length === 0 && (
-                              <p className="text-xs text-slate-400 italic">
-                                No items. Click + to add.
-                              </p>
-                            )}
-                          </div>
-                        );
-                      }
-                    )}
-                  </div>
+                          ))}
+                          {items.length === 0 && (
+                            <p className="text-xs text-slate-400 italic">
+                              No items. Click + to add.
+                            </p>
+                          )}
+                        </div>
+                      );
+                    }
+                  )}
                 </div>
               </div>
             </div>
-          </section>
-        </div>
-      </Modal>
-      {message && (
-        <Toast
-          message={message.text}
-          type={message.type}
-          onClose={() => setMessage(null)}
-        />
-      )}
-    </>
+          </div>
+        </section>
+      </div>
+    </Modal>
   );
 };


### PR DESCRIPTION
## Summary

Nightly unifier routine (run 46, dimension D5 — Toast Architecture in Admin Components). Part of the recurring cleanup of local `useState` + sibling `<Toast>` overlays in admin config modals in favor of the centralized `addToast()` toast queue, following the same pattern already shipped for `SpecialistScheduleConfigurationModal.tsx` (run 42, PR #2273) and `CalendarConfigurationModal.tsx` (run 44, PR #2294).

**Canonical form:** `addToast(message, type)` via `useDashboard()` — the centralized toast queue rendered by `DashboardView`'s `ToastContainer`.

**Anti-pattern fixed:** local `message` `useState` paired with a `<Toast message=... type=... onClose=... />` rendered as a JSX sibling *outside* the component's `</Modal>` closing tag (wrapped in a fragment) — a global-overlay imitation rather than an intentional inline-in-body notification.

**Instance unified:** `components/admin/BloomsTaxonomyConfigurationModal.tsx`
- Removed local `message` state and the sibling `<Toast>` render.
- Replaced both call sites (save-success, save-error) with `addToast(...)`.
- `DashboardProvider` is reachable — this modal is mounted from `components/admin/FeaturePermissionsManager.tsx`, same mount path as the two prior precedents.
- Dropping the `<Toast>` sibling meant the wrapping `<>...</>` fragment was no longer needed since `<Modal>` is now the single direct return value — removed it too. This accounts for most of the diff as a pure reindent (192 insertions / 210 deletions on one file), not a logic change.

**Enforcement:** none added this run — this is the third instance of an identical hand-written anti-pattern shape recurring across independent admin config modals (runs 42, 44, 46). No lint rule can generically detect "local Toast state that could reach DashboardContext," so recurrence prevention continues to rely on the nightly staleness sweep; noting in the memory doc as a pattern worth a dedicated grep in future D5 runs.

**Behavior-preservation evidence:**
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint components/admin/BloomsTaxonomyConfigurationModal.tsx --max-warnings 0` — clean
- `pnpm exec prettier --check components/admin/BloomsTaxonomyConfigurationModal.tsx` — clean
- `pnpm run test` — 587/587 test files, 7108/7108 tests passing (identical count to the pre-change baseline run)
- `pnpm run build` — green
- No test file exists for this component (none needed updating)

**Risk tag:** mechanical (pure equivalence — same two toast messages, same trigger points, only the delivery mechanism changes from a local overlay to the shared toast queue; visually the toast now renders via the same `ToastContainer` styling used by every other converted admin modal).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MH9nLhYEkHeYCn4YqUN3PB)_