### PR TITLE
spec(pronunciation): settle alignment &amp; scoring behaviour (#2335)

### DIFF
--- a/docs/multilingual-pronunciation-engine-spec.md
+++ b/docs/multilingual-pronunciation-engine-spec.md
@@ -368,6 +368,17 @@ of the alignment engine.
 > generates (`Expected /r/, detected /ɹ/`). Human-readable phoneme names are an
 > additional lookup table the code does not yet have.
 
+> **Correction — this example's numbers are wrong** (found while writing it as
+> a test, resolving #2335). `score: 75, passed: false` is not reachable from
+> the stated inputs. One substitution in six target phonemes gives
+> `PER = 1/6 = 0.167`, and §5.1's formula
+> `Accuracy = max(0, round((1 - PER) × 100))` yields **83**, which clears the
+> Close threshold of 80 — so this utterance **passes** at Close, and only fails
+> at Exact. A score of 75 would require `PER = 0.25`, i.e. two errors in eight
+> phonemes. Do not calibrate thresholds against the 75. The corrected example
+> is pinned as a test in
+> `scripts/spikes/alignment-engine/engine.test.ts`.
+
 ---
 
 ## 7. Visual UI annotation component

--- a/scripts/spikes/alignment-engine/DECISIONS.md
+++ b/scripts/spikes/alignment-engine/DECISIONS.md
@@ -203,6 +203,31 @@ every strictness level.
 > sourced. Tracked as its own ticket. Until that reference exists, A9's weight
 > should default to 0.
 
+#### A10a — An empty accepted list is absent evidence, not a failed match
+
+When a question carries **no** accepted stress variants, stress scoring takes
+A9's degradation path: `stressScore: null`, applied weight `0`, sounds-only.
+It does **not** score 0.
+
+Scoring 0 would be silent class-wide failure. No score persists — D4 recomputes
+points on every read — so an admin who cleared the accepted variants after
+authoring would retroactively drag down every historical response on that
+question, with nothing to indicate why. And this is not a hypothetical state:
+it is the state **every** question is in until the accepted-variant reference
+exists, which is why A9's weight defaults to 0 in the meantime.
+
+#### A10b — A syllable-count mismatch counts against the score
+
+Agreement is measured over the **longer** of the two patterns. Detected
+`[1,1,0,1]` against an accepted `[1,0]` scores 1/4, not 1/2 — producing the
+wrong number of syllables is a real difference in what the student said, not a
+free pass. The same applies in reverse: `[1]` against `[1,0]` scores 1/2.
+
+The risk is noisy syllable segmentation manufacturing errors the student did
+not make. That is bounded by A9's low default weight, and syllable-boundary
+reliability is explicitly part of the stress stage's own ticket rather than
+something the alignment contract can fix.
+
 ### A11 — Human-readable sound names are in scope, but do not gate the spec
 
 The spec's example shows _"Expected trilled /r/, detected English retroflex

--- a/scripts/spikes/alignment-engine/DECISIONS.md
+++ b/scripts/spikes/alignment-engine/DECISIONS.md
@@ -1,0 +1,275 @@
+# Alignment & scoring behaviour — decisions
+
+Resolves [#2335 — Define correct alignment & scoring behaviour](https://github.com/OPS-PIvers/SpartBoard/issues/2335),
+a decision ticket on the [Wayfinder Map: Multilingual Pronunciation Engine](https://github.com/OPS-PIvers/SpartBoard/issues/2331).
+
+**Status:** accepted. Where this file and
+`docs/multilingual-pronunciation-engine-spec.md` §4–§6 disagree, this file wins.
+
+**Contents.** `engine.ts` is a reference implementation, `engine.test.ts` the
+executable form of every decision below. Neither is wired into the app and
+neither is imported by feature code — this is a spike directory, in the same
+sense as `pronunciation-bias-probe/` and `english-g2p-probe/`. It runs under
+`pnpm test`, so a later change that violates one of these decisions fails CI.
+
+The ticket prescribed the method (source doc §9.1): **write the review notes
+as tests before deciding how to fix them**, because each note is a behavioural
+claim with a concrete input, and choosing the assertion _is_ the decision.
+That is what happened here, and it immediately paid for itself — see
+[Findings](#findings-from-writing-the-tests).
+
+---
+
+## Decisions
+
+### A1 — Stress is scored, from a separate detection stage
+
+Stress is **in scope** and **does affect the grade**. It does **not** come from
+the phoneme model.
+
+The phoneme model cannot supply it. Verified directly against the vocabulary
+files of both models selected in
+[#2349](https://github.com/OPS-PIvers/SpartBoard/issues/2349):
+
+| Model                                              | Vocab size | Primary stress `ˈ` | Secondary stress `ˌ` |
+| -------------------------------------------------- | ---------- | ------------------ | -------------------- |
+| `facebook/wav2vec2-xlsr-53-espeak-cv-ft` (chosen)  | 392        | absent             | absent               |
+| `facebook/wav2vec2-lv-60-espeak-cv-ft` (runner-up) | 392        | absent             | absent               |
+
+The 85 digit-bearing tokens (`a1`, `iou4`, …) are **Mandarin tone numbers**,
+and Mandarin is out of scope on the map. They are not stress.
+
+This is not bad luck in model selection. A survey of 16 phoneme-recognition
+models across the top ~80 on Hugging Face — wav2vec2, WavLM, HuBERT and
+Whisper-based IPA models — found **15 emit no stress at all**. The single
+exception, `mrrubino/wav2vec2-large-xlsr-53-l2-arctic-phoneme`, carries only
+the _secondary_ mark `ˌ` with no primary `ˈ` in a 40-token vocabulary, which is
+a labelling artifact rather than stress modelling, and it is English-only so it
+fails the Spanish/German requirement regardless.
+
+The reason is structural: stress is **suprasegmental** — it lives in pitch,
+loudness and duration spread across a syllable — while a CTC model assigns each
+audio frame one segment label. There is no place in that output for stress.
+
+So stress is measured by its own stage, from pitch, intensity and syllable
+duration, and reaches the engine as a separate channel (`StressInput`).
+
+> **Scope consequence.** The map lists _"Fluency, prosody, rhythm, and
+> intonation scoring"_ under **Out of scope**. A dedicated stress-detection
+> stage crosses that line, so the map's destination is being **redrawn** to
+> admit stress specifically — not prosody generally. Fluency, rhythm and
+> intonation stay out. Tracked as its own ticket.
+
+### A2 — The stored reference is narrow, exactly as the model emits it
+
+The reference string stores what the model's 392-symbol espeak label set
+actually produces — the American flap in _water_, allophony and all — rather
+than an idealized broad-phonemic form.
+
+Both sides of the comparison then live in one alphabet and nothing needs
+converting. The alternative required a per-language allophone-to-phoneme
+collapse table that does not exist, where every rule is a new way to mark a
+correct student wrong.
+
+Accepted cost: the reference is literal, so a student producing a different but
+still-correct allophone is scored as a substitution. That is the same problem
+A10 solves for stress, and it is why the never-penalize-a-correct-dialect rule
+in [#2342](https://github.com/OPS-PIvers/SpartBoard/issues/2342) matters as
+much as it does.
+
+The engine itself is alphabet-agnostic — it compares strings — so a future
+change of label set needs no engine change.
+
+### A3 — The payload always carries the detected sound
+
+`alignment[].spokenIPA` is always populated on a substitution. The engine is a
+pure function over two token arrays; it has no way to know how the detected
+sounds were produced, so withholding them is not its call to make.
+
+**Whether a human is shown that symbol is a UI gate, not an engine contract.**
+[#2344](https://github.com/OPS-PIvers/SpartBoard/issues/2344) established that
+under a _server-side_ path the detected phoneme is a target-language
+approximation and would be wrong to display. D1 moved inference on-device,
+which is expected to remove that distortion — but
+[#2355](https://github.com/OPS-PIvers/SpartBoard/issues/2355) has not measured
+it yet. **The teacher results UI must not name the detected sound until #2355
+resolves.** Substitution _presence_ is safe today; substitution _identity_ is
+not.
+
+### A4 — No prose in the engine
+
+The `diagnostic` field is **removed**. The engine returns `position`,
+`targetIPA`, `spokenIPA`, `status` and nothing else.
+
+The reference implementation baked an English sentence into every entry
+(`Expected /r/, detected /ɹ/`). SpartBoard ships in English, German, Spanish
+and French — a hard-coded English string would be read by exactly the German
+and Spanish classes this feature exists for. Composing the sentence is the
+results UI's job, through i18n.
+
+### A5 — Extra sounds get a real entry
+
+An inserted sound produces an `alignment[]` entry with `status: 'inserted'`,
+`targetIPA: null`, and the detected sound in `spokenIPA`. The reference
+implementation counted insertions but emitted nothing, which made an insertion
+badge literally unrenderable — the reason the teacher results UI is listed as
+blocked on this ticket.
+
+**Contract change:** `position` is **no longer unique**. An inserted entry
+carries the position of the target sound it follows (`0` when it precedes the
+whole word), so it shares a position with its neighbour. Consumers must render
+`alignment` **in array order**, which is utterance order, and must not sort or
+key by `position`.
+
+### A6 — The error rate keeps its standard definition
+
+`PER = (substitutions + omissions + insertions) / N`, where `N` is the target
+sound count. It is **not** clamped and **not** renormalized, so it can exceed
+1 — a student who adds twelve extra sounds to a six-sound word scores 2.0.
+
+That is the standard definition used in speech-recognition research, which
+keeps our numbers comparable to published error rates, including the ones
+[#2336](https://github.com/OPS-PIvers/SpartBoard/issues/2336) measured. The
+score already clamps at 0, so nothing downstream breaks.
+
+**Rule that follows: PER is an internal metric. Never show it to a teacher as
+a percentage.** The teacher-facing number is `score`.
+
+### A7 — An unconfigured strictness level is rejected, never guessed
+
+`THRESHOLDS[matchLevel] || 80` is gone. An unknown level throws
+`InvalidMatchLevelError`, naming the levels that _are_ configured. The
+authoring path validates before saving, and the picker prevents typos at the
+UI layer.
+
+A picker alone is not sufficient, because the value does not arrive from the
+picker at grading time — it arrives from Firestore. The project has **no
+runtime schema validation** (no `zod`; Firestore documents are read with bare
+`as SomeType` assertions, which guarantee nothing), thresholds ship **tunable**
+so the valid names are admin-configurable and can change _after_ a question is
+authored, PLC sharing moves quizzes between buildings with different presets,
+and D4 established that no score is stored — points are recomputed on every
+read. A question naming a renamed or foreign preset is therefore a normal
+state, not a typo.
+
+> **Landmine, inherited from [D4](https://github.com/OPS-PIvers/SpartBoard/issues/2334).**
+> `gradeAnswer()` ends in a catch-all returning zero. A caller that swallows
+> `InvalidMatchLevelError` converts a loud, fixable failure into a silent 0 for
+> an entire class, permanently, including in the archive. **This error must
+> surface.**
+
+### A8 — Ties are broken toward a substitution, deliberately
+
+When a substitution and an omission are both optimal, the substitution wins.
+
+This is the same outcome the reference implementation produced, but there it
+was an accident of `else if` ordering. It is now a decision, on two grounds: it
+keeps one entry per expected sound so the breakdown lines up with the word, and
+_"you said X instead of Y"_ is more useful to a student than _"you skipped Y
+and also added X"_.
+
+Rejected: breaking ties by phonetic similarity. Better feedback, but it needs a
+phonetic distance table per language that does not exist and is a substantial
+build of its own.
+
+### A9 — Stress folds into one combined score, at a tunable weight
+
+```
+score = round((1 − w) × segmentScore + w × stressScore)
+```
+
+`w` is admin-tunable and expected to default low (10–15%), matching the
+project's standing rule that thresholds ship tunable rather than hard-coded. A
+building that finds regional stress variation failing correct students can dial
+it to zero.
+
+**Degradation is explicit:** with no stress evidence the applied weight
+collapses to `0` and the result is sounds-only, with `stressScore: null`. A
+stress stage that is unavailable, still downloading, or not configured must
+never score every student 0.
+
+### A10 — Any accepted stress variant scores full credit
+
+A question stores **every regionally acceptable stress pattern**, and matching
+any one of them scores 100 on the stress dimension. Partial agreement scores
+the best per-syllable match across the variants.
+
+This is how stress satisfies the never-penalize-a-correct-dialect rule in
+[#2342](https://github.com/OPS-PIvers/SpartBoard/issues/2342), which binds at
+every strictness level.
+
+> **Dependency this creates.** It needs per-dialect accepted stress patterns
+> for Spanish, German and English, which do not exist and must be built or
+> sourced. Tracked as its own ticket. Until that reference exists, A9's weight
+> should default to 0.
+
+### A11 — Human-readable sound names are in scope, but do not gate the spec
+
+The spec's example shows _"Expected trilled /r/, detected English retroflex
+/ɹ/"_ where the code produces _"Expected /r/, detected /ɹ/"_. A full
+human-readable name table **is in scope** for this effort — all symbols the
+model can emit, in all four interface languages.
+
+It does **not** block spec acceptance. This decision fixes where the names live
+(the UI's i18n layer, per A4, not the engine) and what shape they take; writing
+roughly 392 entries × 4 languages is a bulk translation job that no other
+decision depends on. Tracked as its own ticket.
+
+### A12 — What this ticket ships
+
+This directory: the decision record, a reference implementation, and a test
+suite that runs in CI. **No feature code**, consistent with the map's
+plan-don't-do rule and with the fact that the dialect surface
+([#2338](https://github.com/OPS-PIvers/SpartBoard/issues/2338)), the Firestore
+response shape
+([#2354](https://github.com/OPS-PIvers/SpartBoard/issues/2354)) and the
+recording UX ([#2351](https://github.com/OPS-PIvers/SpartBoard/issues/2351))
+are all still open.
+
+---
+
+## Findings from writing the tests
+
+### The spec's canonical worked example is arithmetically wrong
+
+Spec §6.2 gives `El perro` spoken with an English retroflex as
+`score: 75, passed: false` alongside `per: 0.166`. Under the formula the spec
+itself states in §5.1 — `Accuracy = max(0, round((1 − PER) × 100))` — one
+substitution in six target sounds is:
+
+```
+PER   = 1 / 6      = 0.167
+Score = round(83.3) = 83     →  83 ≥ 80, so it PASSES at Close
+```
+
+A score of 75 would require PER 0.25, i.e. two errors in eight sounds, not one
+in six. **The spec's canonical illustration of a failure is actually a pass.**
+
+This matters beyond the arithmetic: it is the example the whole effort has been
+pointing at as the first unit test, and anyone calibrating thresholds against
+it would have been calibrating against a number the stated formula cannot
+produce. Pinned in `engine.test.ts` as
+`'scores 83 and PASSES at Close — not the 75/failed the spec shows'`.
+
+The tap/trill contrast still fails at `Exact` (95), which is the profile that
+matches the pedagogical intent of the example.
+
+### `—` was doing double duty
+
+The reference used the em dash `'—'` as `spokenIPA` on an omission. With A5
+adding insertions, both sides of an entry can now be absent, and a display
+character in a data field is a trap for the results UI. Both are `null`;
+rendering is the UI's business.
+
+---
+
+## What this hands to other tickets
+
+| Ticket                                                                                     | What it inherits                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Teacher results UI (map fog)                                                               | Four statuses to render, including insertions (A5). Must render in array order, not by `position` (A5). Must not name the detected sound until #2355 (A3). Composes all text via i18n (A4). Never displays PER (A6). |
+| [#2342 — thresholds & dialect](https://github.com/OPS-PIvers/SpartBoard/issues/2342)       | The stress weight `w` joins the tunable set (A9). Stress inherits the never-penalize rule via accepted variants (A10).                                                                                               |
+| [#2354 — Firestore response shape](https://github.com/OPS-PIvers/SpartBoard/issues/2354)   | Accepted stress variants and the narrow reference string are per-question stored fields (A2, A10).                                                                                                                   |
+| [#2341 — teacher authoring UX](https://github.com/OPS-PIvers/SpartBoard/issues/2341)       | Strictness is a picker, and the value is validated before save (A7). Accepted stress variants need a confirmation affordance (A10).                                                                                  |
+| [#2355 — retroflex confusion matrix](https://github.com/OPS-PIvers/SpartBoard/issues/2355) | Now gates a UI affordance rather than the engine contract (A3).                                                                                                                                                      |
+| Server-side symbol normalization (map fog)                                                 | Must project G2P output into the model's 392-symbol set, narrow rather than broad (A2).                                                                                                                              |

--- a/scripts/spikes/alignment-engine/DECISIONS.md
+++ b/scripts/spikes/alignment-engine/DECISIONS.md
@@ -251,6 +251,30 @@ response shape
 recording UX ([#2351](https://github.com/OPS-PIvers/SpartBoard/issues/2351))
 are all still open.
 
+### A13 — An empty reference is rejected, not scored
+
+`targetPhonemes: []` throws `EmptyReferenceError`. A question with no reference
+phonemes is broken, not gradeable.
+
+Left ungrarded this was **silent grade inflation**. With `n = 0` the
+divide-by-zero guard short-circuits PER to 0, so `segmentScore` is 100 and the
+student passes — while `insertionCount` faithfully reports every sound they
+produced. Measured on the pre-fix engine: `[]` against `['p','e','r','o']`
+returned `score: 100, passed: true, insertionCount: 4`.
+
+It is the mirror image of the D4 catch-all's silent zero, and the more
+dangerous of the two, because **nobody investigates a pass**.
+
+Reachability is the same argument as A7, and no weaker: there is no runtime
+schema validation, Firestore reads are bare `as` casts, and G2P is precomputed
+at authoring time — so a question whose G2P failed, or which was authored
+before confirmation, carries an empty array and passes an entire class. The
+empty-and-empty case throws too: the defect is the missing reference, not the
+mismatch, so it gets no special case that would report a bogus 100.
+
+Same handling rule as A7 — this must surface, not be swallowed by
+`gradeAnswer()`'s catch-all.
+
 ---
 
 ## Findings from writing the tests
@@ -290,11 +314,12 @@ rendering is the UI's business.
 
 ## What this hands to other tickets
 
-| Ticket                                                                                     | What it inherits                                                                                                                                                                                                     |
-| ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Teacher results UI (map fog)                                                               | Four statuses to render, including insertions (A5). Must render in array order, not by `position` (A5). Must not name the detected sound until #2355 (A3). Composes all text via i18n (A4). Never displays PER (A6). |
-| [#2342 — thresholds & dialect](https://github.com/OPS-PIvers/SpartBoard/issues/2342)       | The stress weight `w` joins the tunable set (A9). Stress inherits the never-penalize rule via accepted variants (A10).                                                                                               |
-| [#2354 — Firestore response shape](https://github.com/OPS-PIvers/SpartBoard/issues/2354)   | Accepted stress variants and the narrow reference string are per-question stored fields (A2, A10).                                                                                                                   |
-| [#2341 — teacher authoring UX](https://github.com/OPS-PIvers/SpartBoard/issues/2341)       | Strictness is a picker, and the value is validated before save (A7). Accepted stress variants need a confirmation affordance (A10).                                                                                  |
-| [#2355 — retroflex confusion matrix](https://github.com/OPS-PIvers/SpartBoard/issues/2355) | Now gates a UI affordance rather than the engine contract (A3).                                                                                                                                                      |
-| Server-side symbol normalization (map fog)                                                 | Must project G2P output into the model's 392-symbol set, narrow rather than broad (A2).                                                                                                                              |
+| Ticket                                                                                     | What it inherits                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Teacher results UI (map fog)                                                               | Four statuses to render, including insertions (A5). Must render in array order, not by `position` (A5). Must not name the detected sound until #2355 (A3). Composes all text via i18n (A4). Never displays PER (A6).                                                                                                          |
+| [#2342 — thresholds & dialect](https://github.com/OPS-PIvers/SpartBoard/issues/2342)       | The stress weight `w` joins the tunable set (A9). Stress inherits the never-penalize rule via accepted variants (A10).                                                                                                                                                                                                        |
+| [#2354 — Firestore response shape](https://github.com/OPS-PIvers/SpartBoard/issues/2354)   | Accepted stress variants and the narrow reference string are per-question stored fields (A2, A10).                                                                                                                                                                                                                            |
+| [#2341 — teacher authoring UX](https://github.com/OPS-PIvers/SpartBoard/issues/2341)       | Strictness is a picker, and the value is validated before save (A7). Accepted stress variants need a confirmation affordance (A10). A question must not be saveable with empty `referencePhonemes` — A13 makes that a hard grading error, so authoring is where it has to be caught.                                          |
+| Feature implementation (post-spec)                                                         | **Two errors must reach a human, not `gradeAnswer()`'s catch-all**: `InvalidMatchLevelError` (A7) and `EmptyReferenceError` (A13). That catch-all returns zero, so swallowing either turns a loud, fixable fault into a permanent silent misgrade — a class-wide 0 for A7, and for A13 an inflated pass nobody will question. |
+| [#2355 — retroflex confusion matrix](https://github.com/OPS-PIvers/SpartBoard/issues/2355) | Now gates a UI affordance rather than the engine contract (A3).                                                                                                                                                                                                                                                               |
+| Server-side symbol normalization (map fog)                                                 | Must project G2P output into the model's 392-symbol set, narrow rather than broad (A2).                                                                                                                                                                                                                                       |

--- a/scripts/spikes/alignment-engine/engine.test.ts
+++ b/scripts/spikes/alignment-engine/engine.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Executable record of the decisions in `DECISIONS.md` (issue #2335).
+ *
+ * Per the ticket's stated method (source doc §9.1): each review note is a
+ * behavioural claim with a concrete input, so each converts directly into a
+ * test case — and deciding the assertion IS the decision. These tests are the
+ * decisions; the reference implementation exists to run them.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluatePronunciation,
+  InvalidMatchLevelError,
+  InvalidStressWeightError,
+} from './engine';
+
+/** The spec's threshold profiles (§5.2). Injected, never hard-coded (A7). */
+const THRESHOLDS = { Loose: 60, Close: 80, Exact: 95 };
+
+/** `El perro` — the canonical example, spec §6.2. */
+const EL_PERRO = ['e', 'l', 'p', 'e', 'r', 'o'];
+
+describe('canonical example — El perro (spec §6.2)', () => {
+  it('scores a fully correct utterance 100', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.score).toBe(100);
+    expect(result.passed).toBe(true);
+    expect(result.metrics.correctCount).toBe(6);
+    expect(result.metrics.per).toBe(0);
+  });
+
+  it('marks the English retroflex as a substitution', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: ['e', 'l', 'p', 'e', 'ɹ', 'o'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.substitutionCount).toBe(1);
+    expect(result.metrics.correctCount).toBe(5);
+    expect(result.alignment[4]).toEqual({
+      position: 5,
+      targetIPA: 'r',
+      spokenIPA: 'ɹ',
+      status: 'substituted',
+    });
+  });
+
+  /**
+   * FINDING — the spec's own worked example is arithmetically wrong.
+   *
+   * §6.2 shows `score: 75, passed: false` alongside `per: 0.166` for this
+   * exact input. Under the formula the spec itself states in §5.1
+   * (`Accuracy = max(0, round((1 - PER) × 100))`), one substitution in six
+   * target sounds gives 1/6 = 0.167 PER and a score of 83 — which CLEARS the
+   * Close threshold of 80. A score of 75 would require PER 0.25, i.e. two
+   * errors in eight sounds, not one in six.
+   *
+   * This matters beyond arithmetic: the spec's canonical illustration of
+   * failure is actually a pass. Anyone calibrating thresholds against it
+   * would be calibrating against a number the formula cannot produce.
+   */
+  it('scores 83 and PASSES at Close — not the 75/failed the spec shows', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: ['e', 'l', 'p', 'e', 'ɹ', 'o'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.per).toBe(0.167);
+    expect(result.score).toBe(83);
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails the same utterance at Exact', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: ['e', 'l', 'p', 'e', 'ɹ', 'o'],
+      matchLevel: 'Exact',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('A5 — extra sounds appear in the breakdown', () => {
+  it('emits an entry for an inserted sound', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'e', 'r', 'o'],
+      spokenPhonemes: ['p', 'e', 'r', 'o', 's'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.insertionCount).toBe(1);
+    expect(result.alignment).toHaveLength(5);
+    expect(result.alignment[4]).toEqual({
+      position: 4,
+      targetIPA: null,
+      spokenIPA: 's',
+      status: 'inserted',
+    });
+  });
+
+  it('positions an insertion before the word at 0, in utterance order', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['a'],
+      spokenPhonemes: ['b', 'a'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.alignment.map((e) => e.status)).toEqual([
+      'inserted',
+      'correct',
+    ]);
+    expect(result.alignment[0].position).toBe(0);
+    expect(result.alignment[0].targetIPA).toBeNull();
+  });
+
+  it('lets an inserted entry share a position with its neighbour', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'o'],
+      spokenPhonemes: ['p', 'o', 's'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    // position is NOT a unique key — consumers must render in array order.
+    const positions = result.alignment.map((e) => e.position);
+    expect(positions).toEqual([1, 2, 2]);
+    expect(new Set(positions).size).toBeLessThan(positions.length);
+  });
+});
+
+describe('A6 — error rate keeps the standard definition', () => {
+  it('lets PER exceed 1 rather than clamping or renormalizing it', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'e'],
+      spokenPhonemes: ['p', 'e', 'a', 'b', 'c', 'd'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.insertionCount).toBe(4);
+    expect(result.metrics.per).toBe(2);
+    expect(result.metrics.per).toBeGreaterThan(1);
+  });
+
+  it('still clamps the score at 0, so nothing goes negative', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'e'],
+      spokenPhonemes: ['p', 'e', 'a', 'b', 'c', 'd'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.score).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('A7 — an unconfigured strictness level is rejected, never guessed', () => {
+  it('throws rather than silently falling back to Close', () => {
+    expect(() =>
+      evaluatePronunciation({
+        targetPhonemes: EL_PERRO,
+        spokenPhonemes: [...EL_PERRO],
+        matchLevel: 'close', // wrong case — a renamed or foreign preset
+        thresholds: THRESHOLDS,
+      })
+    ).toThrow(InvalidMatchLevelError);
+  });
+
+  it('names the configured levels so the failure is actionable', () => {
+    expect(() =>
+      evaluatePronunciation({
+        targetPhonemes: EL_PERRO,
+        spokenPhonemes: [...EL_PERRO],
+        matchLevel: 'Strict',
+        thresholds: THRESHOLDS,
+      })
+    ).toThrow(/Loose, Close, Exact/);
+  });
+
+  it('accepts an admin-added level, since thresholds ship tunable', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Kindergarten',
+      thresholds: { ...THRESHOLDS, Kindergarten: 40 },
+    });
+
+    expect(result.requiredScore).toBe(40);
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe('A8 — tie-break prefers a substitution, deliberately', () => {
+  /**
+   * For target [p, a] against spoken [b], substitution and omission are both
+   * optimal at the final cell (both cost 2). The choice changes which
+   * diagnostic the student sees, so it is decided rather than inherited from
+   * statement order.
+   */
+  it('reports "wrong sound" rather than "skipped plus extra"', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'a'],
+      spokenPhonemes: ['b'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.alignment.map((e) => e.status)).toEqual([
+      'omitted',
+      'substituted',
+    ]);
+    expect(result.metrics.substitutionCount).toBe(1);
+    expect(result.metrics.insertionCount).toBe(0);
+    expect(result.alignment[1]).toEqual({
+      position: 2,
+      targetIPA: 'a',
+      spokenIPA: 'b',
+      status: 'substituted',
+    });
+  });
+});
+
+describe('A3/A4 — payload carries symbols, never prose', () => {
+  it('reports the detected sound on every substitution', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['r'],
+      spokenPhonemes: ['ɹ'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.alignment[0].spokenIPA).toBe('ɹ');
+  });
+
+  it('emits no English diagnostic string anywhere', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: ['e', 'l', 'p', 'ɛ', 'ɹ', 'o'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    for (const entry of result.alignment) {
+      expect(entry).not.toHaveProperty('diagnostic');
+      expect(Object.keys(entry).sort()).toEqual([
+        'position',
+        'spokenIPA',
+        'status',
+        'targetIPA',
+      ]);
+    }
+  });
+
+  it('uses null, not an em dash, for the missing side of an omission', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['p', 'e', 'r', 'o'],
+      spokenPhonemes: ['p', 'e', 'o'],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    const omitted = result.alignment.find((e) => e.status === 'omitted');
+    expect(omitted?.spokenIPA).toBeNull();
+    expect(omitted?.targetIPA).toBe('r');
+  });
+});
+
+describe('A9 — stress folds into one combined score at a tunable weight', () => {
+  it('lowers a perfect sound score when stress is wrong', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: { detected: [0, 1], accepted: [[1, 0]] },
+      stressWeight: 0.15,
+    });
+
+    expect(result.segmentScore).toBe(100);
+    expect(result.stressScore).toBe(0);
+    expect(result.score).toBe(85);
+    expect(result.passed).toBe(true);
+  });
+
+  it('degrades to sounds-only when the stress stage supplies nothing', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stressWeight: 0.15,
+    });
+
+    expect(result.stressScore).toBeNull();
+    expect(result.appliedStressWeight).toBe(0);
+    expect(result.score).toBe(result.segmentScore);
+    expect(result.score).toBe(100);
+  });
+
+  it('rejects a weight outside 0–1', () => {
+    expect(() =>
+      evaluatePronunciation({
+        targetPhonemes: EL_PERRO,
+        spokenPhonemes: [...EL_PERRO],
+        matchLevel: 'Close',
+        thresholds: THRESHOLDS,
+        stressWeight: 1.5,
+      })
+    ).toThrow(InvalidStressWeightError);
+  });
+});
+
+describe('A10 — any accepted stress variant scores full credit (#2342)', () => {
+  it('does not penalize a regionally valid stress pattern', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: {
+        detected: [0, 1],
+        accepted: [
+          [1, 0],
+          [0, 1],
+        ],
+      },
+      stressWeight: 0.15,
+    });
+
+    expect(result.stressScore).toBe(100);
+    expect(result.score).toBe(100);
+  });
+
+  it('gives partial credit for a partly-correct pattern', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: { detected: [1, 1], accepted: [[1, 0]] },
+      stressWeight: 0.5,
+    });
+
+    expect(result.stressScore).toBe(50);
+    expect(result.score).toBe(75);
+  });
+});
+
+describe('A2 — the engine is alphabet-agnostic', () => {
+  /**
+   * The reference is stored exactly as the model emits it (narrow), so the
+   * engine never needs to know which alphabet it is comparing — it compares
+   * strings. This is what makes a future stress-bearing source a drop-in.
+   */
+  it('treats an allophone as a plain substitution', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: ['w', 'ɑ', 'ɾ', 'ɚ'], // narrow: American flap
+      spokenPhonemes: ['w', 'ɑ', 't', 'ɚ'], // released /t/
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.substitutionCount).toBe(1);
+    expect(result.score).toBe(75);
+  });
+
+  it('handles an empty target without dividing by zero', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: [],
+      spokenPhonemes: [],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+    });
+
+    expect(result.metrics.per).toBe(0);
+    expect(result.score).toBe(100);
+  });
+});

--- a/scripts/spikes/alignment-engine/engine.test.ts
+++ b/scripts/spikes/alignment-engine/engine.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  EmptyReferenceError,
   evaluatePronunciation,
   InvalidMatchLevelError,
   InvalidStressWeightError,
@@ -426,16 +427,43 @@ describe('A2 — the engine is alphabet-agnostic', () => {
     expect(result.metrics.substitutionCount).toBe(1);
     expect(result.score).toBe(75);
   });
+});
 
-  it('handles an empty target without dividing by zero', () => {
-    const result = evaluatePronunciation({
-      targetPhonemes: [],
-      spokenPhonemes: [],
-      matchLevel: 'Close',
-      thresholds: THRESHOLDS,
-    });
+describe('A13 — an empty reference is rejected, not scored', () => {
+  /**
+   * Before A13 this was silent grade inflation. With `n = 0` the PER guard
+   * short-circuits to 0, so `segmentScore` is 100 and the student PASSES —
+   * while `insertionCount` still reports every sound they produced. Measured
+   * on the pre-fix engine: `[]` against `['p','e','r','o']` returned
+   * `score: 100, passed: true, insertionCount: 4`.
+   *
+   * It is the mirror of the D4 catch-all's silent zero, and more dangerous,
+   * because nobody investigates a pass. A7's reasoning applies unchanged: no
+   * runtime schema validation, Firestore reads are bare casts, and G2P is
+   * precomputed at authoring time — so a question whose G2P failed or was
+   * never confirmed carries an empty array and passes an entire class.
+   */
+  it('throws when the student produced sounds against an empty reference', () => {
+    expect(() =>
+      evaluatePronunciation({
+        targetPhonemes: [],
+        spokenPhonemes: ['p', 'e', 'r', 'o'],
+        matchLevel: 'Close',
+        thresholds: THRESHOLDS,
+      })
+    ).toThrow(EmptyReferenceError);
+  });
 
-    expect(result.metrics.per).toBe(0);
-    expect(result.score).toBe(100);
+  it('throws on an empty reference even when nothing was spoken', () => {
+    // The defect is the missing reference, not the mismatch — so this does
+    // not get a special case that would report a bogus 100.
+    expect(() =>
+      evaluatePronunciation({
+        targetPhonemes: [],
+        spokenPhonemes: [],
+        matchLevel: 'Close',
+        thresholds: THRESHOLDS,
+      })
+    ).toThrow(EmptyReferenceError);
   });
 });

--- a/scripts/spikes/alignment-engine/engine.test.ts
+++ b/scripts/spikes/alignment-engine/engine.test.ts
@@ -345,6 +345,55 @@ describe('A10 — any accepted stress variant scores full credit (#2342)', () =>
     expect(result.score).toBe(100);
   });
 
+  it('degrades to sounds-only when no accepted variants are configured', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: { detected: [1, 0], accepted: [] },
+      stressWeight: 0.5,
+    });
+
+    // A10a: absent evidence, not a failed match. Scoring 0 here would be a
+    // silent class-wide failure, since no score persists and points are
+    // recomputed on every read (D4) — an admin clearing the variants after
+    // authoring would retroactively drag down every historical response.
+    expect(result.stressScore).toBeNull();
+    expect(result.appliedStressWeight).toBe(0);
+    expect(result.score).toBe(result.segmentScore);
+    expect(result.score).toBe(100);
+  });
+
+  it('counts extra detected syllables against the score', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: { detected: [1, 1, 0, 1], accepted: [[1, 0]] },
+      stressWeight: 0.2,
+    });
+
+    // A10b: the denominator is the LONGER pattern, so this is 1/4 rather than
+    // 1/2 — producing the wrong number of syllables is a real difference.
+    expect(result.stressScore).toBe(25);
+    expect(result.score).toBe(85);
+  });
+
+  it('counts missing detected syllables against the score too', () => {
+    const result = evaluatePronunciation({
+      targetPhonemes: EL_PERRO,
+      spokenPhonemes: [...EL_PERRO],
+      matchLevel: 'Close',
+      thresholds: THRESHOLDS,
+      stress: { detected: [1], accepted: [[1, 0]] },
+      stressWeight: 0.2,
+    });
+
+    expect(result.stressScore).toBe(50);
+  });
+
   it('gives partial credit for a partly-correct pattern', () => {
     const result = evaluatePronunciation({
       targetPhonemes: EL_PERRO,

--- a/scripts/spikes/alignment-engine/engine.ts
+++ b/scripts/spikes/alignment-engine/engine.ts
@@ -150,9 +150,26 @@ export class InvalidStressWeightError extends Error {
  *
  * Returns the best per-syllable agreement across all variants, 0–100.
  * An exact match with any variant returns 100 (A10).
+ *
+ * Returns `null` when there are no accepted variants to compare against.
+ * A10a: an empty `accepted` list is *absent evidence*, not a failed match, so
+ * it takes A9's degradation path (sounds-only) rather than scoring 0. Scoring
+ * 0 would be class-wide silent failure: no score persists (D4 recomputes on
+ * every read), so an admin clearing the accepted variants after authoring
+ * would retroactively drag down every historical response on this question.
+ * This state is not hypothetical — it is the state every question is in until
+ * the accepted-variant reference exists.
+ *
+ * A10b: a syllable-count mismatch counts against the score. The denominator is
+ * the LONGER of the two patterns, so detected `[1,1,0,1]` against an accepted
+ * `[1,0]` scores 1/4, not 1/2 — producing the wrong number of syllables is a
+ * real difference in what the student said, not a free pass. The risk is that
+ * noisy syllable segmentation manufactures errors, which is why A9's weight
+ * defaults low and why syllable-boundary reliability belongs to the stress
+ * stage's own ticket.
  */
-function scoreStress(stress: StressInput): number {
-  if (stress.accepted.length === 0) return 0;
+function scoreStress(stress: StressInput): number | null {
+  if (stress.accepted.length === 0) return null;
 
   let best = 0;
   for (const variant of stress.accepted) {

--- a/scripts/spikes/alignment-engine/engine.ts
+++ b/scripts/spikes/alignment-engine/engine.ts
@@ -315,7 +315,10 @@ export function evaluatePronunciation(input: EvaluateInput): EvaluateResult {
 
   // 3. Scores.
   const totalEdits = substitutions + omissions + insertions;
-  const per = n > 0 ? totalEdits / n : 0;
+  // No divide-by-zero guard: A13 rejects an empty reference above, so n >= 1
+  // here. A guard would be dead code AND misleading — the short-circuit it
+  // used to perform is exactly the silent-100 defect A13 exists to prevent.
+  const per = totalEdits / n;
   const segmentScore = Math.max(0, Math.round((1 - per) * 100));
 
   // A9: stress folds into a single combined score at a tunable weight. With

--- a/scripts/spikes/alignment-engine/engine.ts
+++ b/scripts/spikes/alignment-engine/engine.ts
@@ -1,0 +1,313 @@
+/**
+ * Reference implementation — pronunciation alignment & scoring engine.
+ *
+ * SPIKE / DECISION HARNESS. Not wired into the app, not imported by any
+ * feature code. It exists to prove that the decisions recorded in
+ * `DECISIONS.md` (issue #2335) are internally consistent and to pin them as
+ * executable assertions. See `engine.test.ts`.
+ *
+ * Diverges from the transcribed reference implementation in
+ * `docs/multilingual-pronunciation-engine-spec.md` §4 on every point listed
+ * in DECISIONS.md. Where they differ, DECISIONS.md is authoritative.
+ */
+
+/** Status of a single aligned position. */
+export type AlignmentStatus =
+  | 'correct'
+  | 'substituted'
+  | 'omitted'
+  | 'inserted';
+
+/**
+ * One entry in the alignment breakdown.
+ *
+ * A5: insertions get a real entry (the reference implementation counted them
+ * but emitted nothing, which made an insertion badge unrenderable).
+ *
+ * `position` is the 1-based index into the target sequence. It is NOT a
+ * unique key: an `inserted` entry carries the position of the target sound it
+ * follows (0 when it precedes the whole word), so it shares a position with
+ * the neighbouring entry. Consumers must render `alignment` in array order —
+ * which is utterance order — and must not sort or key by `position`.
+ */
+export interface AlignmentEntry {
+  position: number;
+  /** The expected sound. `null` for `inserted` — there is no target sound. */
+  targetIPA: string | null;
+  /** The detected sound. `null` for `omitted` — the student produced nothing. */
+  spokenIPA: string | null;
+  status: AlignmentStatus;
+}
+
+/**
+ * Stress evidence, supplied by the separate stress-detection stage.
+ *
+ * A1: the selected CTC phoneme models cannot emit stress (verified: zero
+ * stress markers across all 392 vocabulary tokens of both
+ * `wav2vec2-xlsr-53-espeak-cv-ft` and `wav2vec2-lv-60-espeak-cv-ft`), so
+ * stress never travels in the phoneme stream. It arrives here as its own
+ * channel.
+ *
+ * Levels are per syllable; the encoding is the stress stage's to define. The
+ * engine only ever compares them for equality.
+ */
+export interface StressInput {
+  /** Detected stress pattern, one entry per syllable. */
+  detected: number[];
+  /**
+   * Every regionally acceptable stress pattern for this question.
+   *
+   * A10: matching ANY accepted variant scores full stress credit. This is how
+   * stress satisfies the never-penalize-a-correct-dialect rule (#2342).
+   */
+  accepted: number[][];
+}
+
+export interface EvaluateInput {
+  targetPhonemes: string[];
+  spokenPhonemes: string[];
+  /** Key into `thresholds`. Rejected if absent from it (A7). */
+  matchLevel: string;
+  /**
+   * Pass marks by level. Injected rather than hard-coded because thresholds
+   * ship tunable (map standing preference) and are admin-configurable.
+   */
+  thresholds: Record<string, number>;
+  stress?: StressInput;
+  /**
+   * Share of the combined score attributable to stress, 0–1 (A9).
+   * Tunable, expected to default low. Ignored when `stress` is absent.
+   */
+  stressWeight?: number;
+}
+
+export interface EvaluateMetrics {
+  targetPhonemeCount: number;
+  correctCount: number;
+  substitutionCount: number;
+  omissionCount: number;
+  insertionCount: number;
+  /**
+   * Phoneme error rate, (substitutions + omissions + insertions) / N.
+   *
+   * A6: this is the standard speech-recognition definition and CAN exceed 1
+   * when the student produces many extra sounds. It is deliberately NOT
+   * clamped or renormalized, so it stays comparable to published error rates.
+   * It is an internal metric — never surface it to a teacher as a percentage.
+   */
+  per: number;
+}
+
+export interface EvaluateResult {
+  /** Combined score, 0–100. Equals `segmentScore` when stress is not scored. */
+  score: number;
+  /** Sound-only score, 0–100. */
+  segmentScore: number;
+  /** Stress score 0–100, or `null` when no stress evidence was supplied. */
+  stressScore: number | null;
+  /** Stress weight actually applied — 0 when stress evidence was absent. */
+  appliedStressWeight: number;
+  passed: boolean;
+  matchLevel: string;
+  requiredScore: number;
+  metrics: EvaluateMetrics;
+  alignment: AlignmentEntry[];
+}
+
+/**
+ * Thrown when `matchLevel` names a level that is not configured (A7).
+ *
+ * Deliberately a distinct class: D4 (#2334) recorded that `gradeAnswer()` ends in a
+ * catch-all returning zero, so a caller that swallows this would silently
+ * score an entire class 0. Callers must let it surface.
+ */
+export class InvalidMatchLevelError extends Error {
+  public readonly matchLevel: string;
+  public readonly availableLevels: string[];
+
+  constructor(matchLevel: string, availableLevels: string[]) {
+    super(
+      `Unknown matchLevel "${matchLevel}". Configured levels: ${
+        availableLevels.length > 0 ? availableLevels.join(', ') : '(none)'
+      }`
+    );
+    this.name = 'InvalidMatchLevelError';
+    this.matchLevel = matchLevel;
+    this.availableLevels = availableLevels;
+  }
+}
+
+/** Thrown when `stressWeight` is outside 0–1. */
+export class InvalidStressWeightError extends Error {
+  constructor(weight: number) {
+    super(`stressWeight must be between 0 and 1, received ${weight}`);
+    this.name = 'InvalidStressWeightError';
+  }
+}
+
+/**
+ * Scores a detected stress pattern against the accepted variants.
+ *
+ * Returns the best per-syllable agreement across all variants, 0–100.
+ * An exact match with any variant returns 100 (A10).
+ */
+function scoreStress(stress: StressInput): number {
+  if (stress.accepted.length === 0) return 0;
+
+  let best = 0;
+  for (const variant of stress.accepted) {
+    const span = Math.max(variant.length, stress.detected.length);
+    if (span === 0) {
+      best = Math.max(best, 100);
+      continue;
+    }
+    let matched = 0;
+    for (let k = 0; k < span; k++) {
+      if (variant[k] !== undefined && variant[k] === stress.detected[k])
+        matched++;
+    }
+    best = Math.max(best, (matched / span) * 100);
+  }
+  return best;
+}
+
+/**
+ * Aligns expected against detected sounds and returns structured metrics.
+ *
+ * Pure: no I/O, no clock, no randomness, no phoneme-name lookup. It returns
+ * the symbols it compared and nothing more — A4 removed the English prose
+ * `diagnostic` field, which could not survive a four-language UI. Composing
+ * human-readable feedback is the results UI's job, via i18n.
+ */
+export function evaluatePronunciation(input: EvaluateInput): EvaluateResult {
+  const { targetPhonemes, spokenPhonemes, matchLevel, thresholds, stress } =
+    input;
+
+  if (!Object.prototype.hasOwnProperty.call(thresholds, matchLevel)) {
+    throw new InvalidMatchLevelError(matchLevel, Object.keys(thresholds));
+  }
+  const requiredScore = thresholds[matchLevel];
+
+  const stressWeight = input.stressWeight ?? 0;
+  if (!Number.isFinite(stressWeight) || stressWeight < 0 || stressWeight > 1) {
+    throw new InvalidStressWeightError(stressWeight);
+  }
+
+  const n = targetPhonemes.length;
+  const m = spokenPhonemes.length;
+
+  // 1. Levenshtein distance matrix. Equal unit cost for substitution,
+  //    omission and insertion.
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0)
+  );
+  for (let i = 0; i <= n; i++) dp[i][0] = i;
+  for (let j = 0; j <= m; j++) dp[0][j] = j;
+
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      dp[i][j] =
+        targetPhonemes[i - 1] === spokenPhonemes[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j - 1], dp[i - 1][j], dp[i][j - 1]);
+    }
+  }
+
+  // 2. Backtrace.
+  //
+  // A8: when a substitution and an omission are both optimal, substitution
+  // wins. That is the same outcome the reference implementation produced, but
+  // there it was an accident of `else if` ordering; here it is deliberate.
+  // Rationale: it keeps one entry per expected sound so the breakdown lines up
+  // with the word, and "you said X instead of Y" is more useful to a student
+  // than "you skipped Y and also added X".
+  let i = n;
+  let j = m;
+  const alignment: AlignmentEntry[] = [];
+  let substitutions = 0;
+  let omissions = 0;
+  let insertions = 0;
+  let correct = 0;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && targetPhonemes[i - 1] === spokenPhonemes[j - 1]) {
+      alignment.unshift({
+        position: i,
+        targetIPA: targetPhonemes[i - 1],
+        spokenIPA: spokenPhonemes[j - 1],
+        status: 'correct',
+      });
+      correct++;
+      i--;
+      j--;
+    } else if (i > 0 && j > 0 && dp[i][j] === dp[i - 1][j - 1] + 1) {
+      alignment.unshift({
+        position: i,
+        targetIPA: targetPhonemes[i - 1],
+        spokenIPA: spokenPhonemes[j - 1],
+        status: 'substituted',
+      });
+      substitutions++;
+      i--;
+      j--;
+    } else if (i > 0 && dp[i][j] === dp[i - 1][j] + 1) {
+      alignment.unshift({
+        position: i,
+        targetIPA: targetPhonemes[i - 1],
+        spokenIPA: null,
+        status: 'omitted',
+      });
+      omissions++;
+      i--;
+    } else {
+      // Extra sound. `position` is the target sound it follows — 0 when it
+      // precedes the whole word — so it shares a position with its neighbour.
+      alignment.unshift({
+        position: i,
+        targetIPA: null,
+        spokenIPA: spokenPhonemes[j - 1],
+        status: 'inserted',
+      });
+      insertions++;
+      j--;
+    }
+  }
+
+  // 3. Scores.
+  const totalEdits = substitutions + omissions + insertions;
+  const per = n > 0 ? totalEdits / n : 0;
+  const segmentScore = Math.max(0, Math.round((1 - per) * 100));
+
+  // A9: stress folds into a single combined score at a tunable weight. With
+  // no stress evidence the weight collapses to 0 rather than scoring 0, so a
+  // missing or unavailable stress stage degrades to sounds-only instead of
+  // failing every student.
+  const stressScore = stress ? scoreStress(stress) : null;
+  const appliedStressWeight = stressScore === null ? 0 : stressWeight;
+  const score =
+    stressScore === null
+      ? segmentScore
+      : Math.round(
+          (1 - appliedStressWeight) * segmentScore +
+            appliedStressWeight * stressScore
+        );
+
+  return {
+    score,
+    segmentScore,
+    stressScore,
+    appliedStressWeight,
+    passed: score >= requiredScore,
+    matchLevel,
+    requiredScore,
+    metrics: {
+      targetPhonemeCount: n,
+      correctCount: correct,
+      substitutionCount: substitutions,
+      omissionCount: omissions,
+      insertionCount: insertions,
+      per: Number(per.toFixed(3)),
+    },
+    alignment,
+  };
+}

--- a/scripts/spikes/alignment-engine/engine.ts
+++ b/scripts/spikes/alignment-engine/engine.ts
@@ -137,6 +137,24 @@ export class InvalidMatchLevelError extends Error {
   }
 }
 
+/**
+ * Thrown when `targetPhonemes` is empty (A13).
+ *
+ * A question with no reference phonemes cannot be graded at all. Left
+ * ungrarded, `n = 0` short-circuits PER to 0 and every student scores 100 and
+ * passes — with insertions still counted — which is silent grade inflation and
+ * the mirror image of the D4 catch-all's silent zero. Same rule as A7: reject
+ * loudly rather than guess, and do not let a caller swallow it.
+ */
+export class EmptyReferenceError extends Error {
+  constructor() {
+    super(
+      'targetPhonemes is empty — a question with no reference phonemes cannot be graded'
+    );
+    this.name = 'EmptyReferenceError';
+  }
+}
+
 /** Thrown when `stressWeight` is outside 0–1. */
 export class InvalidStressWeightError extends Error {
   constructor(weight: number) {
@@ -208,6 +226,11 @@ export function evaluatePronunciation(input: EvaluateInput): EvaluateResult {
   const stressWeight = input.stressWeight ?? 0;
   if (!Number.isFinite(stressWeight) || stressWeight < 0 || stressWeight > 1) {
     throw new InvalidStressWeightError(stressWeight);
+  }
+
+  // A13: an empty reference is a broken question, not a gradeable one.
+  if (targetPhonemes.length === 0) {
+    throw new EmptyReferenceError();
   }
 
   const n = targetPhonemes.length;

--- a/tests/utils/spotifyAuth.test.ts
+++ b/tests/utils/spotifyAuth.test.ts
@@ -616,10 +616,14 @@ describe('runSpotifyAuthPopup', () => {
     const { spy } = stubOpen(popup);
     const pending = runSpotifyAuthPopup();
 
-    // Flush the async S256 digest + executor so window.open runs and the
-    // 500ms closed-check interval is registered.
-    await vi.advanceTimersByTimeAsync(0);
-    expect(spy).toHaveBeenCalled();
+    // Wait for the async S256 digest + executor so window.open runs and the
+    // 500ms closed-check interval is registered. This must be a waitFor, not
+    // a fixed `advanceTimersByTimeAsync(0)`: the digest is a real
+    // SubtleCrypto call that settles on Node's threadpool rather than the
+    // timer queue, so a single micro-flush races it — it wins on an idle
+    // machine and loses under CI load. vi.waitFor advances fake timers on
+    // each poll, so it works while timers are mocked.
+    await vi.waitFor(() => expect(spy).toHaveBeenCalled());
 
     popup.closed = true;
     await vi.advanceTimersByTimeAsync(500);


### PR DESCRIPTION
Resolves [#2335 — Define correct alignment & scoring behaviour](https://github.com/OPS-PIvers/SpartBoard/issues/2335) on the [Wayfinder Map: Multilingual Pronunciation Engine](https://github.com/OPS-PIvers/SpartBoard/issues/2331).

**No feature code.** `scripts/spikes/alignment-engine/` is a decision harness in the same sense as `pronunciation-bias-probe/` and `english-g2p-probe/` — nothing here is wired into the app or imported by feature code. It does run under `pnpm test`, so a later change that violates one of these decisions fails CI.

## What's here

| File | Purpose |
| --- | --- |
| `DECISIONS.md` | The decision record, A1–A13. Authoritative where it disagrees with the spec doc. |
| `engine.test.ts` | The decisions as executable assertions — 27 tests. |
| `engine.ts` | Reference implementation for the tests to run against. |

The ticket prescribed the method (source doc §9.1): write the review notes as tests *before* deciding how to fix them, since each note is a behavioural claim with a concrete input and choosing the assertion is the decision.

## Decisions

**The four original review notes**

- **A5 — insertions get real alignment entries.** The reference counted them but emitted nothing, so an insertion badge was unrenderable — the reason the teacher results UI was blocked on this ticket. Contract change: `position` is no longer unique, and consumers must render in array order.
- **A6 — PER keeps the standard `(subs + omissions + insertions) / N` definition** and may exceed 1. That keeps it comparable to published error rates. It becomes an internal metric that is never shown to a teacher as a percentage.
- **A7 — an unconfigured strictness level throws** instead of falling back to Close. A picker guards authoring, but the value reaches the grader from Firestore, and the project has no runtime schema validation — thresholds ship tunable, PLC sharing crosses buildings, and D4 recomputes scores on every read, so a renamed or foreign preset is a normal state.
- **A8 — substitution-over-omission tie-breaking is now deliberate**, not an accident of `else if` ordering.

**Added to this ticket's remit by #2336 and #2344**

- **A1 — stress is scored, from a separate detection stage.** Verified against the vocabulary files: neither model selected in #2349 can emit stress (0 stress markers across all 392 tokens of each), and 15 of 16 surveyed phoneme models emit none either — stress is suprasegmental, so CTC frame labelling has no place to put it. This carves stress out of the map's Out-of-scope prosody entry; tracked as #2359 / #2360.
- **A3 — the payload always carries the detected sound**, but naming it to a human stays gated on #2355. Substitution *presence* is safe today; substitution *identity* is not.
- **A9/A10 — stress folds into one score at a tunable weight**, and any regionally accepted stress variant scores full credit, satisfying #2342.

**Also settled**

- **A2 — the stored reference is narrow**, exactly as the model emits it, so both sides share one alphabet and nothing needs converting.
- **A4 — no prose in the engine.** The hard-coded English `diagnostic` string is removed; a four-language UI can't ship it.
- **A11 — human-readable sound names are in scope** but don't gate spec acceptance (#2361).

**Added during review of this PR**

- **A10a — an empty accepted-variant list degrades to sounds-only**, rather than scoring 0. It was scoring 0, which is a class-wide silent failure: no score persists and points recompute on every read, so clearing a question's variants would retroactively drag down every historical response. It is also the state *every* question is in until #2360 lands.
- **A10b — a syllable-count mismatch counts against the score**, denominator being the longer pattern. Previously inherited from array out-of-bounds semantics rather than chosen.
- **A13 — an empty reference is rejected, not scored.** Measured on the pre-fix engine: `[]` against `['p','e','r','o']` returned `score: 100, passed: true, insertionCount: 4` — silent grade *inflation*, the mirror of D4's silent-zero landmine and more dangerous, because nobody investigates a pass.

## Finding: the spec's canonical example is arithmetically wrong

Writing `El perro` as a test immediately showed §6.2's numbers don't hold. It states `score: 75, passed: false` with `per: 0.166`, but under §5.1's own formula one substitution in six phonemes gives `PER = 0.167` and a score of **83** — which clears the Close threshold of 80.

**The spec's canonical illustration of a failure is actually a pass.** A 75 would need `PER = 0.25`, i.e. two errors in eight phonemes. It fails only at Exact. Anyone calibrating thresholds against that example would have been calibrating against a number the formula cannot produce. Corrected inline in the spec doc per its existing convention, and pinned as a test.

## One out-of-scope change

`tests/utils/spotifyAuth.test.ts` — unrelated to this PR's subject, included because it was the only thing keeping CI red and would not have self-healed.

`detects a user-closed popup via the closed-poll interval` waited for `window.open` with a fixed `advanceTimersByTimeAsync(0)`, but what it is waiting on is the async SubtleCrypto S256 digest, which settles on Node's threadpool rather than the timer queue. A single micro-flush races it — winning on an idle machine, losing under CI load, which is why it failed identically on two consecutive runs while passing 3/3 locally. Switched to `vi.waitFor`, the pattern every other test in that file already uses. The test predates this branch (`ef86915`, already on `dev-paul`).

Happy to split this out if preferred.

## Verification

- `npx vitest run scripts/spikes/alignment-engine/ tests/utils/spotifyAuth.test.ts` — 64 passed
- `pnpm run type-check` — clean
- `npx eslint tests/utils/spotifyAuth.test.ts --max-warnings 0` — clean
- `npx prettier --check` — clean
- ESLint ignores `scripts/`, so the spike directory adds no lint surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SugpwZtvR1Ws2vcBypB48q