### PR TITLE
fix(plc): clear stale directory entries when org/building scope changes

### DIFF
--- a/hooks/usePlcBuildingDirectory.ts
+++ b/hooks/usePlcBuildingDirectory.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { shouldClearPlcDirectoryOnScopeChange } from '@/utils/plcDirectorySubscriptionKey';
 
 /**
  * `usePlcBuildingDirectory` — the "PLCs in my building" discovery feed behind
@@ -154,23 +155,38 @@ export const usePlcBuildingDirectory = (
   // Firestore read.
   const buildingId = selectedBuildings[0] ?? buildingIds[0] ?? null;
 
-  const [entries, setEntries] = useState<PlcDirectoryEntry[]>(EMPTY_ENTRIES);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-
   const shouldSubscribe = enabled && !isAuthBypass && Boolean(user) && !!orgId;
 
-  useEffect(() => {
-    if (!shouldSubscribe || !orgId || !user) {
-      // Defer the reset so we don't trip react-hooks/set-state-in-effect on
-      // the signed-out / no-org branch (mirrors the usePlcs pattern).
-      const timer = setTimeout(() => {
-        setEntries(EMPTY_ENTRIES);
-        setLoading(false);
-        setError(null);
-      }, 0);
-      return () => clearTimeout(timer);
+  const [entries, setEntries] = useState<PlcDirectoryEntry[]>(EMPTY_ENTRIES);
+  const [loading, setLoading] = useState<boolean>(shouldSubscribe);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Adjust state during render (not a `useEffect`) when the subscription
+  // scope changes — clears stale entries in the SAME render that observes a
+  // transition, so a consumer never sees the previous org/building's
+  // directory rendered under the new scope. Covers both turning the
+  // subscription off AND staying on while `orgId`/`buildingId` change (e.g.
+  // the user picks a different building, or an admin edits their building
+  // assignment while the PLC hub is open) — see
+  // `utils/plcDirectorySubscriptionKey.ts`.
+  const scope = { shouldSubscribe, orgId, buildingId };
+  const [prevScope, setPrevScope] = useState(scope);
+  if (
+    prevScope.shouldSubscribe !== scope.shouldSubscribe ||
+    prevScope.orgId !== scope.orgId ||
+    prevScope.buildingId !== scope.buildingId
+  ) {
+    const shouldClear = shouldClearPlcDirectoryOnScopeChange(scope, prevScope);
+    setPrevScope(scope);
+    setLoading(shouldSubscribe);
+    if (shouldClear) {
+      setEntries(EMPTY_ENTRIES);
+      setError(null);
     }
+  }
+
+  useEffect(() => {
+    if (!shouldSubscribe || !orgId || !user) return;
 
     const constraints: QueryConstraint[] = [where('orgId', '==', orgId)];
     if (buildingId) {

--- a/hooks/usePlcBuildingDirectory.ts
+++ b/hooks/usePlcBuildingDirectory.ts
@@ -161,14 +161,7 @@ export const usePlcBuildingDirectory = (
   const [loading, setLoading] = useState<boolean>(shouldSubscribe);
   const [error, setError] = useState<Error | null>(null);
 
-  // Adjust state during render (not a `useEffect`) when the subscription
-  // scope changes — clears stale entries in the SAME render that observes a
-  // transition, so a consumer never sees the previous org/building's
-  // directory rendered under the new scope. Covers both turning the
-  // subscription off AND staying on while `orgId`/`buildingId` change (e.g.
-  // the user picks a different building, or an admin edits their building
-  // assignment while the PLC hub is open) — see
-  // `utils/plcDirectorySubscriptionKey.ts`.
+  // Adjust state during render on scope transitions — see utils/plcDirectorySubscriptionKey.ts.
   const scope = { shouldSubscribe, orgId, buildingId };
   const [prevScope, setPrevScope] = useState(scope);
   if (

--- a/tests/hooks/usePlcBuildingDirectory.test.ts
+++ b/tests/hooks/usePlcBuildingDirectory.test.ts
@@ -349,3 +349,83 @@ describe('usePlcBuildingDirectory — result filtering', () => {
     expect(result.current.error).toBeNull();
   });
 });
+
+describe('usePlcBuildingDirectory — scope-change stale-data clear (regression)', () => {
+  /**
+   * Sibling-drift regression: `shouldSubscribe` never flips false when the
+   * user stays signed into the same org but the resolved `orgId` (or
+   * `buildingId`) switches out from under them (e.g. an admin edits the
+   * user's building assignment, or `selectedBuildings` changes) — a clear
+   * gated only on `!shouldSubscribe` (the pre-fix code) leaves the OLD
+   * scope's directory entries rendered under the NEW scope until its first
+   * snapshot lands. Mirrors the useOrgBuildings/#2374 fix for the
+   * single-orgId hook family.
+   */
+  it('clears stale entries when staying subscribed but the orgId changes', () => {
+    const snapshot = captureSnapshot();
+    const { result, rerender } = renderHook(() => usePlcBuildingDirectory());
+
+    act(() => {
+      snapshot.push(
+        fakeSnap([
+          {
+            id: 'plc-old-org',
+            data: {
+              name: 'Old Org PLC',
+              orgId: ORG_ID,
+              buildingId: BUILDING_ID,
+              memberUids: ['other-1'],
+            },
+          },
+        ])
+      );
+    });
+    expect(result.current.entries.map((e) => e.id)).toEqual(['plc-old-org']);
+
+    useAuthMock.mockReturnValue({
+      user: { uid: USER_UID, email: USER_EMAIL },
+      orgId: 'org-other',
+      selectedBuildings: [BUILDING_ID],
+      buildingIds: [],
+    });
+    rerender();
+
+    // Before org-other's first snapshot lands, the old org's entries must
+    // NOT still be showing under the new orgId.
+    expect(result.current.entries).toEqual([]);
+  });
+
+  it('clears stale entries when staying subscribed but the buildingId changes', () => {
+    const snapshot = captureSnapshot();
+    const { result, rerender } = renderHook(() => usePlcBuildingDirectory());
+
+    act(() => {
+      snapshot.push(
+        fakeSnap([
+          {
+            id: 'plc-old-building',
+            data: {
+              name: 'Old Building PLC',
+              orgId: ORG_ID,
+              buildingId: BUILDING_ID,
+              memberUids: ['other-1'],
+            },
+          },
+        ])
+      );
+    });
+    expect(result.current.entries.map((e) => e.id)).toEqual([
+      'plc-old-building',
+    ]);
+
+    useAuthMock.mockReturnValue({
+      user: { uid: USER_UID, email: USER_EMAIL },
+      orgId: ORG_ID,
+      selectedBuildings: ['bldg-other'],
+      buildingIds: [],
+    });
+    rerender();
+
+    expect(result.current.entries).toEqual([]);
+  });
+});

--- a/tests/hooks/usePlcBuildingDirectory.test.ts
+++ b/tests/hooks/usePlcBuildingDirectory.test.ts
@@ -351,16 +351,7 @@ describe('usePlcBuildingDirectory — result filtering', () => {
 });
 
 describe('usePlcBuildingDirectory — scope-change stale-data clear (regression)', () => {
-  /**
-   * Sibling-drift regression: `shouldSubscribe` never flips false when the
-   * user stays signed into the same org but the resolved `orgId` (or
-   * `buildingId`) switches out from under them (e.g. an admin edits the
-   * user's building assignment, or `selectedBuildings` changes) — a clear
-   * gated only on `!shouldSubscribe` (the pre-fix code) leaves the OLD
-   * scope's directory entries rendered under the NEW scope until its first
-   * snapshot lands. Mirrors the useOrgBuildings/#2374 fix for the
-   * single-orgId hook family.
-   */
+  // Sibling-drift regression: mirrors the useOrgBuildings/#2374 fix — staying subscribed while orgId/buildingId changes must still clear stale entries.
   it('clears stale entries when staying subscribed but the orgId changes', () => {
     const snapshot = captureSnapshot();
     const { result, rerender } = renderHook(() => usePlcBuildingDirectory());

--- a/utils/plcDirectorySubscriptionKey.test.ts
+++ b/utils/plcDirectorySubscriptionKey.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { shouldClearPlcDirectoryOnScopeChange } from './plcDirectorySubscriptionKey';
+
+describe('shouldClearPlcDirectoryOnScopeChange', () => {
+  it('clears when the subscription turns off', () => {
+    expect(
+      shouldClearPlcDirectoryOnScopeChange(
+        { shouldSubscribe: false, orgId: null, buildingId: null },
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' }
+      )
+    ).toBe(true);
+  });
+
+  it('clears when staying subscribed but the orgId changes', () => {
+    expect(
+      shouldClearPlcDirectoryOnScopeChange(
+        { shouldSubscribe: true, orgId: 'org-b', buildingId: 'bldg-a' },
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' }
+      )
+    ).toBe(true);
+  });
+
+  it('clears when staying subscribed but the buildingId changes', () => {
+    expect(
+      shouldClearPlcDirectoryOnScopeChange(
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-b' },
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' }
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT clear when the scope is unchanged', () => {
+    expect(
+      shouldClearPlcDirectoryOnScopeChange(
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' },
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' }
+      )
+    ).toBe(false);
+  });
+
+  it('does NOT clear when re-subscribing to the same org/building after being off', () => {
+    expect(
+      shouldClearPlcDirectoryOnScopeChange(
+        { shouldSubscribe: true, orgId: 'org-a', buildingId: 'bldg-a' },
+        { shouldSubscribe: false, orgId: 'org-a', buildingId: 'bldg-a' }
+      )
+    ).toBe(false);
+  });
+});

--- a/utils/plcDirectorySubscriptionKey.ts
+++ b/utils/plcDirectorySubscriptionKey.ts
@@ -1,0 +1,34 @@
+/**
+ * Scope-change logic for `usePlcBuildingDirectory`, which — unlike the
+ * single-`orgId` family in `orgSubscriptionKey.ts` — scopes its Firestore
+ * query on TWO independent inputs: `orgId` AND `buildingId` (the latter
+ * live-derived from `useAuth().selectedBuildings` / `buildingIds`, both of
+ * which can change mid-session — a user picking a different building in the
+ * Sidebar, or a live `onSnapshot` on the member doc when an org admin edits
+ * the user's building assignment while they have the PLC hub open).
+ *
+ * A clear gated only on `!shouldSubscribe` misses staying subscribed while
+ * either scope value changes on its own, leaving the previous org/building's
+ * directory entries rendered under the new scope until the next snapshot
+ * lands. Same bug class `orgSubscriptionKey.ts` fixed for the single-orgId
+ * hooks (useOrgBuildings #2276, generalized to 6 more siblings in #2374) —
+ * `usePlcBuildingDirectory` predates that fix and was never ported.
+ */
+
+export interface PlcDirectoryScope {
+  shouldSubscribe: boolean;
+  orgId: string | null;
+  buildingId: string | null;
+}
+
+/** Whether a hook's directory state must be cleared on a scope transition. */
+export function shouldClearPlcDirectoryOnScopeChange(
+  next: PlcDirectoryScope,
+  prev: PlcDirectoryScope
+): boolean {
+  return (
+    !next.shouldSubscribe ||
+    next.orgId !== prev.orgId ||
+    next.buildingId !== prev.buildingId
+  );
+}


### PR DESCRIPTION
## Root cause

`hooks/usePlcBuildingDirectory.ts` (the "PLCs in my building" discovery feed behind the `/plc` hub) subscribes to a Firestore query scoped by two independent inputs — `orgId` and `buildingId` — but only cleared its `entries` state when `shouldSubscribe` flipped to `false`. When the subscription stayed on but `orgId`/`buildingId` changed underneath it (e.g. the user picks a different building in the Sidebar, or an org admin edits the signed-in user's `buildingIds` via a live `onSnapshot` on the member doc while they have the `/plc` hub open), the effect re-subscribed to the new query but the old scope's directory entries stayed rendered under the new heading until the next snapshot landed, with `loading` never reset either.

This is the exact bug class fixed for 7 org-scoped hooks in #2374 (2026-08-04), unified behind `hooks/useOrgSubscriptionReset.ts`. `usePlcBuildingDirectory` predates that fix and, being in a different family (PLC discovery, not the Organization admin panel), was never ported over — sibling-hook drift.

## Fix

Since this hook keys on a compound `(orgId, buildingId)` scope rather than `orgId` alone, extracted a small, directly-tested pure decision function — `utils/plcDirectorySubscriptionKey.ts` (`shouldClearPlcDirectoryOnScopeChange`) — and wired it into the hook via the established "adjust state during render, not `useEffect`" pattern, so a scope transition clears stale entries in the same render that observes it.

## Rejected band-aid

Just adding `setEntries(EMPTY_ENTRIES)` inline in the effect's early-return branch — that only covers the `!shouldSubscribe` case and reproduces the exact bug #2374 already diagnosed and rejected for the org-hook family.

## Regression test

`tests/hooks/usePlcBuildingDirectory.test.ts` (2 new cases) + `utils/plcDirectorySubscriptionKey.test.ts` (new file, 5 cases for the extracted pure function).

**Fail-before** (orchestrator-verified independently via file-swap against `dev-paul`'s pre-fix hook source):
```
AssertionError: expected [ { id: 'plc-old-org', … } ] to deeply equal []
AssertionError: expected [ { id: 'plc-old-building', … } ] to deeply equal []
 Test Files  1 failed (1)
      Tests  2 failed | 12 passed (14)
```

**Pass-after** (fix restored):
```
 Test Files  2 passed (2)
      Tests  19 passed (19)
```

## Full validation

`pnpm run validate` and `pnpm run build` both green on this branch (independently re-run by the orchestrator after a review-driven comment trim):
- type-check:all — clean
- lint — 0 errors/warnings
- format:check — clean
- test — 598 test files / 7289+ tests passed
- functions test — 40 test files / 778 tests passed (unaffected)
- test:counts guard — passed
- build — succeeded

## Risk tag

**Contained.** Single hook plus a 12-line pure utility; no shared primitive touched, no other callers affected.

---
Part of the nightly automated code-health run (run #36, 2026-08-07). See `docs/routines/debugger.md` for the full routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HNqPofhNVn9C75uyVwr7Px)_