### PR TITLE
nightly(admin-config): lowercase beta-user emails in widget FeaturePermissionsManager

### DIFF
--- a/components/admin/BetaUsersPanel.test.tsx
+++ b/components/admin/BetaUsersPanel.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { BetaUsersPanel } from './BetaUsersPanel';
+import type { FeaturePermission, ToolMetadata } from '@/types';
+import { Timer } from 'lucide-react';
+
+describe('BetaUsersPanel', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const tool: ToolMetadata = {
+    type: 'time-tool',
+    icon: Timer,
+    label: 'Timer',
+    color: 'bg-red-500',
+  };
+
+  const permission: FeaturePermission = {
+    widgetType: 'time-tool',
+    accessLevel: 'beta',
+    betaUsers: [],
+    enabled: true,
+  };
+
+  // Every other "add beta user" call site in the app (GlobalPermissionsManager,
+  // BackgroundManager) lowercases the email before persisting it, because
+  // downstream consumers (Firestore array-contains queries in
+  // CustomWidgetsContext/useBackgrounds, case-sensitive `.includes()` checks in
+  // Cloud Functions) rely on betaUsers arrays being stored lowercase. This
+  // panel was the one outlier that stored whatever case the admin typed.
+  it('stores beta user emails lowercased, matching the rest of the app', () => {
+    const updatePermission = vi.fn();
+    render(
+      <BetaUsersPanel
+        tool={tool}
+        permission={permission}
+        updatePermission={updatePermission}
+        showMessage={vi.fn()}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('user@example.com');
+    fireEvent.change(input, { target: { value: 'Teacher@School.ORG' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(updatePermission).toHaveBeenCalledWith('time-tool', {
+      betaUsers: ['teacher@school.org'],
+    });
+  });
+});

--- a/components/admin/BetaUsersPanel.tsx
+++ b/components/admin/BetaUsersPanel.tsx
@@ -29,7 +29,7 @@ export const BetaUsersPanel: React.FC<BetaUsersPanelProps> = ({
     widgetType: WidgetType | InternalToolType,
     email: string
   ) => {
-    const trimmedEmail = email.trim();
+    const trimmedEmail = email.trim().toLowerCase();
     if (!trimmedEmail) return;
 
     // Basic email format validation


### PR DESCRIPTION
## Root cause
`components/admin/BetaUsersPanel.tsx` — the widget-level beta-tester editor used by `FeaturePermissionsManager.tsx` (Admin Settings → Feature Permissions) — stored beta-user emails with whatever casing the admin typed, instead of lowercasing them. This was the one outlier: `GlobalPermissionsManager.tsx` and `BackgroundManager/index.tsx` (the two sibling "add beta user" implementations elsewhere in the same directory) both lowercase on write.

That normalization matters because several real consumers of `betaUsers[]` compare case-sensitively: Firestore `array-contains` queries (`CustomWidgetsContext`, `useBackgrounds`) and Cloud Function checks in `functions/src/aiGeneration.ts` only lowercase the incoming caller's email, not the stored array. The one path that happened to be safe — `AuthContext.isBetaUser` (used by `canAccessWidget`) — lowercases both sides, which is exactly why this bug went unnoticed: a widget stayed addable from the Dock, but `DashboardContext.getDefaultDockTools` does a plain case-sensitive `.includes()` against the same doc, so a beta-enabled widget would silently not show up as a *default* dock tool for a user whose email an admin had typed with any uppercase letter.

## Band-aid rejected
Considered instead fixing the case-sensitive read in `DashboardContext.tsx`'s `getDefaultDockTools`, but that's out of this area and would leave the actual defect (inconsistent write-time normalization) in place for any other current/future case-sensitive consumer. Normalizing at the single write site matches the codebase's existing established invariant and fixes it at the source.

## Fix
One line — `email.trim()` → `email.trim().toLowerCase()` in `BetaUsersPanel.tsx`'s `addBetaUser`.

## Regression test
`components/admin/BetaUsersPanel.test.tsx` (new) — asserts `updatePermission` is called with a lowercased email after typing `Teacher@School.ORG`.
- Fail-before (reverted to `dev-paul`): `expected "Teacher@School.ORG"` — failed.
- Pass-after (with fix): passes.
- Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul` — reproduced the identical fail-before/pass-after result.

## Evidence
- `pnpm run validate`: type-check, lint, format-check, root tests (593 files / 7270 tests), functions tests (40 files / 775 tests), test-count guard — all green (run by the subagent and independently re-run in full by the orchestrator).
- `pnpm run build`: production + SSR prerender bundles built clean.

## Backlog leads investigated (both stale, no action needed)
1. i18n verbatim-EN sweep since 2026-07-31 — only one locale-touching commit since then (#2317, already fixed and verified fully localized).
2. HTML-entity-in-string-literal bug class (#2267) — swept `components/auth/**`/`components/admin/**`, no sibling instance found.

## Risk
**contained** — single-line write-time normalization, matches an existing established pattern in two sibling files.

---
🤖 Nightly debugger run — Admin & Config area.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEe1QyAqKkzKkB61JyxtjK)_