### PR TITLE
fix(deps): bump postcss to 8.5.25 (source-map arbitrary file read)

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "jsdom": "^27.4.0",
     "lint-staged": "^16.2.7",
     "oauth-1.0a": "^2.2.6",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.25",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 4.1.8(vitest@4.1.8)
       autoprefixer:
         specifier: ^10.4.23
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.25)
       axios:
         specifier: ^1.15.0
         version: 1.15.0
@@ -214,8 +214,8 @@ importers:
         specifier: ^2.2.6
         version: 2.2.6
       postcss:
-        specifier: ^8.5.6
-        version: 8.5.6
+        specifier: ^8.5.25
+        version: 8.5.25
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -4615,8 +4615,8 @@ packages:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5040,8 +5040,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -8575,13 +8575,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.23(postcss@8.5.6):
+  autoprefixer@10.4.23(postcss@8.5.25):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001764
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -11500,7 +11500,7 @@ snapshots:
 
   nano-spawn@2.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -11878,29 +11878,29 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.6):
+  postcss-import@15.1.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.6):
+  postcss-js@4.1.0(postcss@8.5.25):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.6
+      postcss: 8.5.25
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.25)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.6
+      postcss: 8.5.25
       yaml: 2.9.0
 
-  postcss-nested@6.2.0(postcss@8.5.6):
+  postcss-nested@6.2.0(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.25
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -11910,9 +11910,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12750,11 +12750,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.6)
+      postcss: 8.5.25
+      postcss-import: 15.1.0(postcss@8.5.25)
+      postcss-js: 4.1.0(postcss@8.5.25)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.25)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.25)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -13138,7 +13138,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-      postcss: 8.5.6
+      postcss: 8.5.25
       rollup: 4.60.2
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

Resolves the MEDIUM `postcss@8.5.6` item from the dependency-audit scheduled-task journal. `postcss` is a direct devDependency (dev/build tooling only — consumed by `autoprefixer`, `tailwindcss`, `vite`, and the `postcss-*` plugins), so there is **no production runtime impact**.

Two advisories affect the installed 8.5.6:

- **GHSA-6g55-p6wh-862q** (high): arbitrary file read via `sourceMappingURL` when the `from` option is unset. Patched >=8.5.12.
- **GHSA-fxqj-rqcc-2cmp** (moderate): incomplete fix of the above — an attacker-controlled `sourceMappingURL` still reads arbitrary `.map` files when `from` is unset even after the 8.5.12 patch. Patched >=8.5.23.

Both require >=8.5.23. Bumped the direct devDependency from `^8.5.6` to `^8.5.25` (latest).

## Changes

- `package.json`: `postcss` devDependency `^8.5.6` → `^8.5.25`
- `pnpm-lock.yaml`: postcss-scoped resolution updates (8.5.6 → 8.5.25)

## Verification

- `pnpm why postcss` → single `postcss@8.5.25` across all paths
- `pnpm audit` no longer reports either postcss GHSA (root vuln count 135 → 133)
- `prettier --check package.json pnpm-lock.yaml` → clean
- `pnpm run type-check` → exit 0
- `pnpm run lint` (root + functions, `--max-warnings 0`) → exit 0

The diff is exactly `package.json` + `pnpm-lock.yaml`; the dependency-audit journal record lives separately on the `scheduled-tasks` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhsBmaeBjxgCf7vEk77HqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhsBmaeBjxgCf7vEk77HqZ)_