### PR TITLE
fix(common): stop Escape from AIGeneratorOverlay reaching ancestor Modal

### DIFF
--- a/components/common/AIGeneratorOverlay.tsx
+++ b/components/common/AIGeneratorOverlay.tsx
@@ -65,7 +65,10 @@ export const AIGeneratorOverlay: React.FC<AIGeneratorOverlayProps> = ({
       aria-label={title}
       className="absolute inset-0 z-20 bg-white/95 backdrop-blur-sm flex items-center justify-center p-6 animate-in fade-in duration-200"
       onKeyDown={(e) => {
-        if (e.key === 'Escape') onClose();
+        if (e.key !== 'Escape') return;
+        // Stop the bubble to the ancestor Modal's window-level Escape handler, which would otherwise also close/discard the whole editor (same bug class as #2266/#2289/#2314).
+        e.stopPropagation();
+        onClose();
       }}
     >
       <div className="w-full max-w-sm space-y-4">

--- a/tests/components/common/AIGeneratorOverlay.escapePropagation.test.tsx
+++ b/tests/components/common/AIGeneratorOverlay.escapePropagation.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Regression test: AIGeneratorOverlay's Escape handler closed the AI
+ * generator panel, but never called stopPropagation(). The overlay is
+ * rendered as `children` inside the shared `Modal` primitive (via
+ * EditorModalShell, used by the Quiz/Video Activity/Mini App editors).
+ * Modal registers its own unconditional `window`-level Escape handler
+ * that calls the ancestor editor's onClose. Because AIGeneratorOverlay
+ * never stopped propagation, pressing Escape while focus was inside the
+ * "Draft with AI" panel (e.g. typing in the prompt textarea) bubbled past
+ * the overlay and ALSO triggered Modal's onClose — closing/discarding the
+ * entire editor instead of just dismissing the small AI panel.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * onClose(), matching the same fix already applied to ToolDockItem,
+ * RemoteControlMenu, ClassRosterMenu, OverflowMenu, and ActiveClassChip
+ * for this exact bug class.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { Modal } from '@/components/common/Modal';
+import { AIGeneratorOverlay } from '@/components/common/AIGeneratorOverlay';
+
+afterEach(() => {
+  cleanup();
+  delete (document.body.style as { overflow?: string }).overflow;
+  document.body.style.overflow = '';
+});
+
+describe('AIGeneratorOverlay — Escape does not leak to ancestor Modal', () => {
+  it('closes only the overlay on Escape, not the ancestor Modal', () => {
+    const onModalClose = vi.fn();
+    const onOverlayClose = vi.fn();
+
+    render(
+      <Modal isOpen={true} onClose={onModalClose} title="Editor">
+        <AIGeneratorOverlay
+          open={true}
+          onClose={onOverlayClose}
+          title="Draft with AI"
+          generating={false}
+          canGenerate={true}
+          onGenerate={vi.fn()}
+        >
+          <textarea aria-label="prompt" />
+        </AIGeneratorOverlay>
+      </Modal>
+    );
+
+    const textarea = screen.getByLabelText('prompt');
+    textarea.focus();
+    fireEvent.keyDown(textarea, { key: 'Escape', bubbles: true });
+
+    expect(onOverlayClose).toHaveBeenCalledTimes(1);
+    // This is the crux of the regression: Modal's Escape handler is a
+    // window-level `keydown` listener. If the overlay's own handler
+    // doesn't stopPropagation, the event still reaches window and closes
+    // (or prompts to discard) the whole editor.
+    expect(onModalClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Root cause

`AIGeneratorOverlay` (shared "Draft with AI" panel used by the Quiz/Video Activity/Mini App editors, all mounted via `EditorModalShell` → `Modal`) handled Escape with no `stopPropagation()`. `Modal.tsx` (the ancestor full-screen editor shell) registers its own unconditional `window`-level Escape handler that closes/prompts-to-discard the editor. Pressing Escape while focus was inside the AI panel (e.g. typing in the prompt textarea) bubbled past the overlay and also fired the outer editor Modal's handler — closing or prompting to discard the *entire* editor instead of just dismissing the small AI panel.

Confirmed live: `AIGeneratorOverlay` is consumed by `QuizEditor.tsx`, `VideoActivityEditor.tsx`, and `MiniAppEditorModal.tsx`.

## Fix

Added `e.stopPropagation()` in the overlay's Escape handler before calling `onClose()`, consistent with the same bug class's established fix location in `ToolDockItem`/`RemoteControlMenu`/`ClassRosterMenu` (#2266), `BoardNavFab`/`CollectionSwitcherMenu`/`BoardActionsFab` (#2289), and `OverflowMenu` (#2314).

## Rejected band-aid

Did not teach `Modal`/`isEscapeFromWidgetInput` to special-case this overlay — the established, already-repeated pattern is for the nested popover/overlay itself to own `stopPropagation()`.

## Regression test

`tests/components/common/AIGeneratorOverlay.escapePropagation.test.tsx` — renders the real `Modal` wrapping the real `AIGeneratorOverlay`, focuses a child textarea, fires Escape, asserts the overlay's own `onClose` fired but the ancestor `Modal`'s `onClose` did not.

- **Fail-before** (orchestrator-verified via file-swap against `dev-paul`): `expected "vi.fn()" to not be called at all, but actually been called 1 times`
- **Pass-after**: passing (ran together with `Modal.test.tsx` and `ActiveClassChip.escapePropagation.test.tsx`, 18/18 total, no regression on the sibling pattern)

## Verification

- `pnpm run validate` — `598 test files / 7283 tests` (root), `40 test files / 778 tests` (functions), test:counts guard passed
- `pnpm run build` — succeeded
- Independently re-verified by the orchestrator via file-swap fail-before/pass-after, and a full isolated `validate`+`build` re-run post-rebase onto latest `dev-paul`

## Backlog (not fixed here — flagged for a future run)

`QuizEditorModal.tsx`'s own redundant `window`-level Escape listener for `showAiPrompt` still doesn't `stopPropagation()` — no longer observably harmful in the common case now that this fix stops the event at the overlay, but could still theoretically race with `Modal`'s handler in a focus-outside-overlay case. Out of this area's glob (`components/widgets/QuizWidget/**`).

## Risk

**contained** — single-file, minimal diff, matches an established and repeatedly-shipped fix pattern.

---
Generated by the nightly `debugger` routine (see `docs/routines/debugger.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuMip4ugAkSEzB4pAR7TzS)_