### PR TITLE
fix(widgets): stop Escape propagation in RandomClassContextButton popover

### DIFF
--- a/components/widgets/random/RandomClassContextButton.test.tsx
+++ b/components/widgets/random/RandomClassContextButton.test.tsx
@@ -263,6 +263,44 @@ describe('RandomClassContextButton', () => {
     expect(screen.getAllByRole('menuitemradio')).toHaveLength(2);
   });
 
+  describe('Escape does not leak to window-level handlers', () => {
+    it('closes the popover on Escape and stops propagation before it reaches window listeners', () => {
+      const r1 = makeRoster('r1', 'Period 1');
+      const r2 = makeRoster('r2', 'Period 2');
+      mockUseDashboard([r1, r2], 'r1');
+      render(
+        <RandomClassContextButton
+          roster={r1}
+          rosterMode="class"
+          onOpenAbsentModal={noop}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole('button', { name: /Active class: Period 1/i })
+      );
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      const windowKeydownSpy = vi.fn();
+      window.addEventListener('keydown', windowKeydownSpy);
+
+      try {
+        fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        // Crux of the regression: DashboardView's global Escape handler is a
+        // window-level `keydown` listener. This popover is portalled to
+        // document.body outside any `.widget` DraggableWindow ancestor, so if
+        // its own handler doesn't call stopPropagation(), the event still
+        // reaches `window` and DashboardView falls back to targeting the
+        // topmost z-index widget — silently minimizing an unrelated widget
+        // just from dismissing this popover with Escape.
+        expect(windowKeydownSpy).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('keydown', windowKeydownSpy);
+      }
+    });
+  });
+
   it('renders a static (non-interactive) chip when only one class exists and rosterMode is custom', () => {
     const r = makeRoster('r1', 'Period 1');
     mockUseDashboard([r], 'r1');

--- a/components/widgets/random/RandomClassContextButton.tsx
+++ b/components/widgets/random/RandomClassContextButton.tsx
@@ -6,6 +6,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { Z_INDEX } from '@/config/zIndex';
 import type { ClassRoster } from '@/types';
 import { getLocalIsoDate } from '@/utils/localDate';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 
 interface RandomClassContextButtonProps {
   /**
@@ -80,7 +81,20 @@ export const RandomClassContextButton: React.FC<
       closeMenu();
     };
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeMenu();
+      if (event.key !== 'Escape') return;
+      // This is a document-level listener, so it sees every Escape press on
+      // the page, not just ones aimed at this popover — bail if it actually
+      // belongs to a widget's text input (e.g. cancelling a title rename in
+      // another widget while this popover happens to be open).
+      if (isEscapeFromWidgetInput(event)) return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget (same bug class already
+      // fixed for ToolDockItem, RemoteControlMenu, ClassRosterMenu,
+      // OverflowMenu, ActiveClassChip, and FolderPickerPopover).
+      event.stopPropagation();
+      closeMenu();
     };
     let animationFrameId = 0;
     const handleReposition = () => {


### PR DESCRIPTION
## Root cause

`components/widgets/random/RandomClassContextButton.tsx` (live inside `RandomWidget.tsx`'s header) renders its class-switcher/mark-absent popover via `createPortal(..., document.body)`, outside any `.widget` DraggableWindow ancestor. It closed on Escape via a `document`-level `keydown` listener that never called `stopPropagation()` (and skipped the `isEscapeFromWidgetInput` guard). The unhandled native keydown kept bubbling to `DashboardView.tsx`'s global `window`-level Escape handler, which finds no `.widget` ancestor for the portalled popover and falls back to minimizing the topmost z-index widget — so dismissing this popover with Escape could silently minimize an unrelated widget on the live board.

This is the same bug class already fixed 6+ times in this repo (`ToolDockItem`, `RemoteControlMenu`, `ClassRosterMenu`, `OverflowMenu`, `ActiveClassChip`, `FolderPickerPopover` — #2266/#2289/#2314/#2373). `RandomClassContextButton` is a Randomizer-specific fork of `ActiveClassChip` that was copied before/without adopting that fix.

## Fix

Added `event.stopPropagation()` and the `isEscapeFromWidgetInput` guard to the popover's Escape handler, mirroring `ActiveClassChip`'s exact, already-reviewed fix — no new pattern introduced.

## Band-aid rejected

Could have special-cased `DashboardView`'s global fallback handler (e.g. checking `event.defaultPrevented`, or excluding portalled popovers globally) — rejected because that would touch a shared, heavily-relied-on global handler and risk regressing the 6 other already-fixed components. The established, reviewed pattern in this codebase is to fix it locally in the popover's own handler, so this PR follows that precedent exactly.

## Regression test

`components/widgets/random/RandomClassContextButton.test.tsx` — new test `"closes the popover on Escape and stops propagation before it reaches window listeners"`: opens the popover, attaches a spy `keydown` listener on `window`, fires Escape on `document`, asserts the popover closed *and* the window-level spy was never called.

- **Fail-before** (verified independently by the orchestrator via file-swap against dev-paul): `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times` — 12/13 tests passing, 1 failing.
- **Pass-after** (verified independently by the orchestrator): 13/13 tests passing.

## Evidence

- `pnpm run validate` — independently re-run by the orchestrator in an isolated worktree: type-check, lint, format-check, full root suite (597 test files / 7283 tests), full functions suite (40 test files / 778 tests), `test:counts` guard — all green.
- `pnpm run build` — independently re-run by the orchestrator: client + SSR bundle build succeeded, prerender of `/privacy`, `/terms`, `/support` succeeded.

## Additional backlog findings (not fixed here, flagged for a future run)

- `components/widgets/LiveControl.tsx` — same missing-`stopPropagation()` pattern, confirmed reachable via `WidgetRenderer.tsx`.
- `components/widgets/DrawingWidget/PageStrip.tsx` — same missing-`stopPropagation()` pattern on its portalled page popover.
- `components/widgets/Catalyst/CatalystSetPickerPopover.tsx` and `components/widgets/random/RandomGroups.tsx`'s color-picker popover — no local Escape handling at all, so Escape goes straight to the global fallback.

## Risk

**contained** — single-component fix, matches an established and repeatedly-reviewed pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hb94qEZXJ9yAgNmNXNaiU8)_