### PR TITLE
Unify D3 group-heading SettingsLabel — TimeToolConfigurationPanel

### DIFF
--- a/components/admin/TimeToolConfigurationPanel.tsx
+++ b/components/admin/TimeToolConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useBuildingSelection } from '@/hooks/useBuildingSelection';
 import { BuildingSelector } from './BuildingSelector';
@@ -81,6 +81,8 @@ export const TimeToolConfigurationPanel: React.FC<
   const BUILDINGS = useAdminBuildings();
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
+  const accentColorLabelId = useId();
+  const trafficLightColorLabelId = useId();
 
   const buildingDefaults = config.buildingDefaults ?? {};
   const currentBuildingConfig: BuildingTimeToolDefaults = buildingDefaults[
@@ -285,8 +287,14 @@ export const TimeToolConfigurationPanel: React.FC<
         {/* Theme Color & Glow */}
         <div className="flex items-end justify-between gap-4">
           <div className="flex-1">
-            <SettingsLabel className="mb-1">Accent Color</SettingsLabel>
-            <div className="flex gap-1.5">
+            <SettingsLabel as="span" id={accentColorLabelId} className="mb-1">
+              Accent Color
+            </SettingsLabel>
+            <div
+              className="flex gap-1.5"
+              role="group"
+              aria-labelledby={accentColorLabelId}
+            >
               {WIDGET_PALETTE.map((color) => (
                 <button
                   key={color}
@@ -349,14 +357,22 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Timer End Traffic Light Color */}
         <div>
-          <SettingsLabel className="mb-1">
+          <SettingsLabel
+            as="span"
+            id={trafficLightColorLabelId}
+            className="mb-1"
+          >
             Timer-End Traffic Light Color
           </SettingsLabel>
           <p className="text-xxs text-slate-400 mb-2 leading-tight">
             Automatically sets the traffic light widget to this color when the
             timer reaches zero.
           </p>
-          <div className="flex gap-1.5">
+          <div
+            className="flex gap-1.5"
+            role="group"
+            aria-labelledby={trafficLightColorLabelId}
+          >
             {TRAFFIC_COLORS.map(({ value, label }) => (
               <button
                 key={String(value)}


### PR DESCRIPTION
## Nightly unifier — run 48 (2026-08-03), dimension D3: Settings Panel Label Primitives

**Canonical form:** A `<SettingsLabel>` that heads a *group* of sibling controls (button/chip/swatch rows with no single associated input) should render `as="span"` with an `id`, paired with `role="group" aria-labelledby={id}"` on the sibling-control container — not the default `as="label"` (which renders `<label>` and is semantically orphaned when there's no single control to associate with via `htmlFor`). This is the established convention from the runs 26–47 group-heading retrofit series.

**Instances unified (2, one file):** `components/admin/TimeToolConfigurationPanel.tsx`
- **"Accent Color"** (heads the `WIDGET_PALETTE` swatch-button row)
- **"Timer-End Traffic Light Color"** (heads the `TRAFFIC_COLORS` button row)

Both used `useId()` (this is a single-mount admin config panel, not rendered per-widget-instance, matching the file's own convention — no `widget.id` in scope here).

**Correctly left alone in the same file:** "Default Mode", "Display Style", "Number Style", "Default Alert Sound" already use `role="radiogroup" aria-label="..."` directly on their button containers — an already-accessible pattern distinct from the orphaned-`<label>` bug this PR fixes, matching the precedent noted for `Scoreboard/Settings.tsx` in the project's unifier memory doc.

**Behavior/visual preservation evidence:** `SettingsLabel.tsx`'s `combinedClasses` string is computed once and shared identically by both the `as="label"` and `as="span"` render branches — confirmed by reading the component source directly. Zero visual delta; this is purely a semantic/accessibility fix (adds `role="group"`/`aria-labelledby` so screen readers correctly associate the heading with its button group).

**Risk tag:** `mechanical` (pure equivalence — no visual or behavioral change, only ARIA semantics added).

**Verification:**
- `pnpm run validate`: green — 588/588 root test files (7129 tests), 40/40 functions test files (775 tests), same counts as the pre-change baseline on `dev-paul`. Type-check, lint (`--max-warnings 0`), and format-check all clean.
- `pnpm run build`: green (app build + SSR prerender).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WBqsijktUtnL2udFZsGSSG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBqsijktUtnL2udFZsGSSG)_