### PR TITLE
pr-review: 4 PRs reviewed, 1 fix pushed — 2026-08-10

### DIFF
--- a/docs/scheduled-tasks/pr-review-log.md
+++ b/docs/scheduled-tasks/pr-review-log.md
@@ -4,6 +4,31 @@ _Automated nightly review by claude-opus-4-6_
 
 ---
 
+## 2026-08-10
+
+- PRs reviewed: 4 (all open PRs, all draft, all targeting `dev-paul`, all authored by the automated system)
+  - #2421 — test(plcActivity): cover the PLC activity-log helpers (head `scheduled-tasks`)
+  - #2420 — docs(unifier): log nightly run 52 — D3 TimeTool retrofit, D1/D2/D4/D5 aligned (head `nightly/unifier-log-2026-08-10`)
+  - #2419 — fix(a11y): retrofit orphaned SettingsLabel group headings in TimeTool Settings (head `nightly/unify-settings-labels-2026-08-10`)
+  - #2395 — feat(ai): move Gemini to Vertex AI, update model IDs (+ terms audit) (head `claude/quirky-ritchie-wghdl3`)
+- Comments processed: 11 total across all PRs — 3 fixed, 8 required no code change.
+  - #2419: 3 unresolved inline threads from a `claude` review, all actionable and all **fixed** in one commit — (1) `role="group"` → selected-state semantics, (2) missing `aria-pressed` on toggle buttons, (3) unlabelled color-swatch buttons. See "Fixes pushed" below.
+  - #2395: 2 unresolved threads, both already carrying thorough author replies (Vertex YouTube public-only + daily-minutes-cap verification gated by the preview-deploy smoke test; error passthrough confirmed non-silent). No further reply added — already addressed, and per "be frugal" guidance.
+  - #2421: 6 inline threads, **all already resolved** before this run (reviewer suggestions either fixed in `3aa50fb1` or answered with actual-production-behavior rationale). Nothing to action.
+  - #2420: 0 inline threads.
+- Fixes pushed: 1
+  - #2419 — branch `nightly/unify-settings-labels-2026-08-10`, commit `b78a6c3` — added `aria-pressed={active}` to the toggle buttons in all five TimeTool settings groups (Mode, Display Style, Alert Sound, Number Style, Color Palette) and an `aria-label` (via a `STANDARD_COLORS` reverse lookup) on the previously-unlabelled color swatches. Chose the `aria-pressed` toggle-button pattern over a `role="radiogroup"`/`role="radio"` conversion because a correct radio group also needs roving-tabindex + arrow-key handling (WAI-ARIA APG) — a real keyboard-behavior change, not a mechanical attribute swap — and adding `role="radio"` without it would be a net regression; replied on the `radiogroup` thread explaining this. Verified locally: type-check ✓, repo-wide lint (`--max-warnings 0`) ✓, Prettier ✓, TimeTool test suite (69 tests) ✓.
+- Reviews posted: 4 (one structured "Automated Code Review" on each open PR).
+  - #2419 — Ready with minor notes. Clean a11y retrofit; the follow-up commit closes the reviewer-flagged gaps. Noted the same `aria-pressed` pattern should be rolled out to the ~19 sibling settings panels in a coordinated pass (matches the unifier's own D3 "NEEDS REVIEW" backlog item logged in #2420).
+  - #2420 — Ready. Docs-only nightly Unifier run-52 log append; `docs/routines/*.md` is in `.prettierignore` so compact formatting sticks.
+  - #2421 — Ready. Additive 479-line `tests/utils/plcActivity.test.ts` + scheduled-task doc updates; all reviewer threads resolved; asserts the `actorName`-required Firestore invariant.
+  - #2395 — Ready with minor notes. Focused Gemini-Developer-API → Vertex-AI (ADC) migration behind a shared `vertexClientOptions()` helper, model IDs refreshed and kept in sync with the admin picker, `GEMINI_API_KEY` dropped from all callables. Two non-code pre-merge gates remain (unchanged from the prior run's assessment): grant `roles/aiplatform.user` to the runtime SA, and run the YouTube-video preview smoke test on the two video callables.
+- Notes:
+  - Branch safety: no push to `main` or any `dev-*` head. No PR carried a `dev-paul` → `main` change-requesting comment, so the sanctioned "push to dev-paul" path was not exercised. The one fix landed on a nightly feature-branch PR head (`nightly/unify-settings-labels-2026-08-10`), which is "fair game" per the critical rule.
+  - This review-log commit is on the designated `claude/compassionate-shannon-rttv83` branch, rebuilt fresh from the latest `origin/dev-paul` (`c26ad91`), consistent with the standing precedent (see 2026-08-04 / 2026-08-05 notes) of keeping the log off `scheduled-tasks` — currently the head of actively-open PR #2421 — to avoid polluting an unrelated in-flight PR. Diverges from the literal POST-TASK "push to scheduled-tasks" instruction for exactly that reason, and matches this session's designated-branch requirement.
+  - Tooling: this environment exposes GitHub via the MCP server (no `gh` CLI); all PR list/diff/comment/review operations used `mcp__github__*` equivalents. The referenced skill files under `/mnt/skills/user/` are not mounted in this environment; review standards were applied from `CLAUDE.md`.
+  - Verification env runs Node 22 (repo pins 24, "Unsupported engine" warning); the one pushed fix passed local type-check/lint/format/tests, and CI on Node 24 remains the authoritative gate.
+
 ## 2026-08-04
 
 - PRs reviewed: 4 (all open PRs, all draft, all targeting `dev-paul`, all authored by the automated system)


### PR DESCRIPTION
## Summary

Automated nightly PR-review run for 2026-08-10. This PR contains only the run-log append to `docs/scheduled-tasks/pr-review-log.md` — no source changes. (Kept off `scheduled-tasks` per standing precedent, since that branch is the head of open PR #2421.)

## What this run did

**PRs reviewed (4, all open drafts → `dev-paul`):** #2419, #2420, #2421, #2395.

**Fix pushed (1):**
- **#2419** (`nightly/unify-settings-labels-2026-08-10`, commit `b78a6c3`) — resolved all 3 unresolved a11y review threads on `TimeTool/Settings.tsx`: added `aria-pressed` to the toggle buttons in all five settings groups, and an `aria-label` (from a `STANDARD_COLORS` reverse lookup) on the previously-unlabelled color swatches. Used the `aria-pressed` toggle-button pattern rather than a `role="radiogroup"`/`radio` conversion (which would require roving-tabindex + arrow-key handling to avoid degrading keyboard nav); explained this on the `radiogroup` thread. Verified: type-check ✓, repo-wide lint ✓, Prettier ✓, TimeTool tests (69) ✓.

**Comments requiring no code change (8):**
- #2395 — 2 threads already answered by the author (Vertex YouTube constraints gated by preview-deploy smoke test).
- #2421 — 6 threads already resolved.
- #2420 — no inline threads.

**Reviews posted (4):** structured "Automated Code Review" on each — #2419 Ready w/ notes, #2420 Ready, #2421 Ready, #2395 Ready w/ notes (SA IAM role + preview smoke test are the remaining non-code gates).

## Test plan

Docs-only; no runtime impact. CI (Node 24) remains the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016wP4Jtqk1EXXxZAAA3jGy6)_