### PR TITLE
fix(admin): lowercase preset sub-email entries in PresetSubEmailsManager

### DIFF
--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -159,11 +159,7 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
       setError('Must end with @orono.k12.mn.us');
       return;
     }
-    // Lowercase before dedup/store, matching every other "add an email" call
-    // site in the app (BetaUsersPanel, GlobalPermissionsManager,
-    // BackgroundManager) — Firestore array membership and downstream
-    // `.includes()` checks are case-sensitive, so an un-normalized email can
-    // silently duplicate a preset that only differs by case.
+    // Normalize before dedup/store — Firestore and .includes() are case-sensitive.
     const normalized = trimmed.toLowerCase();
     if (draftEmails.includes(normalized)) {
       setEmailInput('');

--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -159,11 +159,17 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
       setError('Must end with @orono.k12.mn.us');
       return;
     }
-    if (draftEmails.includes(trimmed)) {
+    // Lowercase before dedup/store, matching every other "add an email" call
+    // site in the app (BetaUsersPanel, GlobalPermissionsManager,
+    // BackgroundManager) — Firestore array membership and downstream
+    // `.includes()` checks are case-sensitive, so an un-normalized email can
+    // silently duplicate a preset that only differs by case.
+    const normalized = trimmed.toLowerCase();
+    if (draftEmails.includes(normalized)) {
       setEmailInput('');
       return;
     }
-    setDraftEmails((prev) => [...prev, trimmed]);
+    setDraftEmails((prev) => [...prev, normalized]);
     setEmailInput('');
     setError(null);
   };

--- a/tests/components/admin/PresetSubEmailsManager.test.tsx
+++ b/tests/components/admin/PresetSubEmailsManager.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+} from '@testing-library/react';
+
+// Regression guard, same bug class as BetaUsersPanel.test.tsx ("stores beta
+// user emails lowercased, matching the rest of the app"): every other
+// admin-side "add an email" call site (BetaUsersPanel, GlobalPermissionsManager,
+// BackgroundManager) lowercases the trimmed input before storing/deduping it,
+// because Firestore array membership and downstream `.includes()` checks are
+// case-sensitive. PresetSubEmailsManager (`/preset_sub_emails/{buildingId}`,
+// consumed by ShareLinkCreatorModal's sub-email chip picker) was never
+// updated to match — `addEmail()` stores whatever case the admin typed and
+// de-dupes via a case-sensitive `draftEmails.includes(trimmed)`, so adding
+// "Sub@orono.k12.mn.us" and later "sub@orono.k12.mn.us" produces two
+// preset chips for the same real mailbox instead of one.
+
+vi.mock('lucide-react', () => {
+  function icon(name: string) {
+    const Stub = (props: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement('span', { 'data-icon': name, ...props });
+    Stub.displayName = name;
+    return Stub;
+  }
+  return new Proxy(
+    {},
+    {
+      get(target: Record<string, unknown>, prop) {
+        if (prop === '__esModule') return true;
+        if (prop === 'then') return undefined;
+        if (typeof prop === 'string' && !(prop in target)) {
+          target[prop] = icon(prop);
+        }
+        return target[prop as string];
+      },
+    }
+  );
+});
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'admin-1' } }),
+}));
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [
+    { id: 'high', name: 'High School', gradeLevels: [], gradeLabel: '9-12' },
+  ],
+}));
+
+vi.mock('@/config/firebase', () => ({ db: { __mock: 'db' } }));
+
+interface Listener {
+  next: (snap: unknown) => void;
+  error: (err: unknown) => void;
+}
+let listeners: Listener[];
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn((_db: unknown, ...segs: string[]) => segs.join('/')),
+  onSnapshot: vi.fn(
+    (
+      _ref: unknown,
+      next: (snap: unknown) => void,
+      error: (err: unknown) => void
+    ) => {
+      listeners.push({ next, error });
+      return vi.fn();
+    }
+  ),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { PresetSubEmailsManager } from '@/components/admin/PresetSubEmailsManager';
+
+const fakeDocSnap = (data: Record<string, unknown> | undefined) => ({
+  data: () => data,
+});
+
+describe('PresetSubEmailsManager — email case handling', () => {
+  beforeEach(() => {
+    listeners = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('stores a newly-added preset email lowercased, matching the rest of the app', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(fakeDocSnap({ emails: [] }));
+    });
+
+    const input = screen.getByPlaceholderText('ohssub@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(screen.getByText('sub@orono.k12.mn.us')).toBeInTheDocument();
+    expect(screen.queryByText('Sub@Orono.K12.MN.US')).not.toBeInTheDocument();
+  });
+
+  it('de-dupes an existing preset email against a differently-cased new entry', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['sub@orono.k12.mn.us'] })
+      );
+    });
+
+    const input = screen.getByPlaceholderText('ohssub@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'SUB@ORONO.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    // Only one chip for the mailbox, not two case-variant duplicates.
+    expect(screen.getAllByText(/sub@orono\.k12\.mn\.us/i)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Root cause

`components/admin/PresetSubEmailsManager.tsx`'s `addEmail()` (`BuildingPresetEditor`) manages `/preset_sub_emails/{buildingId}` — the per-building list of one-click substitute-teacher email chips shown in `ShareLinkCreatorModal`. It stored the trimmed input verbatim and de-duped via a case-sensitive `draftEmails.includes(trimmed)`. An admin adding `Sub@orono.k12.mn.us` and later `sub@orono.k12.mn.us` got two separate array entries for the same real mailbox instead of one.

Every other "add an email" call site in the app (`BetaUsersPanel.tsx`, `GlobalPermissionsManager.tsx`, `BackgroundManager/index.tsx`) already normalizes to lowercase before storing/deduping for exactly this reason (Firestore array membership and downstream `.includes()` checks are case-sensitive) — this file predates and was missed by those earlier fixes (untouched since 2026-06-27 per `git log`).

## Fix

Lowercase the trimmed input before the dedup check and before storing, mirroring the established pattern exactly. The domain-validation regex (`ORONO_EMAIL_REGEX`) already has the `i` flag, so this doesn't change what's accepted — only what's stored/compared.

## Band-aid rejected

Considered a case-insensitive-only comparison (`.some(e => e.toLowerCase() === trimmed.toLowerCase())`) without also normalizing what gets stored — rejected because it would leave stored casing inconsistent with the rest of the app's convention and any case-sensitive downstream consumers. Normalizing at the single write site matches the existing precedent instead of inventing a new one.

## Regression test

`tests/components/admin/PresetSubEmailsManager.test.tsx` (new file), two tests:
- `"stores a newly-added preset email lowercased, matching the rest of the app"`
- `"de-dupes an existing preset email against a differently-cased new entry"`

- **Fail-before** (verified independently by the orchestrator via file-swap against dev-paul): 2/2 new tests fail — `element not found` (stored as `Sub@Orono.K12.MN.US` instead of lowercase) and `expected length 1 but got 2` (duplicate chip for the same mailbox).
- **Pass-after** (verified independently by the orchestrator): 2/2 pass.

## Evidence

- `pnpm run validate` — independently re-run by the orchestrator in an isolated worktree: type-check, lint, format-check, full root suite (598 test files / 7284 tests), full functions suite (40 test files / 778 tests), `test:counts` guard — all green.
- `pnpm run build` — independently re-run by the orchestrator: client + SSR bundle build succeeded, prerender of `/privacy`, `/terms`, `/support` succeeded.

## Additional backlog findings (not fixed here, flagged for a future run)

- The same case-sensitive dedup pattern (`subEmails.includes(...)`) also exists in `components/share/ShareLinkCreatorModal.tsx` (both the preset-chip click handler and the manual-input `handleAddSubEmail`) — outside this area's glob (`components/share/**`), flagged for whichever area owns it next.

## Risk

**contained** — single-component fix, matches an established and repeatedly-reviewed pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hb94qEZXJ9yAgNmNXNaiU8)_