### PR TITLE
fix(library): stop FolderTree overflow-menu Escape from leaking to window

### DIFF
--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -207,6 +207,10 @@ const FolderRow: React.FC<FolderRowProps> = ({
     const handleKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(e)) return;
+      // Stop here — without stopping propagation an Escape here also bubbles
+      // up to DashboardView's global window-level Escape handler, which
+      // falls back to minimizing the focused widget (see #2266 pattern).
+      e.stopPropagation();
       onOpenMenu(null);
     };
     document.addEventListener('keydown', handleKey);

--- a/components/common/library/FolderTree.tsx
+++ b/components/common/library/FolderTree.tsx
@@ -207,9 +207,7 @@ const FolderRow: React.FC<FolderRowProps> = ({
     const handleKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (isEscapeFromWidgetInput(e)) return;
-      // Stop here — without stopping propagation an Escape here also bubbles
-      // up to DashboardView's global window-level Escape handler, which
-      // falls back to minimizing the focused widget (see #2266 pattern).
+      // Prevent DashboardView's global Escape handler from minimizing the focused widget (see #2266).
       e.stopPropagation();
       onOpenMenu(null);
     };

--- a/tests/components/common/library/FolderTree.escapePropagation.test.tsx
+++ b/tests/components/common/library/FolderTree.escapePropagation.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Regression test: FolderRow's overflow-menu Escape handler (FolderTree.tsx)
+ * already called onOpenMenu(null) to dismiss the menu, but never called
+ * stopPropagation(). FolderSidebar/FolderTree is rendered inside the Quiz /
+ * Video Activity / Mini App / Guided Learning library managers, which live
+ * inside a `.widget` DraggableWindow. Because the handler didn't stop
+ * propagation, the unhandled keydown continued bubbling up to
+ * DashboardView's global `window`-level Escape handler, which — finding no
+ * typing field focused — dispatches a `widget-keyboard-action` targeting the
+ * focused/topmost widget, and DraggableWindow's handler for that event
+ * minimizes the widget. Net effect: dismissing a folder's actions menu with
+ * Escape could also silently minimize the whole widget on the live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before invoking
+ * onOpenMenu(null), matching the same fix already applied to ToolDockItem,
+ * RemoteControlMenu, ClassRosterMenu, OverflowMenu, ActiveClassChip, and
+ * FolderPickerPopover for this exact bug class.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  render,
+  cleanup,
+  screen,
+  fireEvent,
+  act,
+} from '@testing-library/react';
+import type { LibraryFolder } from '@/types';
+import { FolderSidebar } from '@/components/common/library/FolderSidebar';
+
+vi.mock('@dnd-kit/core', () => ({
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+}));
+
+const makeFolder = (id: string, name: string): LibraryFolder => ({
+  id,
+  name,
+  parentId: null,
+  order: 0,
+  createdAt: 0,
+});
+
+afterEach(cleanup);
+
+describe('FolderTree — overflow menu Escape does not leak to window-level handlers', () => {
+  it('closes the menu on Escape and stops propagation before it reaches window listeners', () => {
+    render(
+      <FolderSidebar
+        widget="quiz"
+        folders={[makeFolder('f1', 'Unit 2')]}
+        selectedFolderId={null}
+        onSelectFolder={vi.fn()}
+        itemCounts={{}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Actions for Unit 2' }));
+    expect(
+      screen.getByRole('menuitem', { name: 'Rename' })
+    ).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      expect(
+        screen.queryByRole('menuitem', { name: 'Rename' })
+      ).not.toBeInTheDocument();
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If FolderRow's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the focused widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

`FolderTree.tsx`'s `FolderRow` kebab overflow-menu attaches a `document`-level `keydown` listener that closes the menu on Escape but never called `e.stopPropagation()`.

`FolderSidebar`/`FolderTree` is mounted live inside the Quiz, Video Activity, Mini App, and Guided Learning library managers (confirmed via grep: `QuizManager.tsx` imports and renders `FolderSidebar`, and the same shared component is re-exported for the other three managers via `components/common/library`), which render inside `DraggableWindow` (a `.widget` element). Because the event wasn't stopped, it bubbled from `document` to `window`, where `DashboardView.tsx`'s global Escape handler resolves the focused/topmost widget and dispatches a `widget-keyboard-action` Escape event that minimizes it — silently minimizing the entire widget just because the teacher dismissed a small folder-actions popover.

This is the same "portalled/document-level popover Escape doesn't stopPropagation" bug class already fixed 6x elsewhere (`ToolDockItem`, `RemoteControlMenu`, `ClassRosterMenu`, `OverflowMenu`, `ActiveClassChip`, `FolderPickerPopover`) — a fresh, previously-unaudited instance in the folder-library feature area.

## Fix

Added `e.stopPropagation()` in the handler, matching the established idiom used in the six already-fixed siblings.

## Rejected band-aid

Guarding in `DashboardView`'s global handler to also check for an open folder menu — rejected because it doesn't scale (every future popover would need its own carve-out there) and duplicates the already-established, correct fix location: the popover itself owning propagation of its own dismiss-key.

## Regression test

`tests/components/common/library/FolderTree.escapePropagation.test.tsx` (new file, mirrors the existing `FolderPickerPopover.escapePropagation.test.tsx` pattern) — opens the folder actions menu, dispatches a bubbling Escape `KeyboardEvent` on `document`, and asserts both that the menu closed and that a `window`-level keydown spy was never invoked.

**Fail-before** (orchestrator-verified independently via file-swap against `dev-paul`'s pre-fix source):
```
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 Test Files  1 failed (1)
      Tests  1 failed (1)
```

**Pass-after** (fix restored):
```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Full validation

`pnpm run validate` and `pnpm run build` both green on this branch (independently re-run by the orchestrator after a review-driven comment trim):
- type-check:all — clean
- lint — 0 errors/warnings
- format:check — clean
- test — 598 test files / 7283+ tests passed
- functions test — 40 test files / 778 tests passed (unaffected)
- test:counts guard — passed
- build — succeeded

## Risk tag

**Contained.** Single-file, additive `stopPropagation()` call following an established, well-tested idiom already used 6 times elsewhere in the codebase.

---
Part of the nightly automated code-health run (run #36, 2026-08-07). See `docs/routines/debugger.md` for the full routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HNqPofhNVn9C75uyVwr7Px)_