### PR TITLE
nightly(dashboard-layout): stop Escape leaking from ActiveClassChip & FolderPickerPopover

### DIFF
--- a/components/common/ActiveClassChip.tsx
+++ b/components/common/ActiveClassChip.tsx
@@ -56,6 +56,11 @@ export const ActiveClassChip: React.FC<ActiveClassChipProps> = ({
     const handleKey = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(event)) return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget (see #2266 pattern).
+      event.stopPropagation();
       closeMenu();
     };
     let animationFrameId = 0;

--- a/components/common/library/FolderPickerPopover.tsx
+++ b/components/common/library/FolderPickerPopover.tsx
@@ -150,6 +150,11 @@ export const FolderPickerPopover: React.FC<FolderPickerPopoverProps> = ({
     const handleKey = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(event)) return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget (see #2266 pattern).
+      event.stopPropagation();
       onClose();
     };
     document.addEventListener('mousedown', handlePointer);

--- a/tests/components/common/ActiveClassChip.escapePropagation.test.tsx
+++ b/tests/components/common/ActiveClassChip.escapePropagation.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Regression test: ActiveClassChip's Escape handler already closed the
+ * switch-class popover, but never called stopPropagation(). Because the
+ * popover is portalled to document.body outside any `.widget` DraggableWindow
+ * ancestor, the unhandled keydown continued bubbling up to DashboardView's
+ * global `window`-level Escape handler, which — finding no typing field and
+ * no `.widget` ancestor for the popover — falls back to targeting the
+ * topmost z-index widget and minimizes it. Net effect: dismissing this
+ * popover with Escape (e.g. from the Random / SeatingChart / LunchCount /
+ * Stations widgets) could also silently minimize an unrelated widget on the
+ * live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * closeMenu(), matching the same fix already applied to ToolDockItem,
+ * RemoteControlMenu, ClassRosterMenu, and OverflowMenu for this exact bug
+ * class.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { ActiveClassChip } from '@/components/common/ActiveClassChip';
+import { useDashboard } from '@/context/useDashboard';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+const makeRoster = (id: string, name: string, studentCount = 20) => ({
+  id,
+  name,
+  driveFileId: null,
+  studentCount,
+  createdAt: 0,
+  students: [],
+});
+
+describe('ActiveClassChip — Escape does not leak to window-level handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      rosters: [makeRoster('r1', 'Period 1'), makeRoster('r2', 'Period 2')],
+      activeRosterId: 'r1',
+      setActiveRoster: vi.fn(),
+    });
+  });
+
+  it('closes the popover on Escape and stops propagation before it reaches window listeners', () => {
+    render(<ActiveClassChip />);
+
+    fireEvent.click(screen.getByRole('button', { name: /active class/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If the popover's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the topmost widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/tests/components/common/library/FolderPickerPopover.escapePropagation.test.tsx
+++ b/tests/components/common/library/FolderPickerPopover.escapePropagation.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Regression test: FolderPickerPopover's Escape handler already called
+ * onClose(), but never called stopPropagation(). Because the popover is
+ * portalled to document.body (or rendered inline) outside any `.widget`
+ * DraggableWindow ancestor, the unhandled keydown continued bubbling up to
+ * DashboardView's global `window`-level Escape handler, which — finding no
+ * typing field and no `.widget` ancestor for the popover — falls back to
+ * targeting the topmost z-index widget and minimizes it. Net effect:
+ * dismissing this folder picker with Escape (used from the Quiz / Video
+ * Activity / Mini App / Guided Learning library managers) could also
+ * silently minimize an unrelated widget on the live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * onClose(), matching the same fix already applied to ToolDockItem,
+ * RemoteControlMenu, ClassRosterMenu, OverflowMenu, and ActiveClassChip for
+ * this exact bug class.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { FolderPickerPopover } from '@/components/common/library/FolderPickerPopover';
+
+afterEach(cleanup);
+
+describe('FolderPickerPopover — Escape does not leak to window-level handlers', () => {
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    const onClose = vi.fn();
+
+    render(
+      <FolderPickerPopover
+        folders={[]}
+        selectedFolderId={null}
+        onSelect={vi.fn()}
+        onClose={onClose}
+        variant="dialog"
+      />
+    );
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If the popover's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the topmost widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause
`ActiveClassChip.tsx`'s class-switcher popover (live in `AbsentButton`, `SeatingChartToolbar`, `RandomWidget`, `RandomClassContextButton`, `LunchCount/Widget`, `Stations/Widget`) and `FolderPickerPopover.tsx` (live in `BulkActionBar`, `FolderSelectField`, and the Quiz/Video Activity/Mini App/Guided Learning library managers) are both `createPortal`'d to `document.body`, outside any `.widget` DraggableWindow ancestor. Both close on Escape via a native `document.addEventListener('keydown', ...)` handler, but neither called `stopPropagation()`. Since `DashboardView`'s global Escape handler is a native `window.addEventListener('keydown', ...)`, native DOM bubble order carries the unstopped event straight past the popover to that handler — which finds no `.widget` ancestor for the focused portal content and falls back to minimizing the topmost z-index widget. A teacher dismissing the class-switcher or folder-picker with Escape could silently minimize an unrelated widget (e.g. a running timer).

This is the same bug class already fixed independently 3 times for other portalled popovers: `ToolDockItem`/`RemoteControlMenu`/`ClassRosterMenu` (#2266), `BoardNavFab`/`CollectionSwitcherMenu`/`BoardActionsFab` (#2289), and `OverflowMenu` (#2314) — these two components were fresh, previously-unfixed instances.

## Band-aid rejected
Considered making `DashboardView`'s fallback smarter (e.g. checking for portal focus) instead of fixing each popover — but that's the wrong layer and diverges from the established, repo-wide convention that every portalled popover is responsible for stopping its own Escape from leaking to global listeners. The next new portalled popover would remain just as vulnerable.

## Fix
Added `event.stopPropagation()` in each handler, matching the exact one-line idiom used by the three prior fixes.

## Regression test
Two new test files (`ActiveClassChip.escapePropagation.test.tsx`, `FolderPickerPopover.escapePropagation.test.tsx`) assert the popover closes on Escape *and* a spied `window` `keydown` listener is never invoked.
- Fail-before (reverted to `dev-paul`): both failed — `expected "vi.fn()" to not be called at all, but actually been called 1 times`.
- Pass-after (with fix): both pass, plus existing `ActiveClassChip.test.tsx` (11 tests) unaffected.
- Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul` — reproduced the same fail-before/pass-after result.

## Evidence
- `pnpm run validate`: type-check, lint:app, lint:functions, format-check, full test:all (594 root files / 7271+ tests, 40 functions files / 775 tests) — all green (run by the subagent and independently re-run in full by the orchestrator).
- `pnpm run build`: production + SSR prerender bundles built clean.

## Additional leads flagged (not fixed, outside this area's glob)
The same missing-`stopPropagation()` pattern also appears reachable in `components/widgets/random/RandomClassContextButton.tsx`, `RandomGroups.tsx`, `components/widgets/Catalyst/CatalystSetPickerPopover.tsx`, `components/widgets/DrawingWidget/PageStrip.tsx`, and `components/widgets/LiveControl.tsx` — flagged for a future Widgets-area run, not independently verified for live-consumer reachability.

## Risk
**contained** — two one-line additions matching an established, well-precedented pattern; no behavior change outside the Escape-dismiss path.

---
🤖 Nightly debugger run — Dashboard & Layout area.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK)_