### PR TITLE
spike(g2p): English G2P probe harness and results

### DIFF
--- a/scripts/spikes/english-g2p-probe/.gitignore
+++ b/scripts/spikes/english-g2p-probe/.gitignore
@@ -1,0 +1,8 @@
+# Generated / downloaded data — regenerate with the steps in RESULTS.md (~19 MB)
+cmudict.dict
+g10k.txt
+words.txt
+*.json
+*.pdf
+*.txt
+!RESULTS.md

--- a/scripts/spikes/english-g2p-probe/.gitignore
+++ b/scripts/spikes/english-g2p-probe/.gitignore
@@ -5,4 +5,3 @@ words.txt
 *.json
 *.pdf
 *.txt
-!RESULTS.md

--- a/scripts/spikes/english-g2p-probe/.gitignore
+++ b/scripts/spikes/english-g2p-probe/.gitignore
@@ -1,7 +1,9 @@
-# Generated / downloaded data — regenerate with the steps in RESULTS.md (~19 MB)
+# Pipeline data — downloaded or generated. Regenerate with the steps in RESULTS.md (~19 MB).
 cmudict.dict
-g10k.txt
 words.txt
+g10k.txt
 *.json
-*.pdf
-*.txt
+
+# Ad-hoc reference material pulled while researching (papers, wordlists) is deliberately
+# NOT ignored — it shows up as untracked. Don't commit it, but better visible than silently
+# swallowed, which is what a blanket *.txt / *.pdf rule did here before.

--- a/scripts/spikes/english-g2p-probe/RESULTS.md
+++ b/scripts/spikes/english-g2p-probe/RESULTS.md
@@ -246,9 +246,11 @@ python3 split.py        # accuracy broken down by resolution path
 python3 teacher.py      # K-12 practice corpus + CMUDict cross-check flag rate
 ```
 
-`score2.py` holds the shared ARPAbet/IPA helpers (`esp_phones`, `cmu_phones`, `ed`, `VOW`);
-the other scorers `exec` its header. `score.py` and `score3.py` are earlier iterations kept
-for provenance.
+`score2.py` holds the shared ARPAbet/IPA helpers (`esp_phones`, `cmu_phones`, `ed`, `VOW`)
+and the other scorers import them directly; its own analysis is behind an
+`if __name__ == "__main__":` guard, so importing it does not require `cmu.json` or
+`espeak.json` to exist. `score.py` and `score3.py` are earlier iterations kept for
+provenance.
 
 ## Sources
 

--- a/scripts/spikes/english-g2p-probe/RESULTS.md
+++ b/scripts/spikes/english-g2p-probe/RESULTS.md
@@ -68,6 +68,20 @@ years apart, agreeing to within a point is good evidence the mapping and scoring
 Spot-checks confirm it: _island, choir, yacht, colonel, one, said, friend, subtle, women,
 busy, laughter, daughter, through, though, thought_ all come out correct.
 
+### Independent reproduction
+
+The whole pipeline was later re-run from scratch — fresh `cmudict.dict` and
+`google-10000-english` downloads, corpora rebuilt, espeak re-run over all 117k words — in a
+different session from the one that produced the table above. Every rate reproduced
+identically, including the practice corpus (94.1% / 97.1% / 91.5%, 340/341 CMUDict coverage
+with _piñata_ the sole miss) and the rules-vs-dictionary split (77.1%/22.9% at top-1000).
+
+Two cells drifted, from re-downloading upstream data rather than from the harness: the
+top-10k band matched **9,425** words against CMUDict rather than 9,428 (and its stress
+figure 87.7% rather than 87.8%), and the complement band 108,068 rather than 108,076. All
+accuracy rates were unchanged to 0.1pp. Worth knowing that these corpora are not pinned —
+anyone re-running should expect single-digit membership drift and record the download date.
+
 ### Rules are not the weak part
 
 Split by espeak's own resolution path:

--- a/scripts/spikes/english-g2p-probe/RESULTS.md
+++ b/scripts/spikes/english-g2p-probe/RESULTS.md
@@ -1,0 +1,267 @@
+# English G2P probe — does English need CMUDict + a neural fallback?
+
+Resolves [#2336](https://github.com/OPS-PIvers/SpartBoard/issues/2336) on the
+[Multilingual Pronunciation Engine map](https://github.com/OPS-PIvers/SpartBoard/issues/2331).
+
+**Verdict: rules + a teacher-facing confidence affordance. Drop the neural fallback.
+Keep CMUDict as a cross-check oracle, not as the primary path.**
+
+Measured with **espeak-ng 1.51** (`en-us`, Ubuntu 24.04 package) against **CMUDict**
+(`cmusphinx/cmudict` master, BSD-2-Clause), over all 117,493 alphabetic headwords plus
+frequency-banded and hand-built teacher-corpus subsets. Current espeak-ng upstream is
+1.52.0; numbers may be marginally better there.
+
+---
+
+## First: a correction to the ticket's premise
+
+The ticket claimed espeak-ng got both of the spec's cited examples right "with no dictionary
+and no neural fallback." That is half wrong. Tracing with `espeak-ng -v en-us -q -X`:
+
+| Word                | Resolved by                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `rough` → `ɹˈʌf`    | **Letter-to-sound rule** (`r) ough → [Vf]`, priority 99). Genuine rule win.                                 |
+| `through` → `θɹˈuː` | **`Found: 'through' [Tru:]`** — an entry in espeak's bundled exception dictionary (`en_list`, 5,794 lines). |
+
+So espeak-ng English is **not a pure rule engine**. It is already the architecture the spec
+proposed — exception dictionary plus fallback rules — in a 166 KB compiled `en_dict`.
+
+Share of lookups resolved by the exception dictionary, by frequency band:
+
+| Band              | Dictionary | Rules |
+| ----------------- | ---------- | ----- |
+| Top 1,000         | 22.9%      | 77.1% |
+| Rank 1,000–3,000  | 12.3%      | 87.7% |
+| Rank 5,000–10,000 | 12.1%      | 87.9% |
+
+The real question is therefore not _"rules vs. dictionary"_ but **"is a 166 KB curated
+exception list enough, or do you need a 3.6 MB dictionary plus a neural net on top?"**
+
+---
+
+## Accuracy
+
+| Corpus                                 | n       | literal ARPAbet | segments¹ | + vowel reduction² | stress pattern | PER (norm.) |
+| -------------------------------------- | ------- | --------------- | --------- | ------------------ | -------------- | ----------- |
+| All CMUDict headwords (surname-heavy)  | 117,493 | 56.8%           | 61.5%     | 68.6%              | 72.1%          | 9.7%        |
+| Top 1,000 frequency                    | 1,000   | 88.5%           | 93.1%     | 97.1%              | 93.5%          | 1.9%        |
+| Top 3,000 frequency                    | 3,000   | 83.6%           | 88.2%     | 95.3%              | 91.1%          | 2.7%        |
+| Top 5,000 frequency                    | 5,000   | 81.2%           | 86.3%     | 94.4%              | 89.7%          | 3.0%        |
+| Top ~10,000 frequency                  | 9,428   | 78.3%           | 83.8%     | 92.7%              | 87.8%          | 3.5%        |
+| CMUDict minus top-10k                  | 108,076 | 54.9%           | 59.6%     | 66.5%              | 70.7%          | 10.2%       |
+| **Hand-built K-12 EL practice corpus** | 340     | —               | **94.1%** | **97.1%**          | 91.5%          | —           |
+
+¹ Phone-sequence match, stress ignored, after normalising five _systematic notation_
+differences that are not pronunciation errors: velar-nasal assimilation (`IH NG K` vs
+`IH N K` in _including_ — espeak is phonetically correct), T/D flapping, the cot–caught
+merger, the north–force merger (`F OW R`/`F AO R` for _four_), and `ER`+`R` vs `ER`.
+
+² Additionally treating AH/IH/IY/UH/ER as one reduced class — i.e. not penalising
+unstressed-vowel-quality disagreement, which is not a contrast a learner can be scored on.
+
+### Harness validation
+
+The assumption-free **literal** column on full CMUDict (56.8%) lands within one point of
+Black, Lenzo & Pagel (1998), who report **57.80% words correct / 91.99% letters correct**
+for CART letter-to-sound rules on the same dictionary. Two independent rule systems, 26
+years apart, agreeing to within a point is good evidence the mapping and scoring are sound.
+Spot-checks confirm it: _island, choir, yacht, colonel, one, said, friend, subtle, women,
+busy, laughter, daughter, through, though, thought_ all come out correct.
+
+### Rules are not the weak part
+
+Split by espeak's own resolution path:
+
+| Resolved by           | segments | + reduction |
+| --------------------- | -------- | ----------- |
+| Letter-to-sound rules | 84.0%    | 93.0%       |
+| Exception dictionary  | 82.9%    | 90.0%       |
+
+Dictionary entries score _lower_ because they are the residue of irregular words. The rules
+are carrying the system competently.
+
+---
+
+## Why the neural fallback is not justified
+
+State-of-the-art neural G2P on **held-out CMUDict** (r-G2P, arXiv:2202.11194 Table 1):
+
+| Model                              | PER   | WER        |
+| ---------------------------------- | ----- | ---------- |
+| CNN-encoder + BiLSTM               | 4.81% | 25.13%     |
+| CNN + NSGD                         | 5.58% | 24.10%     |
+| Encoder-decoder + global attention | 5.04% | 21.69%     |
+| Transformer 4×4                    | 5.23% | 22.10%     |
+| Best r-G2P (adversarial)           | 4.84% | **19.85%** |
+
+A neural fallback exists to handle words a dictionary misses. On the actual corpus those
+misses are ~0.3–2.3% and are dominated by abbreviations and loanwords — precisely the class
+where published neural G2P _also_ fails (LatPhon names "proper nouns & foreign words" in its
+own limitations).
+
+So the fallback would be **wrong roughly one time in five, silently, on exactly the hard
+words.** At authoring time, with a human present, a wrong-but-confident phoneme string is
+strictly worse than a flag reading _"I'm unsure about this word — here's my guess, confirm
+or edit."_ A neural model costs a model artifact, cold-start weight in a Cloud Function, a
+training/eval pipeline, and a re-derivation story — to buy a 20%-error guess in place of a
+zero-error human confirmation. That trade is negative.
+
+> **Caution on comparing numbers.** The 1.9–3.5% PER measured here on realistic frequency
+> bands sits in the same range as neural G2P's ~3.5–5% PER, but the metrics are **not
+> directly comparable** — different reference lexicons, different phone sets, and the
+> normalization above. The defensible claim is that on _common English vocabulary_
+> rule-based G2P is not in a different accuracy class from neural G2P. Only on the long tail
+> (names, rare words) does neural roughly double rule performance — and that tail is out of
+> corpus here.
+
+---
+
+## Failure taxonomy
+
+Threat level is for **teacher-authored K-12 language-practice vocabulary**, not general text.
+
+| Category                                                   | Examples                                                                                                                                            | Real threat?                                                                                                                                                                                                                                                                                                                                                               |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Proper nouns / surnames**                                | _Gonzalez, Napolitano, Habegger, Swineford_                                                                                                         | **Low.** Dominates the full-CMUDict error rate (that corpus is WSJ name-heavy) and is why 117k scores 57% while the practice corpus scores 94%. CMUDict does not fix this — its own name coverage is idiosyncratic and US-biased.                                                                                                                                          |
+| **Loanwords**                                              | _salsa, croissant, piñata, edamame, gyro_                                                                                                           | **Moderate — the only genuinely worrying class.** Plausible in an EL classroom. But **CMUDict does not rescue them**: _piñata, jalapeño, quinoa, açaí, naan, pho, edamame_ are all absent from CMUDict. That is an argument for a teacher override field, not for CMUDict.                                                                                                 |
+| **Heteronyms**                                             | _read, lead, bass, live, wind, tear, bow, close, object, present, record, desert_                                                                   | **Genuine, and no dictionary solves it.** CMUDict returns 2–3 undifferentiated variants with no selection mechanism; espeak returns exactly one, silently. 6.4% of CMUDict headwords have ≥2 segmentally distinct pronunciations. Black et al.: English lexical stress "cannot in general be done from the letter context alone." **Only solvable by asking the teacher.** |
+| **Systematic notation / dialect differences (not errors)** | `ex-` prefix (EH-KS vs IH-KS — ~25% of top-5k residual); `-IY AH` vs `-Y AH` (_billion, opinion_); Mary–marry–merry; syllabic consonants (_button_) | **None.** Both forms are attested American English. These inflate any raw espeak-vs-CMUDict WER and must be normalised out before any threshold is set.                                                                                                                                                                                                                    |
+| **Genuine segmental errors**                               | _scissors, husband_ (S vs Z), _species_ (S vs SH), _gnu_                                                                                            | **Low but real** — 3–4 words (~1%) on the practice corpus.                                                                                                                                                                                                                                                                                                                 |
+| **Abbreviations / initialisms**                            | _feb, est, ct, sci, urls, tvs_                                                                                                                      | **None.** Not plausible spoken-response targets, and the bulk of CMUDict OOV.                                                                                                                                                                                                                                                                                              |
+| **Stress on compounds**                                    | _outside, weekend, payday, notebook, archive_ — segments identical, stress differs                                                                  | **Low, but decide explicitly.** 8.5% of the practice corpus. Moot if scoring is segment-based; the largest disagreement class if stress is scored.                                                                                                                                                                                                                         |
+
+---
+
+## CMUDict facts
+
+- **Size**: 3,618,488 bytes raw / 918,216 gzipped. 135,166 entries; 117,493 alphabetic
+  headwords + 8,362 variants. Irrelevant server-side.
+- **License**: **BSD-2-Clause**, © Carnegie Mellon University. Compatible with a proprietary
+  product; requires only notice retention.
+- **Coverage**: 0.5% OOV in top-1,000 web-frequency words, 2.3% in top-3,000, 5.7% in
+  top-10,000 — essentially all abbreviations, domain junk, and spam, not vocabulary. On the
+  341-word K-12 practice corpus, coverage was **340/341 (99.7%)**; the sole miss was
+  _piñata_. **Coverage is a non-problem for this corpus — which is exactly why a fallback
+  for coverage failure is unnecessary.**
+- **ARPAbet → IPA fidelity**: essentially 1:1, with **two stress-dependent exceptions that
+  must not be lost**:
+  - `AH` is _both_ /ʌ/ and /ə/ — disambiguated **only** by the stress digit (AH1 → ʌ;
+    AH0/AH2 → ə).
+  - `ER` splits the same way (ER1 → ɝ, ER0 → ɚ).
+
+  Any pipeline that strips stress digits before mapping **silently destroys the schwa/wedge
+  contrast.**
+
+- **No allophony**: CMUDict encodes no flaps, glottalization, velar-nasal assimilation,
+  dark-l, or length. espeak's output _does_ carry those (ɾ, ŋ, ɚ). Against a phone-level CTC
+  recognizer espeak's narrower transcription is the better-matched reference; against a
+  broad-phonemic scorer CMUDict's is. **This choice belongs to the acoustic model's label
+  set, not to G2P accuracy.**
+
+---
+
+## The alphabet argument — which may outrank everything above
+
+[#2349](https://github.com/OPS-PIvers/SpartBoard/issues/2349) selected
+`facebook/wav2vec2-xlsr-53-espeak-cv-ft`, whose vocabulary is **392 eSpeak phonemes**.
+
+The reference string must therefore be in **espeak's IPA alphabet**. Routing English through
+CMUDict ARPAbet→IPA would inject a systematic alphabet mismatch **larger than espeak's own
+G2P error rate**. That makes espeak-derived output the _matched_ reference, not merely the
+cheap one — and it is an independent argument for the same conclusion.
+
+---
+
+## Recommended source
+
+**espeak-ng's English rule tables as reference data, re-implemented as independent tables —
+not the shipped binary.**
+
+| Candidate                    | License                                                                                                                                                 | Verdict                                                                                                                                                                                                                                                                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **espeak-ng** 1.52.0         | **GPL-3.0-or-later** (repo `COPYING`; no separate grant for `dictsource/*`, so treat `en_rules`/`en_list` as GPL-3)                                     | Best rules, and the alphabet that matches the chosen CTC model. Gated on [#2337](https://github.com/OPS-PIvers/SpartBoard/issues/2337).                                                                                                                                                                               |
+| **CMU Flite** (`lex_lookup`) | **BSD-like** — "free to use in commercial products… GPL code is only included as part of the build process and does not taint any of the run-time code" | **Strongest license-clean English rule source.** Ships CMUDict-derived lexicon + CART LTS rules — direct descendant of the Black/Lenzo/Pagel work cited above. What Epitran uses for English. **Recommended fallback if GPL-3 is refused** — but note it emits CMU-style output, reintroducing the alphabet mismatch. |
+| **CMUDict**                  | BSD-2-Clause                                                                                                                                            | Clean. Use as cross-check oracle.                                                                                                                                                                                                                                                                                     |
+| **Phonetisaurus**            | BSD-3-Clause                                                                                                                                            | Clean. WFST G2P trainer — build your own rules from CMUDict with no espeak dependency. Viable clean-room route.                                                                                                                                                                                                       |
+| **Epitran**                  | MIT                                                                                                                                                     | Clean, but its English path shells out to Flite, installed separately.                                                                                                                                                                                                                                                |
+| **ipa-dict**                 | **MIT overall, mixed per language** — en_US from cmudict-ipa (MIT); **en_UK from ipacards (GPL-3)**; German CC BY-SA                                    | Usable for en_US only. **Do not take en_UK or de.**                                                                                                                                                                                                                                                                   |
+| **g2p_en**                   | Apache-2.0                                                                                                                                              | Clean CMUDict + tiny LSTM fallback, if the fallback decision is ever reversed.                                                                                                                                                                                                                                        |
+| **DeepPhonemizer**           | MIT                                                                                                                                                     | Clean neural G2P, same caveat.                                                                                                                                                                                                                                                                                        |
+| **misaki**                   | Apache-2.0 headline, **but `misaki[en]` pulls `phonemizer-fork` + `espeakng-loader`**                                                                   | **GPL taint via the English extra. Not clean.**                                                                                                                                                                                                                                                                       |
+| **LatPhon**                  | MIT "upon acceptance" — not yet released                                                                                                                | Watch, don't plan on it.                                                                                                                                                                                                                                                                                              |
+
+---
+
+## The recommended design
+
+1. Derive expected phonemes with **espeak-derived rules**, server-side at authoring time.
+2. Look the word up in **CMUDict** as a second opinion.
+3. When they disagree, **flag the item for teacher review** with the derived IPA editable.
+
+On the 341-word practice corpus this flag fires on **5.9%** of items (2.9% under
+vowel-reduction tolerance) and catches every genuine espeak error. That is a well-calibrated
+review queue, and it needs no neural component.
+
+---
+
+## Known limits of this research
+
+- espeak-ng **1.51** tested; upstream is **1.52.0**.
+- The convention-normalization and ARPAbet mapping are **this harness's own design choices**.
+  The **literal** column is the assumption-free number, and it independently reproduces the
+  published 1998 figure — that is the evidence the harness is sound. The normalized columns
+  embed judgment.
+- CMUDict is the only reference scored against. It is itself imperfect, General-American
+  only, and specifically weak on the loanwords that are the main residual risk. **Some
+  fraction of what is counted here as espeak errors are CMUDict errors, and they have not
+  been separated.**
+- **The 341-word "teacher corpus" is this harness's construction**, informed by standard
+  beginner-ESL topical domains — not a sample of real SpartBoard authoring data. **This is
+  the weakest link.** If real teacher input is name-heavy or loanword-heavy, the 94%/97%
+  figures degrade toward the full-CMUDict numbers. See
+  [#2356](https://github.com/OPS-PIvers/SpartBoard/issues/2356).
+- No published evaluation of espeak-ng specifically against CMUDict for English was found.
+  That gap is why this was measured. Treat these as first-party, reproducible, and
+  un-peer-reviewed.
+
+---
+
+## Reproducing
+
+Requires `espeak-ng` and Python 3. Run from this directory; scripts write generated data
+(~19 MB) into the working directory and are gitignored.
+
+```sh
+apt-get install -y --no-install-recommends espeak-ng
+
+# reference data
+curl -LO https://raw.githubusercontent.com/cmusphinx/cmudict/master/cmudict.dict
+curl -Lo g10k.txt https://raw.githubusercontent.com/first20hours/google-10000-english/master/google-10000-english.txt
+
+python3 prep.py         # cmudict.dict -> cmu.json + words.txt
+python3 run_espeak.py   # words.txt    -> espeak.json  (~10 min, 117k words)
+python3 score4.py       # the main accuracy table
+python3 src.py          # dictionary-vs-rules resolution split
+python3 split.py        # accuracy broken down by resolution path
+python3 teacher.py      # K-12 practice corpus + CMUDict cross-check flag rate
+```
+
+`score2.py` holds the shared ARPAbet/IPA helpers (`esp_phones`, `cmu_phones`, `ed`, `VOW`);
+the other scorers `exec` its header. `score.py` and `score3.py` are earlier iterations kept
+for provenance.
+
+## Sources
+
+- Black, Lenzo & Pagel (1998), _Issues in Building General Letter to Sound Rules_ — [ISCA archive](https://www.isca-archive.org/ssw_1998/black98_ssw.pdf)
+- _r-G2P: Evaluating and Enhancing Robustness of Grapheme to Phoneme Conversion_ — [arXiv:2202.11194](https://arxiv.org/pdf/2202.11194)
+- Yolchuyeva et al. (2019), _Transformer based G2P Conversion_ — [arXiv:2004.06338](https://arxiv.org/abs/2004.06338)
+- _LatPhon: Lightweight Multilingual G2P_ — [arXiv:2509.03300](https://arxiv.org/pdf/2509.03300)
+- Xu, Baevski & Auli (2021) — [arXiv:2109.11680](https://arxiv.org/abs/2109.11680); [facebook/wav2vec2-lv-60-espeak-cv-ft](https://huggingface.co/facebook/wav2vec2-lv-60-espeak-cv-ft) (392 eSpeak phonemes)
+- [espeak-ng](https://github.com/espeak-ng/espeak-ng) ([COPYING](https://raw.githubusercontent.com/espeak-ng/espeak-ng/master/COPYING), [dictionary docs](https://github.com/espeak-ng/espeak-ng/blob/master/docs/dictionary.md))
+- [cmusphinx/cmudict](https://github.com/cmusphinx/cmudict) ([LICENSE](https://github.com/cmusphinx/cmudict/blob/master/LICENSE))
+- [CMU Flite COPYING](https://raw.githubusercontent.com/festvox/flite/master/COPYING) · [Epitran](https://github.com/dmort27/epitran) · [Phonetisaurus LICENSE](https://github.com/AdolfVonKleist/Phonetisaurus/blob/master/LICENSE) · [ipa-dict](https://github.com/open-dict-data/ipa-dict) · [misaki pyproject](https://raw.githubusercontent.com/hexgrad/misaki/main/pyproject.toml)
+
+> _Note: "Fast, Not Fancy: Rethinking G2P with Rich Data and Rule-Based Models"
+> ([arXiv:2505.12973](https://arxiv.org/html/2505.12973v1)) is often cited for "rules
+> suffice" but is **Persian-only** (HomoFast eSpeak 6.33% PER vs neural 3.98%). It supports
+> the architecture argument, not any English number. Do not cite it as English evidence._

--- a/scripts/spikes/english-g2p-probe/prep.py
+++ b/scripts/spikes/english-g2p-probe/prep.py
@@ -1,0 +1,16 @@
+import re, collections, json
+ent = collections.defaultdict(list)
+for line in open('cmudict.dict', encoding='utf-8'):
+    line=line.split('#')[0].strip()
+    if not line: continue
+    parts=line.split()
+    w=parts[0]; ph=parts[1:]
+    base=re.sub(r'\(\d+\)$','',w)
+    if not re.fullmatch(r"[a-z']+", base): continue
+    if "'" in base: continue     # keep it simple: alphabetic only
+    ent[base].append(ph)
+words=sorted(ent)
+print('alphabetic headwords:', len(words))
+print('total variants:', sum(len(v) for v in ent.values()))
+json.dump({w:ent[w] for w in words}, open('cmu.json','w'))
+open('words.txt','w').write('\n'.join(words)+'\n')

--- a/scripts/spikes/english-g2p-probe/run_espeak.py
+++ b/scripts/spikes/english-g2p-probe/run_espeak.py
@@ -19,6 +19,13 @@ for i in range(0,len(words),CH):
         for w in chunk:
             q=subprocess.run(['espeak-ng','-v','en-us','-q','--ipa'],input=w,capture_output=True,text=True)
             t=q.stdout.split()
+            # Joined with '' rather than ' ' when espeak splits a word into several
+            # tokens. The separator is irrelevant downstream: esp_phones() segments by
+            # character/digraph and falls through anything unrecognised, so ' ' is
+            # discarded anyway -- esp_phones('ˈɛspɪk') == esp_phones('ˈɛ spɪk'). Worth
+            # knowing if this output is ever consumed by something expecting space-
+            # delimited phones. (4 of ~294 chunks took this path; 0 values in the
+            # resulting espeak.json contain a space and 0 are empty.)
             ipa=t[0] if len(t)==1 else ''.join(t)
             if not ipa:
                 raise RuntimeError(f"espeak-ng produced no output for {w!r} (rc={q.returncode}): {q.stderr.strip()[:200]!r}")

--- a/scripts/spikes/english-g2p-probe/run_espeak.py
+++ b/scripts/spikes/english-g2p-probe/run_espeak.py
@@ -7,13 +7,22 @@ for i in range(0,len(words),CH):
     chunk=words[i:i+CH]
     p=subprocess.run(['espeak-ng','-v','en-us','-q','--ipa'],
                      input='\n'.join(chunk), capture_output=True, text=True)
+    # Fail loudly. A missing binary already raises FileNotFoundError, but espeak-ng
+    # exits 0 even on an unrecognised option, so empty stdout -- not returncode -- is
+    # the reliable signal. Without this the per-word fallback below writes '' for every
+    # word and the scorers report 0% against a full-looking espeak.json.
+    if p.returncode!=0 or not p.stdout.strip():
+        raise RuntimeError(f"espeak-ng batch failed (rc={p.returncode}): {p.stderr.strip()[:200]!r}")
     toks=p.stdout.split()
     if len(toks)!=len(chunk):
         bad+=1
         for w in chunk:
             q=subprocess.run(['espeak-ng','-v','en-us','-q','--ipa'],input=w,capture_output=True,text=True)
             t=q.stdout.split()
-            out[w]=t[0] if len(t)==1 else ''.join(t)
+            ipa=t[0] if len(t)==1 else ''.join(t)
+            if not ipa:
+                raise RuntimeError(f"espeak-ng produced no output for {w!r} (rc={q.returncode}): {q.stderr.strip()[:200]!r}")
+            out[w]=ipa
     else:
         for w,t in zip(chunk,toks): out[w]=t
     if i % 20000 == 0: print(i, file=sys.stderr, flush=True)

--- a/scripts/spikes/english-g2p-probe/run_espeak.py
+++ b/scripts/spikes/english-g2p-probe/run_espeak.py
@@ -1,0 +1,21 @@
+import subprocess, sys, json
+words=[w.strip() for w in open('words.txt') if w.strip()]
+out={}
+CH=400
+bad=0
+for i in range(0,len(words),CH):
+    chunk=words[i:i+CH]
+    p=subprocess.run(['espeak-ng','-v','en-us','-q','--ipa'],
+                     input='\n'.join(chunk), capture_output=True, text=True)
+    toks=p.stdout.split()
+    if len(toks)!=len(chunk):
+        bad+=1
+        for w in chunk:
+            q=subprocess.run(['espeak-ng','-v','en-us','-q','--ipa'],input=w,capture_output=True,text=True)
+            t=q.stdout.split()
+            out[w]=t[0] if len(t)==1 else ''.join(t)
+    else:
+        for w,t in zip(chunk,toks): out[w]=t
+    if i % 20000 == 0: print(i, file=sys.stderr, flush=True)
+print('chunks needing fallback:', bad, file=sys.stderr)
+json.dump(out, open('espeak.json','w'))

--- a/scripts/spikes/english-g2p-probe/score.py
+++ b/scripts/spikes/english-g2p-probe/score.py
@@ -1,0 +1,67 @@
+import json, re, sys, collections
+
+DI = {'tʃ':'CH','dʒ':'JH','eɪ':'EY','aɪ':'AY','aʊ':'AW','ɔɪ':'OY','oʊ':'OW'}
+UNI = {
+ 'p':'P','b':'B','t':'T','d':'D','k':'K','ɡ':'G','f':'F','v':'V','θ':'TH','ð':'DH',
+ 's':'S','z':'Z','ʃ':'SH','ʒ':'ZH','h':'HH','m':'M','n':'N','ŋ':'NG','l':'L',
+ 'ɹ':'R','r':'R','w':'W','j':'Y','ɾ':'T','ʔ':'T','x':'K','ɬ':'L',
+ 'i':'IY','ɪ':'IH','ɛ':'EH','e':'EH','æ':'AE','ɑ':'AA','ɔ':'AO','ʊ':'UH','u':'UW',
+ 'ʌ':'AH','ə':'AH','ɐ':'AH','ɜ':'ER','ɚ':'ER','ᵻ':'IH','a':'AE','o':'OW',
+}
+DROP = set('ˈˌː̩̃ʲ')
+unmapped = collections.Counter()
+
+def to_arpa(s):
+    out=[]; i=0
+    while i < len(s):
+        if s[i] in DROP: i+=1; continue
+        if s[i:i+2] in DI: out.append(DI[s[i:i+2]]); i+=2; continue
+        c=s[i]
+        if c in UNI: out.append(UNI[c])
+        else: unmapped[c]+=1
+        i+=1
+    return out
+
+def strip_stress(ph): return [re.sub(r'\d','',p) for p in ph]
+
+# lenient equivalence classes for genuinely ambiguous contrasts
+LEN = {'T':'TD','D':'TD','AH':'RED','IH':'RED','AA':'LOT','AO':'LOT','UH':'RED2','UW':'RED2'}
+def leni(ph): return [LEN.get(p,p) for p in ph]
+
+def ed(a,b):
+    m,n=len(a),len(b)
+    prev=list(range(n+1))
+    for i in range(1,m+1):
+        cur=[i]+[0]*n
+        for j in range(1,n+1):
+            cur[j]=min(prev[j]+1, cur[j-1]+1, prev[j-1]+(a[i-1]!=b[j-1]))
+        prev=cur
+    return prev[n]
+
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+
+def evaluate(words, label):
+    n=exact=lenient=0; pe=pt=0; wrong=[]
+    for w in words:
+        if w not in cmu or w not in esp: continue
+        n+=1
+        hyp=to_arpa(esp[w])
+        refs=[strip_stress(r) for r in cmu[w]]
+        if any(hyp==r for r in refs): exact+=1; lenient+=1
+        elif any(leni(hyp)==leni(r) for r in refs): lenient+=1
+        else: wrong.append((w,' '.join(hyp),' '.join(refs[0])))
+        best=min((ed(hyp,r),len(r)) for r in refs)
+        pe+=best[0]; pt+=best[1]
+    print(f"\n=== {label} (n={n}) ===")
+    print(f"  word accuracy, exact ARPAbet match (no stress): {exact/n*100:.1f}%   WER {100-exact/n*100:.1f}%")
+    print(f"  word accuracy, lenient (T/D flap, AH~IH reduction, AA~AO merger, UH~UW): {lenient/n*100:.1f}%   WER {100-lenient/n*100:.1f}%")
+    print(f"  phoneme error rate (edit dist / ref len): {pe/pt*100:.1f}%")
+    return wrong
+
+allw=sorted(cmu)
+wrong=evaluate(allw,'FULL CMUDict headwords (alphabetic)')
+print('\nunmapped espeak chars:', dict(unmapped))
+print('\nsample of 40 mismatches:')
+import random; random.seed(1)
+for w,h,r in random.sample(wrong,40): print(f'  {w:22s} espeak={h:38s} cmu={r}')
+json.dump(wrong, open('wrong_all.json','w'))

--- a/scripts/spikes/english-g2p-probe/score.py
+++ b/scripts/spikes/english-g2p-probe/score.py
@@ -52,6 +52,9 @@ def evaluate(words, label):
         else: wrong.append((w,' '.join(hyp),' '.join(refs[0])))
         best=min((ed(hyp,r),len(r)) for r in refs)
         pe+=best[0]; pt+=best[1]
+    if n==0:
+        print(f"\n=== {label} — 0 words matched. Are cmu.json and espeak.json built? ===")
+        return wrong
     print(f"\n=== {label} (n={n}) ===")
     print(f"  word accuracy, exact ARPAbet match (no stress): {exact/n*100:.1f}%   WER {100-exact/n*100:.1f}%")
     print(f"  word accuracy, lenient (T/D flap, AH~IH reduction, AA~AO merger, UH~UW): {lenient/n*100:.1f}%   WER {100-lenient/n*100:.1f}%")
@@ -63,5 +66,5 @@ wrong=evaluate(allw,'FULL CMUDict headwords (alphabetic)')
 print('\nunmapped espeak chars:', dict(unmapped))
 print('\nsample of 40 mismatches:')
 import random; random.seed(1)
-for w,h,r in random.sample(wrong,40): print(f'  {w:22s} espeak={h:38s} cmu={r}')
+for w,h,r in random.sample(wrong,min(40,len(wrong))): print(f'  {w:22s} espeak={h:38s} cmu={r}')
 json.dump(wrong, open('wrong_all.json','w'))

--- a/scripts/spikes/english-g2p-probe/score2.py
+++ b/scripts/spikes/english-g2p-probe/score2.py
@@ -77,6 +77,9 @@ if __name__ == "__main__":
             if collect and not okp: wrong.append((w,' '.join(plain(h)),' '.join(plain(refs[0]))))
             b=min((ed(plain(h),plain(r)),len(r)) for r in refs)
             pe+=b[0]; pt+=b[1]
+        if n==0:
+            print(f"{label:44s} n=      0  -- no words matched. Are cmu.json and espeak.json built?")
+            return wrong
         print(f"{label:44s} n={n:7d}  exact={ex/n*100:5.1f}%  practice={pr/n*100:5.1f}%  stress={stx/n*100:5.1f}%  PER={pe/pt*100:4.1f}%")
         return wrong
 
@@ -94,6 +97,6 @@ if __name__ == "__main__":
     ev(tail,'CMUDict MINUS top-10k (rare words + surnames)')
     print("\n--- mismatches (practice metric) inside top-10k frequency band, sample 45 ---")
     random.seed(3)
-    for a,b,c in random.sample(w,45): print(f'  {a:18s} espeak={b:34s} cmu={c}')
+    for a,b,c in random.sample(w,min(45,len(w))): print(f'  {a:18s} espeak={b:34s} cmu={c}')
     print(f'\ntotal practice-metric mismatches in top-10k band: {len(w)}')
     json.dump(w,open('wrong_freq.json','w'))

--- a/scripts/spikes/english-g2p-probe/score2.py
+++ b/scripts/spikes/english-g2p-probe/score2.py
@@ -1,0 +1,95 @@
+import json, re, collections, random
+
+DI = {'tʃ':'CH','dʒ':'JH','eɪ':'EY','aɪ':'AY','aʊ':'AW','ɔɪ':'OY','oʊ':'OW'}
+UNI = {'p':'P','b':'B','t':'T','d':'D','k':'K','ɡ':'G','f':'F','v':'V','θ':'TH','ð':'DH',
+ 's':'S','z':'Z','ʃ':'SH','ʒ':'ZH','h':'HH','m':'M','n':'N','ŋ':'NG','l':'L',
+ 'ɹ':'R','r':'R','w':'W','j':'Y','ɾ':'T','ʔ':'T','x':'K','ɬ':'L',
+ 'i':'IY','ɪ':'IH','ɛ':'EH','e':'EH','æ':'AE','ɑ':'AA','ɔ':'AO','ʊ':'UH','u':'UW',
+ 'ʌ':'AH','ə':'AH','ɐ':'AH','ɜ':'ER','ɚ':'ER','ᵻ':'IH','a':'AE','o':'OW'}
+VOW={'IY','IH','EH','AE','AA','AO','UH','UW','AH','ER','EY','OW','AY','AW','OY'}
+DROP=set('ː̩̃ʲ')
+
+def esp_phones(s):
+    """returns list of (phone, stress) ; stress 1/2/0"""
+    out=[]; i=0; pend=0
+    while i<len(s):
+        c=s[i]
+        if c=='ˈ': pend=1; i+=1; continue
+        if c=='ˌ': pend=2; i+=1; continue
+        if c in DROP: i+=1; continue
+        if s[i:i+2] in DI: p=DI[s[i:i+2]]; i+=2
+        elif c in UNI: p=UNI[c]; i+=1
+        else: i+=1; continue
+        if p in VOW: out.append((p,pend)); pend=0
+        else: out.append((p,0))
+    return out
+
+def cmu_phones(ph):
+    out=[]
+    for p in ph:
+        m=re.match(r'([A-Z]+)(\d)?$',p)
+        out.append((m.group(1), int(m.group(2)) if m.group(2) else 0))
+    return out
+
+FLAP={'T':'TD','D':'TD'}
+LOT={'AA':'LOT','AO':'LOT'}
+def practice(seq):
+    """metric relevant to pronunciation practice:
+       - unstressed vowels all collapse to one reduced class
+       - intervocalic T/D flap collapsed
+       - cot-caught merger collapsed"""
+    o=[]
+    for p,st in seq:
+        if p in VOW:
+            o.append('V0' if st==0 else LOT.get(p,p))
+        else:
+            o.append(FLAP.get(p,p))
+    return o
+def plain(seq): return [p for p,_ in seq]
+def stresspat(seq): return [st for p,st in seq if p in VOW]
+
+def ed(a,b):
+    m,n=len(a),len(b); prev=list(range(n+1))
+    for i in range(1,m+1):
+        cur=[i]+[0]*n
+        for j in range(1,n+1):
+            cur[j]=min(prev[j]+1,cur[j-1]+1,prev[j-1]+(a[i-1]!=b[j-1]))
+        prev=cur
+    return prev[n]
+
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+
+def ev(words,label,collect=False):
+    n=ex=pr=stx=0; pe=pt=0; wrong=[]
+    for w in words:
+        if w not in CMUP or w not in esp: continue
+        n+=1
+        h=esp_phones(esp[w]); refs=CMUP[w]
+        okx=any(plain(h)==plain(r) for r in refs)
+        okp=any(practice(h)==practice(r) for r in refs)
+        oks=any(stresspat(h)==stresspat(r) for r in refs)
+        ex+=okx; pr+=okp; stx+=oks
+        if collect and not okp: wrong.append((w,' '.join(plain(h)),' '.join(plain(refs[0]))))
+        b=min((ed(plain(h),plain(r)),len(r)) for r in refs)
+        pe+=b[0]; pt+=b[1]
+    print(f"{label:44s} n={n:7d}  exact={ex/n*100:5.1f}%  practice={pr/n*100:5.1f}%  stress={stx/n*100:5.1f}%  PER={pe/pt*100:4.1f}%")
+    return wrong
+
+allw=sorted(CMUP)
+freq=[w.strip() for w in open('g10k.txt') if w.strip()]
+freq=[w for w in freq if w in CMUP]
+print("METRIC KEY: exact = exact ARPAbet phone match ignoring stress; practice = unstressed vowels")
+print("collapsed + T/D flap collapsed + cot-caught merged; stress = stress pattern match; PER = phone edit rate\n")
+ev(allw,'ALL CMUDict headwords (117k, name-heavy)')
+ev(freq[:1000],'Top 1000 frequency words')
+ev(freq[:2000],'Top 2000 frequency words')
+ev(freq[:5000],'Top 5000 frequency words')
+w=ev(freq[:10000],'Top ~10000 frequency words',collect=True)
+tail=[x for x in allw if x not in set(freq)]
+ev(tail,'CMUDict MINUS top-10k (rare words + surnames)')
+print("\n--- mismatches (practice metric) inside top-10k frequency band, sample 45 ---")
+random.seed(3)
+for a,b,c in random.sample(w,45): print(f'  {a:18s} espeak={b:34s} cmu={c}')
+print(f'\ntotal practice-metric mismatches in top-10k band: {len(w)}')
+json.dump(w,open('wrong_freq.json','w'))

--- a/scripts/spikes/english-g2p-probe/score2.py
+++ b/scripts/spikes/english-g2p-probe/score2.py
@@ -28,6 +28,13 @@ def cmu_phones(ph):
     out=[]
     for p in ph:
         m=re.match(r'([A-Z]+)(\d)?$',p)
+        # Never fires on real CMUDict -- 0 of 799,783 tokens -- but a named error beats
+        # `AttributeError: 'NoneType' object has no attribute 'group'` if this is ever
+        # pointed at another lexicon. Reports the whole entry, not just the token:
+        # cmu_phones() receives only the phone list, so that is as close as it can get
+        # to naming the offending word.
+        if m is None:
+            raise ValueError(f"Unrecognised CMUDict phoneme {p!r} in entry {ph!r}")
         out.append((m.group(1), int(m.group(2)) if m.group(2) else 0))
     return out
 

--- a/scripts/spikes/english-g2p-probe/score2.py
+++ b/scripts/spikes/english-g2p-probe/score2.py
@@ -57,39 +57,43 @@ def ed(a,b):
         prev=cur
     return prev[n]
 
-cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
-CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+# Everything below runs only when this file is executed directly. The other
+# scorers do `from score2 import esp_phones, cmu_phones, VOW, ed`, so importing
+# must not touch cmu.json / espeak.json — they may not exist yet.
+if __name__ == "__main__":
+    cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+    CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
 
-def ev(words,label,collect=False):
-    n=ex=pr=stx=0; pe=pt=0; wrong=[]
-    for w in words:
-        if w not in CMUP or w not in esp: continue
-        n+=1
-        h=esp_phones(esp[w]); refs=CMUP[w]
-        okx=any(plain(h)==plain(r) for r in refs)
-        okp=any(practice(h)==practice(r) for r in refs)
-        oks=any(stresspat(h)==stresspat(r) for r in refs)
-        ex+=okx; pr+=okp; stx+=oks
-        if collect and not okp: wrong.append((w,' '.join(plain(h)),' '.join(plain(refs[0]))))
-        b=min((ed(plain(h),plain(r)),len(r)) for r in refs)
-        pe+=b[0]; pt+=b[1]
-    print(f"{label:44s} n={n:7d}  exact={ex/n*100:5.1f}%  practice={pr/n*100:5.1f}%  stress={stx/n*100:5.1f}%  PER={pe/pt*100:4.1f}%")
-    return wrong
+    def ev(words,label,collect=False):
+        n=ex=pr=stx=0; pe=pt=0; wrong=[]
+        for w in words:
+            if w not in CMUP or w not in esp: continue
+            n+=1
+            h=esp_phones(esp[w]); refs=CMUP[w]
+            okx=any(plain(h)==plain(r) for r in refs)
+            okp=any(practice(h)==practice(r) for r in refs)
+            oks=any(stresspat(h)==stresspat(r) for r in refs)
+            ex+=okx; pr+=okp; stx+=oks
+            if collect and not okp: wrong.append((w,' '.join(plain(h)),' '.join(plain(refs[0]))))
+            b=min((ed(plain(h),plain(r)),len(r)) for r in refs)
+            pe+=b[0]; pt+=b[1]
+        print(f"{label:44s} n={n:7d}  exact={ex/n*100:5.1f}%  practice={pr/n*100:5.1f}%  stress={stx/n*100:5.1f}%  PER={pe/pt*100:4.1f}%")
+        return wrong
 
-allw=sorted(CMUP)
-freq=[w.strip() for w in open('g10k.txt') if w.strip()]
-freq=[w for w in freq if w in CMUP]
-print("METRIC KEY: exact = exact ARPAbet phone match ignoring stress; practice = unstressed vowels")
-print("collapsed + T/D flap collapsed + cot-caught merged; stress = stress pattern match; PER = phone edit rate\n")
-ev(allw,'ALL CMUDict headwords (117k, name-heavy)')
-ev(freq[:1000],'Top 1000 frequency words')
-ev(freq[:2000],'Top 2000 frequency words')
-ev(freq[:5000],'Top 5000 frequency words')
-w=ev(freq[:10000],'Top ~10000 frequency words',collect=True)
-tail=[x for x in allw if x not in set(freq)]
-ev(tail,'CMUDict MINUS top-10k (rare words + surnames)')
-print("\n--- mismatches (practice metric) inside top-10k frequency band, sample 45 ---")
-random.seed(3)
-for a,b,c in random.sample(w,45): print(f'  {a:18s} espeak={b:34s} cmu={c}')
-print(f'\ntotal practice-metric mismatches in top-10k band: {len(w)}')
-json.dump(w,open('wrong_freq.json','w'))
+    allw=sorted(CMUP)
+    freq=[w.strip() for w in open('g10k.txt') if w.strip()]
+    freq=[w for w in freq if w in CMUP]
+    print("METRIC KEY: exact = exact ARPAbet phone match ignoring stress; practice = unstressed vowels")
+    print("collapsed + T/D flap collapsed + cot-caught merged; stress = stress pattern match; PER = phone edit rate\n")
+    ev(allw,'ALL CMUDict headwords (117k, name-heavy)')
+    ev(freq[:1000],'Top 1000 frequency words')
+    ev(freq[:2000],'Top 2000 frequency words')
+    ev(freq[:5000],'Top 5000 frequency words')
+    w=ev(freq[:10000],'Top ~10000 frequency words',collect=True)
+    tail=[x for x in allw if x not in set(freq)]
+    ev(tail,'CMUDict MINUS top-10k (rare words + surnames)')
+    print("\n--- mismatches (practice metric) inside top-10k frequency band, sample 45 ---")
+    random.seed(3)
+    for a,b,c in random.sample(w,45): print(f'  {a:18s} espeak={b:34s} cmu={c}')
+    print(f'\ntotal practice-metric mismatches in top-10k band: {len(w)}')
+    json.dump(w,open('wrong_freq.json','w'))

--- a/scripts/spikes/english-g2p-probe/score3.py
+++ b/scripts/spikes/english-g2p-probe/score3.py
@@ -1,5 +1,5 @@
 import json, re, collections, random
-exec(open('score2.py').read().split("cmu=json.load")[0])   # reuse esp_phones/cmu_phones/VOW/ed
+from score2 import esp_phones, cmu_phones, VOW, ed
 
 cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
 CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}

--- a/scripts/spikes/english-g2p-probe/score3.py
+++ b/scripts/spikes/english-g2p-probe/score3.py
@@ -13,7 +13,7 @@ def norm(seq, reduce_vowels):
         if ph=='NG' and nxt in ('K','G'): ph='N'          # velar nasal assimilation
         if ph in ('T','D'): ph='TD'                        # flapping
         if ph in ('AA','AO'): ph='LOT'                     # cot-caught
-        if ph in ('OW','AO','LOT') and nxt=='R': ph='OHR'  # north/force merger
+        if ph in ('OW','LOT') and nxt=='R': ph='OHR'       # north/force merger
         o.append(ph); os_.append(s)
     # collapse ER R -> ER, R R -> R, and any doubled identical phone
     o2=[];s2=[]

--- a/scripts/spikes/english-g2p-probe/score3.py
+++ b/scripts/spikes/english-g2p-probe/score3.py
@@ -37,6 +37,9 @@ def ev(words,label):
         if not okR: resid.append((w,' '.join(x for x,_ in h),' '.join(x for x,_ in refs[0])))
         H=norm(h,False); b=min((ed(H,norm(r,False)),len(norm(r,False))) for r in refs)
         pe+=b[0]; pt+=b[1]
+    if n==0:
+        print(f"{label:42s} n=      0 | no words matched. Are cmu.json and espeak.json built?")
+        return resid
     print(f"{label:42s} n={n:7d} | raw={raw/n*100:5.1f}% | +conventions={nseg/n*100:5.1f}% | +vowel-reduction={nred/n*100:5.1f}% | PER={pe/pt*100:4.1f}%")
     return resid
 
@@ -55,5 +58,5 @@ ev([x for x in allw if x not in fs],'CMUDict minus top-10k (rare + surnames)')
 print(f"\nresidual errors in top-5000 band: {len(r5)}; in top-10k band: {len(r10)}")
 print("\n--- residual sample (top-5000 band), 50 ---")
 random.seed(7)
-for a,b,c in random.sample(r5,50): print(f'  {a:18s} espeak={b:32s} cmu={c}')
+for a,b,c in random.sample(r5,min(50,len(r5))): print(f'  {a:18s} espeak={b:32s} cmu={c}')
 json.dump(r10,open('resid10.json','w')); json.dump(r5,open('resid5.json','w'))

--- a/scripts/spikes/english-g2p-probe/score3.py
+++ b/scripts/spikes/english-g2p-probe/score3.py
@@ -1,0 +1,59 @@
+import json, re, collections, random
+exec(open('score2.py').read().split("cmu=json.load")[0])   # reuse esp_phones/cmu_phones/VOW/ed
+
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+
+def norm(seq, reduce_vowels):
+    """Normalise away KNOWN systematic espeak-vs-CMUDict transcription conventions."""
+    p=[x for x,_ in seq]; st=[s for _,s in seq]
+    o=[];os_=[]
+    for i,(ph,s) in enumerate(zip(p,st)):
+        nxt=p[i+1] if i+1<len(p) else ''
+        if ph=='NG' and nxt in ('K','G'): ph='N'          # velar nasal assimilation
+        if ph in ('T','D'): ph='TD'                        # flapping
+        if ph in ('AA','AO'): ph='LOT'                     # cot-caught
+        if ph in ('OW','AO','LOT') and nxt=='R': ph='OHR'  # north/force merger
+        o.append(ph); os_.append(s)
+    # collapse ER R -> ER, R R -> R, and any doubled identical phone
+    o2=[];s2=[]
+    for ph,s in zip(o,os_):
+        if o2 and ((o2[-1]=='ER' and ph=='R') or (o2[-1]==ph=='R')): continue
+        o2.append(ph); s2.append(s)
+    if reduce_vowels:
+        o2=['V0' if (ph in VOW or ph in('LOT','OHR')) and s==0 else ph for ph,s in zip(o2,s2)]
+    return o2
+
+def ev(words,label):
+    n=0; raw=0; nseg=0; nred=0; pe=pt=0; resid=[]
+    for w in words:
+        if w not in CMUP or w not in esp: continue
+        n+=1
+        h=esp_phones(esp[w]); refs=CMUP[w]
+        if any([x for x,_ in h]==[x for x,_ in r] for r in refs): raw+=1
+        okS=any(norm(h,False)==norm(r,False) for r in refs)
+        okR=any(norm(h,True)==norm(r,True) for r in refs)
+        nseg+=okS; nred+=okR
+        if not okR: resid.append((w,' '.join(x for x,_ in h),' '.join(x for x,_ in refs[0])))
+        H=norm(h,False); b=min((ed(H,norm(r,False)),len(norm(r,False))) for r in refs)
+        pe+=b[0]; pt+=b[1]
+    print(f"{label:42s} n={n:7d} | raw={raw/n*100:5.1f}% | +conventions={nseg/n*100:5.1f}% | +vowel-reduction={nred/n*100:5.1f}% | PER={pe/pt*100:4.1f}%")
+    return resid
+
+allw=sorted(CMUP)
+freq=[w.strip() for w in open('g10k.txt') if w.strip()]; freq=[w for w in freq if w in CMUP]
+fs=set(freq)
+print("raw = literal ARPAbet match | +conventions = after normalising 5 systematic espeak/CMUDict")
+print("notation differences (velar-nasal, flap, cot-caught, north-force, ER+R) | +vowel-reduction =")
+print("additionally treating all unstressed vowels as one reduced class\n")
+ev(allw,'ALL CMUDict headwords (name-heavy)')
+ev(freq[:1000],'Top 1000 frequency')
+ev(freq[:2000],'Top 2000 frequency')
+r5=ev(freq[:5000],'Top 5000 frequency')
+r10=ev(freq,'Top ~10000 frequency')
+ev([x for x in allw if x not in fs],'CMUDict minus top-10k (rare + surnames)')
+print(f"\nresidual errors in top-5000 band: {len(r5)}; in top-10k band: {len(r10)}")
+print("\n--- residual sample (top-5000 band), 50 ---")
+random.seed(7)
+for a,b,c in random.sample(r5,50): print(f'  {a:18s} espeak={b:32s} cmu={c}')
+json.dump(r10,open('resid10.json','w')); json.dump(r5,open('resid5.json','w'))

--- a/scripts/spikes/english-g2p-probe/score4.py
+++ b/scripts/spikes/english-g2p-probe/score4.py
@@ -1,0 +1,50 @@
+import json, re, collections, random
+exec(open('score2.py').read().split("cmu=json.load")[0])
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+RED={'AH','IH','IY','UH','ER'}
+
+def conv(seq):
+    p=[x for x,_ in seq]; o=[]
+    for i,ph in enumerate(p):
+        nxt=p[i+1] if i+1<len(p) else ''
+        if ph=='NG' and nxt in ('K','G'): ph='N'
+        if ph in ('T','D'): ph='TD'
+        if ph in ('AA','AO'): ph='LOT'
+        if ph in ('OW','LOT') and nxt=='R': ph='OHR'
+        if o and ((o[-1]=='ER' and ph=='R') or (o[-1]==ph=='R')): continue
+        o.append(ph)
+    return o
+def redu(s): return ['RED' if x in RED else x for x in s]
+def stresspat(seq): return [st for p,st in seq if p in VOW]
+
+def ev(words,label,keep=False):
+    n=0;a=b=c=d=0;pe=pt=0;res=[]
+    for w in words:
+        if w not in CMUP or w not in esp: continue
+        n+=1; h=esp_phones(esp[w]); R=CMUP[w]
+        a+= any([x for x,_ in h]==[x for x,_ in r] for r in R)
+        okc=any(conv(h)==conv(r) for r in R); b+=okc
+        okr=any(redu(conv(h))==redu(conv(r)) for r in R); c+=okr
+        d+= any(stresspat(h)==stresspat(r) for r in R)
+        if keep and not okr: res.append((w,' '.join(x for x,_ in h),' '.join(x for x,_ in R[0])))
+        H=conv(h); m=min((ed(H,conv(r)),len(conv(r))) for r in R); pe+=m[0]; pt+=m[1]
+    print(f"{label:40s} n={n:6d} | literal {a/n*100:5.1f}% | segments {b/n*100:5.1f}% | segments+reduction {c/n*100:5.1f}% | stress {d/n*100:5.1f}% | PER {pe/pt*100:4.1f}%")
+    return res
+
+freq=[w.strip() for w in open('g10k.txt') if w.strip()]; freq=[w for w in freq if w in CMUP]
+fs=set(freq); allw=sorted(CMUP)
+print("segments = phone-sequence match, STRESS IGNORED, 5 notation conventions normalised")
+print("segments+reduction = additionally AH/IH/IY/UH/ER treated as one reduced class")
+print("stress = stress pattern (primary/secondary/none per vowel) matches exactly\n")
+ev(allw,'ALL CMUDict (117k, surname-heavy)')
+ev(freq[:1000],'Top 1000 frequency')
+ev(freq[:3000],'Top 3000 frequency')
+r=ev(freq[:5000],'Top 5000 frequency',keep=True)
+ev(freq,'Top ~10000 frequency')
+ev([x for x in allw if x not in fs],'CMUDict minus top-10k')
+print(f"\nresidual (segments+reduction failures) in top-5000: {len(r)}")
+print("--- residual sample 60 ---")
+random.seed(11)
+for x in random.sample(r,60): print(f'  {x[0]:18s} espeak={x[1]:32s} cmu={x[2]}')
+json.dump(r,open('resid_final.json','w'))

--- a/scripts/spikes/english-g2p-probe/score4.py
+++ b/scripts/spikes/english-g2p-probe/score4.py
@@ -29,6 +29,9 @@ def ev(words,label,keep=False):
         d+= any(stresspat(h)==stresspat(r) for r in R)
         if keep and not okr: res.append((w,' '.join(x for x,_ in h),' '.join(x for x,_ in R[0])))
         H=conv(h); m=min((ed(H,conv(r)),len(conv(r))) for r in R); pe+=m[0]; pt+=m[1]
+    if n==0:
+        print(f"{label:40s} n=     0 | no words matched. Are cmu.json and espeak.json built?")
+        return res
     print(f"{label:40s} n={n:6d} | literal {a/n*100:5.1f}% | segments {b/n*100:5.1f}% | segments+reduction {c/n*100:5.1f}% | stress {d/n*100:5.1f}% | PER {pe/pt*100:4.1f}%")
     return res
 
@@ -46,5 +49,5 @@ ev([x for x in allw if x not in fs],'CMUDict minus top-10k')
 print(f"\nresidual (segments+reduction failures) in top-5000: {len(r)}")
 print("--- residual sample 60 ---")
 random.seed(11)
-for x in random.sample(r,60): print(f'  {x[0]:18s} espeak={x[1]:32s} cmu={x[2]}')
+for x in random.sample(r,min(60,len(r))): print(f'  {x[0]:18s} espeak={x[1]:32s} cmu={x[2]}')
 json.dump(r,open('resid_final.json','w'))

--- a/scripts/spikes/english-g2p-probe/score4.py
+++ b/scripts/spikes/english-g2p-probe/score4.py
@@ -1,5 +1,5 @@
 import json, re, collections, random
-exec(open('score2.py').read().split("cmu=json.load")[0])
+from score2 import esp_phones, cmu_phones, VOW, ed
 cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
 CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
 RED={'AH','IH','IY','UH','ER'}

--- a/scripts/spikes/english-g2p-probe/split.py
+++ b/scripts/spikes/english-g2p-probe/split.py
@@ -1,5 +1,5 @@
 import json
-exec(open('score2.py').read().split("cmu=json.load")[0])
+from score2 import esp_phones, cmu_phones
 cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
 CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
 RED={'AH','IH','IY','UH','ER'}

--- a/scripts/spikes/english-g2p-probe/split.py
+++ b/scripts/spikes/english-g2p-probe/split.py
@@ -19,12 +19,11 @@ src={}
 for f in ['src_top-1000.json','src_rank_1000-3000.json','src_rank_5000-10000.json']:
     src.update(json.load(open(f)))
 for kind in ['letter-to-sound rules','dictionary entry']:
-    for lab,sel in [('all sampled',None)]:
-        ws=[w for w,k in src.items() if k==kind]
-        n=a=b=0
-        for w in ws:
-            if w not in CMUP: continue
-            n+=1; h=esp_phones(esp[w]); R=CMUP[w]
-            a+=any(conv(h)==conv(r) for r in R)
-            b+=any(redu(conv(h))==redu(conv(r)) for r in R)
-        print(f"{kind:24s} n={n:5d}  segments={a/n*100:5.1f}%  segments+reduction={b/n*100:5.1f}%")
+    ws=[w for w,k in src.items() if k==kind]
+    n=a=b=0
+    for w in ws:
+        if w not in CMUP: continue
+        n+=1; h=esp_phones(esp[w]); R=CMUP[w]
+        a+=any(conv(h)==conv(r) for r in R)
+        b+=any(redu(conv(h))==redu(conv(r)) for r in R)
+    print(f"{kind:24s} n={n:5d}  segments={a/n*100:5.1f}%  segments+reduction={b/n*100:5.1f}%")

--- a/scripts/spikes/english-g2p-probe/split.py
+++ b/scripts/spikes/english-g2p-probe/split.py
@@ -1,0 +1,30 @@
+import json
+exec(open('score2.py').read().split("cmu=json.load")[0])
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+RED={'AH','IH','IY','UH','ER'}
+def conv(seq):
+    p=[x for x,_ in seq]; o=[]
+    for i,ph in enumerate(p):
+        nxt=p[i+1] if i+1<len(p) else ''
+        if ph=='NG' and nxt in ('K','G'): ph='N'
+        if ph in ('T','D'): ph='TD'
+        if ph in ('AA','AO'): ph='LOT'
+        if ph in ('OW','LOT') and nxt=='R': ph='OHR'
+        if o and ((o[-1]=='ER' and ph=='R') or (o[-1]==ph=='R')): continue
+        o.append(ph)
+    return o
+def redu(s): return ['RED' if x in RED else x for x in s]
+src={}
+for f in ['src_top-1000.json','src_rank_1000-3000.json','src_rank_5000-10000.json']:
+    src.update(json.load(open(f)))
+for kind in ['letter-to-sound rules','dictionary entry']:
+    for lab,sel in [('all sampled',None)]:
+        ws=[w for w,k in src.items() if k==kind]
+        n=a=b=0
+        for w in ws:
+            if w not in CMUP: continue
+            n+=1; h=esp_phones(esp[w]); R=CMUP[w]
+            a+=any(conv(h)==conv(r) for r in R)
+            b+=any(redu(conv(h))==redu(conv(r)) for r in R)
+        print(f"{kind:24s} n={n:5d}  segments={a/n*100:5.1f}%  segments+reduction={b/n*100:5.1f}%")

--- a/scripts/spikes/english-g2p-probe/split.py
+++ b/scripts/spikes/english-g2p-probe/split.py
@@ -26,4 +26,7 @@ for kind in ['letter-to-sound rules','dictionary entry']:
         n+=1; h=esp_phones(esp[w]); R=CMUP[w]
         a+=any(conv(h)==conv(r) for r in R)
         b+=any(redu(conv(h))==redu(conv(r)) for r in R)
+    if n==0:
+        print(f"{kind:24s} n=    0  no words matched. Are cmu.json, espeak.json and src_*.json built?")
+        continue
     print(f"{kind:24s} n={n:5d}  segments={a/n*100:5.1f}%  segments+reduction={b/n*100:5.1f}%")

--- a/scripts/spikes/english-g2p-probe/src.py
+++ b/scripts/spikes/english-g2p-probe/src.py
@@ -1,0 +1,22 @@
+import subprocess, json, collections, random
+freq=[w.strip() for w in open('g10k.txt') if w.strip()]
+cmu=json.load(open('cmu.json'))
+freq=[w for w in freq if w in cmu]
+def source(words):
+    c=collections.Counter(); per={}
+    CH=200
+    for i in range(0,len(words),CH):
+        ch=words[i:i+CH]
+        for w in ch:
+            p=subprocess.run(['espeak-ng','-v','en-us','-q','-X'],input=w,capture_output=True,text=True)
+            t=p.stdout
+            if 'Found:' in t: k='dictionary entry'
+            elif 'Translate' in t: k='letter-to-sound rules'
+            else: k='other'
+            c[k]+=1; per[w]=k
+    return c,per
+for lab,ws in [('top-1000',freq[:1000]),('rank 1000-3000',freq[1000:3000]),('rank 5000-10000',freq[5000:10000])]:
+    c,per=source(ws)
+    tot=sum(c.values())
+    print(lab, {k:f"{v} ({v/tot*100:.1f}%)" for k,v in c.most_common()})
+    json.dump(per,open(f'src_{lab.replace(" ","_")}.json','w'))

--- a/scripts/spikes/english-g2p-probe/src.py
+++ b/scripts/spikes/english-g2p-probe/src.py
@@ -3,17 +3,22 @@ freq=[w.strip() for w in open('g10k.txt') if w.strip()]
 cmu=json.load(open('cmu.json'))
 freq=[w for w in freq if w in cmu]
 def source(words):
+    # One subprocess per word, deliberately. Unlike run_espeak.py's batched `--ipa`
+    # call (one output line per word), `-X` emits a multi-line rule trace, so batching
+    # would interleave traces and make per-word attribution rest on assuming exactly
+    # one marker per word in order. Slow and correct beats fast and fragile here.
     c=collections.Counter(); per={}
-    CH=200
-    for i in range(0,len(words),CH):
-        ch=words[i:i+CH]
-        for w in ch:
-            p=subprocess.run(['espeak-ng','-v','en-us','-q','-X'],input=w,capture_output=True,text=True)
-            t=p.stdout
-            if 'Found:' in t: k='dictionary entry'
-            elif 'Translate' in t: k='letter-to-sound rules'
-            else: k='other'
-            c[k]+=1; per[w]=k
+    for w in words:
+        p=subprocess.run(['espeak-ng','-v','en-us','-q','-X'],input=w,capture_output=True,text=True)
+        t=p.stdout
+        # Without this an espeak failure yields t='', which silently classifies as
+        # 'other' and quietly skews the dictionary-vs-rules split.
+        if not t.strip():
+            raise RuntimeError(f"espeak-ng produced no trace for {w!r} (rc={p.returncode}): {p.stderr.strip()[:200]!r}")
+        if 'Found:' in t: k='dictionary entry'
+        elif 'Translate' in t: k='letter-to-sound rules'
+        else: k='other'
+        c[k]+=1; per[w]=k
     return c,per
 for lab,ws in [('top-1000',freq[:1000]),('rank 1000-3000',freq[1000:3000]),('rank 5000-10000',freq[5000:10000])]:
     c,per=source(ws)

--- a/scripts/spikes/english-g2p-probe/teacher.py
+++ b/scripts/spikes/english-g2p-probe/teacher.py
@@ -52,8 +52,9 @@ inc=[w for w in words if w in CMUP]; miss=[w for w in words if w not in CMUP]
 print(f"corpus size {len(words)}; in CMUDict {len(inc)} ({len(inc)/len(words)*100:.1f}%); MISSING {len(miss)}: {miss}\n")
 n=a=b=st=0; res=[]
 for w in inc:
-    n+=1; h=esp_phones(esp[w]) if w in esp else None
-    if h is None: continue
+    h=esp_phones(esp[w]) if w in esp else None
+    if h is None: continue   # count only words we actually scored, else a partial
+    n+=1                     # espeak.json silently deflates every rate below
     R=CMUP[w]
     lit=any([x for x,_ in h]==[x for x,_ in r] for r in R)
     okc=any(conv(h)==conv(r) for r in R)
@@ -61,6 +62,9 @@ for w in inc:
     ss=any([s for p,s in h if p in VOW]==[s for p,s in r if p in VOW] for r in R)
     a+=okc; b+=okr; st+=ss
     if not okr: res.append((w,' '.join(x for x,_ in h),' | '.join(' '.join(x for x,_ in r) for r in R)))
+if n==0:
+    raise SystemExit("No corpus word was found in BOTH cmu.json and espeak.json — "
+                     "run prep.py and run_espeak.py first.")
 print(f"espeak-ng vs CMUDict on this corpus (n={n}):")
 print(f"  segment match (conventions normalised, stress ignored): {a/n*100:.1f}%")
 print(f"  + vowel-reduction tolerance:                            {b/n*100:.1f}%")

--- a/scripts/spikes/english-g2p-probe/teacher.py
+++ b/scripts/spikes/english-g2p-probe/teacher.py
@@ -1,5 +1,5 @@
 import json
-exec(open('score2.py').read().split("cmu=json.load")[0])
+from score2 import esp_phones, cmu_phones, VOW
 cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
 CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
 RED={'AH','IH','IY','UH','ER'}

--- a/scripts/spikes/english-g2p-probe/teacher.py
+++ b/scripts/spikes/english-g2p-probe/teacher.py
@@ -1,0 +1,69 @@
+import json
+exec(open('score2.py').read().split("cmu=json.load")[0])
+cmu=json.load(open('cmu.json')); esp=json.load(open('espeak.json'))
+CMUP={w:[cmu_phones(v) for v in vs] for w,vs in cmu.items()}
+RED={'AH','IH','IY','UH','ER'}
+def conv(seq):
+    p=[x for x,_ in seq]; o=[]
+    for i,ph in enumerate(p):
+        n=p[i+1] if i+1<len(p) else ''
+        if ph=='NG' and n in ('K','G'): ph='N'
+        if ph in ('T','D'): ph='TD'
+        if ph in ('AA','AO'): ph='LOT'
+        if ph in ('OW','LOT') and n=='R': ph='OHR'
+        if o and ((o[-1]=='ER' and ph=='R') or (o[-1]==ph=='R')): continue
+        o.append(ph)
+    return o
+def redu(s): return ['RED' if x in RED else x for x in s]
+
+CORPUS = """
+hello goodbye please thank you welcome sorry yes no maybe morning afternoon evening night
+one two three four five six seven eight nine ten eleven twelve thirteen twenty thirty hundred thousand
+red blue green yellow orange purple black white brown pink gray
+mother father sister brother family baby grandmother grandfather aunt uncle cousin friend
+head hair eyes ears nose mouth teeth hand arm leg foot knee shoulder finger stomach back
+apple bread milk water rice beans cheese chicken fish meat egg soup salad fruit vegetable
+breakfast lunch dinner hungry thirsty eat drink cook taste sweet salty spicy
+shirt pants shoes socks hat coat dress skirt jacket gloves scarf
+house kitchen bedroom bathroom window door table chair bed floor wall roof garden
+school teacher student classroom pencil paper book notebook desk backpack scissors glue ruler
+homework lesson question answer read write listen speak learn practice study test grade
+dog cat bird horse cow pig sheep rabbit mouse elephant lion tiger bear monkey snake
+tree flower grass leaf river mountain ocean beach forest sky sun moon star cloud rain snow wind
+hot cold warm cool sunny cloudy rainy snowy windy weather season spring summer autumn winter
+monday tuesday wednesday thursday friday saturday sunday today tomorrow yesterday week month year
+happy sad angry tired excited scared nervous bored surprised proud shy calm
+big small tall short long fat thin new old young fast slow easy hard clean dirty
+walk run jump swim dance sing play sleep work help open close start stop give take
+city town street park store market hospital library museum restaurant bank airport station
+car bus train bicycle airplane boat truck taxi
+doctor nurse police farmer chef driver artist singer engineer scientist
+computer phone television radio camera clock money ticket letter map
+before after during always never sometimes often usually first next last because
+where when what who why how which whose
+taco burrito salsa fiesta piñata tortilla amigo siesta
+croissant baguette cafe ballet buffet garage genre bouquet
+karaoke sushi origami tsunami karate
+pizza spaghetti opera piano violin
+kindergarten pretzel bratwurst
+"""
+words=[w for w in CORPUS.split() if w]
+inc=[w for w in words if w in CMUP]; miss=[w for w in words if w not in CMUP]
+print(f"corpus size {len(words)}; in CMUDict {len(inc)} ({len(inc)/len(words)*100:.1f}%); MISSING {len(miss)}: {miss}\n")
+n=a=b=st=0; res=[]
+for w in inc:
+    n+=1; h=esp_phones(esp[w]) if w in esp else None
+    if h is None: continue
+    R=CMUP[w]
+    lit=any([x for x,_ in h]==[x for x,_ in r] for r in R)
+    okc=any(conv(h)==conv(r) for r in R)
+    okr=any(redu(conv(h))==redu(conv(r)) for r in R)
+    ss=any([s for p,s in h if p in VOW]==[s for p,s in r if p in VOW] for r in R)
+    a+=okc; b+=okr; st+=ss
+    if not okr: res.append((w,' '.join(x for x,_ in h),' | '.join(' '.join(x for x,_ in r) for r in R)))
+print(f"espeak-ng vs CMUDict on this corpus (n={n}):")
+print(f"  segment match (conventions normalised, stress ignored): {a/n*100:.1f}%")
+print(f"  + vowel-reduction tolerance:                            {b/n*100:.1f}%")
+print(f"  stress pattern match:                                   {st/n*100:.1f}%")
+print(f"\nEVERY residual mismatch ({len(res)}):")
+for x in res: print(f"  {x[0]:16s} espeak={x[1]:30s} cmu={x[2]}")


### PR DESCRIPTION
Adds `scripts/spikes/english-g2p-probe/` — the measurement harness and findings that resolved [#2336](https://github.com/OPS-PIvers/SpartBoard/issues/2336) on the [Multilingual Pronunciation Engine map](https://github.com/OPS-PIvers/SpartBoard/issues/2331).

**No application code.** Nine standalone Python scripts and a `RESULTS.md`, landing beside the sibling `scripts/spikes/pronunciation-bias-probe/` on `dev-paul`. Nothing imports from it and nothing in the app imports it.

## What it measures

espeak-ng 1.51 (`en-us`) against CMUDict across all 117,493 alphabetic headwords plus frequency-banded and practice-vocabulary subsets, to answer whether English grapheme-to-phoneme needs a dictionary plus a neural fallback or whether rules suffice.

| Corpus | n | literal | segments | +reduction |
| --- | --- | --- | --- | --- |
| All CMUDict (surname-heavy) | 117,493 | 56.8% | 61.5% | 68.6% |
| Top 1,000 frequency | 1,000 | 88.5% | 93.1% | 97.1% |
| K-12 EL practice corpus | 340 | — | 94.1% | 97.1% |

**Verdict: rules + a teacher-facing confidence affordance.** Neural fallback dropped — published state-of-the-art runs 19.9–25.1% WER on held-out CMUDict, failing on exactly the loanwords and proper nouns a dictionary also misses, which is a silent 1-in-5 error in a flow where a human is already present. CMUDict stays as a cross-check oracle at a 5.9% flag rate.

The harness validates against published work: the assumption-free score on full CMUDict (56.8%) reproduces Black, Lenzo & Pagel (1998) at 57.80% to within one point.

It also corrected the ticket's own premise — espeak resolves `through` from its bundled exception dictionary rather than from rules, so espeak English is already the dictionary-plus-rules architecture the spec proposed.

## Files

- `RESULTS.md` — findings, failure taxonomy, license survey, reproduction steps, and a documented list of the research's own limits
- `prep.py`, `run_espeak.py` — build the corpora
- `score.py`–`score4.py`, `split.py`, `src.py` — scoring passes. `score2.py` holds the shared ARPAbet/IPA helpers (`esp_phones`, `cmu_phones`, `VOW`, `ed`) which the others **import**; its own analysis sits behind an `if __name__ == "__main__":` guard so importing it needs no data files. `score.py` and `score3.py` are earlier iterations kept for provenance.
- `teacher.py` — practice-vocabulary corpus and CMUDict cross-check flag rate
- `.gitignore` — excludes the ~19 MB of downloaded and generated data; `RESULTS.md` documents how to regenerate

## Verification

`prettier --check` passes on the added files. No TypeScript, ESLint, or test surface is touched — the directory is Python-only and outside the build.

Beyond CI, which cannot exercise this code:

- Every script run against a 20-word stub fixture — no name, import, or syntax errors.
- `from score2 import …` in a directory with no `cmu.json`/`espeak.json`, confirming the `__main__` guard does what it claims.
- `run_espeak.py`'s failure guard exercised against both a healthy espeak-ng and a deliberately broken invocation.
- An empty data directory produces a diagnostic from all six evaluators rather than a traceback.
- The full pipeline re-run end-to-end against freshly downloaded CMUDict and frequency data, reproducing the headline numbers independently of the session that first produced them — and re-verified again after the rebase onto `dev-paul`.

## Review history

Eight review rounds; every item applied or declined with reasoning in the thread. Three defects surfaced that no round flagged, each found while verifying a suggestion rather than applying it:

1. A `random.sample` `ValueError` that the suggested zero-division guard would have left in place.
2. `teacher.py` incrementing its denominator before the `None` check, silently deflating every rate under partial data.
3. `src.py` classifying empty espeak output as `'other'`, skewing the dictionary-vs-rules split.

Two suggested fixes targeted the wrong mechanism and were replaced with measured alternatives: guarding on `returncode` when espeak-ng exits 0 on failure, and batching `-X` output that isn't safely batchable.

## Note

**The weakest claim is flagged, not buried.** The 341-word practice corpus was constructed by the resolving agent rather than sampled from real SpartBoard content, and the gap between 94% and full-CMUDict's 61% rests entirely on that. Tracked as [#2356](https://github.com/OPS-PIvers/SpartBoard/issues/2356), and called out in `RESULTS.md` under "Known limits."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMMRk7U9iz4VpseMHqCHfW