### PR TITLE
nightly(widgets): wire up the dead RevealGrid "Set Generator" button

### DIFF
--- a/components/widgets/RevealGrid/Settings.test.tsx
+++ b/components/widgets/RevealGrid/Settings.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RevealGridSettings } from './Settings';
+import { useDashboard } from '@/context/useDashboard';
+import { useGoogleDrive } from '@/hooks/useGoogleDrive';
+import { useDialog } from '@/context/useDialog';
+import { WidgetData } from '@/types';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+vi.mock('@/hooks/useGoogleDrive', () => ({
+  useGoogleDrive: vi.fn(),
+}));
+vi.mock('@/context/useDialog', () => ({
+  useDialog: vi.fn(),
+}));
+vi.mock('@/components/common/TypographySettings', () => ({
+  TypographySettings: () => null,
+}));
+
+const mockUpdateWidget = vi.fn();
+const mockAddToast = vi.fn();
+const mockShowAlert = vi.fn();
+
+const baseWidget: WidgetData = {
+  id: 'rg-test-1',
+  type: 'reveal-grid',
+  x: 0,
+  y: 0,
+  w: 600,
+  h: 400,
+  z: 1,
+  flipped: true,
+  config: {
+    cards: [],
+    columns: 3,
+  },
+};
+
+describe('RevealGridSettings — Reveal Grid Set Generator button', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      updateWidget: mockUpdateWidget,
+      addToast: mockAddToast,
+    });
+    (useGoogleDrive as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      driveService: null,
+    });
+    (useDialog as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      showAlert: mockShowAlert,
+    });
+  });
+
+  it('gives the teacher feedback instead of silently doing nothing when clicked', () => {
+    render(<RevealGridSettings widget={baseWidget} />);
+
+    const button = screen.getByRole('button', {
+      name: /Reveal Grid Set Generator/i,
+    });
+    fireEvent.click(button);
+
+    // Regression: the button previously had no onClick handler at all, so
+    // clicking it produced no visible reaction of any kind — a dead control
+    // styled to look fully interactive (see CLAUDE.md "Clarity over
+    // cleverness"). It must now surface a "coming soon" toast, matching the
+    // established pattern for unbuilt features elsewhere in the app
+    // (OrganizationPanel's `comingSoon` helper).
+    expect(mockAddToast).toHaveBeenCalledTimes(1);
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.stringMatching(/coming soon/i),
+      'info'
+    );
+  });
+});

--- a/components/widgets/RevealGrid/Settings.tsx
+++ b/components/widgets/RevealGrid/Settings.tsx
@@ -22,7 +22,7 @@ import { TypographySettings } from '@/components/common/TypographySettings';
 export const RevealGridSettings: React.FC<{ widget: WidgetData }> = ({
   widget,
 }) => {
-  const { updateWidget } = useDashboard();
+  const { updateWidget, addToast } = useDashboard();
   const { driveService } = useGoogleDrive();
   const { showAlert } = useDialog();
   const [isLoadingDrive, setIsLoadingDrive] = useState(false);
@@ -489,6 +489,9 @@ export const RevealGridSettings: React.FC<{ widget: WidgetData }> = ({
 
           <button
             type="button"
+            onClick={() =>
+              addToast('AI set generation is coming soon!', 'info')
+            }
             className="col-span-2 flex items-center justify-center gap-2 py-2 bg-purple-50 text-purple-600 rounded-xl hover:bg-purple-100 transition-colors text-xs font-bold"
           >
             <Sparkles className="w-4 h-4" /> Reveal Grid Set Generator


### PR DESCRIPTION
## Root cause
`components/widgets/RevealGrid/Settings.tsx` has a "Reveal Grid Set Generator" button (Sparkles/AI icon, styled identically to the two working buttons next to it — "Paste from Sheet" and "Upload CSV") with **no `onClick` handler at all**. Every teacher who flips a RevealGrid widget to its settings panel sees and can click it; nothing happens — no toast, no modal, no console error, no `disabled` styling to signal it's unfinished. No `RevealGridSetGenerator` component or AI-generation utility exists anywhere in the repo to back it — a fully orphaned stub, not a dropped wiring connection.

## Band-aid rejected
Building the actual AI set-generation feature is out of scope for a nightly pass (large, speculative surface). Silently `disabled`-ing the button would just trade one uninformative dead control for another.

## Fix
Wired the button to the codebase's existing "coming soon" toast convention (`OrganizationPanel.tsx`'s `comingSoon` helper), using the widget's own `addToast` from `useDashboard()` — shows "AI set generation is coming soon!" on click.

## Regression test
`components/widgets/RevealGrid/Settings.test.tsx` (new) — asserts `addToast` is called once on click.
- Fail-before (reverted to `dev-paul`'s version): `expected "vi.fn()" to be called 1 times, but got 0 times`
- Pass-after (with fix): 1/1 passing
- Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul` — reproduced the same fail-before/pass-after result.

## Evidence
- `pnpm run validate`: type-check, lint, format-check, root tests (593 files / 7270 tests), functions tests (40 files / 775 tests), test-count guard — all green (run twice, by the subagent and independently by the orchestrator).
- `pnpm run build`: production + SSR prerender bundles built clean.

## Risk
**contained** — single-file UI fix, no behavior change to any working code path, only replaces a silent no-op with user feedback.

---
🤖 Nightly debugger run — Widgets area.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK)_