### PR TITLE
Unify D3 group-heading SettingsLabel — Clock/TextWidget/WorkSymbols

### DIFF
--- a/components/admin/ClockConfigurationPanel.tsx
+++ b/components/admin/ClockConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useBuildingSelection } from '@/hooks/useBuildingSelection';
 import { BuildingSelector } from './BuildingSelector';
@@ -35,6 +35,8 @@ export const ClockConfigurationPanel: React.FC<
   const BUILDINGS = useAdminBuildings();
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
+  const fontFamilyLabelId = useId();
+  const clockStyleLabelId = useId();
 
   const buildingDefaults = config.buildingDefaults ?? {};
   const currentBuildingConfig: BuildingClockDefaults = buildingDefaults[
@@ -92,8 +94,14 @@ export const ClockConfigurationPanel: React.FC<
 
         {/* Font Family */}
         <div>
-          <SettingsLabel className="mb-1">Default Font Family</SettingsLabel>
-          <div className="flex bg-white rounded-lg border border-slate-200 p-1 gap-1">
+          <SettingsLabel as="span" id={fontFamilyLabelId} className="mb-1">
+            Default Font Family
+          </SettingsLabel>
+          <div
+            className="flex bg-white rounded-lg border border-slate-200 p-1 gap-1"
+            role="group"
+            aria-labelledby={fontFamilyLabelId}
+          >
             {FONT_FAMILY_OPTIONS.map((opt) => (
               <button
                 key={opt.value}
@@ -147,8 +155,14 @@ export const ClockConfigurationPanel: React.FC<
 
         {/* Clock Style */}
         <div>
-          <SettingsLabel className="mb-1">Default Display Style</SettingsLabel>
-          <div className="flex bg-white rounded-lg border border-slate-200 p-1 gap-1">
+          <SettingsLabel as="span" id={clockStyleLabelId} className="mb-1">
+            Default Display Style
+          </SettingsLabel>
+          <div
+            className="flex bg-white rounded-lg border border-slate-200 p-1 gap-1"
+            role="group"
+            aria-labelledby={clockStyleLabelId}
+          >
             {CLOCK_STYLE_OPTIONS.map((opt) => (
               <button
                 key={opt.value}

--- a/components/widgets/TextWidget/Settings.tsx
+++ b/components/widgets/TextWidget/Settings.tsx
@@ -19,8 +19,17 @@ export const TextSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   return (
     <div className="space-y-6">
       <div>
-        <SettingsLabel>Templates</SettingsLabel>
-        <div className="grid grid-cols-2 gap-2">
+        <SettingsLabel
+          as="span"
+          id={`text-widget-templates-label-${widget.id}`}
+        >
+          Templates
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-2 gap-2"
+          role="group"
+          aria-labelledby={`text-widget-templates-label-${widget.id}`}
+        >
           {TEXT_WIDGET_TEMPLATES.map((t) => (
             <button
               key={t.name}

--- a/components/widgets/WorkSymbols/Settings.tsx
+++ b/components/widgets/WorkSymbols/Settings.tsx
@@ -25,10 +25,18 @@ export const WorkSymbolsAppearanceSettings: React.FC<{
       <TextSizePresetSettings config={config} updateConfig={updateConfig} />
 
       <div>
-        <SettingsLabel icon={AlignVerticalSpaceAround}>
+        <SettingsLabel
+          as="span"
+          id={`worksymbols-title-position-label-${widget.id}`}
+          icon={AlignVerticalSpaceAround}
+        >
           Title Position
         </SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <div
+          className="flex bg-slate-100 p-1 rounded-xl"
+          role="group"
+          aria-labelledby={`worksymbols-title-position-label-${widget.id}`}
+        >
           <button
             onClick={() => updateConfig({ titlePosition: 'bottom' })}
             className={`flex-1 py-1.5 text-xs font-bold rounded-lg transition-colors ${


### PR DESCRIPTION
## Nightly Unifier — Run 47, Dimension D3 (Settings Panel Label Primitives)

**Canonical form:** `<SettingsLabel as="span" id="...">Heading</SettingsLabel>` + `role="group" aria-labelledby="..."` on the sibling-controls container, for labels that head a *group* of controls (button/chip groups) rather than pairing 1:1 with one form input. A bare `<label>` in that case is semantically orphaned — no single control to associate with. Established across the runs 26–46 retrofit series (DrawingWidget → RevealGrid ×2 → RandomSettings → MusicWidget ×2 → SyntaxFramer ×2 → Checklist → MathToolInstance).

**Instances unified (3 files, 3 group-heading conversions):**
- `components/admin/ClockConfigurationPanel.tsx` — "Default Font Family" and "Default Display Style" (2 groups). Single mount point (admin config-panel registry, `FeatureConfigurationPanel.tsx`) → used `useId()`.
- `components/widgets/TextWidget/Settings.tsx` — "Templates". Renders per-widget-instance via `DraggableWindow` → used `widget.id`-interpolated id (matches the DrawingWidget/RevealGrid/WorkSymbols convention).
- `components/widgets/WorkSymbols/Settings.tsx` — "Title Position". Same per-instance shape → `widget.id`-interpolated id.

A fresh repo-wide sweep for this specific pattern found these 3 as genuine, previously-unaudited instances outside the file list the runs 26–46 series had already walked — consistent with this routine's standing lesson that a "closed, no further candidates" note on this series should be read as scoped to the files actually audited, not a repo-wide exhaustiveness claim.

**Enforcement:** None added this run — this is a retrofit of pre-existing `SettingsLabel` call sites to the already-established `as="span"` group-heading convention, not a new drift class needing a new lint rule. The convention itself (documented in `SettingsLabel.tsx`'s own inline comments) is the enforcement surface for future call sites.

**Behavior/visual-preservation evidence:**
- `SettingsLabel.tsx`'s `combinedClasses` is computed once and shared identically by both the `as="label"` and `as="span"` render branches — confirmed by reading the component source directly (not just citing precedent). Only the wrapping element tag changes (`<label>` → `<span>`); `className`, icon, and children are identical. Zero visual delta.
- `role="group"` + `aria-labelledby` is additive (a11y-only), no visual effect.
- Verified independently in-worktree (not just trusting the subagent's own report): `tsc --noEmit` ✅, targeted `eslint --max-warnings 0` on the 3 changed files ✅, `prettier --check` on the 3 changed files ✅, full root `pnpm test` — **588/588 test files, 7129/7129 tests passed** ✅, `pnpm -C functions test` — **40/40 files, 775/775 tests passed** ✅, full `pnpm run build` (app + SSR prerender) ✅.

**Risk tag:** `mechanical` — pure DOM-tag-and-attribute-shape equivalence, same pattern shipped cleanly across 9+ prior runs in this series.

**Deferred:** D1, D2, D4, D5 all did fresh sweeps this run and reported "aligned" (no genuine new drift found) — see the run-47 memory-doc update PR for full detail. D2's `Dock.tsx:1586` NEEDS-REVIEW item (decimal-RGB brand-blue on the collapsed dock FAB, blocked on a human decision since run 30) remains open, now 18 consecutive runs unresolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KWqdAKmBjsRAs4QchV2Qo)_