### PR TITLE
fix(schedule): add events below the list, drop delete confirm, keep settings open

### DIFF
--- a/components/common/DialogContainer.tsx
+++ b/components/common/DialogContainer.tsx
@@ -487,6 +487,12 @@ export const DialogContainer: React.FC = () => {
 
   return createPortal(
     <div
+      // Dialogs render in a portal on document.body, so a pointerdown on this
+      // overlay reads as a "click outside" to any open widget SettingsPanel and
+      // would close it out from under the dialog that it opened. Marking the
+      // overlay excludes it from that check, so confirming/cancelling a dialog
+      // leaves the settings panel underneath exactly as it was.
+      data-settings-exclude
       className="fixed inset-0 z-dialog flex items-center justify-center p-4 bg-slate-900/60 backdrop-blur-sm animate-in fade-in duration-150"
       onClick={() => {
         // Clicking the backdrop dismisses alerts, cancels confirms/prompts

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -104,6 +104,10 @@ const ToastContainer: React.FC = () => {
   // unpredictably or drop entirely.
   return (
     <div
+      // Toasts sit outside every widget's DOM subtree, so clicking one (e.g. an
+      // "Undo" action) would otherwise register as a click outside an open
+      // SettingsPanel and close it. Exclude the whole stack from that check.
+      data-settings-exclude
       className="fixed z-toast space-y-3 pointer-events-none"
       style={{
         top: 'calc(1.5rem + env(safe-area-inset-top, 0px))',

--- a/components/widgets/Schedule/Settings.tsx
+++ b/components/widgets/Schedule/Settings.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { useDialog } from '@/context/useDialog';
 import { useFeaturePermissions } from '@/hooks/useFeaturePermissions';
@@ -23,6 +29,7 @@ import {
   ChevronDown,
   Copy,
   ArrowUpDown,
+  FolderPlus,
 } from 'lucide-react';
 import {
   DndContext,
@@ -125,6 +132,10 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
   const [expandedItemIds, setExpandedItemIds] = useState<Set<string>>(
     new Set()
   );
+  // Id of the row whose task field should take focus on mount, so a freshly
+  // added event is immediately typeable (and scrolled into view) without the
+  // user hunting for the new row.
+  const [autoFocusItemId, setAutoFocusItemId] = useState<string | null>(null);
 
   // Effective selected schedule: honor user's pick, fall back to today's active schedule
   const effectiveSelectedId = useMemo(() => {
@@ -305,9 +316,16 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     [config, schedules, widget.id, updateWidget]
   );
 
+  // Latest item read/write helpers, for callbacks that outlive their render
+  // (the Undo toast action). Both are recreated whenever `config` changes, so a
+  // captured copy would write a stale config back to Firestore.
+  const itemOpsRef = useRef({ getScheduleItems, saveScheduleItems });
+  itemOpsRef.current = { getScheduleItems, saveScheduleItems };
+
   const handleAddItem = (scheduleId: string) => {
+    const id = crypto.randomUUID();
     const newItem: ScheduleItem = {
-      id: crypto.randomUUID(),
+      id,
       task: '',
       startTime: '',
       endTime: '',
@@ -315,11 +333,13 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
       linkedWidgets: [],
     };
     saveScheduleItems(scheduleId, [...getScheduleItems(scheduleId), newItem]);
+    setAutoFocusItemId(id);
   };
 
   const handleAddOneOffItem = (scheduleId: string) => {
+    const id = crypto.randomUUID();
     const newItem: ScheduleItem = {
-      id: crypto.randomUUID(),
+      id,
       task: '',
       startTime: '',
       endTime: '',
@@ -328,6 +348,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
       oneOffDate: getTodayStr(),
     };
     saveScheduleItems(scheduleId, [...getScheduleItems(scheduleId), newItem]);
+    setAutoFocusItemId(id);
   };
 
   const handleUpdateItem = (
@@ -341,17 +362,42 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     saveScheduleItems(scheduleId, newItems);
   };
 
-  const handleDeleteItem = async (scheduleId: string, itemId: string) => {
-    const confirmed = await showConfirm(
-      'Are you sure you want to delete this event?',
-      { title: 'Delete Event', variant: 'danger', confirmLabel: 'Delete' }
+  // Deleting a single event is low-stakes and reversible, so it happens
+  // immediately — no confirmation dialog. An "Undo" toast covers mistakes.
+  // Blank rows (nothing typed yet) delete silently: there is nothing to restore
+  // and a toast for an empty row is pure noise while building a schedule.
+  const handleDeleteItem = (scheduleId: string, itemId: string) => {
+    const items = getScheduleItems(scheduleId);
+    const index = items.findIndex((i) => i.id === itemId);
+    if (index === -1) return;
+    const removed = items[index];
+
+    saveScheduleItems(
+      scheduleId,
+      items.filter((i) => i.id !== itemId)
     );
-    if (confirmed) {
-      saveScheduleItems(
-        scheduleId,
-        getScheduleItems(scheduleId).filter((i) => i.id !== itemId)
-      );
-    }
+
+    const label = removed.task?.trim();
+    const isBlank =
+      !label && !removed.startTime && !removed.endTime && !removed.time;
+    if (isBlank) return;
+
+    addToast(label ? `Deleted "${label}"` : 'Event deleted', 'info', {
+      label: 'Undo',
+      onClick: () => {
+        // Re-insert into the *current* list rather than restoring a snapshot,
+        // so any edits made between the delete and the undo survive. Reads the
+        // live helpers via ref because this closure outlives the render that
+        // created it (the toast lingers for 10s).
+        const { getScheduleItems: getLive, saveScheduleItems: saveLive } =
+          itemOpsRef.current;
+        const current = getLive(scheduleId);
+        if (current.some((i) => i.id === removed.id)) return;
+        const restored = [...current];
+        restored.splice(Math.min(index, restored.length), 0, removed);
+        saveLive(scheduleId, restored);
+      },
+    });
   };
 
   const handleSortByTime = (scheduleId: string) => {
@@ -461,7 +507,12 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
             <>
               {/* ── Selected schedule header ──────────────────────── */}
               <div>
-                {/* Name + delete */}
+                {/* Name + schedule-level actions. Both the "add another
+                    schedule" and "delete this schedule" affordances live on
+                    this row — the one place in the panel that is about the
+                    schedule rather than its events. Nothing below the event
+                    list operates on schedules, so no control down there can be
+                    mistaken for an event action. */}
                 <div className="flex items-center gap-2">
                   <input
                     type="text"
@@ -474,6 +525,15 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                     className="flex-1 font-bold text-slate-700 bg-transparent border-none p-0 focus:ring-0 outline-none text-sm"
                     placeholder="Schedule Name"
                   />
+                  <button
+                    type="button"
+                    onClick={handleAddSchedule}
+                    className="p-1 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors shrink-0"
+                    aria-label="New schedule"
+                    title="New schedule (e.g. an early-release day)"
+                  >
+                    <FolderPlus className="w-3.5 h-3.5" />
+                  </button>
                   <button
                     type="button"
                     onClick={() =>
@@ -523,6 +583,9 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
               </div>
 
               {/* ── Items toolbar ─────────────────────────────────── */}
+              {/* Whole-list operations only. The actions that *append* an event
+                  live directly below the list, where the new row appears — so
+                  adding several events in a row never means scrolling back up. */}
               <div className="flex items-center justify-between border-t border-slate-100 pt-2">
                 <button
                   type="button"
@@ -532,34 +595,14 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                 >
                   <ArrowUpDown className="w-3 h-3" /> Sort
                 </button>
-                <div className="flex items-center gap-3">
-                  <button
-                    type="button"
-                    onClick={() => handleAddItem(selectedSchedule.id)}
-                    aria-label="Add event"
-                    className="text-xxs flex items-center gap-1 text-blue-600 hover:text-blue-700 font-medium"
-                  >
-                    <Plus className="w-3 h-3" /> Add
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleAddOneOffItem(selectedSchedule.id)}
-                    className="text-xxs flex items-center gap-1 text-amber-600 hover:text-amber-700 font-medium"
-                    title="Add a one-time event for today only"
-                  >
-                    <CalendarPlus className="w-3 h-3" /> Today Only
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      handleImportFromCalendar(selectedSchedule.id)
-                    }
-                    className="text-xxs flex items-center gap-1 text-indigo-500 hover:text-indigo-700 font-medium"
-                    title="Import today's events from Calendar widget"
-                  >
-                    <CalendarDays className="w-3 h-3" /> Import
-                  </button>
-                </div>
+                <button
+                  type="button"
+                  onClick={() => handleImportFromCalendar(selectedSchedule.id)}
+                  className="text-xxs flex items-center gap-1 text-indigo-500 hover:text-indigo-700 font-medium"
+                  title="Import today's events from Calendar widget"
+                >
+                  <CalendarDays className="w-3 h-3" /> Import
+                </button>
               </div>
 
               {/* ── Items list ────────────────────────────────────── */}
@@ -587,11 +630,13 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                         }
                         isExpanded={expandedItemIds.has(item.id ?? '')}
                         onToggleExpand={toggleItemExpanded}
+                        autoFocus={item.id === autoFocusItemId}
                       />
                     ))}
                   </SortableContext>
                 </DndContext>
-                {selectedSchedule.items.length === 0 && (
+
+                {selectedSchedule.items.length === 0 ? (
                   <div className="text-center py-6 text-slate-400 border-2 border-dashed rounded-xl bg-slate-50">
                     <p className="text-xs">No events scheduled.</p>
                     <button
@@ -601,19 +646,31 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                       Add your first event
                     </button>
                   </div>
+                ) : (
+                  /* Add actions sit at the end of the list so the next row
+                     appears right where the button is — no scrolling back up
+                     between events. */
+                  <div className="flex items-stretch gap-2 pt-0.5">
+                    <button
+                      type="button"
+                      onClick={() => handleAddItem(selectedSchedule.id)}
+                      className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg border border-dashed border-blue-200 text-blue-600 hover:bg-blue-50 hover:border-blue-300 text-xs font-semibold transition-colors"
+                    >
+                      <Plus className="w-3.5 h-3.5" /> Add Event
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleAddOneOffItem(selectedSchedule.id)}
+                      className="shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-lg border border-dashed border-amber-200 text-amber-600 hover:bg-amber-50 hover:border-amber-300 text-xxs font-semibold transition-colors"
+                      title="Add a one-time event for today only"
+                    >
+                      <CalendarPlus className="w-3.5 h-3.5" /> Today Only
+                    </button>
+                  </div>
                 )}
               </div>
             </>
           )}
-
-          {/* Add new schedule button */}
-          <button
-            type="button"
-            onClick={handleAddSchedule}
-            className="w-full text-xxs flex items-center justify-center gap-1 text-slate-400 hover:text-blue-600 font-medium py-1.5 border border-dashed border-slate-200 rounded-lg hover:border-blue-300 transition-colors"
-          >
-            <Plus className="w-3 h-3" /> New Schedule
-          </button>
         </>
       )}
 

--- a/components/widgets/Schedule/Settings.tsx
+++ b/components/widgets/Schedule/Settings.tsx
@@ -132,10 +132,14 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
   const [expandedItemIds, setExpandedItemIds] = useState<Set<string>>(
     new Set()
   );
-  // Id of the row whose task field should take focus on mount, so a freshly
-  // added event is immediately typeable (and scrolled into view) without the
-  // user hunting for the new row.
-  const [autoFocusItemId, setAutoFocusItemId] = useState<string | null>(null);
+  // The row whose task field should take focus on mount, so a freshly added
+  // event is immediately typeable (and scrolled into view) without the user
+  // hunting for the new row. Tagged with the schedule it belongs to — see the
+  // reset below.
+  const [autoFocusItem, setAutoFocusItem] = useState<{
+    scheduleId: string;
+    itemId: string;
+  } | null>(null);
 
   // Effective selected schedule: honor user's pick, fall back to today's active schedule
   const effectiveSelectedId = useMemo(() => {
@@ -149,6 +153,20 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
     const today = new Date().getDay();
     return schedules.find((s) => s.days.includes(today))?.id ?? schedules[0].id;
   }, [selectedScheduleId, schedules]);
+
+  // Drop a pending autofocus as soon as the visible schedule changes. Rows
+  // unmount when the selection moves, so without this, switching to another
+  // schedule and back would re-mount the last-added row with autoFocus still
+  // true and yank focus to an event added minutes ago.
+  //
+  // Comparing during render (rather than resetting inside each of the five
+  // handlers that move the selection) means no call site can forget to do it,
+  // and no future one can regress it. This is React's "adjusting state while
+  // rendering" pattern: the setter runs before paint, so the stale value is
+  // never handed to a child.
+  if (autoFocusItem && autoFocusItem.scheduleId !== effectiveSelectedId) {
+    setAutoFocusItem(null);
+  }
 
   const selectedSchedule =
     schedules.find((s) => s.id === effectiveSelectedId) ?? null;
@@ -333,7 +351,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
       linkedWidgets: [],
     };
     saveScheduleItems(scheduleId, [...getScheduleItems(scheduleId), newItem]);
-    setAutoFocusItemId(id);
+    setAutoFocusItem({ scheduleId, itemId: id });
   };
 
   const handleAddOneOffItem = (scheduleId: string) => {
@@ -348,7 +366,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
       oneOffDate: getTodayStr(),
     };
     saveScheduleItems(scheduleId, [...getScheduleItems(scheduleId), newItem]);
-    setAutoFocusItemId(id);
+    setAutoFocusItem({ scheduleId, itemId: id });
   };
 
   const handleUpdateItem = (
@@ -630,7 +648,7 @@ export const ScheduleSettings: React.FC<{ widget: WidgetData }> = ({
                         }
                         isExpanded={expandedItemIds.has(item.id ?? '')}
                         onToggleExpand={toggleItemExpanded}
-                        autoFocus={item.id === autoFocusItemId}
+                        autoFocus={item.id === autoFocusItem?.itemId}
                       />
                     ))}
                   </SortableContext>

--- a/components/widgets/Schedule/components/SortableScheduleItem.tsx
+++ b/components/widgets/Schedule/components/SortableScheduleItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ScheduleItem, WidgetType } from '@/types';
 import { GripVertical, Trash2, Timer, Link, CheckCircle2 } from 'lucide-react';
 import { useSortable } from '@dnd-kit/sortable';
@@ -41,10 +41,13 @@ interface SortableScheduleItemProps {
   onDelete: (itemId: string) => void;
   isExpanded: boolean;
   onToggleExpand: (itemId: string) => void;
+  /** Focus this row's task field on mount — set for a just-added event. */
+  autoFocus?: boolean;
 }
 
 export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
-  React.memo(({ item, onUpdate, onDelete, isExpanded, onToggleExpand }) => {
+  React.memo((props) => {
+    const { item, onUpdate, onDelete, isExpanded, onToggleExpand } = props;
     const {
       attributes,
       listeners,
@@ -53,6 +56,20 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
       transition,
       isDragging,
     } = useSortable({ id: item.id });
+
+    // Move keyboard focus into a freshly added row and pull it into view, so a
+    // just-added event is immediately typeable. Focusing an element is DOM
+    // synchronization, so an effect is the right tool; it runs on the mount of
+    // a newly added item.
+    const autoFocus = props.autoFocus ?? false;
+    const taskInputRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+      if (!autoFocus) return;
+      const el = taskInputRef.current;
+      if (!el) return;
+      el.focus({ preventScroll: true });
+      el.scrollIntoView({ block: 'nearest' });
+    }, [autoFocus]);
 
     const style = {
       transform: CSS.Transform.toString(transform),
@@ -87,6 +104,7 @@ export const SortableScheduleItem: React.FC<SortableScheduleItemProps> =
             <GripVertical className="w-4 h-4" />
           </div>
           <input
+            ref={taskInputRef}
             type="text"
             value={item.task}
             onChange={(e) => onUpdate(item.id, { task: e.target.value })}

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -53,6 +53,14 @@ Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
   value: vi.fn(),
 });
 
+// Likewise scrollIntoView, which the settings panel calls when focusing a
+// newly added event row.
+Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+  configurable: true,
+  writable: true,
+  value: vi.fn(),
+});
+
 // Mock useScaledFont to return a fixed size
 vi.mock('@/hooks/useScaledFont', () => ({
   useScaledFont: () => 16,
@@ -989,6 +997,71 @@ describe('ScheduleSettings', () => {
             ],
           }),
         })
+      );
+    });
+
+    it('does not re-focus a previously added row after switching schedules and back', () => {
+      // Regression: autoFocusItemId was set on add but never cleared. Rows
+      // unmount when the schedule selection changes, so returning to the
+      // original schedule re-mounted the last-added row with autoFocus still
+      // true and yanked focus to an event added minutes earlier.
+      const scheduleA = {
+        id: 'sched-a',
+        name: 'A',
+        days: [],
+        items: threeItems,
+      };
+      const scheduleB = { id: 'sched-b', name: 'B', days: [], items: [] };
+      const build = (selected: string) =>
+        ({
+          id: 'schedule-1',
+          type: 'schedule',
+          config: {
+            items: [],
+            schedules: [scheduleA, scheduleB],
+            settingsSelectedScheduleId: selected,
+          },
+        }) as unknown as WidgetData;
+
+      const { rerender } = render(
+        <ScheduleSettings widget={build('sched-a')} />
+      );
+
+      // Add an event to schedule A — its row takes focus.
+      fireEvent.click(screen.getByRole('button', { name: /add event/i }));
+      const added = mockUpdateWidget.mock.calls.at(-1)?.[1] as {
+        config: { schedules: { id: string; items: { id: string }[] }[] };
+      };
+      const newItemId = added.config.schedules[0].items.at(-1)?.id;
+      expect(newItemId).toBeTruthy();
+
+      const withNewItem = {
+        ...scheduleA,
+        items: [...threeItems, { id: newItemId, task: '', mode: 'clock' }],
+      };
+      const widgetWith = (selected: string) =>
+        ({
+          id: 'schedule-1',
+          type: 'schedule',
+          config: {
+            items: [],
+            schedules: [withNewItem, scheduleB],
+            settingsSelectedScheduleId: selected,
+          },
+        }) as unknown as WidgetData;
+
+      // Switch to schedule B (rows unmount)...
+      rerender(<ScheduleSettings widget={widgetWith('sched-b')} />);
+      fireEvent.click(screen.getByRole('button', { name: 'B' }));
+
+      // ...then back to A, re-mounting the row that was focused on add.
+      rerender(<ScheduleSettings widget={widgetWith('sched-a')} />);
+      fireEvent.click(screen.getByRole('button', { name: 'A' }));
+
+      // Focus must NOT have been stolen by the stale autofocus.
+      const taskInputs = screen.getAllByPlaceholderText('Task name');
+      expect(taskInputs.some((el) => el === document.activeElement)).toBe(
+        false
       );
     });
 

--- a/components/widgets/ScheduleWidget.test.tsx
+++ b/components/widgets/ScheduleWidget.test.tsx
@@ -83,11 +83,20 @@ vi.mock('lucide-react', () => ({
   Link: () => <div>Link Icon</div>,
   ArrowUpDown: () => <div>ArrowUpDown Icon</div>,
   CalendarPlus: () => <div>CalendarPlus Icon</div>,
+  FolderPlus: () => <div>FolderPlus Icon</div>,
   Ban: () => <div>Ban Icon</div>,
 }));
 
 const mockUpdateWidget = vi.fn();
 const mockAddWidget = vi.fn();
+const mockAddToast =
+  vi.fn<
+    (
+      message: string,
+      type?: string,
+      action?: { label: string; onClick: () => void }
+    ) => void
+  >();
 
 const mockDashboardContext = {
   activeDashboard: {
@@ -96,6 +105,7 @@ const mockDashboardContext = {
   },
   updateWidget: mockUpdateWidget,
   addWidget: mockAddWidget,
+  addToast: mockAddToast,
 };
 
 describe('ScheduleWidget', () => {
@@ -665,6 +675,7 @@ describe('ScheduleSettings', () => {
       subscribeToPermission: vi.fn(),
     });
     mockUpdateWidget.mockClear();
+    mockAddToast.mockClear();
   });
 
   const createWidget = (config: Partial<ScheduleConfig> = {}): WidgetData => {
@@ -853,5 +864,159 @@ describe('ScheduleSettings', () => {
         }),
       })
     );
+  });
+
+  describe('event add/delete ergonomics', () => {
+    const threeItems = [
+      {
+        id: 'a',
+        startTime: '09:00',
+        task: 'Math',
+        done: false,
+        mode: 'clock' as const,
+        linkedWidgets: [],
+      },
+      {
+        id: 'b',
+        startTime: '10:00',
+        task: 'Reading',
+        done: false,
+        mode: 'clock' as const,
+        linkedWidgets: [],
+      },
+      {
+        id: 'c',
+        startTime: '11:00',
+        task: 'Recess',
+        done: false,
+        mode: 'clock' as const,
+        linkedWidgets: [],
+      },
+    ];
+
+    it('renders the Add Event button AFTER the last event row, so adding never needs a scroll back up', () => {
+      render(<ScheduleSettings widget={createWidget({ items: threeItems })} />);
+
+      const addButton = screen.getByRole('button', { name: /add event/i });
+      const lastRowInput = screen.getByDisplayValue('Recess');
+
+      // Node.DOCUMENT_POSITION_FOLLOWING === 4: addButton comes after the row.
+      expect(
+        lastRowInput.compareDocumentPosition(addButton) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it('puts the schedule-level "New Schedule" action up in the name row, never below the event list', () => {
+      render(<ScheduleSettings widget={createWidget({ items: threeItems })} />);
+
+      const newSchedule = screen.getByRole('button', { name: /new schedule/i });
+      const firstRowInput = screen.getByDisplayValue('Math');
+
+      // It sits ABOVE the first event row (in the schedule-name header), so no
+      // control under the event list can be mistaken for an event action.
+      expect(
+        firstRowInput.compareDocumentPosition(newSchedule) &
+          Node.DOCUMENT_POSITION_PRECEDING
+      ).toBeTruthy();
+
+      // It shares the header row with the delete-schedule button.
+      const deleteSchedule = screen.getByRole('button', {
+        name: /delete schedule/i,
+      });
+      expect(newSchedule.parentElement).toBe(deleteSchedule.parentElement);
+    });
+
+    it('deletes an event immediately with no confirmation dialog, offering Undo instead', () => {
+      render(<ScheduleSettings widget={createWidget({ items: threeItems })} />);
+
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /delete event/i })[1]
+      );
+
+      // Removed straight away — no awaiting a confirm dialog.
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'schedule-1',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            items: [
+              expect.objectContaining({ id: 'a' }),
+              expect.objectContaining({ id: 'c' }),
+            ],
+          }),
+        })
+      );
+
+      // ...and the safety net is an Undo toast naming the deleted event.
+      expect(mockAddToast).toHaveBeenCalledWith(
+        'Deleted "Reading"',
+        'info',
+        expect.objectContaining({ label: 'Undo' })
+      );
+    });
+
+    it('restores the event at its original index when Undo is clicked', () => {
+      const { rerender } = render(
+        <ScheduleSettings widget={createWidget({ items: threeItems })} />
+      );
+
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /delete event/i })[1]
+      );
+      const action = mockAddToast.mock.calls[0][2];
+
+      // Simulate the config round-trip the real app performs: updateWidget is
+      // mocked, so the component must be re-rendered with the post-delete
+      // config for the Undo handler to see the live (2-item) list.
+      rerender(
+        <ScheduleSettings
+          widget={createWidget({ items: [threeItems[0], threeItems[2]] })}
+        />
+      );
+      mockUpdateWidget.mockClear();
+
+      act(() => action?.onClick());
+
+      // 'Reading' goes back between 'Math' and 'Recess', not onto the end.
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'schedule-1',
+        expect.objectContaining({
+          config: expect.objectContaining({
+            items: [
+              expect.objectContaining({ id: 'a' }),
+              expect.objectContaining({ id: 'b', task: 'Reading' }),
+              expect.objectContaining({ id: 'c' }),
+            ],
+          }),
+        })
+      );
+    });
+
+    it('deletes a blank, never-filled row silently (no Undo toast noise)', () => {
+      const widget = createWidget({
+        items: [
+          {
+            id: 'blank',
+            task: '',
+            startTime: '',
+            endTime: '',
+            done: false,
+            mode: 'clock' as const,
+            linkedWidgets: [],
+          },
+        ],
+      });
+      render(<ScheduleSettings widget={widget} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /delete event/i }));
+
+      expect(mockUpdateWidget).toHaveBeenCalledWith(
+        'schedule-1',
+        expect.objectContaining({
+          config: expect.objectContaining({ items: [] }),
+        })
+      );
+      expect(mockAddToast).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/components/common/DialogContainer.settingsExclude.test.tsx
+++ b/tests/components/common/DialogContainer.settingsExclude.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Regression test: dialogs must not close an open widget SettingsPanel.
+ *
+ * BUG: DialogContainer portals its overlay onto document.body. SettingsPanel
+ * closes itself on any pointerdown outside its own subtree (and outside the
+ * widget), so pressing "Delete" in a confirm dialog that the settings panel
+ * had just opened closed the panel out from under the user — the schedule
+ * widget's settings window appeared to vanish (taking the user's in-progress
+ * edits with it, as far as they could tell) the moment they confirmed.
+ *
+ * FIX: the overlay carries `data-settings-exclude`, the opt-out marker
+ * SettingsPanel's click-outside handler checks with `target.closest()`.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup, screen } from '@testing-library/react';
+
+afterEach(cleanup);
+
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({
+    currentDialog: {
+      kind: 'confirm',
+      message: 'Are you sure you want to delete this schedule?',
+      options: { variant: 'danger', confirmLabel: 'Delete' },
+      resolve: vi.fn(),
+    },
+    showAlert: vi.fn(),
+    showConfirm: vi.fn(),
+    showPrompt: vi.fn(),
+  }),
+}));
+
+import { DialogContainer } from '@/components/common/DialogContainer';
+
+describe('DialogContainer — settings-panel exclusion', () => {
+  it('marks the overlay with data-settings-exclude so buttons inside it never read as a click-outside', () => {
+    render(<DialogContainer />);
+
+    const confirmButton = screen.getByRole('button', { name: 'Delete' });
+
+    // This is exactly the lookup SettingsPanel's pointerdown handler performs.
+    expect(confirmButton.closest('[data-settings-exclude]')).not.toBeNull();
+  });
+});

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -287,6 +287,81 @@ describe('SettingsPanel', () => {
     }
   });
 
+  it('stays open when the user clicks inside a dialog the panel itself opened', () => {
+    // Regression: dialogs (confirm/alert/prompt) render in a portal on
+    // document.body, so pressing a button inside one read as a "click outside"
+    // and closed the settings panel underneath. Deleting a schedule item, for
+    // example, made the whole settings window vanish the moment the user
+    // confirmed. DialogContainer's overlay now carries data-settings-exclude,
+    // which this handler must honour.
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+
+      const HarnessWithClose = () => {
+        const widgetRef = useRef<HTMLDivElement>(null);
+        return (
+          <>
+            <div ref={widgetRef} data-testid="fake-widget" />
+            <SettingsPanel
+              widget={MOCK_WIDGET}
+              widgetRef={widgetRef}
+              settings={<div data-testid="settings-content">Settings</div>}
+              shouldRenderSettings
+              onClose={onClose}
+              updateWidget={vi.fn()}
+              globalStyle={MOCK_GLOBAL_STYLE}
+              title="Test Widget"
+            />
+          </>
+        );
+      };
+
+      act(() => {
+        render(<HarnessWithClose />);
+      });
+      // Let the 50ms arm-the-listener timer elapse.
+      act(() => {
+        vi.advanceTimersByTime(60);
+      });
+
+      // Stand in for DialogContainer's portaled overlay + its confirm button.
+      const overlay = document.createElement('div');
+      overlay.setAttribute('data-settings-exclude', '');
+      const confirmButton = document.createElement('button');
+      overlay.appendChild(confirmButton);
+      document.body.appendChild(overlay);
+
+      try {
+        act(() => {
+          confirmButton.dispatchEvent(
+            new PointerEvent('pointerdown', { bubbles: true })
+          );
+        });
+        expect(onClose).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(overlay);
+      }
+
+      // Sanity check: an equivalent click with no exclusion marker still closes,
+      // so the assertion above is testing the marker, not a dead listener.
+      const plainEl = document.createElement('div');
+      document.body.appendChild(plainEl);
+      try {
+        act(() => {
+          plainEl.dispatchEvent(
+            new PointerEvent('pointerdown', { bubbles: true })
+          );
+        });
+        expect(onClose).toHaveBeenCalledTimes(1);
+      } finally {
+        document.body.removeChild(plainEl);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('positions the panel using getBoundingClientRect, not world coordinates', () => {
     // Mock getBoundingClientRect to return a screen rect that DIFFERS from the
     // widget's world coordinates — simulating a zoom/pan transform on the canvas.


### PR DESCRIPTION
## Problem

Building a schedule by hand forced a scroll on every single event. The **Add** button sat *above* the event list while a **New Schedule** button sat *below* it — so the control nearest the last row was the one that did **not** add an event.

Separately, deleting one event opened a confirmation dialog, and confirming it made the entire settings panel disappear — which read as "I just lost everything I typed."

## Root cause of the disappearing settings panel

`SettingsPanel.tsx:186-210` closes the panel on any `pointerdown` outside the panel and its widget, unless the target matches `[data-settings-exclude]`. `DialogContainer` portals its overlay onto `document.body` and did **not** carry that marker — so a click on any button inside any confirm/alert/prompt registered as a click-outside.

This was never Schedule-specific: **every** widget that opens a dialog from its settings had the same bug (including Schedule's own "Delete Schedule" confirm). Fixed at the source rather than worked around in the widget.

## Changes

**Event add placement** (`Schedule/Settings.tsx`)
- Controls split by what they act on: `Sort` and `Import` (whole-list operations) stay above the list; `Add Event` and `Today Only` moved directly under the last row, where the new row appears.
- A freshly added row focuses its task field and scrolls into view, so you can type immediately.

**"New Schedule" disambiguation**
- Consolidated to a single `FolderPlus` button in the schedule-name row, beside the existing delete-schedule button — the one row that is about the schedule rather than its events.
- The bottom "New Schedule" button is removed, so nothing below the event list operates on schedules.

**Single-event delete**
- No confirmation dialog. The row goes immediately, with an **Undo** toast as the safety net (10s).
- Undo re-inserts at the original index into the **live** list (read through a ref), so edits made during the toast window aren't clobbered by a stale snapshot.
- Blank, never-filled rows delete silently — an Undo offer for an empty row is noise.
- Deleting a **whole schedule** keeps its confirm; that destroys every event in it.

**Panel-close bug** (`DialogContainer.tsx`, `DashboardView.tsx`)
- The dialog overlay now carries `data-settings-exclude`.
- The toast stack carries it too, so clicking "Undo" doesn't close the panel either. Side effect: dismissing any toast by clicking it no longer closes an open settings panel.

## Testing

- New regression coverage on **both sides** of the contract: `SettingsPanel` honouring the marker, and `DialogContainer` actually emitting it — so the fix can't silently rot from either end.
- New Schedule settings tests: add-button DOM position relative to the last row, "New Schedule" living in the header row, instant delete with an Undo toast, undo-restores-at-original-index, and silent blank-row delete.
- `pnpm run type-check` clean; ESLint clean at `--max-warnings 0`; Prettier clean.

## Notes for review

Two judgement calls worth a second opinion:
- Blank rows delete with no toast at all (rather than always offering Undo).
- The toast-stack exclusion is deliberately whole-stack rather than action-toasts-only, which changes click-to-dismiss behavior slightly beyond the reported bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGUy1WRaYxhkrnGc3VAcho)_