### PR TITLE
fix(drawing): rehydrate page objects before PNG/PDF export

### DIFF
--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -736,12 +736,11 @@ export const DrawingWidget: React.FC<{
   // page has no live subscription, so we read it from Firestore here.
   const resolveExportPages = useCallback(async (): Promise<DrawingPage[]> => {
     if (!config.subcollectionMigrated) {
-      // Pre-migration the dashboard doc is still the source of truth, but the
-      // active page's array can lag `objects` by a render, so prefer the live
-      // slice for it and take the rest verbatim.
-      return pages.map((p) =>
-        p.id === activePage.id ? { ...p, objects } : { ...p }
-      );
+      // Pre-migration the dashboard doc is still the source of truth and
+      // `objects` IS `activePage.objects` (see the assignment above), so
+      // every page already carries its content. `renderPageToPng` copies
+      // before sorting, so handing it these arrays directly is safe.
+      return pages;
     }
     const uid = user?.uid;
     if (!uid || !dashboardId) {

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -726,14 +726,7 @@ export const DrawingWidget: React.FC<{
     return `Whiteboard-${timestamp}`;
   };
 
-  // Pages to hand the export pipeline, with `objects[]` guaranteed populated.
-  //
-  // Post-migration (PR 2.6) the dashboard doc's `pages[].objects` is emptied
-  // on purpose — it's a denormalized `{ id, background }` cache, and the real
-  // objects live in the page-nested subcollection. Handing `pages` straight
-  // to the exporter would therefore paint the background template and nothing
-  // else. The active page is covered by the live `objects` array; every OTHER
-  // page has no live subscription, so we read it from Firestore here.
+  // Post-migration pages[].objects is empty; the active page uses live objects, every other page is read from Firestore.
   const resolveExportPages = useCallback(async (): Promise<DrawingPage[]> => {
     if (!config.subcollectionMigrated) {
       // Pre-migration the dashboard doc is still the source of truth and

--- a/components/widgets/DrawingWidget/Widget.tsx
+++ b/components/widgets/DrawingWidget/Widget.tsx
@@ -51,6 +51,7 @@ import { DRAWING_DEFAULTS } from './constants';
 import { useDrawingCanvas } from './useDrawingCanvas';
 import { migrateDrawingConfig, nextZ } from '@/utils/migrateDrawingConfig';
 import { deleteDrawingPageSubcollection } from '@/utils/deleteDrawingPageSubcollection';
+import { hydrateDrawingPagesFromSubcollection } from '@/utils/hydrateDrawingPages';
 import { db } from '@/config/firebase';
 import { logError } from '@/utils/logError';
 import type { DrawingPage } from '@/types';
@@ -725,6 +726,50 @@ export const DrawingWidget: React.FC<{
     return `Whiteboard-${timestamp}`;
   };
 
+  // Pages to hand the export pipeline, with `objects[]` guaranteed populated.
+  //
+  // Post-migration (PR 2.6) the dashboard doc's `pages[].objects` is emptied
+  // on purpose — it's a denormalized `{ id, background }` cache, and the real
+  // objects live in the page-nested subcollection. Handing `pages` straight
+  // to the exporter would therefore paint the background template and nothing
+  // else. The active page is covered by the live `objects` array; every OTHER
+  // page has no live subscription, so we read it from Firestore here.
+  const resolveExportPages = useCallback(async (): Promise<DrawingPage[]> => {
+    if (!config.subcollectionMigrated) {
+      // Pre-migration the dashboard doc is still the source of truth, but the
+      // active page's array can lag `objects` by a render, so prefer the live
+      // slice for it and take the rest verbatim.
+      return pages.map((p) =>
+        p.id === activePage.id ? { ...p, objects } : { ...p }
+      );
+    }
+    const uid = user?.uid;
+    if (!uid || !dashboardId) {
+      // Migrated but we can't address the subcollection — exporting now would
+      // silently produce blank pages, so fail loudly instead. The message
+      // deliberately avoids the word "blocked" so the PDF handler's pop-up
+      // blocker branch doesn't misclassify it.
+      throw new Error('Drawing content is unavailable for export.');
+    }
+    return hydrateDrawingPagesFromSubcollection({
+      db,
+      uid,
+      dashboardId,
+      widgetId: widget.id,
+      pages,
+      livePageId: activePage.id,
+      liveObjects: objects,
+    });
+  }, [
+    config.subcollectionMigrated,
+    pages,
+    activePage.id,
+    objects,
+    user?.uid,
+    dashboardId,
+    widget.id,
+  ]);
+
   const handleExportCurrentPng = async () => {
     closeExportMenu();
     try {
@@ -733,10 +778,16 @@ export const DrawingWidget: React.FC<{
       // (which lives as a CSS div on the live canvas) gets baked into pixels.
       // Selection chrome is never on the offscreen canvas so we don't need
       // to clear selection first.
-      const dataUrl = await exportPagePng(activePage, {
-        w: canvasSize.width,
-        h: canvasSize.height,
-      });
+      // `activePage.objects` is empty post-migration (denormalized cache) —
+      // splice in the live subcollection-backed `objects` so the export
+      // carries the strokes the teacher can see, not just the background.
+      const dataUrl = await exportPagePng(
+        { ...activePage, objects },
+        {
+          w: canvasSize.width,
+          h: canvasSize.height,
+        }
+      );
       downloadDataUrl(
         dataUrl,
         `${exportFilenameStem()}-page-${currentPage + 1}.png`
@@ -755,7 +806,7 @@ export const DrawingWidget: React.FC<{
     if (pages.length === 0) return;
     try {
       setIsExporting(true);
-      const dataUrls = await exportAllPagesPng(pages, {
+      const dataUrls = await exportAllPagesPng(await resolveExportPages(), {
         w: canvasSize.width,
         h: canvasSize.height,
       });
@@ -780,7 +831,10 @@ export const DrawingWidget: React.FC<{
       // PDF export goes through the browser print dialog (one-shot OS-level
       // "Save as PDF"); the dialog owns the final filename so we no longer
       // pass one in.
-      await exportPdf(pages, { w: canvasSize.width, h: canvasSize.height });
+      await exportPdf(await resolveExportPages(), {
+        w: canvasSize.width,
+        h: canvasSize.height,
+      });
     } catch (e) {
       console.error('PDF export failed:', e);
       const message =

--- a/tests/components/widgets/DrawingWidget/exportSubcollection.test.tsx
+++ b/tests/components/widgets/DrawingWidget/exportSubcollection.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import type {
+  DrawableObject,
+  DrawingConfig,
+  DrawingPage,
+  WidgetData,
+} from '@/types';
+
+/**
+ * Regression coverage for the post-migration export path.
+ *
+ * Once `migrateDrawingToSubcollection` runs, the dashboard doc's
+ * `pages[].objects` is deliberately emptied — it becomes a denormalized
+ * `{ id, background }` cache and the objects live in the page-nested
+ * subcollection. The export handlers used to hand `activePage` / `pages`
+ * (both sourced from `widget.config`) straight to the export pipeline, so
+ * every migrated widget exported background-only PNGs and PDFs.
+ *
+ * These tests assert the pages reaching the export pipeline actually carry
+ * their objects: the active page from the live subscription, the rest read
+ * back from Firestore.
+ */
+
+const liveObjects: DrawableObject[] = [
+  {
+    id: 'live-1',
+    kind: 'path',
+    z: 0,
+    points: [{ x: 1, y: 1 }],
+    color: '#111111',
+    width: 4,
+  } as DrawableObject,
+];
+
+const page2Objects: DrawableObject[] = [
+  {
+    id: 'remote-1',
+    kind: 'path',
+    z: 0,
+    points: [{ x: 2, y: 2 }],
+    color: '#222222',
+    width: 4,
+  } as DrawableObject,
+];
+
+const addToast = vi.fn();
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    updateWidget: vi.fn(),
+    bringToFront: vi.fn(),
+    activeDashboard: { id: 'dash-1', widgets: [] },
+    addToast,
+    addWidget: vi.fn(),
+    drawingWidgetsMigrating: new Set<string>(),
+  }),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({ user: { uid: 'uid-1' }, canAccessFeature: () => true }),
+}));
+vi.mock('@/hooks/useStorage', () => ({
+  useStorage: () => ({ uploadFile: vi.fn() }),
+}));
+
+// Live page subscription — stands in for the real subcollection listener.
+vi.mock('@/components/widgets/DrawingWidget/useDrawingObjectsDoc', () => ({
+  useDrawingObjectsDoc: () => ({
+    objects: liveObjects,
+    addObject: vi.fn(),
+    updateObject: vi.fn(),
+    removeObject: vi.fn(),
+    clear: vi.fn(),
+    loading: false,
+  }),
+}));
+
+// Firestore surface used by the non-active-page rehydration.
+vi.mock('firebase/firestore', () => ({
+  collection: (_db: unknown, ...segments: string[]) => segments.join('/'),
+  getDocs: (ref: string) => {
+    if (ref.includes('/pages/page-2/objects')) {
+      return Promise.resolve({
+        docs: page2Objects.map((o) => ({ data: () => o })),
+      });
+    }
+    return Promise.resolve({ docs: [] });
+  },
+  doc: vi.fn(),
+  deleteDoc: vi.fn(),
+  writeBatch: vi.fn(),
+  onSnapshot: vi.fn(),
+  setDoc: vi.fn(),
+}));
+
+interface PageSize {
+  w: number;
+  h: number;
+}
+const exportPagePng = vi
+  .fn<(page: DrawingPage, size: PageSize) => Promise<string>>()
+  .mockResolvedValue('data:image/png;base64,AAA');
+const exportAllPagesPng = vi
+  .fn<(pages: readonly DrawingPage[], size: PageSize) => Promise<string[]>>()
+  .mockResolvedValue(['data:image/png;base64,AAA']);
+const exportPdf = vi
+  .fn<(pages: readonly DrawingPage[], size: PageSize) => Promise<void>>()
+  .mockResolvedValue(undefined);
+const downloadDataUrl = vi.fn<(dataUrl: string, filename: string) => void>();
+vi.mock('@/components/widgets/DrawingWidget/exportCanvas', () => ({
+  exportPagePng,
+  exportAllPagesPng,
+  exportPdf,
+  downloadDataUrl,
+}));
+
+const { DrawingWidget } =
+  await import('@/components/widgets/DrawingWidget/Widget');
+
+const makeWidget = (config: DrawingConfig): WidgetData =>
+  ({
+    id: 'widget-1',
+    type: 'drawing',
+    x: 0,
+    y: 0,
+    w: 800,
+    h: 600,
+    z: 1,
+    flipped: false,
+    minimized: false,
+    config,
+  }) as unknown as WidgetData;
+
+// Post-migration config: objects stripped from the denormalized page cache.
+const migratedConfig = (): DrawingConfig =>
+  ({
+    subcollectionMigrated: true,
+    currentPage: 0,
+    pages: [
+      { id: 'page-1', objects: [], background: 'blank' },
+      { id: 'page-2', objects: [], background: 'grid' },
+    ],
+  }) as unknown as DrawingConfig;
+
+const idsOf = (page: DrawingPage): string[] => page.objects.map((o) => o.id);
+
+const openExportMenu = (getByLabelText: (t: string) => HTMLElement) => {
+  fireEvent.click(getByLabelText('Export'));
+};
+
+const clickExportItem = (label: string) => {
+  const popover = document.querySelector(
+    '[data-testid="drawing-export-popover"]'
+  );
+  const button = Array.from(popover?.querySelectorAll('button') ?? []).find(
+    (b) => b.textContent === label
+  );
+  if (!button) throw new Error(`export item not found: ${label}`);
+  fireEvent.click(button);
+};
+
+describe('DrawingWidget export — subcollection-migrated widgets', () => {
+  beforeEach(() => {
+    exportPagePng.mockClear();
+    exportAllPagesPng.mockClear();
+    exportPdf.mockClear();
+    downloadDataUrl.mockClear();
+    addToast.mockClear();
+  });
+  afterEach(cleanup);
+
+  it('exports the current page with its live objects, not the emptied cache', async () => {
+    const { getByLabelText } = render(
+      <DrawingWidget widget={makeWidget(migratedConfig())} />
+    );
+    openExportMenu(getByLabelText);
+    clickExportItem('Export PNG (this page)');
+
+    await waitFor(() => expect(exportPagePng).toHaveBeenCalledTimes(1));
+    const [page] = exportPagePng.mock.calls[0];
+    expect(page.id).toBe('page-1');
+    expect(idsOf(page)).toEqual(['live-1']);
+  });
+
+  it('exports all pages with objects rehydrated from the subcollection', async () => {
+    const { getByLabelText } = render(
+      <DrawingWidget widget={makeWidget(migratedConfig())} />
+    );
+    openExportMenu(getByLabelText);
+    clickExportItem('Export PNG (all pages)');
+
+    await waitFor(() => expect(exportAllPagesPng).toHaveBeenCalledTimes(1));
+    const [pages] = exportAllPagesPng.mock.calls[0];
+    expect(pages.map((p) => [p.id, idsOf(p)])).toEqual([
+      ['page-1', ['live-1']],
+      ['page-2', ['remote-1']],
+    ]);
+  });
+
+  it('exports a PDF with objects rehydrated from the subcollection', async () => {
+    const { getByLabelText } = render(
+      <DrawingWidget widget={makeWidget(migratedConfig())} />
+    );
+    openExportMenu(getByLabelText);
+    clickExportItem('Export PDF');
+
+    await waitFor(() => expect(exportPdf).toHaveBeenCalledTimes(1));
+    const [pages] = exportPdf.mock.calls[0];
+    expect(pages.map(idsOf)).toEqual([['live-1'], ['remote-1']]);
+  });
+
+  it('still exports pre-migration configs straight from the dashboard doc', async () => {
+    const legacyObjects: DrawableObject[] = [
+      {
+        id: 'legacy-1',
+        kind: 'path',
+        z: 0,
+        points: [{ x: 3, y: 3 }],
+        color: '#333333',
+        width: 4,
+      } as DrawableObject,
+    ];
+    const config = {
+      currentPage: 0,
+      pages: [
+        { id: 'page-a', objects: legacyObjects, background: 'blank' },
+        { id: 'page-b', objects: [], background: 'lines' },
+      ],
+    } as unknown as DrawingConfig;
+
+    const { getByLabelText } = render(
+      <DrawingWidget widget={makeWidget(config)} />
+    );
+    openExportMenu(getByLabelText);
+    clickExportItem('Export PNG (all pages)');
+
+    await waitFor(() => expect(exportAllPagesPng).toHaveBeenCalledTimes(1));
+    const [pages] = exportAllPagesPng.mock.calls[0];
+    expect(idsOf(pages[0])).toEqual(['legacy-1']);
+    expect(pages[1].objects).toEqual([]);
+  });
+});

--- a/tests/utils/hydrateDrawingPages.test.ts
+++ b/tests/utils/hydrateDrawingPages.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Firestore } from 'firebase/firestore';
+import type { DrawableObject, DrawingPage } from '@/types';
+
+// Mock the Firestore surface the util touches. `collection(...)` returns the
+// joined path so `getDocs` can key its canned response off it — that also
+// asserts the util addresses the exact page-nested path the migration writes.
+interface FakeSnapshot {
+  docs: { data: () => DrawableObject }[];
+}
+const getDocsMock = vi.fn<(ref: string) => FakeSnapshot>();
+vi.mock('firebase/firestore', () => ({
+  collection: (_db: unknown, ...segments: string[]) => segments.join('/'),
+  getDocs: (ref: string) => getDocsMock(ref),
+}));
+
+const { hydrateDrawingPagesFromSubcollection } =
+  await import('@/utils/hydrateDrawingPages');
+
+const db = {} as Firestore;
+
+const obj = (id: string, z: number): DrawableObject =>
+  ({
+    id,
+    kind: 'path',
+    z,
+    points: [{ x: 0, y: 0 }],
+    color: '#000',
+    width: 2,
+  }) as DrawableObject;
+
+const snapshotOf = (objects: DrawableObject[]) => ({
+  docs: objects.map((o) => ({ data: () => o })),
+});
+
+// Post-migration shape: the dashboard doc keeps id + background only.
+const denormalizedPages: DrawingPage[] = [
+  { id: 'page-1', objects: [], background: 'blank' },
+  { id: 'page-2', objects: [], background: 'grid' },
+];
+
+const pathFor = (pageId: string) =>
+  `users/uid-1/dashboards/dash-1/drawings/widget-1/pages/${pageId}/objects`;
+
+describe('hydrateDrawingPagesFromSubcollection', () => {
+  beforeEach(() => {
+    getDocsMock.mockReset();
+  });
+
+  it('fills objects[] for every page from the page-nested subcollection', async () => {
+    getDocsMock.mockImplementation((ref: string) => {
+      if (ref === pathFor('page-1')) return snapshotOf([obj('a', 0)]);
+      if (ref === pathFor('page-2')) return snapshotOf([obj('b', 0)]);
+      throw new Error(`unexpected path: ${ref}`);
+    });
+
+    const out = await hydrateDrawingPagesFromSubcollection({
+      db,
+      uid: 'uid-1',
+      dashboardId: 'dash-1',
+      widgetId: 'widget-1',
+      pages: denormalizedPages,
+    });
+
+    expect(out.map((p) => p.objects.map((o) => o.id))).toEqual([['a'], ['b']]);
+    // Page metadata from the denormalized cache is carried through untouched.
+    expect(out.map((p) => p.background)).toEqual(['blank', 'grid']);
+  });
+
+  it('serves the live page from liveObjects instead of re-reading it', async () => {
+    getDocsMock.mockImplementation((ref: string) => {
+      if (ref === pathFor('page-2')) return snapshotOf([obj('b', 0)]);
+      throw new Error(`unexpected path: ${ref}`);
+    });
+
+    const live = [obj('live-a', 0), obj('live-b', 1)];
+    const out = await hydrateDrawingPagesFromSubcollection({
+      db,
+      uid: 'uid-1',
+      dashboardId: 'dash-1',
+      widgetId: 'widget-1',
+      pages: denormalizedPages,
+      livePageId: 'page-1',
+      liveObjects: live,
+    });
+
+    expect(out[0].objects.map((o) => o.id)).toEqual(['live-a', 'live-b']);
+    expect(out[1].objects.map((o) => o.id)).toEqual(['b']);
+    // Only the non-live page was read.
+    expect(getDocsMock).toHaveBeenCalledTimes(1);
+    expect(getDocsMock).toHaveBeenCalledWith(pathFor('page-2'));
+    // The live array is copied, not aliased — the export pipeline sorts in
+    // place, which must not reorder the widget's live state.
+    expect(out[0].objects).not.toBe(live);
+  });
+
+  it('sorts fetched objects ascending by z (last-drawn-on-top)', async () => {
+    getDocsMock.mockImplementation(() =>
+      snapshotOf([obj('c', 5), obj('a', 1), obj('b', 3)])
+    );
+
+    const out = await hydrateDrawingPagesFromSubcollection({
+      db,
+      uid: 'uid-1',
+      dashboardId: 'dash-1',
+      widgetId: 'widget-1',
+      pages: [denormalizedPages[0]],
+    });
+
+    expect(out[0].objects.map((o) => o.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty page list for an empty page list', async () => {
+    const out = await hydrateDrawingPagesFromSubcollection({
+      db,
+      uid: 'uid-1',
+      dashboardId: 'dash-1',
+      widgetId: 'widget-1',
+      pages: [],
+    });
+    expect(out).toEqual([]);
+    expect(getDocsMock).not.toHaveBeenCalled();
+  });
+});

--- a/utils/hydrateDrawingPages.ts
+++ b/utils/hydrateDrawingPages.ts
@@ -1,0 +1,75 @@
+import { collection, getDocs, type Firestore } from 'firebase/firestore';
+import type { DrawableObject, DrawingPage } from '@/types';
+
+/**
+ * Rehydrate `DrawingPage.objects[]` from the page-nested Firestore
+ * subcollection written by {@link migrateDrawingToSubcollection}.
+ *
+ * Why this exists: post-migration the dashboard document keeps `pages[]` only
+ * as a denormalized cache of `{ id, background }` — `objects[]` is emptied on
+ * purpose so a dashboard snapshot doesn't ship the whole canvas. The live
+ * widget reads objects through `useDrawingObjectsDoc`, but that hook is
+ * page-scoped: it only subscribes to the page currently on screen. Any
+ * consumer that needs the objects for pages OTHER than the active one (the
+ * all-pages PNG export and the PDF export) has to go to Firestore for them,
+ * or it silently renders background-only pages.
+ *
+ * The active page is served from the caller's live `objects[]` rather than a
+ * fresh read: that array is the same state the canvas is painting, so the
+ * export matches what the teacher sees on screen even if a just-drawn stroke
+ * has not round-tripped through the Firestore listener yet. It also saves a
+ * redundant read on the common single-page export.
+ *
+ * Reads run in parallel — a page count in the low tens is the realistic
+ * ceiling for a classroom whiteboard, and the export is a user-initiated
+ * one-shot, so latency matters more than read smoothing.
+ */
+
+interface HydrateOptions {
+  db: Firestore;
+  uid: string;
+  dashboardId: string;
+  widgetId: string;
+  /** Denormalized page cache off the dashboard doc (id + background). */
+  pages: readonly DrawingPage[];
+  /** Page the widget currently has a live subscription for, if any. */
+  livePageId?: string | null;
+  /** Live objects for `livePageId`, used verbatim instead of re-reading. */
+  liveObjects?: readonly DrawableObject[];
+}
+
+export const hydrateDrawingPagesFromSubcollection = async ({
+  db,
+  uid,
+  dashboardId,
+  widgetId,
+  pages,
+  livePageId,
+  liveObjects,
+}: HydrateOptions): Promise<DrawingPage[]> =>
+  Promise.all(
+    pages.map(async (page) => {
+      if (livePageId && page.id === livePageId && liveObjects) {
+        return { ...page, objects: [...liveObjects] };
+      }
+      const snapshot = await getDocs(
+        collection(
+          db,
+          'users',
+          uid,
+          'dashboards',
+          dashboardId,
+          'drawings',
+          widgetId,
+          'pages',
+          page.id,
+          'objects'
+        )
+      );
+      const objects = snapshot.docs.map((d) => d.data() as DrawableObject);
+      // Ascending z — matches the live renderer's last-drawn-on-top order and
+      // the ordering `useDrawingObjectsDoc` hands its consumers.
+      objects.sort((a, b) => a.z - b.z);
+      return { ...page, objects };
+    })
+  );

--- a/utils/hydrateDrawingPages.ts
+++ b/utils/hydrateDrawingPages.ts
@@ -1,29 +1,7 @@
 import { collection, getDocs, type Firestore } from 'firebase/firestore';
 import type { DrawableObject, DrawingPage } from '@/types';
 
-/**
- * Rehydrate `DrawingPage.objects[]` from the page-nested Firestore
- * subcollection written by {@link migrateDrawingToSubcollection}.
- *
- * Why this exists: post-migration the dashboard document keeps `pages[]` only
- * as a denormalized cache of `{ id, background }` — `objects[]` is emptied on
- * purpose so a dashboard snapshot doesn't ship the whole canvas. The live
- * widget reads objects through `useDrawingObjectsDoc`, but that hook is
- * page-scoped: it only subscribes to the page currently on screen. Any
- * consumer that needs the objects for pages OTHER than the active one (the
- * all-pages PNG export and the PDF export) has to go to Firestore for them,
- * or it silently renders background-only pages.
- *
- * The active page is served from the caller's live `objects[]` rather than a
- * fresh read: that array is the same state the canvas is painting, so the
- * export matches what the teacher sees on screen even if a just-drawn stroke
- * has not round-tripped through the Firestore listener yet. It also saves a
- * redundant read on the common single-page export.
- *
- * Reads run in parallel — a page count in the low tens is the realistic
- * ceiling for a classroom whiteboard, and the export is a user-initiated
- * one-shot, so latency matters more than read smoothing.
- */
+// Post-migration pages[].objects is stripped; read non-active pages from subcollection; live page uses in-memory objects to match what's on screen.
 
 interface HydrateOptions {
   db: Firestore;


### PR DESCRIPTION
## Summary

Drawing widgets that have completed the objects-subcollection migration exported **background-only** PNGs and PDFs — every stroke, shape, text object and image was silently dropped from the saved file.

`migrateDrawingToSubcollection` empties `pages[].objects` on the dashboard document by design (`utils/migrateDrawingToSubcollection.ts:183-187`): post-migration `pages[]` is a denormalized `{ id, background }` cache, and the objects live at `/users/{uid}/dashboards/{id}/drawings/{widgetId}/pages/{pageId}/objects`. But all three export handlers passed page data sourced straight from `widget.config`:

| Export | Handler | Was passed | Result post-migration |
| --- | --- | --- | --- |
| PNG (this page) | `handleExportCurrentPng` | `activePage` | background only |
| PNG (all pages) | `handleExportAllPng` | `pages` | background only |
| PDF | `handleExportPdf` | `pages` | background only |

`exportCanvas.renderPageToPng` painted the background template via `paintBackground`, then iterated an empty `page.objects`. The widget's live `objects` (read from the subcollection by `useDrawingObjectsDoc`) was never spliced back in.

`PageStrip` already draws this distinction for its thumbnails — it takes `activePageObjects` for the live page and renders a placeholder for non-active migrated pages — so the export handlers were the remaining gap, not a deliberate choice.

## Changes

- **`utils/hydrateDrawingPages.ts`** (new) — `hydrateDrawingPagesFromSubcollection()` reads `objects[]` back for a set of pages from the page-nested subcollection. The caller's live page is served from its in-memory `objects` instead of a redundant read, so the export matches what's on screen even before a just-drawn stroke round-trips through the listener. Objects are sorted ascending by `z` to match the live renderer.
- **`components/widgets/DrawingWidget/Widget.tsx`**
  - Current-page PNG now exports `{ ...activePage, objects }`.
  - All-pages PNG and PDF go through a new `resolveExportPages()` callback. `useDrawingObjectsDoc` is page-scoped (only the visible page has a listener), so pages other than the active one are read from Firestore.
  - A migrated widget with no addressable subcollection path (missing `uid` or `dashboardId`) now throws rather than silently emitting blank pages. The error message deliberately avoids the word "blocked" so the PDF handler's pop-up-blocker branch doesn't misclassify it.
  - Pre-migration configs continue reading from the dashboard doc; behaviour there is unchanged.

## Testing

- `tests/components/widgets/DrawingWidget/exportSubcollection.test.tsx` (new) — drives the real export popover and asserts the pages reaching the export pipeline carry their objects: active page from the live subscription, non-active page rehydrated from Firestore. Verified as a real regression gate: all three migrated-widget cases fail against the pre-fix `Widget.tsx` (objects arrive as `[]`), and pass with it. A fourth case pins the pre-migration path.
- `tests/utils/hydrateDrawingPages.test.ts` (new) — covers path construction, `z` ordering, live-page reuse (asserts the non-live page is the only read, and that the live array is copied rather than aliased since the exporter sorts), and the empty-page-list case.
- `pnpm run validate` passes clean (type-check root + functions, lint, format-check, root tests, functions tests, test-count guard).
- No runtime browser verification: reaching a migrated widget requires real Google Sign-In plus live Firestore, and `VITE_AUTH_BYPASS` short-circuits the Firestore listeners the bug depends on. The failing-then-passing test reproduction stands in for it.

## Related data-loss finding — not fixed here

The task also asked whether the same stripping breaks dashboard JSON export/import. Findings:

- The Sidebar JSON export/import described in `CLAUDE.md` **does not exist in the codebase** — that documentation is stale. No dashboard-to-file download or `accept=".json"` import UI remains.
- The equivalent paths that *do* exist have the same defect, and each loses drawing content for migrated widgets because they copy only the dashboard document:
  - **Google Drive `.spart` sync** — `googleDriveService.exportDashboard` does `JSON.stringify(dashboard)`, so the Drive backup stores empty `pages[].objects`.
  - **`duplicateDashboard`** (`context/DashboardContext.tsx:3654`) — `structuredClone` of the dashboard doc; the `/drawings/...` subcollections are never copied, so a duplicated board's whiteboards come up empty.
  - **Synced/shared boards** — already documented as a known limitation in `useDrawingObjectsDoc.ts:39-53`.

These are genuine data-loss bugs but need a different fix (hydrating subcollections at write time, plus re-writing them on import/duplicate) and touch the sync pipeline, so they're deliberately left out of this PR rather than bundled in.

---
_Generated by [Claude Code](https://claude.ai/code/session_015yPzPeEDFYu1zq89Z8w4Jd)_