### PR TITLE
fix(functions): paginate expireSubShares expired-doc sweep

### DIFF
--- a/functions/src/expireSubShares.test.ts
+++ b/functions/src/expireSubShares.test.ts
@@ -246,6 +246,28 @@ describe('runExpireSubShares', () => {
     expect(stores.shared_boards.has('share-1')).toBe(false);
   });
 
+  // The two sweeps run independently (Promise.allSettled) with different hostField/
+  // deleteBoardsSubcollection args — assert on result.collections too, not just result.boards.
+  it('deletes an expired shared_collections share with no driveGrants immediately', async () => {
+    const { db, stores } = makeStubDb({
+      shared_collections: [
+        {
+          id: 'collection-1',
+          data: { intendedMode: 'substitute', expiresAt: NOW - DAY },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.collections).toEqual({
+      deleted: 1,
+      inGrace: 0,
+      orphanedGrants: 0,
+    });
+    expect(stores.shared_collections.has('collection-1')).toBe(false);
+  });
+
   it('leaves a share with driveGrants in the 7-day grace window untouched', async () => {
     const { db, stores } = makeStubDb({
       shared_boards: [

--- a/functions/src/expireSubShares.test.ts
+++ b/functions/src/expireSubShares.test.ts
@@ -1,0 +1,393 @@
+// Unit tests for the hourly `expireSubShares` sweep.
+//
+// Regression coverage for the pagination-cliff bug fixed alongside extracting
+// the testable `runExpireSubShares` core (mirrors `gcPlcOrphans.test.ts` /
+// `expireActivityWallShares.test.ts` / `finalizeIdleQuizAttempts.test.ts`):
+//
+// The expired-substitute-share lookup was a single un-paginated
+// `.where('intendedMode', '==', 'substitute').where('expiresAt', '<=', now)
+// .limit(MAX_DELETES_PER_RUN).get()` with NO explicit `orderBy`. A Firestore
+// query with no explicit `orderBy` falls back to document-ID order (NOT the
+// range-filtered field) — the same behavior already confirmed for the
+// identical bug in `expireActivityWallShares.ts` (#2268). Docs held in the
+// 7-day Drive-grant grace window are matched by the query but deliberately
+// left undeleted, so once the matching-but-undeleted backlog exceeded one
+// page, the same arbitrary doc-id-ordered slice was re-fetched every hour
+// and any genuinely-expired share whose doc id happened to sort past that
+// page was NEVER visited by this sweep — permanently missing both its
+// eventual deletion and its "unrevoked Drive permissions" warning log.
+//
+// The fix paginates (`startAfter` cursor on
+// `orderBy('expiresAt').orderBy(FieldPath.documentId())`) up to a much
+// larger `MAX_SWEEP_PER_RUN` ceiling.
+//
+// Stub Firestore mirrors the Admin SDK surface the sweep uses:
+//   db.collection('shared_boards'|'shared_collections')
+//     .where(f, op, v).orderBy(field).limit(n).startAfter(docSnap).get()
+//   db.batch() -> { delete(ref), commit() }
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('firebase-admin', () => ({
+  apps: [{ name: '[DEFAULT]' }],
+  initializeApp: vi.fn(),
+  // The sweep paginates with admin.firestore.FieldPath.documentId(); expose
+  // it as the '__name__' sentinel so the stub CollectionRef.orderBy gets a
+  // stable value (mirrors gcPlcOrphans.test.ts / expireActivityWallShares
+  // .test.ts's stub).
+  firestore: Object.assign(vi.fn(), {
+    FieldPath: { documentId: vi.fn(() => '__name__') },
+  }),
+}));
+
+vi.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: (_opts: unknown, handler: () => Promise<void>) => handler,
+}));
+
+import { runExpireSubShares, SWEEP_PAGE_SIZE } from './expireSubShares';
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+interface StubDoc {
+  id: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * In-memory Firestore mirroring the Admin SDK surface `runExpireSubShares`
+ * uses. Only the where/orderBy/limit/startAfter/get + batch().delete/commit
+ * surface is supported — enough to faithfully exercise the sweep without an
+ * emulator (mirrors `expireActivityWallShares.test.ts`'s stub).
+ */
+function makeStubDb(seed: {
+  shared_boards?: StubDoc[];
+  shared_collections?: StubDoc[];
+}) {
+  const stores: Record<string, Map<string, Record<string, unknown>>> = {
+    shared_boards: new Map(
+      (seed.shared_boards ?? []).map((d) => [d.id, d.data])
+    ),
+    shared_collections: new Map(
+      (seed.shared_collections ?? []).map((d) => [d.id, d.data])
+    ),
+  };
+
+  type Filter = [string, string, unknown];
+
+  function matches(
+    id: string,
+    data: Record<string, unknown>,
+    filters: Filter[]
+  ): boolean {
+    return filters.every(([field, op, value]) => {
+      const actual = data[field];
+      if (op === '<=')
+        return typeof actual === 'number' && actual <= (value as number);
+      if (op === '==') return actual === value;
+      throw new Error(`Unsupported op in stub: ${op}`);
+    });
+  }
+
+  function fieldValue(
+    id: string,
+    data: Record<string, unknown>,
+    field: string
+  ): unknown {
+    return field === '__name__' ? id : data[field];
+  }
+
+  /** Lexicographic/numeric compare; undefined sorts first ("smallest"). */
+  function compareValues(a: unknown, b: unknown): number {
+    if (a === b) return 0;
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    return (a as string | number) < (b as string | number) ? -1 : 1;
+  }
+
+  function collectionRef(
+    collectionName: string,
+    filters: Filter[] = [],
+    order: string[] = [],
+    lim?: number,
+    afterId?: string
+  ) {
+    const store = stores[collectionName];
+    return {
+      where: (field: string, op: string, value: unknown) =>
+        collectionRef(
+          collectionName,
+          [...filters, [field, op, value]],
+          order,
+          lim,
+          afterId
+        ),
+      orderBy: (field: string) =>
+        collectionRef(collectionName, filters, [...order, field], lim, afterId),
+      limit: (n: number) =>
+        collectionRef(collectionName, filters, order, n, afterId),
+      startAfter: (cursor: { id: string }) =>
+        collectionRef(collectionName, filters, order, lim, cursor.id),
+      get: () => {
+        let rows = [...store.entries()].filter(([id, data]) =>
+          matches(id, data, filters)
+        );
+        // Mirror real Firestore: with NO explicit orderBy, results sort by
+        // document ID, not the range-filtered field. This is the crux of the
+        // regression being tested — see module header.
+        const effectiveOrder = order.length > 0 ? order : ['__name__'];
+        rows = rows.sort(([idA, dataA], [idB, dataB]) => {
+          for (const field of effectiveOrder) {
+            const cmp = compareValues(
+              fieldValue(idA, dataA, field),
+              fieldValue(idB, dataB, field)
+            );
+            if (cmp !== 0) return cmp;
+          }
+          return 0;
+        });
+        if (afterId !== undefined) {
+          const afterData = store.get(afterId) ?? {};
+          const afterValues = effectiveOrder.map((f) =>
+            fieldValue(afterId, afterData, f)
+          );
+          rows = rows.filter(([id, data]) => {
+            for (let i = 0; i < effectiveOrder.length; i++) {
+              const cmp = compareValues(
+                fieldValue(id, data, effectiveOrder[i]),
+                afterValues[i]
+              );
+              if (cmp !== 0) return cmp > 0;
+            }
+            return false;
+          });
+        }
+        const sliced = lim === undefined ? rows : rows.slice(0, lim);
+        return Promise.resolve({
+          empty: sliced.length === 0,
+          size: sliced.length,
+          docs: sliced.map(([id, data]) => ({
+            id,
+            data: () => data,
+            ref: {
+              id,
+              collection: (subName: string) => {
+                if (subName !== 'boards') {
+                  throw new Error(
+                    `Unexpected subcollection in stub: ${subName}`
+                  );
+                }
+                return {
+                  get: () => Promise.resolve({ empty: true, docs: [] }),
+                };
+              },
+            },
+          })),
+        });
+      },
+    };
+  }
+
+  const db = {
+    collection: (name: string) => {
+      if (!(name in stores)) {
+        throw new Error(`Unexpected collection in stub: ${name}`);
+      }
+      return collectionRef(name);
+    },
+    batch: () => {
+      const pendingDeletes: { id: string; collectionName: string }[] = [];
+      return {
+        delete: (ref: { id: string }) => {
+          // Every doc ref in this stub comes from `shared_boards` or
+          // `shared_collections` — figure out which store it belongs to by
+          // checking membership (both id spaces are disjoint in these tests).
+          for (const [name, store] of Object.entries(stores)) {
+            if (store.has(ref.id)) {
+              pendingDeletes.push({ id: ref.id, collectionName: name });
+              break;
+            }
+          }
+        },
+        commit: () => {
+          for (const { id, collectionName } of pendingDeletes) {
+            stores[collectionName].delete(id);
+          }
+          return Promise.resolve();
+        },
+      };
+    },
+  };
+
+  return {
+    db: db as unknown as Parameters<typeof runExpireSubShares>[0],
+    stores,
+  };
+}
+
+describe('runExpireSubShares', () => {
+  it('deletes an expired share with no driveGrants immediately', async () => {
+    const { db, stores } = makeStubDb({
+      shared_boards: [
+        {
+          id: 'share-1',
+          data: { intendedMode: 'substitute', expiresAt: NOW - DAY },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.boards).toEqual({
+      deleted: 1,
+      inGrace: 0,
+      orphanedGrants: 0,
+    });
+    expect(stores.shared_boards.has('share-1')).toBe(false);
+  });
+
+  it('leaves a share with driveGrants in the 7-day grace window untouched', async () => {
+    const { db, stores } = makeStubDb({
+      shared_boards: [
+        {
+          id: 'share-1',
+          data: {
+            intendedMode: 'substitute',
+            expiresAt: NOW - DAY, // expired 1 day ago — well within 7-day grace
+            driveGrants: [
+              { email: 'sub@example.com', fileId: 'f1', permissionId: 'p1' },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.boards).toEqual({
+      deleted: 0,
+      inGrace: 1,
+      orphanedGrants: 0,
+    });
+    expect(stores.shared_boards.has('share-1')).toBe(true);
+  });
+
+  it('force-deletes a share with driveGrants once the grace window has elapsed', async () => {
+    const { db, stores } = makeStubDb({
+      shared_boards: [
+        {
+          id: 'share-1',
+          data: {
+            intendedMode: 'substitute',
+            expiresAt: NOW - 8 * DAY, // expired 8 days ago — past 7-day grace
+            driveGrants: [
+              { email: 'sub@example.com', fileId: 'f1', permissionId: 'p1' },
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.boards).toEqual({
+      deleted: 1,
+      inGrace: 0,
+      orphanedGrants: 1,
+    });
+    expect(stores.shared_boards.has('share-1')).toBe(false);
+  });
+
+  it('leaves a not-yet-expired substitute share untouched', async () => {
+    const { db, stores } = makeStubDb({
+      shared_boards: [
+        {
+          id: 'share-1',
+          data: { intendedMode: 'substitute', expiresAt: NOW + DAY },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.boards).toEqual({
+      deleted: 0,
+      inGrace: 0,
+      orphanedGrants: 0,
+    });
+    expect(stores.shared_boards.has('share-1')).toBe(true);
+  });
+
+  it('ignores non-substitute shares regardless of expiresAt', async () => {
+    const { db, stores } = makeStubDb({
+      shared_boards: [
+        {
+          id: 'share-1',
+          data: { intendedMode: 'normal', expiresAt: NOW - DAY },
+        },
+      ],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    expect(result.boards).toEqual({
+      deleted: 0,
+      inGrace: 0,
+      orphanedGrants: 0,
+    });
+    expect(stores.shared_boards.has('share-1')).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Pagination regression — an expired share past the first page must still be
+// swept. Before the fix, the expired-doc lookup was a single un-paginated
+// `.limit(MAX_DELETES_PER_RUN)` page with NO `orderBy`, so once more than one
+// page's worth of expired-but-still-undeletable (grace-window) docs
+// accumulated, Firestore's default document-ID ordering meant the SAME top
+// page was re-fetched every run — any expired share whose doc id sorted past
+// that page was never reached, forever.
+// ===========================================================================
+
+describe('runExpireSubShares — pagination past the first page', () => {
+  it('sweeps an expired share whose doc id sorts past SWEEP_PAGE_SIZE', async () => {
+    // A full page of expired, grace-window (undeletable) filler docs — these
+    // occupy the "first page" under document-ID ordering and, pre-fix,
+    // permanently crowd out anything sorting after them since they never get
+    // deleted (grace hasn't elapsed) and free no slots for a later doc.
+    const filler: StubDoc[] = Array.from(
+      { length: SWEEP_PAGE_SIZE },
+      (_, i) => ({
+        id: `share-${String(i).padStart(6, '0')}`,
+        data: {
+          intendedMode: 'substitute',
+          expiresAt: NOW - DAY, // expired, but still within 7-day grace
+          driveGrants: [
+            { email: 'sub@example.com', fileId: 'f1', permissionId: 'p1' },
+          ],
+        },
+      })
+    );
+    // The target: expired LONGER ago than any filler doc (genuinely the
+    // stalest share in the collection) with NO driveGrants — an immediate,
+    // uncontested delete candidate — but its doc id sorts lexicographically
+    // last, so a doc-ID-ordered `.limit(SWEEP_PAGE_SIZE)` page excludes it
+    // entirely while 500 grace-window fillers occupy every slot.
+    const target: StubDoc = {
+      id: 'share-zzz-target',
+      data: { intendedMode: 'substitute', expiresAt: NOW - 30 * DAY },
+    };
+
+    const { db, stores } = makeStubDb({
+      shared_boards: [...filler, target],
+    });
+
+    const result = await runExpireSubShares(db, NOW);
+
+    // The target must be found and deleted; the 500 grace-window fillers
+    // must be visited (counted as inGrace) but left in place.
+    expect(result.boards.deleted).toBe(1);
+    expect(result.boards.inGrace).toBe(SWEEP_PAGE_SIZE);
+    expect(stores.shared_boards.has('share-zzz-target')).toBe(false);
+  });
+});

--- a/functions/src/expireSubShares.ts
+++ b/functions/src/expireSubShares.ts
@@ -30,13 +30,38 @@
  * district hasn't enabled it, and the GCP docs flag DWD as a
  * privilege-escalation risk because it lets the service account
  * impersonate any user including super-admins).
+ *
+ * PAGINATION: the expired-doc lookup PAGINATES (`startAfter` cursor on
+ * `orderBy('expiresAt').orderBy(FieldPath.documentId())`, mirroring the
+ * identical fix already applied to `gcPlcOrphans.ts` /
+ * `expireActivityWallShares.ts` / `finalizeIdleQuizAttempts.ts`) up to
+ * `MAX_SWEEP_PER_RUN` — a safety ceiling, not a page size. Docs held in the
+ * 7-day Drive-grant grace window are matched by the query but deliberately
+ * NOT deleted yet, so without pagination a single un-paginated `.limit()`
+ * page would keep re-fetching the SAME arbitrary doc-id-ordered slice every
+ * hour (a query with no explicit `orderBy` is NOT implicitly sorted by the
+ * inequality field — it falls back to document-id order, confirmed by the
+ * identical bug already found/fixed in `expireActivityWallShares.ts`,
+ * #2268). Once the count of matching-but-still-in-grace docs exceeded one
+ * page, any genuinely-older expired share whose doc id happened to sort
+ * past that page would never be reached by this sweep — permanently
+ * stranding its `driveGrants` past the intended 7-day grace window with no
+ * warning ever logged for it.
  */
 
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as admin from 'firebase-admin';
 
-/** Cap per-run delete count to keep one slow sweep from monopolising. */
-const MAX_DELETES_PER_RUN = 500;
+/**
+ * Overall safety ceiling on expired docs visited per run (per collection) —
+ * a runaway guard, NOT an expected limit. The fetch PAGINATES
+ * (`SWEEP_PAGE_SIZE` pages, `startAfter` cursor), so every expired doc up to
+ * this ceiling is visited every run — not just the first page.
+ */
+export const MAX_SWEEP_PER_RUN = 5000;
+
+/** Page size for the paginated expired-doc fetch (`startAfter` cursor). */
+export const SWEEP_PAGE_SIZE = 500;
 
 /** Days a doc with unrevoked grants is left in place for the client revoker. */
 const ORPHAN_GRACE_DAYS = 7;
@@ -63,6 +88,53 @@ interface SweepResult {
 }
 
 /**
+ * Paginates the "expired substitute share" query for one collection up to
+ * `MAX_SWEEP_PER_RUN`, `SWEEP_PAGE_SIZE` docs at a time, via a `startAfter`
+ * cursor on `orderBy('expiresAt').orderBy(FieldPath.documentId())` (the
+ * doc-id tiebreaker keeps pagination correct when multiple docs share an
+ * identical `expiresAt`). Docs held in the Drive-grant grace window are
+ * matched but not deleted, so without this cursor a single un-paginated page
+ * would keep re-fetching the same doc-id-ordered slice forever once the
+ * backlog exceeded one page — see the module header for the full history.
+ */
+async function fetchExpiredDocsPaginated(
+  db: FirebaseFirestore.Firestore,
+  collectionName: string,
+  now: number
+): Promise<ExpiredDocSnap[]> {
+  const results: ExpiredDocSnap[] = [];
+  let lastDoc: ExpiredDocSnap | undefined;
+  while (results.length < MAX_SWEEP_PER_RUN) {
+    const pageLimit = Math.min(
+      SWEEP_PAGE_SIZE,
+      MAX_SWEEP_PER_RUN - results.length
+    );
+    // Equality on intendedMode + range on expiresAt — requires a composite
+    // index on (intendedMode ASC, expiresAt ASC); declared in
+    // firestore.indexes.json for both collections.
+    let query = db
+      .collection(collectionName)
+      .where('intendedMode', '==', 'substitute')
+      .where('expiresAt', '<=', now)
+      .orderBy('expiresAt', 'asc')
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(pageLimit);
+    if (lastDoc) query = query.startAfter(lastDoc);
+    const page = await query.get();
+    if (page.empty) break;
+    results.push(...page.docs);
+    lastDoc = page.docs[page.docs.length - 1];
+    if (page.size < pageLimit) break;
+  }
+  if (results.length >= MAX_SWEEP_PER_RUN) {
+    console.warn(
+      `[expireSubShares] hit MAX_SWEEP_PER_RUN ceiling (${MAX_SWEEP_PER_RUN}) for ${collectionName} — raise it or shard the sweep`
+    );
+  }
+  return results;
+}
+
+/**
  * Sweep one substitute-share collection. `hostField` is the doc field holding
  * the host uid (`originalAuthor` on /shared_boards, `hostUid` on
  * /shared_collections) — only used for logging. When `deleteBoardsSubcollection`
@@ -75,17 +147,9 @@ async function sweepCollection(
   hostField: 'originalAuthor' | 'hostUid',
   deleteBoardsSubcollection: boolean
 ): Promise<SweepResult> {
-  // Equality on intendedMode + range on expiresAt — requires a composite
-  // index on (intendedMode ASC, expiresAt ASC); declared in
-  // firestore.indexes.json for both collections.
-  const snap = await db
-    .collection(collectionName)
-    .where('intendedMode', '==', 'substitute')
-    .where('expiresAt', '<=', now)
-    .limit(MAX_DELETES_PER_RUN)
-    .get();
+  const expiredDocs = await fetchExpiredDocsPaginated(db, collectionName, now);
 
-  if (snap.empty) {
+  if (expiredDocs.length === 0) {
     console.log(`[expireSubShares] no expired substitute ${collectionName}`);
     return { deleted: 0, inGrace: 0, orphanedGrants: 0 };
   }
@@ -97,7 +161,7 @@ async function sweepCollection(
   let stillInGrace = 0;
   let orphanedGrantCount = 0;
 
-  for (const doc of snap.docs) {
+  for (const doc of expiredDocs) {
     const data = doc.data() as SubstituteShareData & { hostUid?: string };
     const grants = Array.isArray(data.driveGrants) ? data.driveGrants : [];
     const expiredAt = typeof data.expiresAt === 'number' ? data.expiresAt : 0;
@@ -141,7 +205,7 @@ async function sweepCollection(
     // Collection shares — each with its own get() + batch-commit chain —
     // doesn't serialize toward the function timeout. The cap keeps us well
     // under Firestore's per-client connection limits rather than fanning out
-    // all (up to MAX_DELETES_PER_RUN) parents at once.
+    // all (up to MAX_SWEEP_PER_RUN) parents at once.
     const BOARD_CLEANUP_CONCURRENCY = 10;
     const boardBatchSize = 250;
     for (let i = 0; i < readyToDelete.length; i += BOARD_CLEANUP_CONCURRENCY) {
@@ -162,8 +226,8 @@ async function sweepCollection(
     }
   }
 
-  // Batched delete of parents. Firestore caps each batch at 500 ops which
-  // lines up with MAX_DELETES_PER_RUN; we still chunk defensively.
+  // Batched delete of parents. Firestore caps each batch at 500 ops, so we
+  // chunk defensively (readyToDelete can hold up to MAX_SWEEP_PER_RUN docs).
   const batchSize = 250;
   let deleted = 0;
   for (let i = 0; i < readyToDelete.length; i += batchSize) {
@@ -182,6 +246,54 @@ async function sweepCollection(
   return { deleted, inGrace: stillInGrace, orphanedGrants: orphanedGrantCount };
 }
 
+/**
+ * Core sweep, extracted from the scheduler wrapper so it can be exercised
+ * against a stub Firestore in tests (mirrors `runGcPlcOrphans` /
+ * `runExpireActivityWallShares` / `runFinalizeIdleQuizAttempts`).
+ */
+export async function runExpireSubShares(
+  db: FirebaseFirestore.Firestore,
+  now: number = Date.now()
+): Promise<{ boards: SweepResult; collections: SweepResult }> {
+  // Run both sweeps independently: a failure in one (Firestore quota, a
+  // batch-commit error, a missing index) must not abort the other and leave
+  // its expired shares un-reaped for the hour.
+  const [boardsResult, collectionsResult] = await Promise.allSettled([
+    sweepCollection(db, 'shared_boards', now, 'originalAuthor', false),
+    sweepCollection(db, 'shared_collections', now, 'hostUid', true),
+  ]);
+  const failures: unknown[] = [];
+  if (boardsResult.status === 'rejected') {
+    console.error(
+      '[expireSubShares] shared_boards sweep failed:',
+      boardsResult.reason
+    );
+    failures.push(boardsResult.reason);
+  }
+  if (collectionsResult.status === 'rejected') {
+    console.error(
+      '[expireSubShares] shared_collections sweep failed:',
+      collectionsResult.reason
+    );
+    failures.push(collectionsResult.reason);
+  }
+  // Both sweeps have already completed (allSettled above guarantees neither
+  // aborted the other), so re-throwing here is safe and surfaces a persistent
+  // failure as a failed invocation — an error metric that can drive a Cloud
+  // Monitoring alert — instead of a silent success that lets expired shares
+  // accumulate until someone notices the logs.
+  if (failures.length > 0) {
+    throw new Error(
+      `[expireSubShares] ${failures.length} sweep(s) failed; see logged reasons above.`
+    );
+  }
+  return {
+    boards: (boardsResult as PromiseFulfilledResult<SweepResult>).value,
+    collections: (collectionsResult as PromiseFulfilledResult<SweepResult>)
+      .value,
+  };
+}
+
 export const expireSubShares = onSchedule(
   {
     schedule: 'every 60 minutes',
@@ -191,39 +303,6 @@ export const expireSubShares = onSchedule(
   },
   async () => {
     const db = admin.firestore();
-    const now = Date.now();
-
-    // Run both sweeps independently: a failure in one (Firestore quota, a
-    // batch-commit error, a missing index) must not abort the other and leave
-    // its expired shares un-reaped for the hour.
-    const [boardsResult, collectionsResult] = await Promise.allSettled([
-      sweepCollection(db, 'shared_boards', now, 'originalAuthor', false),
-      sweepCollection(db, 'shared_collections', now, 'hostUid', true),
-    ]);
-    const failures: unknown[] = [];
-    if (boardsResult.status === 'rejected') {
-      console.error(
-        '[expireSubShares] shared_boards sweep failed:',
-        boardsResult.reason
-      );
-      failures.push(boardsResult.reason);
-    }
-    if (collectionsResult.status === 'rejected') {
-      console.error(
-        '[expireSubShares] shared_collections sweep failed:',
-        collectionsResult.reason
-      );
-      failures.push(collectionsResult.reason);
-    }
-    // Both sweeps have already completed (allSettled above guarantees neither
-    // aborted the other), so re-throwing here is safe and surfaces a persistent
-    // failure as a failed invocation — an error metric that can drive a Cloud
-    // Monitoring alert — instead of a silent success that lets expired shares
-    // accumulate until someone notices the logs.
-    if (failures.length > 0) {
-      throw new Error(
-        `[expireSubShares] ${failures.length} sweep(s) failed; see logged reasons above.`
-      );
-    }
+    await runExpireSubShares(db, Date.now());
   }
 );


### PR DESCRIPTION
## Root cause

`functions/src/expireSubShares.ts`'s `sweepCollection` fetched expired substitute-mode `shared_boards`/`shared_collections` docs via a single un-paginated query with no explicit `orderBy`:

```ts
const snap = await db
  .collection(collectionName)
  .where('intendedMode', '==', 'substitute')
  .where('expiresAt', '<=', now)
  .limit(500)
  .get();
```

Docs held in the 7-day Drive-grant grace window are matched by this query but deliberately left un-deleted. With no explicit `orderBy`, Firestore falls back to document-ID order (the same behavior already confirmed and fixed for the identical query shape in `expireActivityWallShares.ts`, #2268). Once the matching-but-not-yet-deleted backlog exceeded one 500-doc page, the same arbitrary doc-ID-ordered slice was re-fetched every hour — any genuinely-expired share whose doc ID happened to sort past that slice was permanently invisible to the sweep, silently stranding its `driveGrants` past the intended 7-day grace window.

This is the same pagination-cliff bug class already fixed in `gcPlcOrphans.ts` (at 3 different nesting levels) and `expireActivityWallShares.ts`/`finalizeIdleQuizAttempts.ts` — but `expireSubShares.ts` itself, the pattern's original source per those files' own comments, had never been patched and had zero test coverage.

## Fix

Added `fetchExpiredDocsPaginated()`: pages through `orderBy('expiresAt').orderBy(FieldPath.documentId())` with a `startAfter` cursor, up to a `MAX_SWEEP_PER_RUN` (5000) safety ceiling / `SWEEP_PAGE_SIZE` (500) per page — mirroring the sibling sweeps' fix exactly. Also extracted a testable `runExpireSubShares(db, now)` core from the `onSchedule` wrapper, matching the established pattern in the sibling files.

## Band-aid rejected

Considered simply raising the old `MAX_DELETES_PER_RUN` limit — rejected because that only pushes the same silent cliff further out without fixing it; the missing piece is the `startAfter` cursor, not the page size.

## Regression test

`functions/src/expireSubShares.test.ts` (new file) — `"sweeps an expired share whose doc id sorts past SWEEP_PAGE_SIZE"`: seeds `SWEEP_PAGE_SIZE` (500) grace-window filler docs plus one genuinely-older target doc whose ID sorts lexically last.

- **Fail-before** (verified independently by the orchestrator by temporarily reverting just `expireSubShares.ts` to its dev-paul version): all 6 tests fail (the extracted `runExpireSubShares` export doesn't exist pre-fix).
- **Pass-after** (verified independently by the orchestrator): 6/6 pass.

## Evidence

- `pnpm run validate` — independently re-run by the orchestrator in an isolated worktree: type-check (root+functions), lint, format-check, full root suite (597 test files / 7282 tests), full functions suite (41 test files / 784 tests), `test:counts` guard — all green.
- `pnpm run build` — independently re-run by the orchestrator: client + SSR bundle build succeeded, prerender of `/privacy`, `/terms`, `/support` succeeded.

## Additional backlog findings (not fixed here, flagged for a future run)

- `expireSubShares.ts` had zero test coverage before this change; the new suite covers the core sweep paths (immediate delete, grace-window hold, forced delete past grace, non-expired, non-substitute, pagination) but the `boards/` subcollection cleanup path (concurrency-bounded reaping for `shared_collections`) still has no dedicated stub coverage.

## Risk

**contained** — mirrors an established, already-shipped pagination fix pattern applied 3x previously in this exact codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hb94qEZXJ9yAgNmNXNaiU8)_