### PR TITLE
fix(a11y): retrofit orphaned SettingsLabel group headings to as="span" (D3, run 50)

### DIFF
--- a/components/admin/BackgroundManager/GridPresetCard.tsx
+++ b/components/admin/BackgroundManager/GridPresetCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { Video, Pencil, Check, X, Tag, Plus, Trash2, Star } from 'lucide-react';
 import { Toggle } from '@/components/common/Toggle';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
@@ -31,6 +31,8 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
 }) => {
   const BUILDINGS = useAdminBuildings();
   const isVideo = Boolean(extractYouTubeId(preset.url));
+  const accessLevelLabelId = useId();
+  const buildingsLabelId = useId();
 
   return (
     <div className="bg-white border border-slate-200 rounded-xl overflow-hidden hover:border-brand-blue-light transition-all flex flex-col h-auto">
@@ -149,8 +151,14 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
 
         {/* Access Level */}
         <div className="shrink-0">
-          <SettingsLabel>Access Level</SettingsLabel>
-          <div className="flex gap-1">
+          <SettingsLabel as="span" id={accessLevelLabelId}>
+            Access Level
+          </SettingsLabel>
+          <div
+            className="flex gap-1"
+            role="group"
+            aria-labelledby={accessLevelLabelId}
+          >
             {(['admin', 'beta', 'public'] as AccessLevel[]).map((level) => (
               <button
                 key={level}
@@ -235,8 +243,14 @@ export const GridPresetCard: React.FC<PresetCardProps> = ({
 
         {/* Building Assignment */}
         <div className="shrink-0">
-          <SettingsLabel>Buildings</SettingsLabel>
-          <div className="flex flex-wrap gap-1">
+          <SettingsLabel as="span" id={buildingsLabelId}>
+            Buildings
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap gap-1"
+            role="group"
+            aria-labelledby={buildingsLabelId}
+          >
             {BUILDINGS.map((b) => {
               const assigned = (preset.buildingIds ?? []).includes(b.id);
               return (

--- a/components/common/SurfaceColorSettings.tsx
+++ b/components/common/SurfaceColorSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { Palette, LucideIcon } from 'lucide-react';
 import { WidgetConfig } from '@/types';
 import { SettingsLabel } from './SettingsLabel';
@@ -21,12 +21,19 @@ export const SurfaceColorSettings = <
 }: SurfaceColorSettingsProps<T>) => {
   const cardColor = config.cardColor ?? '#ffffff';
   const cardOpacity = config.cardOpacity ?? 1;
+  const surfaceLabelId = useId();
 
   return (
     <div>
-      <SettingsLabel icon={icon}>{label}</SettingsLabel>
+      <SettingsLabel as="span" id={surfaceLabelId} icon={icon}>
+        {label}
+      </SettingsLabel>
       <div className="space-y-3 rounded-xl border border-slate-100 bg-slate-50 p-3">
-        <div className="flex flex-wrap gap-2">
+        <div
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-labelledby={surfaceLabelId}
+        >
           {SURFACE_COLOR_PRESETS.map((color) => (
             <button
               key={color}

--- a/components/common/TextSizePresetSettings.tsx
+++ b/components/common/TextSizePresetSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { Type } from 'lucide-react';
 import { SettingsLabel } from './SettingsLabel';
 import { TEXT_SIZE_PRESETS } from '@/config/widgetAppearance';
@@ -40,10 +40,18 @@ export const TextSizePresetSettings: React.FC<TextSizePresetSettingsProps> = ({
         ? scaleToPreset(fallbackScale)
         : 'medium');
 
+  const textSizeLabelId = useId();
+
   return (
     <div>
-      <SettingsLabel icon={Type}>Text Size</SettingsLabel>
-      <div className="grid grid-cols-2 gap-2">
+      <SettingsLabel as="span" id={textSizeLabelId} icon={Type}>
+        Text Size
+      </SettingsLabel>
+      <div
+        className="grid grid-cols-2 gap-2"
+        role="group"
+        aria-labelledby={textSizeLabelId}
+      >
         {TEXT_SIZE_PRESETS.map((preset) => (
           <button
             type="button"

--- a/components/common/TypographySettings.tsx
+++ b/components/common/TypographySettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { Type, Palette } from 'lucide-react';
 import { SettingsLabel } from './SettingsLabel';
 import { FONTS } from '@/config/fonts';
@@ -25,12 +25,20 @@ export const TypographySettings = <
   showColorPicker = true,
 }: TypographySettingsProps<T>) => {
   const { fontFamily = 'global', fontColor = '#334155' } = config;
+  const typographyLabelId = useId();
+  const textColorLabelId = useId();
 
   return (
     <>
       <div>
-        <SettingsLabel icon={Type}>Typography</SettingsLabel>
-        <div className="grid grid-cols-4 gap-2">
+        <SettingsLabel as="span" id={typographyLabelId} icon={Type}>
+          Typography
+        </SettingsLabel>
+        <div
+          className="grid grid-cols-4 gap-2"
+          role="group"
+          aria-labelledby={typographyLabelId}
+        >
           {FONTS.map((f) => (
             <button
               key={f.id}
@@ -62,8 +70,14 @@ export const TypographySettings = <
 
       {showColorPicker && (
         <div>
-          <SettingsLabel icon={Palette}>Text Color</SettingsLabel>
-          <div className="flex flex-wrap gap-2 px-1 mb-2">
+          <SettingsLabel as="span" id={textColorLabelId} icon={Palette}>
+            Text Color
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap gap-2 px-1 mb-2"
+            role="group"
+            aria-labelledby={textColorLabelId}
+          >
             {TEXT_COLOR_PRESETS.map((color) => (
               <button
                 key={color}

--- a/components/widgets/ClockWidget/Settings.tsx
+++ b/components/widgets/ClockWidget/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, ClockConfig } from '@/types';
@@ -56,6 +56,9 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
     { id: 'minimal', label: t('widgets.clock.styles.minimal') },
   ];
 
+  const clockStyleLabelId = useId();
+  const colorPaletteLabelId = useId();
+
   return (
     <div className="space-y-6">
       {/* Font Family — shared picker (Clock manages color via themeColor below) */}
@@ -69,10 +72,14 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Clock Style */}
       <div>
-        <SettingsLabel icon={Sparkles}>
+        <SettingsLabel as="span" id={clockStyleLabelId} icon={Sparkles}>
           {t('widgets.clock.displayStyle')}
         </SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <div
+          className="flex bg-slate-100 p-1 rounded-xl"
+          role="group"
+          aria-labelledby={clockStyleLabelId}
+        >
           {styles.map((s) => (
             <button
               key={s.id}
@@ -92,10 +99,14 @@ export const ClockAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Color & Glow */}
       <div className="flex items-end justify-between gap-4">
         <div className="flex-1">
-          <SettingsLabel icon={Palette}>
+          <SettingsLabel as="span" id={colorPaletteLabelId} icon={Palette}>
             {t('widgets.clock.colorPalette')}
           </SettingsLabel>
-          <div className="flex gap-1.5">
+          <div
+            className="flex gap-1.5"
+            role="group"
+            aria-labelledby={colorPaletteLabelId}
+          >
             {colors.map((c) => (
               <button
                 key={c}

--- a/components/widgets/Countdown/Settings.tsx
+++ b/components/widgets/Countdown/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useDashboard } from '@/context/useDashboard';
 import { WidgetData, CountdownConfig } from '@/types';
 import { Toggle } from '@/components/common/Toggle';
@@ -177,13 +177,20 @@ export const CountdownAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
     updateWidget(widget.id, { config: { ...config, ...updates } });
 
   const eventColor = config.eventColor ?? '#2d3f89';
+  const eventTitleColorLabelId = useId();
 
   return (
     <div className="space-y-6">
       <TypographySettings config={config} updateConfig={updateConfig} />
       <div>
-        <SettingsLabel icon={Palette}>Event Title Color</SettingsLabel>
-        <div className="flex flex-wrap gap-2 px-1 mb-2">
+        <SettingsLabel as="span" id={eventTitleColorLabelId} icon={Palette}>
+          Event Title Color
+        </SettingsLabel>
+        <div
+          className="flex flex-wrap gap-2 px-1 mb-2"
+          role="group"
+          aria-labelledby={eventTitleColorLabelId}
+        >
           {TEXT_COLOR_PRESETS.map((color) => (
             <button
               key={color}

--- a/components/widgets/LunchCount/Settings.tsx
+++ b/components/widgets/LunchCount/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { WidgetData, LunchCountConfig } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { RosterModeControl } from '@/components/common/RosterModeControl';
@@ -72,6 +72,7 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
   const schoolSite: LunchCountConfig['schoolSite'] =
     toLunchCountSchoolSite(rawSchoolSite ?? '') ?? 'schumann-elementary';
   const gradeOptions = GRADE_OPTIONS[schoolSite];
+  const gradeLevelLabelId = useId();
 
   /** When the school site changes, clear the grade selection if it's no longer valid */
   const handleSiteChange = (newSite: LunchCountConfig['schoolSite']) => {
@@ -189,8 +190,14 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
 
         {/* Grade Level */}
         <div>
-          <SettingsLabel icon={GraduationCap}>Grade Level</SettingsLabel>
-          <div className="flex gap-2 flex-wrap">
+          <SettingsLabel as="span" id={gradeLevelLabelId} icon={GraduationCap}>
+            Grade Level
+          </SettingsLabel>
+          <div
+            className="flex gap-2 flex-wrap"
+            role="group"
+            aria-labelledby={gradeLevelLabelId}
+          >
             {gradeOptions.map((opt) => (
               <button
                 key={opt.value}

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -16,6 +16,8 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as MaterialsConfig;
   const availableMaterialsLabelId = useId();
+  const typographyLabelId = useId();
+  const titleColorLabelId = useId();
   const {
     selectedItems = [],
     activeItems = [],
@@ -111,8 +113,14 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
 
         <div>
-          <SettingsLabel icon={Type}>Typography</SettingsLabel>
-          <div className="grid grid-cols-4 gap-2">
+          <SettingsLabel as="span" id={typographyLabelId} icon={Type}>
+            Typography
+          </SettingsLabel>
+          <div
+            className="grid grid-cols-4 gap-2"
+            role="group"
+            aria-labelledby={typographyLabelId}
+          >
             {fonts.map((f) => (
               <button
                 key={f.id}
@@ -139,8 +147,14 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
 
         <div>
-          <SettingsLabel icon={Palette}>Title Color</SettingsLabel>
-          <div className="flex flex-wrap gap-2">
+          <SettingsLabel as="span" id={titleColorLabelId} icon={Palette}>
+            Title Color
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap gap-2"
+            role="group"
+            aria-labelledby={titleColorLabelId}
+          >
             {WIDGET_PALETTE.map((c) => (
               <button
                 key={c}

--- a/components/widgets/MusicWidget/Settings.tsx
+++ b/components/widgets/MusicWidget/Settings.tsx
@@ -349,11 +349,20 @@ export const MusicAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
   const textColors = [...WIDGET_PALETTE, '#ffffff'];
 
+  const backgroundLabelId = useId();
+  const textColorLabelId = useId();
+
   return (
     <div className="grid grid-cols-2 gap-4">
       <div>
-        <SettingsLabel icon={Palette}>Background</SettingsLabel>
-        <div className="flex flex-wrap gap-1.5 mt-1">
+        <SettingsLabel as="span" id={backgroundLabelId} icon={Palette}>
+          Background
+        </SettingsLabel>
+        <div
+          className="flex flex-wrap gap-1.5 mt-1"
+          role="group"
+          aria-labelledby={backgroundLabelId}
+        >
           {bgColors.map((c) => (
             <button
               key={c.hex}
@@ -378,8 +387,14 @@ export const MusicAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
       </div>
       <div>
-        <SettingsLabel icon={Palette}>Text Color</SettingsLabel>
-        <div className="flex flex-wrap gap-1.5 mt-1">
+        <SettingsLabel as="span" id={textColorLabelId} icon={Palette}>
+          Text Color
+        </SettingsLabel>
+        <div
+          className="flex flex-wrap gap-1.5 mt-1"
+          role="group"
+          aria-labelledby={textColorLabelId}
+        >
           {textColors.map((c) => (
             <button
               key={c}

--- a/components/widgets/TimeTool/Settings.tsx
+++ b/components/widgets/TimeTool/Settings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimeToolConfig, WidgetData } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
@@ -74,14 +74,22 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
     (w) => w.type === 'stations'
   );
 
+  const modeLabelId = useId();
+  const displayStyleLabelId = useId();
+  const alertSoundLabelId = useId();
+
   return (
     <div className="space-y-6 p-1">
       {/* Mode Selection */}
       <div>
-        <SettingsLabel icon={TimerIcon}>
+        <SettingsLabel as="span" id={modeLabelId} icon={TimerIcon}>
           {t('widgets.timeTool.mode')}
         </SettingsLabel>
-        <div className="grid grid-cols-2 gap-2">
+        <div
+          className="grid grid-cols-2 gap-2"
+          role="group"
+          aria-labelledby={modeLabelId}
+        >
           {TIME_TOOL_MODES.map((m) => (
             <button
               key={m}
@@ -130,10 +138,14 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Display Style */}
       <div>
-        <SettingsLabel icon={Sparkles}>
+        <SettingsLabel as="span" id={displayStyleLabelId} icon={Sparkles}>
           {t('widgets.clock.displayStyle')}
         </SettingsLabel>
-        <div className="grid grid-cols-2 gap-2">
+        <div
+          className="grid grid-cols-2 gap-2"
+          role="group"
+          aria-labelledby={displayStyleLabelId}
+        >
           {TIME_TOOL_VISUAL_TYPES.map((v) => (
             <button
               key={v}
@@ -158,10 +170,14 @@ export const TimeToolSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Sound Selector */}
       <div>
-        <SettingsLabel icon={Bell}>
+        <SettingsLabel as="span" id={alertSoundLabelId} icon={Bell}>
           {t('widgets.timeTool.alertSound')}
         </SettingsLabel>
-        <div className="grid grid-cols-4 gap-2">
+        <div
+          className="grid grid-cols-4 gap-2"
+          role="group"
+          aria-labelledby={alertSoundLabelId}
+        >
           {SOUNDS.map((s) => (
             <button
               key={s}
@@ -472,6 +488,9 @@ export const TimeToolAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
   const colors = WIDGET_PALETTE;
 
+  const numberStyleLabelId = useId();
+  const colorPaletteLabelId = useId();
+
   return (
     <div className="space-y-6 p-1">
       {/* Font Family — shared picker (TimeTool manages color via themeColor below) */}
@@ -485,10 +504,14 @@ export const TimeToolAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
 
       {/* Clock Style */}
       <div>
-        <SettingsLabel icon={Sparkles}>
+        <SettingsLabel as="span" id={numberStyleLabelId} icon={Sparkles}>
           {t('widgets.timeTool.numberStyle')}
         </SettingsLabel>
-        <div className="flex bg-slate-100 p-1 rounded-xl">
+        <div
+          className="flex bg-slate-100 p-1 rounded-xl"
+          role="group"
+          aria-labelledby={numberStyleLabelId}
+        >
           {styles.map((s) => (
             <button
               key={s.id}
@@ -508,10 +531,14 @@ export const TimeToolAppearanceSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Color & Glow */}
       <div className="flex items-end justify-between gap-4">
         <div className="flex-1">
-          <SettingsLabel icon={Palette}>
+          <SettingsLabel as="span" id={colorPaletteLabelId} icon={Palette}>
             {t('widgets.clock.colorPalette')}
           </SettingsLabel>
-          <div className="flex gap-1.5">
+          <div
+            className="flex gap-1.5"
+            role="group"
+            aria-labelledby={colorPaletteLabelId}
+          >
             {colors.map((c) => (
               <button
                 key={c}


### PR DESCRIPTION
## Summary

Nightly unifier run 50 — Dimension D3 (Settings Panel Label Primitives), continuing the runs 26–49 group-heading retrofit series.

**Canonical form:** `<SettingsLabel as="span" id={useId()} icon={...}>Label</SettingsLabel>` paired with `role="group" aria-labelledby={id}` on the sibling button-group container, for any `<SettingsLabel>` that heads a *group* of controls (checkbox/chip/button groups) rather than pairing 1:1 with one form input. A bare `<label>` in that shape is semantically orphaned — it has no single control to associate with.

**Instances unified (10, across 9 files):**
- `components/common/TypographySettings.tsx` — "Typography" font grid, "Text Color" swatch grid (shared primitive, used by many widgets)
- `components/common/TextSizePresetSettings.tsx` — "Text Size" preset grid (shared primitive)
- `components/common/SurfaceColorSettings.tsx` — surface/card color swatch grid (shared primitive)
- `components/admin/BackgroundManager/GridPresetCard.tsx` — "Access Level" and "Buildings" button groups
- `components/widgets/ClockWidget/Settings.tsx` — "Display Style" and "Color Palette" groups
- `components/widgets/Countdown/Settings.tsx` — "Event Title Color" swatch group
- `components/widgets/LunchCount/Settings.tsx` — "Grade Level" group
- `components/widgets/MaterialsWidget/Settings.tsx` — "Typography" and "Title Color" groups
- `components/widgets/MusicWidget/Settings.tsx` — "Background" and "Text Color" groups
- `components/widgets/TimeTool/Settings.tsx` — "Mode", "Display Style", "Alert Sound", "Number Style", "Color Palette" groups

**Enforcement / recurrence prevention:** 3 of the 9 files are *shared* settings primitives (`TypographySettings`, `TextSizePresetSettings`, `SurfaceColorSettings`) consumed by many widgets' Settings panels. Fixing the pattern at the source means every current and future consumer of these primitives inherits the correct accessible markup automatically, rather than needing its own retrofit pass.

**Behavior/visual preservation evidence:**
- `SettingsLabel.tsx`'s `combinedClasses` computation is identical regardless of the `as` prop — only the rendered tag (`<span>` vs `<label>`) and the `id`/`role`/`aria-labelledby` wiring differ. Verified by reading the component source directly. Zero visual delta.
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint <changed files> --max-warnings 0` — clean
- `pnpm exec prettier --check <changed files>` — clean
- `pnpm test` — 7282/7282 tests passed (2031/2031 suites)
- `pnpm run build` — clean, including SSR prerender
- Rebased onto latest `dev-paul` (unrelated docs-only commits since branch creation) and re-verified `tsc`/`build` clean post-rebase.

**Risk tag:** mechanical (pure DOM-tag + ARIA-attribute equivalence, no visual or behavioral change).

**Deferred to backlog:** none new. All other D3 candidates checked this run resolved to already-catalogued Intentional Exceptions or NEEDS REVIEW items requiring a human decision (unchanged, not touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_0159SEQARMfkAK92y9G8W4i2)_