### PR TITLE
fix(a11y): retrofit orphaned SettingsLabel group headings to as="span" (D3, nightly unifier)

### DIFF
--- a/components/admin/BreathingConfigurationPanel.tsx
+++ b/components/admin/BreathingConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useAdminBuildings } from '@/hooks/useAdminBuildings';
 import { useBuildingSelection } from '@/hooks/useBuildingSelection';
 import { BuildingSelector } from './BuildingSelector';
@@ -42,6 +42,9 @@ export const BreathingConfigurationPanel: React.FC<
   const BUILDINGS = useAdminBuildings();
   const [selectedBuildingId, setSelectedBuildingId] =
     useBuildingSelection(BUILDINGS);
+  const patternLabelId = useId();
+  const visualLabelId = useId();
+  const colorLabelId = useId();
 
   const buildingDefaults = config.buildingDefaults ?? {};
   const currentBuildingConfig: BuildingBreathingDefaults = buildingDefaults[
@@ -85,8 +88,14 @@ export const BreathingConfigurationPanel: React.FC<
 
         {/* Pattern Selection */}
         <div>
-          <SettingsLabel className="mb-1">Default Pattern</SettingsLabel>
-          <div className="flex flex-wrap bg-white rounded-lg border border-slate-200 p-1 gap-1">
+          <SettingsLabel as="span" id={patternLabelId} className="mb-1">
+            Default Pattern
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap bg-white rounded-lg border border-slate-200 p-1 gap-1"
+            role="group"
+            aria-labelledby={patternLabelId}
+          >
             {PATTERNS.map((opt) => (
               <button
                 key={opt.value}
@@ -109,8 +118,14 @@ export const BreathingConfigurationPanel: React.FC<
 
         {/* Visual Selection */}
         <div>
-          <SettingsLabel className="mb-1">Default Visual Style</SettingsLabel>
-          <div className="flex flex-wrap bg-white rounded-lg border border-slate-200 p-1 gap-1">
+          <SettingsLabel as="span" id={visualLabelId} className="mb-1">
+            Default Visual Style
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap bg-white rounded-lg border border-slate-200 p-1 gap-1"
+            role="group"
+            aria-labelledby={visualLabelId}
+          >
             {VISUALS.map((opt) => (
               <button
                 key={opt.value}
@@ -134,7 +149,9 @@ export const BreathingConfigurationPanel: React.FC<
         {/* Color Theme */}
         <div>
           <div className="flex items-center justify-between mb-1">
-            <SettingsLabel className="mb-0">Default Color Theme</SettingsLabel>
+            <SettingsLabel as="span" id={colorLabelId} className="mb-0">
+              Default Color Theme
+            </SettingsLabel>
             {!currentBuildingConfig.color ? (
               <span className="text-xxs text-slate-400 italic">
                 Inherit (Default)
@@ -148,7 +165,11 @@ export const BreathingConfigurationPanel: React.FC<
               </button>
             )}
           </div>
-          <div className="flex flex-wrap gap-2 p-2 bg-white rounded-lg border border-slate-200">
+          <div
+            className="flex flex-wrap gap-2 p-2 bg-white rounded-lg border border-slate-200"
+            role="group"
+            aria-labelledby={colorLabelId}
+          >
             {WIDGET_PALETTE.map((color) => (
               <button
                 key={color}

--- a/components/widgets/Breathing/BreathingSettings.tsx
+++ b/components/widgets/Breathing/BreathingSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { BreathingConfig, WidgetData } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { WIDGET_PALETTE } from '@/config/colors';
@@ -12,6 +12,7 @@ export const BreathingSettings: React.FC<{ widget: WidgetData }> = ({
 }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as BreathingConfig;
+  const patternLabelId = useId();
 
   const patterns = [
     { id: '4-4-4-4', label: 'Box Breathing' },
@@ -23,8 +24,14 @@ export const BreathingSettings: React.FC<{ widget: WidgetData }> = ({
     <div className="space-y-6 p-1">
       {/* Pattern Selection */}
       <div>
-        <SettingsLabel icon={Activity}>Pattern</SettingsLabel>
-        <div className="grid grid-cols-1 gap-2">
+        <SettingsLabel as="span" id={patternLabelId} icon={Activity}>
+          Pattern
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-1 gap-2"
+          role="group"
+          aria-labelledby={patternLabelId}
+        >
           {patterns.map((p) => (
             <button
               key={p.id}
@@ -58,6 +65,8 @@ export const BreathingAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as BreathingConfig;
+  const visualLabelId = useId();
+  const colorLabelId = useId();
 
   const visuals = [
     { id: 'circle', label: 'Sphere' },
@@ -71,8 +80,14 @@ export const BreathingAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
     <div className="space-y-6 p-1">
       {/* Visual Selection */}
       <div>
-        <SettingsLabel icon={Eye}>Visual Style</SettingsLabel>
-        <div className="grid grid-cols-3 gap-2">
+        <SettingsLabel as="span" id={visualLabelId} icon={Eye}>
+          Visual Style
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-3 gap-2"
+          role="group"
+          aria-labelledby={visualLabelId}
+        >
           {visuals.map((v) => (
             <button
               key={v.id}
@@ -95,8 +110,14 @@ export const BreathingAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Color Selection */}
       <div>
-        <SettingsLabel icon={Palette}>Color Theme</SettingsLabel>
-        <div className="flex flex-wrap gap-2">
+        <SettingsLabel as="span" id={colorLabelId} icon={Palette}>
+          Color Theme
+        </SettingsLabel>
+        <div
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-labelledby={colorLabelId}
+        >
           {colors.map((c) => (
             <button
               key={c}

--- a/components/widgets/DiceWidget/Settings.tsx
+++ b/components/widgets/DiceWidget/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, DiceConfig } from '@/types';
 import { Dices, Hash, Palette, Circle } from 'lucide-react';
@@ -9,6 +9,7 @@ export const DiceSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   const config = widget.config as DiceConfig;
   const { updateWidget } = useDashboard();
   const count = config.count ?? 1;
+  const diceCountLabelId = useId();
 
   const updateConfig = (updates: Partial<DiceConfig>) => {
     updateWidget(widget.id, {
@@ -19,8 +20,14 @@ export const DiceSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
   return (
     <div className="space-y-6">
       <div>
-        <SettingsLabel icon={Hash}>Number of Dice</SettingsLabel>
-        <div className="grid grid-cols-3 gap-2">
+        <SettingsLabel as="span" id={diceCountLabelId} icon={Hash}>
+          Number of Dice
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-3 gap-2"
+          role="group"
+          aria-labelledby={diceCountLabelId}
+        >
           {[1, 2, 3, 4, 5, 6].map((n) => (
             <button
               key={n}

--- a/components/widgets/HotspotImage/Settings.tsx
+++ b/components/widgets/HotspotImage/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import {
   WidgetData,
@@ -370,6 +370,7 @@ export const HotspotImageAppearanceSettings: React.FC<{
 }> = ({ widget }) => {
   const { updateWidget } = useDashboard();
   const config = widget.config as HotspotImageConfig;
+  const popoverThemeLabelId = useId();
 
   if (!config.baseImageUrl) {
     return (
@@ -382,8 +383,14 @@ export const HotspotImageAppearanceSettings: React.FC<{
   return (
     <div className="space-y-4">
       <div>
-        <SettingsLabel>Popover Theme</SettingsLabel>
-        <div className="flex gap-2">
+        <SettingsLabel as="span" id={popoverThemeLabelId}>
+          Popover Theme
+        </SettingsLabel>
+        <div
+          className="flex gap-2"
+          role="group"
+          aria-labelledby={popoverThemeLabelId}
+        >
           {[
             { value: 'light', label: 'Light' },
             { value: 'dark', label: 'Dark' },

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { WidgetData, MaterialsConfig, MaterialsGlobalConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { getMaterialsCatalog } from './constants';
@@ -15,6 +15,7 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   const { featurePermissions } = useAuth();
   const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as MaterialsConfig;
+  const availableMaterialsLabelId = useId();
   const {
     selectedItems = [],
     activeItems = [],
@@ -165,7 +166,13 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Item Selection */}
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <SettingsLabel className="mb-0">Available Materials</SettingsLabel>
+          <SettingsLabel
+            as="span"
+            id={availableMaterialsLabelId}
+            className="mb-0"
+          >
+            Available Materials
+          </SettingsLabel>
           <button
             onClick={toggleAll}
             className="text-xs text-blue-600 font-bold hover:underline"
@@ -174,7 +181,11 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
           </button>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-[250px] overflow-y-auto pr-1">
+        <div
+          className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-[250px] overflow-y-auto pr-1"
+          role="group"
+          aria-labelledby={availableMaterialsLabelId}
+        >
           {materialsCatalog.map((item) => {
             const isSelected = selectedSet.has(item.id);
             return (

--- a/components/widgets/NextUp/Settings.tsx
+++ b/components/widgets/NextUp/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useId, useState, useEffect } from 'react';
 import {
   WidgetData,
   NextUpConfig,
@@ -31,6 +31,7 @@ export const NextUpSettings: React.FC<{ widget: WidgetData }> = ({
   >([]);
   const [loadingFiles, setLoadingFiles] = useState(false);
   const [copied, setCopy] = useState(false);
+  const visualStyleLabelId = useId();
 
   // Load existing queue files
   useEffect(() => {
@@ -391,9 +392,15 @@ export const NextUpSettings: React.FC<{ widget: WidgetData }> = ({
 
         {/* Visual Styling */}
         <section className="space-y-4">
-          <SettingsLabel>Visual Style</SettingsLabel>
+          <SettingsLabel as="span" id={visualStyleLabelId}>
+            Visual Style
+          </SettingsLabel>
 
-          <div className="grid grid-cols-5 gap-2">
+          <div
+            className="grid grid-cols-5 gap-2"
+            role="group"
+            aria-labelledby={visualStyleLabelId}
+          >
             {[
               '#2d3f89',
               '#ad2122',


### PR DESCRIPTION
## Canonical form

`SettingsLabel` heading a group of sibling toggle/chip/swatch buttons (no single paired input) should use `as="span" id={...}` + `role="group" aria-labelledby={...}` on the sibling-controls container, instead of the default `as="label"` (which is semantically orphaned — a `<label>` with no single associated control). This is the established convention from the runs 26-48 group-heading retrofit series (`DrawingWidget`, `RevealGrid`, `RandomSettings`, `MusicWidget`, `SyntaxFramer`, `Checklist`, `MathToolInstance`, `ClockConfigurationPanel`, `TextWidget`, `WorkSymbols`, `TimeToolConfigurationPanel`).

## Instances unified (10 across 6 files)

- `components/widgets/Breathing/BreathingSettings.tsx` — "Pattern", "Visual Style", "Color Theme"
- `components/admin/BreathingConfigurationPanel.tsx` — "Default Pattern", "Default Visual Style", "Default Color Theme"
- `components/widgets/NextUp/Settings.tsx` — "Visual Style"
- `components/widgets/HotspotImage/Settings.tsx` — "Popover Theme"
- `components/widgets/DiceWidget/Settings.tsx` — "Number of Dice"
- `components/widgets/MaterialsWidget/Settings.tsx` — "Available Materials"

Each converted `SettingsLabel` gets `as="span" id={<name>LabelId}` (via `useId()`, since none of these 6 files had an existing `widget.id`-interpolation convention of their own) and the sibling button-group container gets `role="group" aria-labelledby={<name>LabelId}`.

## Enforcement

No new enforcement added this run (this is itself the continuation of an established retrofit convention, not a fresh anti-pattern) — a genuinely fresh sweep of files outside the previously-audited list found these 10 additional untouched instances, consistent with the pattern from runs 46-48 that a "closed" retrofit series is only closed for the files actually audited, not repo-wide.

## Behavior/visual-preservation evidence

Read `components/common/SettingsLabel.tsx` directly: `combinedClasses` is computed once from `baseClasses`/`layoutClasses`/`className` and is shared byte-identically by both the `as="label"` and `as="span"` render branches — only the wrapping element and `htmlFor` semantics differ. This is a pure a11y-semantics fix (orphaned `<label>` → `role="group"`/`aria-labelledby` pairing) with zero visual delta.

Independently re-verified by the orchestrator (not just the subagent's own claim):
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint <6 changed files> --max-warnings 0` — clean
- Read `SettingsLabel.tsx` source directly to confirm the `combinedClasses` equivalence claim

Subagent's own full run: `pnpm run test` → 592/592 files, 7269/7269 tests (matches this run's baseline exactly) — `pnpm run build` → client + SSR bundles succeeded — `pnpm exec prettier --check` clean.

## Risk tag

**mechanical** (pure a11y-semantics equivalence, zero visual delta, following an established repo-wide convention)

## Deferred / not touched this run

- D1 (Empty States), D2 (Brand Colors), D4 (Import Paths), D5 (Toast Architecture) all reported "aligned" this run after fresh sweeps — no drift found beyond already-catalogued exceptions.
- D1 flagged a new backlog candidate: `components/widgets/Calendar/Widget.tsx:467-499` "Connect Google Calendar" — a clickable OAuth-consent button styled like an empty state (icon+title+subtitle), likely an intentional exception analogous to `ShuffleList`'s "interaction target, not empty state" — not converted, logged for a future run's classification.
- D2 re-confirmed `components/layout/Dock.tsx:1586` is still an unresolved NEEDS-REVIEW item (static rgba brand-blue vs. admin-themeable `--spart-primary`, now unresolved for many consecutive runs) — still needs a human decision, not fixed in isolation.

---
_Generated by [Claude Code](https://claude.ai/code/session_0118k1B6qLHvK6yHNgQeJHL9)_