### PR TITLE
spike(pronunciation): retroflex confusion screen on the committed clips (#2355)

### DIFF
--- a/scripts/spikes/retroflex-confusion/.gitignore
+++ b/scripts/spikes/retroflex-confusion/.gitignore
@@ -1,0 +1,13 @@
+# Model artifacts — downloaded, not committed (~2.3 GB across four
+# quantizations). Fetch with the commands in RESULTS.md ("Reproducing").
+model/
+*.onnx
+vocab.json
+preprocessor_config.json
+config.json
+
+# Local virtualenv, if created here rather than alongside.
+venv/
+
+# Python bytecode from the harness.
+__pycache__/

--- a/scripts/spikes/retroflex-confusion/RESULTS.md
+++ b/scripts/spikes/retroflex-confusion/RESULTS.md
@@ -1,0 +1,293 @@
+# Retroflex confusion screen — does the on-device model report `ɹ`, or collapse it?
+
+Resolves [#2355](https://github.com/OPS-PIvers/SpartBoard/issues/2355) on the
+[Multilingual Pronunciation Engine map](https://github.com/OPS-PIvers/SpartBoard/issues/2331).
+
+**Verdict: the retroflex survives. `ɹ` is reported cleanly, at every quantization,
+with the correct answer 25–40× ahead of its nearest rival — so per-phoneme
+diagnostic feedback is not disqualified, and the spec's worked example is
+reproducible on-device.**
+
+**Two problems the ticket did not anticipate, both pointing the other way: a
+_correct_ Spanish tap is reported as a trill in all four quantizations, and a
+_correct_ trill's token count is not stable, so holding it longer buys an
+insertion penalty.**
+
+Measured with **onnxruntime 1.28.0** against
+[`qnighy/wav2vec2-xlsr-53-espeak-cv-ft-ONNX`](https://huggingface.co/qnighy/wav2vec2-xlsr-53-espeak-cv-ft-ONNX),
+all four exported quantizations, and **espeak-ng 1.51** (`es-419`, Ubuntu package)
+for the references. Stimuli are the five human clips already committed at
+`../pronunciation-bias-probe/audio/`.
+
+---
+
+## First: the ticket asked for a measurement its stimuli cannot produce
+
+#2355 specifies "a **3×3 confusion matrix** over {`ɹ`, `ɾ`, `r`} at the target
+rhotic position, **n ≥ 30 per cell**", and a pass criterion of "`ɹ` reported
+**≥ 70%**" on the Anglo clips.
+
+That design was inherited from the Gemini bias probe, where the 40-observation
+cells came from **re-running a sampling model ten to thirty times over one
+file**. The variance lived in the model.
+
+**This model has no such variance.** Greedy CTC decoding is `argmax` over a
+fixed graph: same bytes in, same string out. Verified rather than assumed —
+three consecutive runs of the Anglo clip returned `peɹo` identically.
+
+So one clip is one observation, permanently, and the corpus holds **exactly one
+Anglo-`ɹ` clip**. The load-bearing cell could only ever read 0% or 100%. The
+`≥ 70%` criterion is not merely unmet; it is unevaluable.
+
+What follows is therefore a **necessary-condition screen**, not the matrix. It
+refutes far better than it confirms: a collapse appearing here would be real,
+while its absence rests on one speaker.
+
+## What was measured
+
+|               |                                                                                                                            |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Model         | `qnighy/wav2vec2-xlsr-53-espeak-cv-ft-ONNX`, vocab 392 tokens                                                              |
+| Rhotic tokens | `ɹ`=27, `ɾ`=15, `r`=31 — three distinct entries, as [#2349](https://github.com/OPS-PIvers/SpartBoard/issues/2349) required |
+| Decode        | Own argmax + CTC collapse (per S1 — the convenience API discards timing)                                                   |
+| Audio         | 22 050 Hz mono, resampled to the model's 16 kHz; zero-mean unit-variance normalization                                     |
+| Frame stride  | ~20.2 ms measured, matching S1's assumption                                                                                |
+
+Model files, sizes and md5(12) — **not committed**, see _Reproducing_ below:
+
+| file                | size          | md5(12)        |
+| ------------------- | ------------- | -------------- |
+| `model.onnx` (fp32) | 1 263 763 411 | `eabcc597e3a4` |
+| `model_fp16.onnx`   | 632 071 092   | `9cb5d9fbc219` |
+| `model_q4.onnx`     | 241 430 967   | `b9e69f089908` |
+| `model_q4f16.onnx`  | 196 651 670   | `2ed0b7407c29` |
+
+All five fixture md5s were re-checked against the table in
+`../pronunciation-bias-probe/README.md` and match, so this measured the same
+bytes the Gemini probe did.
+
+## References, and why the trill is one token
+
+```
+espeak-ng -v es-419 -q --ipa=3 pero    ->  pˈeɾo
+espeak-ng -v es-419 -q --ipa=3 perro   ->  pˈero
+```
+
+Both are **four tokens** after stress-mark removal. The Spanish trill is a
+single `r` in the reference even though it is several tongue contacts in the
+mouth — which is the root of the second finding below.
+
+## Results
+
+Edit distance from the espeak reference, in the units the alignment engine
+charges. `0` is an exact match.
+
+| clip                  | intended                                  | fp32  | fp16  | q4    | q4f16 |
+| --------------------- | ----------------------------------------- | ----- | ----- | ----- | ----- |
+| `pero_anglo_r_human`  | English retroflex — the learner **ERROR** | 1     | 1     | 1     | 1     |
+| `pero_tap_human`      | Spanish tap — **CORRECT**                 | 3     | 3     | 1     | 1     |
+| `perro_trill_human_1` | trill, weakest — **CORRECT**              | 0     | 0     | 1     | 1     |
+| `perro_trill_human_2` | trill, middle — **CORRECT**               | 2     | 2     | 2     | 2     |
+| `perro_trill_human_3` | trill, strongest — **CORRECT**            | 0     | 1     | 1     | 1     |
+| **exact / 5**         |                                           | **2** | **1** | **0** | **0** |
+| **total edits**       |                                           | **6** | **7** | **6** | **6** |
+
+### 1. The retroflex survives — this is the finding the ticket exists for
+
+The Anglo clip decodes as `peɹo` against a `peɾo` reference: **one edit,
+`sub ɾ→ɹ`**, identically in all four quantizations.
+
+That is _precisely_ the spec's worked example — expected `/ɾ/`, detected `/ɹ/`.
+[#2344](https://github.com/OPS-PIvers/SpartBoard/issues/2344) found that example
+**irreproducible server-side**: once the prompt named Spanish, Gemini returned
+`ɹ` in **0 of 40** samples. On-device it comes back first try, and the margin is
+not marginal:
+
+| clip             | top-3 posteriors at the rhotic frame  |
+| ---------------- | ------------------------------------- |
+| retroflex (fp32) | `ɹ`=0.799 · `<pad>`=0.119 · `r`=0.032 |
+| retroflex (q4)   | `ɹ`=0.788 · `<pad>`=0.140 · `r`=0.018 |
+
+The nearest competing _phoneme_ is 25–40× behind. On this evidence the property
+[D1](https://github.com/OPS-PIvers/SpartBoard/issues/2333) assumed — that a CTC
+model with no language-ID input reports the phone it heard rather than the one
+the language expects — **holds for this contrast**, and per-phoneme diagnostics
+are not disqualified.
+
+### 2. A correct tap is reported as a trill, in every quantization
+
+`pero_tap_human` yields `sub ɾ→r` in all four variants: a student who taps
+correctly is marked **wrong**, and a diagnostic UI would tell them "you produced
+a trill" when they produced a tap. That is the same class of failure #2344
+documented server-side, pointing the opposite way.
+
+**Confidence does not separate this from the good case:**
+
+| clip       | top-3 posteriors at the rhotic frame  |
+| ---------- | ------------------------------------- |
+| tap (fp32) | `r`=0.488 · `<pad>`=0.316 · `ɾ`=0.060 |
+| tap (q4)   | `r`=0.402 · `ɾ`=0.320 · `d`=0.101     |
+
+fp32 is confidently wrong — the correct `ɾ` is 8× behind. q4 is nearly a
+coin-flip. **A confidence gate on whether to name the detected phoneme would
+not have caught this**, because the wrong answer on the tap is about as
+confident as the right answer on the retroflex. That is a direct input to
+[#2362](https://github.com/OPS-PIvers/SpartBoard/issues/2362).
+
+**Confounded, and it must not be over-read.** The clip is one speaker
+deliberately producing a tap, and `../pronunciation-bias-probe/RESULTS.md`
+records that the speaker's L1 is nowhere documented. A deliberate tap by an
+unknown speaker is weak ground truth. This is the first thing the expansion
+below should settle.
+
+### 3. A held trill decodes as more than one `r`
+
+A trill is several tongue contacts; CTC emits a peak per contact; the reference
+holds exactly **one** `r`. So the same correct trill decodes differently
+depending on how long it was held and which quantization ran it:
+
+- fp32: trills 1 and 3 → `pero` (exact match), trill 2 → `erɹo`
+- q4: trills 1 and 3 → `perro` (**one insertion each**), trill 2 → `erɹo`
+
+Nothing in A5/A6 or S1 addresses this, and A5/A6 **dock insertions** — so a
+student holding a correct trill a beat longer loses points for it. The fix is
+plausibly a collapse rule before alignment, but that is a scoring-design
+decision, not a measurement, and it is ticketed separately.
+
+### 4. Quantization does not eat the contrast — the q4 pinning stands
+
+The ticket's fourth criterion ("no cell differs by more than ~10 points")
+**passes**. The rhotic _identity_ is identical across all four variants on all
+five clips; only spurious insertions and deletions move.
+
+Exact-match count appears to favour fp32 (2 vs 0), but that metric is
+misleading at n=5: **total edit distance is 6 / 7 / 6 / 6**, and the direction
+reverses by clip — fp32 is better on the trills, q4 is better on the tap. There
+is no evidence here for revisiting
+[#2349](https://github.com/OPS-PIvers/SpartBoard/issues/2349)'s `q4` choice,
+which matters because q4 is 241 MB against fp32's 1.26 GB and
+[#2350](https://github.com/OPS-PIvers/SpartBoard/issues/2350) has to move that
+over one school access point.
+
+### 5. The retired synthetic tap emits no rhotic at all
+
+`perro_tap.wav` (espeak-ng synthesis, retired by the Gemini probe) decodes as
+`peːho` — **no rhotic token in any variant**. Independent corroboration of that
+probe's decision to retire it, and of map rule 2. It also shows the model does
+not hallucinate a rhotic where none is heard.
+
+## What this does not cover
+
+Say it in the test, per the map's rule about sweeps that look like they prove
+more than they do:
+
+- **n = 1 per condition, one speaker, deliberate productions.** Not a confusion
+  matrix. Finding 1 is the sturdiest — wide margin, stable across four
+  quantizations — but it is still one clip.
+- **No real learner speech.** A student failing to trill produces an unstable
+  in-between articulation, not a clean retroflex. Inherited verbatim from the
+  Gemini probe's own caveats.
+- **One word, one language, one dialect.** `pero`/`perro`, `es-419`. Nothing
+  here speaks to German or English contrasts.
+- **No browser parity run.** Everything ran under `onnxruntime` (Python) on CPU.
+  #2355 asked for a confirming `onnxruntime-web` run to prove the shipping path
+  agrees; that is still owed, and it is a different risk (operator coverage and
+  the single-threaded WASM constraint) from anything measured here.
+- **`<pad>` ranks second on two of the four reported cells.** Whether a
+  posterior that close to the blank should count as a detection at all is
+  unexamined.
+
+## Expanding this — how to get the measurement #2355 actually asked for
+
+Recorded deliberately so a later session does not rediscover any of the above.
+Both routes were scoped in this session; neither was taken.
+
+### Route A — L2-ARCTIC (best annotation, needs a human step and a licence call)
+
+[L2-ARCTIC](https://psi.engr.tamu.edu/l2-arctic-corpus/) is 24 non-native
+English speakers, **4 of them L1 Spanish** (2M/2F), with **14,098 phone
+substitutions annotated by hand**. Annotations are TextGrid, and a substitution
+is written `CPL,PPL,s` — _the phoneme the word wanted, the phoneme the speaker
+produced_. That is ground truth of exactly the right shape.
+
+It gives the **mirror** of our question: Spanish speakers putting taps and
+trills into English words, rather than English speakers putting retroflexes
+into Spanish ones. That mirroring matters less than it first appears — this
+model is given no target text and no language ID, so there is no supplied
+expectation for it to normalize toward; the residual worry is a statistical
+leaning learned in training, which the mirror probes just as well.
+
+To use it:
+
+1. **A human must request it.** The download is behind a form (name, email,
+   affiliation, plus a checkbox accepting CC BY-NC 4.0); the link arrives by
+   email as a Google Drive URL. An agent must not accept that licence on
+   someone's behalf.
+2. **Route the licence question.** CC BY-**NC**, used to validate a district
+   product. Nothing from the corpus would be committed — only the harness and
+   the numbers, as the sibling spikes already do with their data — but
+   "measurement output is not the corpus" is a call for a human, per the map's
+   Notes on non-engineering decisions.
+3. Restrict to the 4 Spanish-L1 speakers, keep TextGrid intervals whose
+   annotation involves a rhotic, map each interval onto CTC frames via the
+   ~20 ms stride (`decode.py` already returns frame spans), and ask the one
+   question that matters: **does the model report the phoneme the annotator
+   heard, or the one the word wanted?**
+4. Only ~150 utterances per speaker are hand-annotated, so budget on roughly
+   600 annotated Spanish-L1 utterances, not the full 27 hours.
+
+### Route B — record English speakers ourselves (right stimulus, no licence)
+
+The direct test, and the only route that fills the Anglo-`ɹ` cell with known
+ground truth: 10–15 L1-English adults reading a Spanish word list. Published L2
+Spanish rhotic studies exist but **none release audio** — this data does not
+exist off the shelf.
+
+- The existing clips were cut from one phone recording with `ffmpeg`; the
+  method is proven and in `../pronunciation-bias-probe/README.md`.
+- **Record the speaker's L1 this time**, and the consent basis. Finding 2 is
+  confounded precisely because the current corpus records neither, and that gap
+  was knowingly accepted on 2026-08-02 — do not re-accept it by default.
+- Adults reading a word list is a far lighter consent question than
+  [#2352](https://github.com/OPS-PIvers/SpartBoard/issues/2352)'s student audio,
+  and does not depend on it.
+- Include deliberate taps **and** deliberate trills from the same speakers, so
+  finding 2 can be attributed to the model rather than to one voice.
+
+### Route C — Common Voice Spanish (breadth for the tap/trill cells only)
+
+[Common Voice](https://commonvoice.mozilla.org/) Spanish is **CC-0**, so unlike
+Route A its clips could be committed. Thousands of speakers with accent
+metadata, which would give findings 2 and 3 the speaker variety they lack. Two
+limits: it contains no Anglo-`ɹ`-in-Spanish material, and its IPA is derived
+from the sentence text rather than the audio — it says what the sentence should
+have sounded like, not what the speaker did, so it is not ground truth for a
+substitution.
+
+## Reproducing
+
+```bash
+sudo apt-get install -y --no-install-recommends espeak-ng   # 1.51
+python3 -m venv venv && ./venv/bin/pip install onnxruntime numpy scipy
+
+mkdir -p model && cd model
+BASE=https://huggingface.co/qnighy/wav2vec2-xlsr-53-espeak-cv-ft-ONNX/resolve/main
+curl -sSLO $BASE/vocab.json
+curl -sSLO $BASE/preprocessor_config.json
+for v in model.onnx model_fp16.onnx model_q4.onnx model_q4f16.onnx; do
+  curl -sSL -o $v $BASE/onnx/$v
+done
+cd ..
+
+MODEL_DIR=./model ./venv/bin/python measure/compare.py     # the table above
+MODEL_DIR=./model ./venv/bin/python measure/decode.py model_q4.onnx \
+  ../pronunciation-bias-probe/audio/*.wav                  # strings + posteriors
+```
+
+The four `.onnx` files total ~2.3 GB and are **not committed** — see
+`measure/.gitignore`.
+
+## Scope
+
+Spike code, not production code. Committed so the #2355 result is auditable and
+so the expansion routes above survive the session that found them.

--- a/scripts/spikes/retroflex-confusion/RESULTS.md
+++ b/scripts/spikes/retroflex-confusion/RESULTS.md
@@ -285,7 +285,7 @@ MODEL_DIR=./model ./venv/bin/python measure/decode.py model_q4.onnx \
 ```
 
 The four `.onnx` files total ~2.3 GB and are **not committed** — see
-`measure/.gitignore`.
+`.gitignore`.
 
 ## Scope
 

--- a/scripts/spikes/retroflex-confusion/measure/compare.py
+++ b/scripts/spikes/retroflex-confusion/measure/compare.py
@@ -115,7 +115,8 @@ def edits(ref, hyp):
 
 def main():
     import json
-    vocab = json.load(open(f"{MODEL_DIR}/vocab.json"))
+    with open(f"{MODEL_DIR}/vocab.json") as f:
+        vocab = json.load(f)
     vocab_inv = {v: k for k, v in vocab.items()}
     grid = {}
 

--- a/scripts/spikes/retroflex-confusion/measure/compare.py
+++ b/scripts/spikes/retroflex-confusion/measure/compare.py
@@ -1,0 +1,155 @@
+"""Score every committed clip against its espeak reference, in all four
+quantizations, and print the edit operations the alignment engine would charge.
+
+Stating the result in edits rather than in raw phoneme strings is the point:
+"the model returned perro" means nothing until you know the reference is
+`pero` and the extra token is an insertion A5/A6 dock.
+
+WHAT THIS COVERS, AND WHAT IT DOES NOT
+--------------------------------------
+Five clips, ONE speaker, deliberate productions, n = 1 per condition. Greedy
+CTC decoding is deterministic (verified: three identical runs), so re-running a
+clip cannot add observations -- only new recordings can.
+
+This is therefore a necessary-condition SCREEN, not the 3x3 confusion matrix
+with n >= 30 per cell that #2355 specifies. It can refute (a collapse that
+shows up here is real) far better than it can confirm. Any reading about
+tap/trill confusability is additionally confounded: the speaker's L1 is not
+recorded anywhere, and a deliberate tap is not a learner's tap.
+
+Usage:
+    MODEL_DIR=/path/to/model python3 compare.py
+"""
+
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import onnxruntime as ort  # noqa: E402
+from decode import MODEL_DIR, decode, read_wav  # noqa: E402
+
+AUDIO = os.environ.get(
+    "AUDIO_DIR",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                 "../../pronunciation-bias-probe/audio"),
+)
+
+# clip -> (target word, what the speaker was deliberately producing)
+CLIPS = [
+    ("pero_anglo_r_human.wav", "pero", "English retroflex (the learner ERROR)"),
+    ("pero_tap_human.wav", "pero", "Spanish tap (CORRECT)"),
+    ("perro_trill_human_1.wav", "perro", "trill, weakest (CORRECT)"),
+    ("perro_trill_human_2.wav", "perro", "trill, middle (CORRECT)"),
+    ("perro_trill_human_3.wav", "perro", "trill, strongest (CORRECT)"),
+]
+
+VARIANTS = [
+    ("model.onnx", "fp32"),
+    ("model_fp16.onnx", "fp16"),
+    ("model_q4.onnx", "q4"),
+    ("model_q4f16.onnx", "q4f16"),
+]
+
+STRESS = "ˈˌ"
+ZWJ = "‍"  # espeak --ipa=3 writes this inside diphthongs; strip it
+
+
+def reference(word):
+    """espeak-ng's narrow IPA for the word, stress marks and ZWJ removed."""
+    raw = subprocess.run(
+        ["espeak-ng", "-v", "es-419", "-q", "--ipa=3", word],
+        capture_output=True, text=True, check=True).stdout.strip()
+    out = raw
+    for ch in STRESS + ZWJ:
+        out = out.replace(ch, "")
+    return out, raw
+
+
+def tokenize(s, vocab):
+    """Longest-match tokenization against the model's own vocabulary.
+
+    Necessary because the model's alphabet has multi-character tokens; naive
+    per-character splitting would miscount every diphthong and length mark.
+    """
+    toks, i = [], 0
+    while i < len(s):
+        for n in (3, 2, 1):
+            if s[i:i + n] in vocab:
+                toks.append(s[i:i + n])
+                i += n
+                break
+        else:
+            toks.append(s[i])
+            i += 1
+    return toks
+
+
+def edits(ref, hyp):
+    """Levenshtein distance plus the operation list, ref -> hyp."""
+    n, m = len(ref), len(hyp)
+    d = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n + 1):
+        d[i][0] = i
+    for j in range(m + 1):
+        d[0][j] = j
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            d[i][j] = min(d[i - 1][j] + 1, d[i][j - 1] + 1,
+                          d[i - 1][j - 1] + (ref[i - 1] != hyp[j - 1]))
+    ops, i, j = [], n, m
+    while i > 0 or j > 0:
+        if i > 0 and j > 0 and d[i][j] == d[i - 1][j - 1] + (ref[i - 1] != hyp[j - 1]):
+            if ref[i - 1] != hyp[j - 1]:
+                ops.append(f"sub {ref[i-1]}->{hyp[j-1]}")
+            i, j = i - 1, j - 1
+        elif j > 0 and d[i][j] == d[i][j - 1] + 1:
+            ops.append(f"ins {hyp[j-1]}")
+            j -= 1
+        else:
+            ops.append(f"del {ref[i-1]}")
+            i -= 1
+    return d[n][m], list(reversed(ops))
+
+
+def main():
+    import json
+    vocab = json.load(open(f"{MODEL_DIR}/vocab.json"))
+    vocab_inv = {v: k for k, v in vocab.items()}
+    grid = {}
+
+    for model_file, label in VARIANTS:
+        sess = ort.InferenceSession(f"{MODEL_DIR}/{model_file}",
+                                    providers=["CPUExecutionProvider"])
+        print(f"\n{'='*72}\n{label}\n{'='*72}")
+        exact = total = 0
+        for fn, word, desc in CLIPS:
+            ref_s, raw = reference(word)
+            ref = tokenize(ref_s, vocab)
+            toks, _, _ = decode(sess, vocab_inv, read_wav(f"{AUDIO}/{fn}"))
+            hyp = [t for t, _, _ in toks]
+            dist, ops = edits(ref, hyp)
+            exact += dist == 0
+            total += dist
+            grid[(label, fn)] = dist
+            print(f"\n{fn}\n  intent : {desc}")
+            print(f"  target : {word}  espeak={raw!r}  ref={ref}")
+            print(f"  model  : {hyp}")
+            print(f"  {'MATCH ' if dist == 0 else 'DIFFER'}  edits={dist}"
+                  f"   {'; '.join(ops) if ops else '-'}")
+        grid[(label, "_exact")] = exact
+        grid[(label, "_total")] = total
+        print(f"\n  exact matches: {exact}/{len(CLIPS)}   total edits: {total}")
+
+    labels = [lab for _, lab in VARIANTS]
+    print(f"\n\n{'='*72}\nSUMMARY — edit distance vs the espeak reference\n{'='*72}")
+    print(f"{'clip':<30}" + "".join(f"{lab:>8}" for lab in labels))
+    for fn, _, _ in CLIPS:
+        print(f"{fn[:29]:<30}" + "".join(f"{grid[(l, fn)]:>8}" for l in labels))
+    print(f"{'exact / 5':<30}" + "".join(f"{grid[(l, '_exact')]:>8}" for l in labels))
+    print(f"{'total edits':<30}" + "".join(f"{grid[(l, '_total')]:>8}" for l in labels))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spikes/retroflex-confusion/measure/decode.py
+++ b/scripts/spikes/retroflex-confusion/measure/decode.py
@@ -54,6 +54,10 @@ def decode(session, vocab_inv, audio):
 
     tokens is a list of (symbol, start_frame, end_frame) after the CTC
     collapse: merge runs of the same id, then drop <pad>.
+
+    The returned logits are the batch element, shape [frames, 392] — the
+    session output is [1, frames, 392] and the leading axis is dropped here so
+    callers can index frames directly.
     """
     x = normalize(audio)[None, :]
     feeds = {session.get_inputs()[0].name: x}

--- a/scripts/spikes/retroflex-confusion/measure/decode.py
+++ b/scripts/spikes/retroflex-confusion/measure/decode.py
@@ -83,7 +83,8 @@ def softmax(logits):
 
 
 def load(model_file):
-    vocab = json.load(open(f"{MODEL_DIR}/vocab.json"))
+    with open(f"{MODEL_DIR}/vocab.json") as f:
+        vocab = json.load(f)
     session = ort.InferenceSession(
         f"{MODEL_DIR}/{model_file}", providers=["CPUExecutionProvider"]
     )

--- a/scripts/spikes/retroflex-confusion/measure/decode.py
+++ b/scripts/spikes/retroflex-confusion/measure/decode.py
@@ -1,0 +1,118 @@
+"""Greedy CTC decode for wav2vec2-xlsr-53-espeak-cv-ft (ONNX).
+
+Owns the argmax + CTC collapse itself, per S1 in the stress-detection spike:
+`pipeline('automatic-speech-recognition')` discards frame timing, so the
+convenience API cannot be used here either.
+
+Prints the phoneme string, the frame span each symbol came from, and the
+posteriors on the three contrastive rhotics at every frame where one of them
+is the argmax.
+
+Usage:
+    MODEL_DIR=/path/to/model python3 decode.py model_q4.onnx clip.wav [...]
+
+See ../RESULTS.md for how to fetch the model files (they are not committed).
+"""
+
+import json
+import os
+import sys
+import wave
+from math import gcd
+
+import numpy as np
+import onnxruntime as ort
+from scipy.signal import resample_poly
+
+MODEL_DIR = os.environ.get("MODEL_DIR", "./model")
+TARGET_SR = 16000
+PAD_ID = 0
+RHOTICS = ("ɹ", "ɾ", "r")
+
+
+def read_wav(path):
+    """Read a mono 16-bit wav and resample to the model's 16 kHz."""
+    with wave.open(path) as w:
+        assert w.getnchannels() == 1, f"{path} is not mono"
+        assert w.getsampwidth() == 2, f"{path} is not 16-bit PCM"
+        sr = w.getframerate()
+        raw = w.readframes(w.getnframes())
+    audio = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    if sr != TARGET_SR:
+        g = gcd(sr, TARGET_SR)
+        audio = resample_poly(audio, TARGET_SR // g, sr // g).astype(np.float32)
+    return audio
+
+
+def normalize(audio):
+    """Wav2Vec2FeatureExtractor with do_normalize: zero mean, unit variance."""
+    return ((audio - audio.mean()) / np.sqrt(audio.var() + 1e-7)).astype(np.float32)
+
+
+def decode(session, vocab_inv, audio):
+    """Return (tokens, frame_ids, logits).
+
+    tokens is a list of (symbol, start_frame, end_frame) after the CTC
+    collapse: merge runs of the same id, then drop <pad>.
+    """
+    x = normalize(audio)[None, :]
+    feeds = {session.get_inputs()[0].name: x}
+    if "attention_mask" in {i.name for i in session.get_inputs()}:
+        feeds["attention_mask"] = np.ones(x.shape, dtype=np.int64)
+    logits = session.run(None, feeds)[0]  # [1, frames, 392]
+    ids = logits[0].argmax(-1)
+
+    out, prev, start = [], None, 0
+    for i, t in enumerate(ids):
+        if t != prev:
+            if prev is not None and prev != PAD_ID:
+                out.append((vocab_inv[prev], start, i))
+            prev, start = t, i
+    if prev is not None and prev != PAD_ID:
+        out.append((vocab_inv[prev], start, len(ids)))
+    return out, ids, logits[0]
+
+
+def softmax(logits):
+    e = np.exp(logits - logits.max(-1, keepdims=True))
+    return e / e.sum(-1, keepdims=True)
+
+
+def load(model_file):
+    vocab = json.load(open(f"{MODEL_DIR}/vocab.json"))
+    session = ort.InferenceSession(
+        f"{MODEL_DIR}/{model_file}", providers=["CPUExecutionProvider"]
+    )
+    return vocab, {v: k for k, v in vocab.items()}, session
+
+
+def main():
+    model_file = sys.argv[1]
+    vocab, vocab_inv, session = load(model_file)
+    rho = {s: vocab[s] for s in RHOTICS}
+
+    print(f"=== {model_file} ===")
+    for p in sys.argv[2:]:
+        audio = read_wav(p)
+        toks, ids, logits = decode(session, vocab_inv, audio)
+        probs = softmax(logits)
+        stride = len(audio) / TARGET_SR * 1000 / len(ids)
+
+        print(f"\n{p.rsplit('/', 1)[-1]}  ({len(audio)/TARGET_SR:.2f}s, "
+              f"{len(ids)} frames, {stride:.1f} ms/frame)")
+        print("  string: " + "".join(t for t, _, _ in toks))
+        print("  spans : " + "  ".join(
+            f"{t}[{a*stride:.0f}-{b*stride:.0f}ms]" for t, a, b in toks))
+
+        hits = [i for i, t in enumerate(ids) if t in rho.values()]
+        if not hits:
+            print("  rhotic frames: NONE")
+            continue
+        print("  rhotic frames:")
+        for i in hits:
+            cells = "  ".join(f"{s}={probs[i, k]:.3f}" for s, k in rho.items())
+            print(f"    f{i} ({i*stride:.0f}ms) argmax={vocab_inv[ids[i]]}   {cells}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves [#2355](https://github.com/OPS-PIvers/SpartBoard/issues/2355) on the [Wayfinder Map: Multilingual Pronunciation Engine](https://github.com/OPS-PIvers/SpartBoard/issues/2331).

**No feature code.** A spike directory like its five siblings. Model artifacts are downloaded, not committed (~2.3 GB); `RESULTS.md` has the commands.

## Verdict

**The retroflex survives.** The Anglo-`ɹ` clip decodes as `peɹo` against a `peɾo` reference — one edit, `sub ɾ→ɹ` — identically in **all four quantizations**, with `ɹ` at 0.79–0.80 and the nearest competing phoneme 25–40× behind.

That is exactly the spec's worked example: expected `/ɾ/`, detected `/ɹ/`. [#2344](https://github.com/OPS-PIvers/SpartBoard/issues/2344) found it **irreproducible server-side** — Gemini returned `ɹ` in **0 of 40** samples once the prompt named Spanish. On-device it comes back first try. Per-phoneme diagnostic feedback is not disqualified.

## The ticket asked for a measurement its stimuli cannot produce

#2355 specified a 3×3 confusion matrix at **n ≥ 30 per cell** and a `ɹ ≥ 70%` pass mark. That design was inherited from the Gemini probe, where 40-observation cells came from re-sampling a stochastic model over **one file** — the variance lived in the model.

Greedy CTC decoding has no such variance (verified: three identical runs). One clip is one observation, permanently, and the corpus holds **exactly one** retroflex clip. The load-bearing cell could only read 0% or 100%. This is a **necessary-condition screen** and says so in both the harness docstring and `RESULTS.md`.

## Results

Edit distance from the espeak reference, in the units the alignment engine charges.

| clip | intended | fp32 | fp16 | q4 | q4f16 |
| --- | --- | --- | --- | --- | --- |
| `pero_anglo_r_human` | retroflex — the learner **ERROR** | 1 | 1 | 1 | 1 |
| `pero_tap_human` | tap — **CORRECT** | 3 | 3 | 1 | 1 |
| `perro_trill_human_1` | trill, weakest — **CORRECT** | 0 | 0 | 1 | 1 |
| `perro_trill_human_2` | trill, middle — **CORRECT** | 2 | 2 | 2 | 2 |
| `perro_trill_human_3` | trill, strongest — **CORRECT** | 0 | 1 | 1 | 1 |
| **exact / 5** | | **2** | **1** | **0** | **0** |
| **total edits** | | **6** | **7** | **6** | **6** |

## Two problems the ticket did not anticipate

1. **A correct tap is reported as a trill**, in every quantization (`sub ɾ→r`). A student who taps correctly is marked wrong, and a diagnostic UI would tell them "you produced a trill". **Confidence does not separate this from the good case** — fp32 is confidently wrong (`r`=0.488 vs `ɾ`=0.060), so a confidence gate on naming the phoneme would not catch it. Direct input to [#2362](https://github.com/OPS-PIvers/SpartBoard/issues/2362). Confounded by the fixtures' undocumented speaker L1, and flagged as such.

2. **A held trill decodes as more than one `r`.** A trill is several tongue contacts, CTC emits a peak per contact, the reference holds exactly one. So how long a student holds a *correct* trill decides whether it scores exact or picks up an insertion — which A5/A6 dock.

## What did not change

**The `q4` pinning stands.** Exact-match count appears to favour fp32 (2 vs 0), but total edit distance is 6/7/6/6 and the direction reverses by clip. The rhotic *identity* is byte-identical across all four variants on all five clips, so the ticket's fourth criterion passes and there is no case for revisiting [#2349](https://github.com/OPS-PIvers/SpartBoard/issues/2349) — which matters, since q4 is 241 MB against fp32's 1.26 GB and [#2350](https://github.com/OPS-PIvers/SpartBoard/issues/2350) has to move that over one access point.

## Expansion routes, written down deliberately

`RESULTS.md` records all three so a later session doesn't rediscover them: **L2-ARCTIC** (4 Spanish-L1 speakers, 14,098 hand-annotated substitutions in `CPL,PPL,s` form — but behind a form a human must sign, under CC BY-NC), **recording L1-English speakers directly** (right stimulus, no licence, and records the speaker L1 the current fixtures omit), and **Common Voice Spanish** (CC-0 breadth, no retroflex material, labels derived from text rather than audio).

## Verification

- `npx prettier --check scripts/spikes/retroflex-confusion/` — clean
- `scripts/` is eslint-ignored, same as the five sibling spikes; no TS touched
- Both harnesses re-run from their committed location and reproduce the table exactly
- All five fixture md5s re-checked against `pronunciation-bias-probe/README.md` — identical bytes to the Gemini probe
- **Not covered:** no `onnxruntime-web` parity run. #2355 asked for one and it is still owed; it is a different risk (operator coverage, single-threaded WASM) from anything measured here, and it is recorded as an open gap rather than quietly dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xEEsiiMtH5mXJTgxmnXFt

---
_Generated by [Claude Code](https://claude.ai/code/session_016xEEsiiMtH5mXJTgxmnXFt)_