### PR TITLE
nightly(state-data): clear stale data when a super admin switches foreign orgs

### DIFF
--- a/hooks/useOrgBuildings.ts
+++ b/hooks/useOrgBuildings.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { AuthContext } from '@/context/AuthContextValue';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import type { BuildingRecord, BuildingType } from '@/types/organization';
 import { slugOrFallback } from '@/utils/slug';
 
@@ -44,26 +45,13 @@ export const useOrgBuildings = (orgId: string | null) => {
     !isAuthBypass && Boolean(user) && Boolean(orgId) && !reuseAuthBuildings;
   const [ownLoading, setOwnLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    // Parse the orgId back out of the previous key. Use indexOf/slice rather
-    // than split(':') so an orgId that ever contained a colon can't be
-    // truncated.
-    const prevOrgId = prevKey.slice(prevKey.indexOf(':') + 1);
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setOwnLoading(shouldSubscribe);
-    // Clear stale own-subscription data both when leaving own-subscription
-    // mode AND when switching to a *different* foreign org (a super admin
-    // hopping between two orgs, neither of which is their own — both keys have
-    // shouldSubscribe=true but different orgIds). Without the orgId comparison,
-    // org-A's buildings would flash under org-B's heading until B's first
-    // snapshot lands.
-    if (!shouldSubscribe || orgId !== prevOrgId) {
+    if (shouldClear) {
       setOwnBuildings([]);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useOrgDomains.test.ts
+++ b/hooks/useOrgDomains.test.ts
@@ -89,6 +89,51 @@ describe('useOrgDomains', () => {
     });
   });
 
+  it('clears stale domains when switching between two foreign orgs', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'super-admin' } });
+    const orgADomain: DomainRecord = { ...mockDomain, id: 'org-a-only' };
+    const orgBDomain: DomainRecord = { ...mockDomain, id: 'org-b-only' };
+    const byOrg: Record<string, DomainRecord> = {
+      'org-a': orgADomain,
+      'org-b': orgBDomain,
+    };
+    // collection() is called with (db, 'organizations', orgId, 'domains');
+    // return the orgId so the snapshot mock can serve org-specific data.
+    mockCollection.mockImplementation(
+      (_db: unknown, _orgs: string, orgId: string) => orgId
+    );
+    mockOnSnapshot.mockImplementation(
+      (
+        ref: string,
+        onNext: (snap: {
+          docs: { id: string; data: () => DomainRecord }[];
+        }) => void
+      ) => {
+        const domain = byOrg[ref];
+        queueMicrotask(() =>
+          onNext({ docs: [{ id: domain.id, data: () => domain }] })
+        );
+        return () => undefined;
+      }
+    );
+
+    const { result, rerender } = renderHook(
+      ({ orgId }: { orgId: string }) => useOrgDomains(orgId),
+      { initialProps: { orgId: 'org-a' } }
+    );
+    await waitFor(() => {
+      expect(result.current.domains).toEqual([orgADomain]);
+    });
+
+    // Switch to org-b: org-a's domains must be cleared immediately (not
+    // flashed under org-b's heading) before org-b's snapshot lands.
+    rerender({ orgId: 'org-b' });
+    expect(result.current.domains).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.domains).toEqual([orgBDomain]);
+    });
+  });
+
   it('addDomain writes a new doc with a derived id', async () => {
     mockUseAuth.mockReturnValue({ user: { uid: 'u' } });
     mockOnSnapshot.mockReturnValue(() => undefined);

--- a/hooks/useOrgDomains.ts
+++ b/hooks/useOrgDomains.ts
@@ -14,6 +14,7 @@ import type {
   DomainRole,
 } from '@/types/organization';
 import { slugOrFallback } from '@/utils/slug';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 
 /**
  * Subscribes to `/organizations/{orgId}/domains`. Reads allowed for org
@@ -29,16 +30,13 @@ export const useOrgDomains = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setDomains([]);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useOrgMembers.test.ts
+++ b/hooks/useOrgMembers.test.ts
@@ -312,6 +312,52 @@ describe('useOrgMembers', () => {
     ).rejects.toThrow(/No organization/);
   });
 
+  it('clears stale members when switching between two foreign orgs', async () => {
+    mockUseAuth.mockReturnValue({ user: { uid: 'super-admin' } });
+    const orgAMember: MemberRecord = { ...mockMember, email: 'org-a-only' };
+    const orgBMember: MemberRecord = { ...mockMember, email: 'org-b-only' };
+    const byOrg: Record<string, MemberRecord> = {
+      'org-a': orgAMember,
+      'org-b': orgBMember,
+    };
+    // collection() is called with (db, 'organizations', orgId, 'members');
+    // return the orgId so the snapshot mock can serve org-specific data.
+    mockCollection.mockImplementation(
+      (_db: unknown, _orgs: string, orgId: string) => orgId
+    );
+    mockOnSnapshot.mockImplementation(
+      (
+        ref: string,
+        onNext: (snap: {
+          docs: { id: string; data: () => MemberRecord }[];
+        }) => void
+      ) => {
+        const member = byOrg[ref];
+        queueMicrotask(() =>
+          onNext({ docs: [{ id: member.email, data: () => member }] })
+        );
+        return () => undefined;
+      }
+    );
+
+    const { result, rerender } = renderHook(
+      ({ orgId }: { orgId: string }) => useOrgMembers(orgId),
+      { initialProps: { orgId: 'org-a' } }
+    );
+    await waitFor(() => {
+      expect(result.current.members).toEqual([orgAMember]);
+    });
+
+    // Switch to org-b: org-a's members must be cleared immediately (not
+    // flashed under org-b's heading) before org-b's snapshot lands.
+    rerender({ orgId: 'org-b' });
+    expect(result.current.members).toEqual([]);
+    expect(result.current.users).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.members).toEqual([orgBMember]);
+    });
+  });
+
   it('writes reject when orgId is null', async () => {
     mockUseAuth.mockReturnValue({ user: null });
     const { result } = renderHook(() => useOrgMembers(null));

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -164,6 +164,7 @@ export const useOrgMembers = (orgId: string | null) => {
 
   useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
+    // Unconditional (not gated by shouldClear): activity data is per-org and must be refetched on any key change.
     setActivityMs(new Map());
     setActivityPartial({ partial: false, failedBatchCount: 0 });
     if (shouldClear) {

--- a/hooks/useOrgMembers.ts
+++ b/hooks/useOrgMembers.ts
@@ -9,6 +9,7 @@ import {
 import { httpsCallable } from 'firebase/functions';
 import { db, functions, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import type { MemberRecord, UserRecord } from '@/types/organization';
 
 // Response shape returned by the `createOrganizationInvites` callable
@@ -161,18 +162,15 @@ export const useOrgMembers = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
     setActivityMs(new Map());
     setActivityPartial({ partial: false, failedBatchCount: 0 });
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setMembers([]);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useOrgRoles.ts
+++ b/hooks/useOrgRoles.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import type { CapabilityId, RoleRecord } from '@/types/organization';
 
 // Key-by-key compare so we can't be tripped up by key-ordering differences
@@ -47,16 +48,13 @@ export const useOrgRoles = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setRoles([]);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useOrgStudentPage.ts
+++ b/hooks/useOrgStudentPage.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { doc, onSnapshot, setDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import type { StudentPageConfig } from '@/types/organization';
 
 /**
@@ -22,16 +23,13 @@ export const useOrgStudentPage = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setStudentPage(null);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useOrgSubscriptionReset.ts
+++ b/hooks/useOrgSubscriptionReset.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import {
+  orgSubscriptionKey,
+  shouldClearOnOrgKeyChange,
+} from '@/utils/orgSubscriptionKey';
+
+/**
+ * Detects `shouldSubscribe`/`orgId` transitions for org-scoped Firestore
+ * subscription hooks and tells the caller whether to reset. Adjusts state
+ * during render (not a `useEffect`) so a transition is applied in the SAME
+ * render that observes it — a consumer reading the hook's data this render
+ * never sees the prior org's stale value.
+ *
+ * `onTransition` fires exactly once per key change, with `shouldClear` true
+ * when the subscription is turning off OR staying on for a *different* org
+ * (see `shouldClearOnOrgKeyChange`). Callers should always reset their
+ * `loading` flag from `shouldSubscribe` and clear their data state when
+ * `shouldClear` is true.
+ */
+export function useOrgSubscriptionReset(
+  shouldSubscribe: boolean,
+  orgId: string | null,
+  onTransition: (shouldClear: boolean) => void
+): void {
+  const nextKey = orgSubscriptionKey(shouldSubscribe, orgId);
+  const [prevKey, setPrevKey] = useState(nextKey);
+  if (prevKey !== nextKey) {
+    const shouldClear = shouldClearOnOrgKeyChange(
+      shouldSubscribe,
+      orgId,
+      prevKey
+    );
+    setPrevKey(nextKey);
+    onTransition(shouldClear);
+  }
+}

--- a/hooks/useOrganization.ts
+++ b/hooks/useOrganization.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import type { OrgRecord } from '@/types/organization';
 
 /**
@@ -22,16 +23,13 @@ export const useOrganization = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setOrganization(null);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/hooks/useTestClasses.ts
+++ b/hooks/useTestClasses.ts
@@ -11,6 +11,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { useOrgSubscriptionReset } from '@/hooks/useOrgSubscriptionReset';
 import { slugOrFallback } from '@/utils/slug';
 
 export interface TestClassRecord {
@@ -60,16 +61,13 @@ export const useTestClasses = (orgId: string | null) => {
   const shouldSubscribe = !isAuthBypass && Boolean(user) && Boolean(orgId);
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
 
-  const [prevKey, setPrevKey] = useState(`${shouldSubscribe}:${orgId ?? ''}`);
-  const nextKey = `${shouldSubscribe}:${orgId ?? ''}`;
-  if (prevKey !== nextKey) {
-    setPrevKey(nextKey);
+  useOrgSubscriptionReset(shouldSubscribe, orgId, (shouldClear) => {
     setLoading(shouldSubscribe);
-    if (!shouldSubscribe) {
+    if (shouldClear) {
       setTestClasses([]);
       setError(null);
     }
-  }
+  });
 
   useEffect(() => {
     if (!shouldSubscribe || !orgId) return;

--- a/utils/orgSubscriptionKey.test.ts
+++ b/utils/orgSubscriptionKey.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import {
+  orgIdFromKey,
+  orgSubscriptionKey,
+  shouldClearOnOrgKeyChange,
+} from './orgSubscriptionKey';
+
+describe('orgSubscriptionKey', () => {
+  it('builds a composite key from the subscribe flag and orgId', () => {
+    expect(orgSubscriptionKey(true, 'org-a')).toBe('true:org-a');
+    expect(orgSubscriptionKey(false, null)).toBe('false:');
+  });
+});
+
+describe('orgIdFromKey', () => {
+  it('recovers the orgId component', () => {
+    expect(orgIdFromKey('true:org-a')).toBe('org-a');
+    expect(orgIdFromKey('false:')).toBe('');
+  });
+
+  it('preserves a colon inside the orgId itself', () => {
+    // Regression: split(':') would truncate at the first colon.
+    expect(orgIdFromKey('true:weird:org')).toBe('weird:org');
+  });
+});
+
+describe('shouldClearOnOrgKeyChange', () => {
+  it('clears when the subscription turns off', () => {
+    expect(shouldClearOnOrgKeyChange(false, null, 'true:org-a')).toBe(true);
+  });
+
+  it('does NOT clear when re-subscribing to the same org after being off', () => {
+    // (unreachable in practice — orgId only changes via a param change — but
+    // documents the boundary the orgId comparison alone would miss.)
+    expect(shouldClearOnOrgKeyChange(true, 'org-a', 'false:org-a')).toBe(false);
+  });
+
+  /**
+   * The bug this module fixes: a super admin switching between two foreign
+   * orgs never flips `shouldSubscribe` (both keys are `true:<orgId>`), so a
+   * clear condition of `!shouldSubscribe` alone — the code every one of
+   * useOrgDomains/useOrgMembers/useOrgRoles/useOrgStudentPage/useOrganization/
+   * useTestClasses shipped with before this fix — misses org-A -> org-B and
+   * leaves org A's data rendered under org B's heading until org B's first
+   * snapshot lands.
+   */
+  it('clears when staying subscribed but switching to a different org', () => {
+    expect(shouldClearOnOrgKeyChange(true, 'org-b', 'true:org-a')).toBe(true);
+  });
+
+  it('does NOT clear when the key changes but the org stays the same', () => {
+    // e.g. a re-render that recomputes the same shouldSubscribe/orgId pair
+    // shouldn't reach this function at all in practice (the caller only
+    // invokes it on an actual key change), but the org-identity check alone
+    // must not misfire when orgId is unchanged.
+    expect(shouldClearOnOrgKeyChange(true, 'org-a', 'true:org-a')).toBe(false);
+  });
+});

--- a/utils/orgSubscriptionKey.ts
+++ b/utils/orgSubscriptionKey.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared key logic for org-scoped Firestore subscription hooks (useOrgBuildings,
+ * useOrgDomains, useOrgMembers, useOrgRoles, useOrgStudentPage, useOrganization,
+ * useTestClasses). Each hook subscribes to a doc/collection scoped by `orgId`
+ * and gates the subscription behind a `shouldSubscribe` flag (auth-bypass /
+ * signed-out / no orgId all disable it).
+ *
+ * The hooks track transitions with a composite `${shouldSubscribe}:${orgId}`
+ * key so a single `useState` comparison catches every transition. The subtle
+ * part is deciding when stale data must be CLEARED: not just when unsubscribing
+ * (`shouldSubscribe` flips to false), but also when staying subscribed while
+ * `orgId` changes — a super admin hopping from foreign org A to foreign org B
+ * never sees `shouldSubscribe` go false (both keys are `true:<orgId>`), so a
+ * clear gated only on `!shouldSubscribe` leaves org A's data rendered under
+ * org B's heading until B's first snapshot lands. See useOrgBuildings (#2276)
+ * for the original fix this generalizes.
+ */
+
+/** Build the composite transition key from a hook's current inputs. */
+export function orgSubscriptionKey(
+  shouldSubscribe: boolean,
+  orgId: string | null
+): string {
+  return `${shouldSubscribe}:${orgId ?? ''}`;
+}
+
+/**
+ * Extract the `orgId` component back out of a key built by
+ * `orgSubscriptionKey`. Uses indexOf/slice rather than `split(':')` so an
+ * orgId that ever contained a colon can't be truncated.
+ */
+export function orgIdFromKey(key: string): string {
+  return key.slice(key.indexOf(':') + 1);
+}
+
+/**
+ * Whether a hook's org-scoped state must be cleared on a key transition.
+ * True when the subscription is turning off, OR when it stays on but now
+ * points at a different org.
+ */
+export function shouldClearOnOrgKeyChange(
+  shouldSubscribe: boolean,
+  orgId: string | null,
+  prevKey: string
+): boolean {
+  return !shouldSubscribe || orgId !== orgIdFromKey(prevKey);
+}


### PR DESCRIPTION
## Root cause
Six sibling org-scoped Firestore subscription hooks — `useOrgDomains`, `useOrgMembers`, `useOrgRoles`, `useOrgStudentPage`, `useOrganization`, `useTestClasses` — tracked subscription transitions with a composite `${shouldSubscribe}:${orgId}` key but only cleared their state `if (!shouldSubscribe)`. A super admin browsing the Organization admin panel (`components/admin/Organization/OrganizationPanel.tsx`) who opens foreign org A then foreign org B never flips `shouldSubscribe` (both keys are `true:<orgId>`), so org A's domains/members/roles/student-page-config/org-record/test-classes stay in state — visibly rendered under org B's heading — until org B's first Firestore snapshot lands.

This is the same bug class already found and fixed once in `useOrgBuildings` (#2276), but the fix was never propagated to its six siblings — a "sibling-hook drift" pattern this codebase has hit before (a fix landing in one hook of a family is a strong signal to diff it against every sibling, not just trust the bug class is fully audited).

For `useOrgMembers` specifically this is a real data-integrity risk, not just a visual flash: `OrganizationPanel` passes the raw (possibly-stale) `buildings` array into `UsersView`, gated only by `usersLoading || rolesLoading` — not `buildingsLoading` — so an admin could invite a user into org B tagged with org A's building ids.

## Band-aid rejected
Patching each of the six hooks individually with the inline `orgId !== prevOrgId` check (copy-pasting `useOrgBuildings`'s fix six more times) would close the immediate bug but leave the same footgun for the next hook added to this family. Instead, extracted the logic into a pure, unit-tested helper (`utils/orgSubscriptionKey.ts`) and a thin hook (`hooks/useOrgSubscriptionReset.ts`), then wired all seven org-scoped hooks — including `useOrgBuildings` itself — through the shared primitive, closing the whole bug class rather than one instance.

## Fix
- `utils/orgSubscriptionKey.ts`: `orgSubscriptionKey()`, `orgIdFromKey()`, `shouldClearOnOrgKeyChange()` — pure functions, unit tested.
- `hooks/useOrgSubscriptionReset.ts`: thin hook wrapping the "adjust state during render" pattern (per CLAUDE.md — not a `useEffect`, so a transition applies in the same render that observes it).
- All 7 org-scoped hooks (`useOrgBuildings`, `useOrgDomains`, `useOrgMembers`, `useOrgRoles`, `useOrgStudentPage`, `useOrganization`, `useTestClasses`) now call the shared hook instead of duplicating the key-tracking logic.

## Regression test
New "clears stale X when switching between two foreign orgs" tests added for the previously-unfixed hooks (`useOrgDomains`, `useOrgMembers`), plus a unit test suite for the extracted `utils/orgSubscriptionKey.ts`.
- Fail-before (reverted `useOrgMembers.ts`/`useOrgDomains.ts` to `dev-paul` via file-swap, not `git stash`): both new tests failed, showing org-A's stale record still present after switching to org-B (e.g. `expected [ {...} ] to deeply equal []`).
- Pass-after (with fix): all pass. Full `hooks/` + `utils/` suite: 92 files / 1082 tests.
- Independently re-verified by the orchestrator via the same file-swap technique against `dev-paul` — reproduced the identical concrete fail (`expected [ { email: 'org-a-only', ... } ] to deeply equal []`) → pass.

## Evidence
- `pnpm run validate`: type-check, lint, format-check, root tests (593 files / 7278 tests), functions tests (40 files / 775 tests), test-count guard — all green (run by the subagent and independently re-run in full by the orchestrator).
- `pnpm run build`: production + SSR prerender bundles built clean.

## Backlog leads investigated (no fix needed)
Dedup-fence and partial-credit `isCorrect` invariant patterns re-audited across `videoActivityGrading.ts`, `useQuizSession.ts`, `assignmentExportShared.ts`, `useGuidedLearningAssignments.ts`, `quizMaxPoints.ts`, `plcContributions.ts` — all already correctly guarded. Also checked GuidedLearning's `duplicateSet`/`duplicateBuildingSet` for the "drops authored settings on duplicate" bug fixed in #2316 — not susceptible (spreads the full source doc).

## Risk
**architectural** — touches 7 hook files and introduces 2 new shared utility files, but each hook's change is a mechanical swap of inline logic for the shared primitive; behavior is identical except for the 6 previously-buggy hooks now correctly clearing stale data.

---
🤖 Nightly debugger run — State & Data area.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK)_