### PR TITLE
fix(deps): SECURITY — bump hono to ^4.13.0 (four MODERATE CVEs incl. CORS ReDoS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "pnpm": {
     "overrides": {
-      "hono": "^4.12.14",
+      "hono": "^4.13.0",
       "dompurify": "^3.4.11",
       "diff": "^8.0.3",
       "flatted": "^3.4.2",
@@ -115,7 +115,7 @@
     "firebase-functions-test": "^3.4.1",
     "firebase-tools": "^15.22.3",
     "globals": "^17.2.0",
-    "hono": "^4.12.14",
+    "hono": "^4.13.0",
     "husky": "^9.1.7",
     "jsdom": "^27.4.0",
     "lint-staged": "^16.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: ^4.12.14
+  hono: ^4.13.0
   dompurify: ^3.4.11
   diff: ^8.0.3
   flatted: ^3.4.2
@@ -92,7 +92,7 @@ importers:
         version: 5.0.0(firebase@12.8.0)
       '@google/genai':
         specifier: ^1.51.0
-        version: 1.51.0(@modelcontextprotocol/sdk@1.25.2(hono@4.12.15)(zod@4.3.6))
+        version: 1.51.0(@modelcontextprotocol/sdk@1.25.2(hono@4.13.0)(zod@4.3.6))
       '@playwright/test':
         specifier: ^1.58.0
         version: 1.58.0
@@ -194,13 +194,13 @@ importers:
         version: 3.4.1(firebase-admin@13.6.0(encoding@0.1.13))(firebase-functions@7.2.5(firebase-admin@13.6.0(encoding@0.1.13)))(jest@30.2.0(@types/node@24.12.2)(ts-node@10.9.2(@types/node@24.12.2)(typescript@5.9.3)))
       firebase-tools:
         specifier: ^15.22.3
-        version: 15.22.3(@types/node@24.12.2)(encoding@0.1.13)(hono@4.12.15)
+        version: 15.22.3(@types/node@24.12.2)(encoding@0.1.13)(hono@4.13.0)
       globals:
         specifier: ^17.2.0
         version: 17.2.0
       hono:
-        specifier: ^4.12.14
-        version: 4.12.15
+        specifier: ^4.13.0
+        version: 4.13.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -1083,7 +1083,7 @@ packages:
     resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.14
+      hono: ^4.13.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3628,8 +3628,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -7222,14 +7222,14 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google/genai@1.51.0(@modelcontextprotocol/sdk@1.25.2(hono@4.12.15)(zod@4.3.6))':
+  '@google/genai@1.51.0(@modelcontextprotocol/sdk@1.25.2(hono@4.13.0)(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.6
       ws: 8.21.1
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.15)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.13.0)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -7265,9 +7265,9 @@ snapshots:
       protobufjs: 7.5.6
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.9(hono@4.12.15)':
+  '@hono/node-server@1.19.9(hono@4.13.0)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.13.0
 
   '@humanfs/core@0.19.1': {}
 
@@ -7651,9 +7651,9 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
-  '@modelcontextprotocol/sdk@1.25.2(hono@4.12.15)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.25.2(hono@4.13.0)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.15)
+      '@hono/node-server': 1.19.9(hono@4.13.0)
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
       content-type: 1.0.5
@@ -9854,7 +9854,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  firebase-tools@15.22.3(@types/node@24.12.2)(encoding@0.1.13)(hono@4.12.15):
+  firebase-tools@15.22.3(@types/node@24.12.2)(encoding@0.1.13)(hono@4.13.0):
     dependencies:
       '@apphosting/common': 0.0.8
       '@electric-sql/pglite': 0.3.15
@@ -9862,7 +9862,7 @@ snapshots:
       '@google-cloud/cloud-sql-connector': 1.9.0
       '@google-cloud/pubsub': 5.3.0
       '@inquirer/prompts': 7.10.1(@types/node@24.12.2)
-      '@modelcontextprotocol/sdk': 1.25.2(hono@4.12.15)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.25.2(hono@4.13.0)(zod@4.3.6)
       abort-controller: 3.0.0
       ajv: 8.17.1
       ajv-formats: 3.0.1(ajv@8.17.1)
@@ -10315,7 +10315,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.15: {}
+  hono@4.13.0: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Raises the `hono` direct devDependency and the `pnpm.overrides.hono` pin from `^4.12.14` to `^4.13.0`, moving the resolved version **4.12.15 → 4.13.0**. This clears all four MODERATE advisories affecting `hono` <4.12.34, tracked as a MEDIUM item in the `dependency-audit` scheduled-tasks journal.

## CVEs resolved

| GHSA | Severity | Issue | Patched |
| --- | --- | --- | --- |
| GHSA-qp7p-654g-cw7p | moderate | CSS declaration injection via JSX SSR style objects | >=4.12.18 |
| GHSA-p77w-8qqv-26rm | moderate | Cache middleware ignores `Vary: Authorization`/`Cookie` (cross-user cache leak) | >=4.12.18 |
| GHSA-wgpf-jwqj-8h8p | moderate | Lambda@Edge adapter drops repeated request headers | >=4.12.25 |
| GHSA-8j4g-w8fx-2239 | moderate | CORS middleware ReDoS via `Access-Control-Request-Headers` | >=4.12.34 |

All four require >=4.12.34; `^4.13.0` tracks the latest patched release and stays within the 4.x major.

## Scope / impact

- `hono` is **not imported by any application source** — it's a dev/tooling dependency (also pulled transitively via `@modelcontextprotocol/sdk`). No production runtime impact.
- Lockfile diff is hono-scoped only (version bump + peer-context re-keys).

## Verification

- `pnpm why hono` → single `hono@4.13.0`
- All four tracked GHSAs gone from `pnpm audit`
- `prettier --check` (package.json + lockfile) clean
- `pnpm run type-check` exit 0
- `pnpm run lint` (root + functions, `--max-warnings 0`) exit 0
- `pnpm install --frozen-lockfile` consistent

## Note (out of scope)

`pnpm audit` still reports separate advisories on `@hono/node-server` (a distinct package, transitive via `@modelcontextprotocol/sdk`), which are not part of this item and will be tracked separately in the journal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6VLvZm1DEGN1vX678Zjpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6VLvZm1DEGN1vX678Zjpf)_