### PR TITLE
fix(widgets): stop Escape propagation in RandomClassContextButton popover

### DIFF
--- a/components/widgets/random/RandomClassContextButton.test.tsx
+++ b/components/widgets/random/RandomClassContextButton.test.tsx
@@ -281,4 +281,32 @@ describe('RandomClassContextButton', () => {
     ).not.toBeInTheDocument();
     expect(container.firstChild).not.toBeNull();
   });
+
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    const r1 = makeRoster('r1', 'Period 1');
+    const r2 = makeRoster('r2', 'Period 2');
+    mockUseDashboard([r1, r2], 'r1');
+    render(
+      <RandomClassContextButton
+        roster={r1}
+        rosterMode="class"
+        onOpenAbsentModal={noop}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Active class: Period 1/i })
+    );
+    expect(screen.getAllByRole('menuitemradio')).toHaveLength(2);
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
 });

--- a/components/widgets/random/RandomClassContextButton.tsx
+++ b/components/widgets/random/RandomClassContextButton.tsx
@@ -81,13 +81,7 @@ export const RandomClassContextButton: React.FC<
     };
     const handleKey = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
-      // This popover is portalled to document.body, outside any `.widget`
-      // DraggableWindow. Without stopping propagation, an unhandled Escape
-      // here bubbles up to DashboardView's global window-level Escape
-      // handler, which falls back to targeting the topmost z-index widget
-      // and minimizes it — an unrelated widget disappearing just because
-      // this popover was dismissed. Matches the same fix applied to
-      // ToolDockItem, RemoteControlMenu, and ClassRosterMenu.
+      // Portalled outside .widget; stop propagation or DashboardView's global handler minimizes the topmost widget.
       event.stopPropagation();
       closeMenu();
     };

--- a/components/widgets/random/RandomClassContextButton.tsx
+++ b/components/widgets/random/RandomClassContextButton.tsx
@@ -80,7 +80,16 @@ export const RandomClassContextButton: React.FC<
       closeMenu();
     };
     const handleKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') closeMenu();
+      if (event.key !== 'Escape') return;
+      // This popover is portalled to document.body, outside any `.widget`
+      // DraggableWindow. Without stopping propagation, an unhandled Escape
+      // here bubbles up to DashboardView's global window-level Escape
+      // handler, which falls back to targeting the topmost z-index widget
+      // and minimizes it — an unrelated widget disappearing just because
+      // this popover was dismissed. Matches the same fix applied to
+      // ToolDockItem, RemoteControlMenu, and ClassRosterMenu.
+      event.stopPropagation();
+      closeMenu();
     };
     let animationFrameId = 0;
     const handleReposition = () => {


### PR DESCRIPTION
## Root cause

`RandomClassContextButton` (the Randomizer widget's class-switcher/mark-absent popover, mounted live in `RandomWidget.tsx`) portals its menu to `document.body` and closed it on Escape via a bare `document.addEventListener('keydown', ...)` handler that never called `stopPropagation()`.

Because the popover renders outside any `.widget`/`DraggableWindow` ancestor, the unhandled keydown bubbled from `document` up to `window`, where `DashboardView.tsx`'s global Escape handler fires unconditionally, finds no typing field / no `.widget` ancestor for the popover trigger, and falls back to minimizing the topmost z-index widget. Dismissing the Randomizer's class popover with Escape could silently minimize an unrelated widget on the live board.

This is the same "portalled popover Escape doesn't stopPropagation" bug class already fixed 4x elsewhere in this codebase (`ToolDockItem`/`RemoteControlMenu`/`ClassRosterMenu`, `BoardNavFab`/`CollectionSwitcherMenu`/`BoardActionsFab`, `OverflowMenu`) — this is a fresh, previously-unaudited instance in the Randomizer widget.

## Fix

Added `event.stopPropagation()` in the Escape handler, matching the established fix pattern exactly.

## Rejected band-aid

Guarding with `isEscapeFromWidgetInput(e)` (used elsewhere to protect text-input Escape) would not fix this — the popover isn't a text input, it's the unhandled-bubbling problem itself. The only root-cause fix is stopping propagation at the source, not special-casing `DashboardView`'s global handler to exclude this one popover.

## Regression test

`components/widgets/random/RandomClassContextButton.test.tsx` — opens the popover, dispatches a bubbling Escape `KeyboardEvent` on `document`, and asserts a `window`-level keydown spy is never invoked.

**Fail-before** (orchestrator-verified independently via file-swap against `dev-paul`'s pre-fix source):
```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 ❯ expect(windowKeydownSpy).not.toHaveBeenCalled();
 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

**Pass-after** (fix restored):
```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

## Full validation

`pnpm run validate` and `pnpm run build` both green on this branch (independently re-run by the orchestrator after a review-driven comment trim):
- type-check:all — clean
- lint — 0 errors/warnings
- format:check — clean
- test — 598 test files / 7283+ tests passed
- functions test — 40 test files / 778 tests passed (unaffected)
- test:counts guard — passed
- build — succeeded

## Risk tag

**Contained.** Single-file, 2-line logic fix plus one new test, matching an exact, already-4x-precedented pattern.

---
Part of the nightly automated code-health run (run #36, 2026-08-07). See `docs/routines/debugger.md` for the full routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HNqPofhNVn9C75uyVwr7Px)_