### PR TITLE
fix(widgets): stop Escape propagation in RandomClassContextButton popover

### DIFF
--- a/components/widgets/random/RandomClassContextButton.test.tsx
+++ b/components/widgets/random/RandomClassContextButton.test.tsx
@@ -281,4 +281,41 @@ describe('RandomClassContextButton', () => {
     ).not.toBeInTheDocument();
     expect(container.firstChild).not.toBeNull();
   });
+
+  // Regression: the popover is portalled to document.body outside any
+  // `.widget` DraggableWindow ancestor and closed on Escape via a
+  // document-level keydown listener that never called stopPropagation().
+  // The unhandled keydown kept bubbling to DashboardView's global
+  // window-level Escape handler, which — finding no `.widget` ancestor for
+  // the portalled popover — falls back to minimizing the topmost z-index
+  // widget on the board. Same bug class already fixed for ActiveClassChip,
+  // ToolDockItem, RemoteControlMenu, ClassRosterMenu, and OverflowMenu.
+  it('closes the popover on Escape and stops propagation before it reaches window listeners', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    mockUseDashboard([r1, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r1}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
 });

--- a/components/widgets/random/RandomClassContextButton.tsx
+++ b/components/widgets/random/RandomClassContextButton.tsx
@@ -80,7 +80,13 @@ export const RandomClassContextButton: React.FC<
       closeMenu();
     };
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeMenu();
+      if (event.key !== 'Escape') return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which falls
+      // back to minimizing the topmost widget (see #2266 pattern).
+      event.stopPropagation();
+      closeMenu();
     };
     let animationFrameId = 0;
     const handleReposition = () => {


### PR DESCRIPTION
## Root cause

`components/widgets/random/RandomClassContextButton.tsx` — the class-switcher popover (rendered inside the live `RandomWidget`) is portalled to `document.body` outside any `.widget` `DraggableWindow` ancestor, and dismissed on Escape via a `document.addEventListener('keydown', ...)` listener that never called `stopPropagation()`.

`components/layout/DashboardView.tsx` installs a global `window`-level Escape handler. When it fires and finds no `.widget` ancestor for the focused element (always true for portal-to-body content), it falls back to minimizing the topmost z-index widget on the whole board. Dismissing this small popover with Escape would therefore silently minimize (or un-flip settings on) an unrelated widget elsewhere on the dashboard.

This is the same bug class already fixed 4 times in this repo (#2266, #2289, #2314, #2373 — the last of which fixed `ActiveClassChip`, the component `RandomClassContextButton` is a documented fork of). The fork reintroduced the gap that `ActiveClassChip` had already patched.

## Fix

Added `event.stopPropagation()` in the popover's Escape branch before `closeMenu()`, matching the established pattern (and comment) from the `ActiveClassChip` fix verbatim.

## Rejected band-aid

Did not touch `DashboardView.tsx`'s fallback-to-topmost-widget logic — that's the shared root cause behind all 5 instances of this bug class and is out of this fix's file scope. The sustainable fix is for each portalled popover to own its Escape interaction via `stopPropagation()`, consistent with all prior fixes.

## Regression test

`components/widgets/random/RandomClassContextButton.test.tsx` — opens the popover, attaches a `window`-level `keydown` spy, fires Escape on `document`, asserts the popover closed **and** the spy was never called.

- **Fail-before** (orchestrator-verified via file-swap against `dev-paul`): `expected "vi.fn()" to not be called at all, but actually been called 1 times`
- **Pass-after**: 13/13 tests in file passing

## Verification

- `pnpm run validate` (type-check:all, lint, format:check, unit + functions tests, test:counts) — clean
- `pnpm run build` — succeeded
- Independently re-verified by the orchestrator via file-swap fail-before/pass-after, and a full isolated `validate`+`build` re-run post-rebase onto latest `dev-paul`

## Backlog (not fixed here — flagged for a future run)

Same bug class, confirmed live but not yet fixed: `components/widgets/LiveControl.tsx`, `components/widgets/DrawingWidget/PageStrip.tsx`. `CatalystSetPickerPopover.tsx` is a false alarm (no Escape handling at all, dismissal is click-outside only).

## Risk

**contained** — single-file, minimal diff, matches an established and repeatedly-shipped fix pattern.

---
Generated by the nightly `debugger` routine (see `docs/routines/debugger.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuMip4ugAkSEzB4pAR7TzS)_