### PR TITLE
fix(admin): lowercase sign-in domain before persisting in DomainsView

### DIFF
--- a/components/admin/Organization/views/DomainsView.tsx
+++ b/components/admin/Organization/views/DomainsView.tsx
@@ -284,16 +284,21 @@ const AddDomainModal: React.FC<{
           <Btn
             variant="primary"
             disabled={!domain}
-            onClick={() =>
+            onClick={() => {
+              const normalized = domain.trim().toLowerCase();
               onAdd({
-                domain: domain.startsWith('@') ? domain : `@${domain}`,
+                // Lowercased so it exact-matches the lowercased email/hd
+                // candidate resolveOrgIdForDomain() queries against.
+                domain: normalized.startsWith('@')
+                  ? normalized
+                  : `@${normalized}`,
                 authMethod: method,
                 status: 'pending',
                 role: 'staff',
                 users: 0,
                 addedAt: new Date().toISOString().slice(0, 10),
-              })
-            }
+              });
+            }}
           >
             Send verification
           </Btn>

--- a/tests/components/admin/Organization/DomainsView.test.tsx
+++ b/tests/components/admin/Organization/DomainsView.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Regression test: adding a sign-in domain must persist it lowercased.
+ *
+ * `resolveOrgIdForDomain` (functions/src/classlinkShared.ts) resolves a
+ * signed-in user's org via an EXACT Firestore string match on the `domain`
+ * field, always comparing against a lowercased candidate derived from the
+ * user's verified email/hd claim (functions/src/resolveOrgForUser.ts). If an
+ * admin types a domain with any uppercase letters in the "Add sign-in
+ * domain" form, the stored `domain` field never matches that lowercased
+ * candidate, and every real user on that domain silently fails to resolve
+ * to the organization — even though the admin panel shows the domain as
+ * added/verified. This mirrors the established "lowercase on write" pattern
+ * already used by every other admin email/domain input in this app (see
+ * BetaUsersPanel, GlobalPermissionsManager, BackgroundManager).
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DomainsView } from '@/components/admin/Organization/views/DomainsView';
+import type { DomainRecord } from '@/components/admin/Organization/types';
+
+describe('DomainsView — Add sign-in domain', () => {
+  it('lowercases the domain before handing it to onAdd', () => {
+    const onAdd = vi.fn();
+    render(<DomainsView domains={[]} onAdd={onAdd} onRemove={vi.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /add domain/i })[0]);
+
+    const input = screen.getByPlaceholderText('orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Orono.K12.MN.US' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /send verification/i }));
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    const record = onAdd.mock.calls[0][0] as Partial<DomainRecord>;
+    expect(record.domain).toBe('@orono.k12.mn.us');
+  });
+});


### PR DESCRIPTION
## Root cause

`components/admin/Organization/views/DomainsView.tsx`'s "Add sign-in domain" form persisted the domain string exactly as an org admin typed it (only normalizing a missing leading `@`, no case-folding). `functions/src/classlinkShared.ts::resolveOrgIdForDomain` resolves a signed-in user's organization via an **exact Firestore string `==`** match on that same `domain` field, and `functions/src/resolveOrgForUser.ts` always lowercases the candidate domain it builds from the user's verified email/`hd` claim before querying (confirmed by reading both files — `normalizeEmailDomain()` lowercases, and the `hd` claim path does `'@' + hd.trim().toLowerCase()`).

So any domain saved with uppercase letters (e.g. an admin typing/pasting `Orono.K12.MN.US`) would never exact-match a real user's lowercased email domain — every teacher/student on that domain would silently fail org resolution, even though the admin panel showed the domain as added/verified.

Confirmed the write path: `hooks/useOrgDomains.ts`'s `addDomain()` writes `domain: domain.domain` verbatim with no normalization of its own — `DomainsView.tsx` (the point of input capture) is the only place that needs the fix, and this is the codebase's established convention (`GlobalPermissionsManager`, `BackgroundManager` already lowercase-on-write for the same class of admin-entered value; `BetaUsersPanel` was fixed for the identical pattern on a prior night).

## Fix

Trim + lowercase the domain string before constructing the record passed to `onAdd`.

## Rejected band-aid

Did not add case-insensitive matching in the Cloud Function query — out of this area's glob, and would require a Firestore field-normalization migration for existing docs. Fixed at the point of input capture instead, matching the codebase's established convention.

## Regression test

`tests/components/admin/Organization/DomainsView.test.tsx` — opens the "Add sign-in domain" modal, types `Orono.K12.MN.US`, submits, asserts `onAdd` was called with `domain: '@orono.k12.mn.us'`.

- **Fail-before** (orchestrator-verified via file-swap against `dev-paul`): `expected '@Orono.K12.MN.US' to be '@orono.k12.mn.us'`
- **Pass-after**: passing

## Verification

- `pnpm run validate` — clean (root + functions, test:counts guard passed)
- `pnpm run build` — succeeded
- Independently re-verified by the orchestrator via file-swap fail-before/pass-after, and a full isolated `validate`+`build` re-run post-rebase onto latest `dev-paul`

## Backlog (not fixed here — flagged for a future run)

If any pre-existing domain docs were already written with mixed case before this fix, they'll need a one-time backfill migration (Cloud Functions, out of this area's glob) to lowercase the stored `domain` field in Firestore — this PR only fixes new writes going forward.

## Risk

**contained** — single-file UI fix; the noted backfill-migration follow-up (if needed) is a separate, larger piece of work tracked in the backlog, not part of this PR.

---
Generated by the nightly `debugger` routine (see `docs/routines/debugger.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuMip4ugAkSEzB4pAR7TzS)_