### PR TITLE
fix(a11y): retrofit orphaned SettingsLabel group headings to as="span"

### DIFF
--- a/components/admin/BackgroundManager/GridPresetCard.tsx
+++ b/components/admin/BackgroundManager/GridPresetCard.tsx
@@ -149,8 +149,14 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
 
         {/* Access Level */}
         <div className="shrink-0">
-          <SettingsLabel>Access Level</SettingsLabel>
-          <div className="flex gap-1">
+          <SettingsLabel as="span" id={`accesslevel-label-${preset.id}`}>
+            Access Level
+          </SettingsLabel>
+          <div
+            className="flex gap-1"
+            role="group"
+            aria-labelledby={`accesslevel-label-${preset.id}`}
+          >
             {(['admin', 'beta', 'public'] as AccessLevel[]).map((level) => (
               <button
                 key={level}
@@ -235,8 +241,14 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
 
         {/* Building Assignment */}
         <div className="shrink-0">
-          <SettingsLabel>Buildings</SettingsLabel>
-          <div className="flex flex-wrap gap-1">
+          <SettingsLabel as="span" id={`buildings-label-${preset.id}`}>
+            Buildings
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap gap-1"
+            role="group"
+            aria-labelledby={`buildings-label-${preset.id}`}
+          >
             {BUILDINGS.map((b) => {
               const assigned = (preset.buildingIds ?? []).includes(b.id);
               return (

--- a/components/widgets/ClockWidget/Settings.tsx
+++ b/components/widgets/ClockWidget/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, ClockConfig } from '@/types';
@@ -47,6 +47,8 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
   const { t } = useTranslation();
   const { updateWidget } = useDashboard();
   const config = widget.config as ClockConfig;
+  const displayStyleLabelId = useId();
+  const colorPaletteLabelId = useId();
 
   const colors = WIDGET_PALETTE;
 
@@ -69,10 +71,14 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Clock Style */}
       <div>
-        <SettingsLabel icon={Sparkles}>
+        <SettingsLabel as="span" id={displayStyleLabelId} icon={Sparkles}>
           {t('widgets.clock.displayStyle')}
         </SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <div
+          className="flex bg-slate-100 p-1 rounded-xl"
+          role="group"
+          aria-labelledby={displayStyleLabelId}
+        >
           {styles.map((s) => (
             <button
               key={s.id}
@@ -92,10 +98,14 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Color & Glow */}
       <div className="flex items-end justify-between gap-4">
         <div className="flex-1">
-          <SettingsLabel icon={Palette}>
+          <SettingsLabel as="span" id={colorPaletteLabelId} icon={Palette}>
             {t('widgets.clock.colorPalette')}
           </SettingsLabel>
-          <div className="flex gap-1.5">
+          <div
+            className="flex gap-1.5"
+            role="group"
+            aria-labelledby={colorPaletteLabelId}
+          >
             {colors.map((c) => (
               <button
                 key={c}

--- a/components/widgets/Countdown/Settings.tsx
+++ b/components/widgets/Countdown/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, CountdownConfig } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
@@ -175,6 +175,7 @@ export const CountdownAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as CountdownConfig;
   const updateConfig = (updates: Partial<CountdownConfig>) =>
     updateWidget(widget.id, { config: { ...config, ...updates } });
+  const eventColorLabelId = useId();
 
   const eventColor = config.eventColor ?? '#2d3f89';
 
@@ -182,8 +183,14 @@ export const CountdownAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
     <div className="space-y-6">
       <TypographySettings config={config} updateConfig={updateConfig} />
       <div>
-        <SettingsLabel icon={Palette}>Event Title Color</SettingsLabel>
-        <div className="flex flex-wrap gap-2 px-1 mb-2">
+        <SettingsLabel as="span" id={eventColorLabelId} icon={Palette}>
+          Event Title Color
+        </SettingsLabel>
+        <div
+          className="flex flex-wrap gap-2 px-1 mb-2"
+          role="group"
+          aria-labelledby={eventColorLabelId}
+        >
           {TEXT_COLOR_PRESETS.map((color) => (
             <button
               key={color}

--- a/components/widgets/LunchCount/Settings.tsx
+++ b/components/widgets/LunchCount/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { WidgetData, LunchCountConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { RosterModeControl } from '@/components/common/RosterModeControl';
@@ -64,6 +64,7 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
     lunchTimeMinute = '',
     gradeLevel = '',
   } = config;
+  const gradeLevelLabelId = useId();
 
   // Legacy widget configs may contain a canonical short-form building ID
   // (e.g. `schumann`) instead of the long-form `schoolSite` this widget
@@ -189,8 +190,14 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
 
         {/* Grade Level */}
         <div>
-          <SettingsLabel icon={GraduationCap}>Grade Level</SettingsLabel>
-          <div className="flex gap-2 flex-wrap">
+          <SettingsLabel as="span" id={gradeLevelLabelId} icon={GraduationCap}>
+            Grade Level
+          </SettingsLabel>
+          <div
+            className="flex gap-2 flex-wrap"
+            role="group"
+            aria-labelledby={gradeLevelLabelId}
+          >
             {gradeOptions.map((opt) => (
               <button
                 key={opt.value}


### PR DESCRIPTION
## Nightly Unifier — Run 50, Dimension D3 (Settings Panel Label Primitives)

**Canonical form:** `<SettingsLabel as="span" id="unique-id">Group Heading</SettingsLabel>` paired with `role="group" aria-labelledby="unique-id"` on the container of sibling controls — used when a label heads a *group* of controls (button/chip groups) rather than pairing 1:1 with a single form control. A bare `<label>` in that case is semantically orphaned (no single control to associate with). This continues the runs 26–49 group-heading retrofit series.

**Instances unified (5, across 4 files):**
- `components/admin/BackgroundManager/GridPresetCard.tsx` — "Access Level" and "Buildings" button groups (id scoped per-preset via `preset.id`, since this card renders in a list)
- `components/widgets/ClockWidget/Settings.tsx` — "Display Style" and "Color Palette" button groups (id scoped via `useId()`)
- `components/widgets/Countdown/Settings.tsx` — "Event Title Color" swatch group (id scoped via `useId()`)
- `components/widgets/LunchCount/Settings.tsx` — "Grade Level" button group (id scoped via `useId()`)

**Enforcement:** No new lint rule added — this dimension's enforcement is the existing `SettingsLabel` component's `as="span"` variant itself (added in an earlier PR, #2141 review-fix). Tonight's work is a retrofit of pre-existing bare-`<label>` usages to the already-established group-heading form, continuing the ongoing series that has covered this same anti-pattern across many other files in prior nightly runs.

**Behavior/visual-preservation evidence:**
- Visual output is unchanged — `SettingsLabel`'s `as="span"` renders identical Tailwind classes to `as="label"` (`text-xxs font-black text-slate-400 uppercase tracking-widest block mb-2`), just a different DOM tag.
- Accessibility is *improved*, not changed in a risky way: previously an orphaned `<label>` with no `htmlFor`/associated control now becomes a `<span>` correctly paired with its sibling button group via `role="group"`/`aria-labelledby`.
- Each `id` is scoped per-component-instance (`useId()` for singleton Settings panels; `preset.id`-derived for the list-rendered `GridPresetCard`) to avoid DOM id collisions across multiple widget/preset instances on the same dashboard — a documented gotcha from earlier runs in this series.
- `pnpm run validate` (type-check, lint, format-check, full unit test suite — root + functions) passes clean on this branch.

**Risk tag:** `mechanical` (pure DOM-tag + ARIA-attribute equivalence change, no visual or logic change)

---

Automated nightly consistency run (see `docs/routines/unifier.md`). Other dimensions checked tonight (D1 Empty States, D2 Brand Colors, D4 Import Paths, D5 Toast Architecture) came back aligned with no drift found — no changes needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtJgTHGHaCXfeEwjUQRCWV)_