### PR TITLE
fix(imports): use @/ alias for i18n import in tests/setup.ts (run 53)

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,7 +4,7 @@
 // top-level TZ assignment here.
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import '../i18n'; // Initialise i18next with English translations for all tests
+import '@/i18n'; // Initialise i18next with English translations for all tests
 import { mockPointerEvent, mockCanvasGetContext } from './testHelpers/mocks';
 
 vi.stubEnv('VITE_FIREBASE_API_KEY', '');


### PR DESCRIPTION
## Nightly Unifier — D4 (Import Path Convention), run 53

**Canonical form:** `@/` alias for all cross-directory imports (maps to the repo root, not `src/`), e.g. `import '@/i18n'`. Relative `'../foo'` is only acceptable within a flat sibling context.

**Instance unified (1):** `tests/setup.ts` — `import '../i18n'` → `import '@/i18n'`. `tests/setup.ts` sits at the repo root's `tests/` directory and was importing the sibling root-level `i18n/` directory via a relative path — the exact cross-directory anti-pattern this dimension targets. The run-31 sweep converted `i18n/index.ts`'s own locale imports to `@/locales/*.json` but didn't cover this consumer of the `i18n/` module itself.

**Staleness check performed (no other action needed):**
- Verified `eslint.config.js`'s `components/plc/**` `no-restricted-imports` regex still covers every canonical section id currently in `components/plc/sections.ts`'s `PLC_SECTIONS` list — no drift found, still in sync.
- Repo-wide grep for cross-directory `'../`/`'../../` imports outside `components/plc/` and `components/widgets/*/math-tools/` (which already have enforcement) turned up only this one genuine instance; everything else matched the D4-E1/D4-E2 gray-zone exceptions (same-directory `./` imports, `'../WidgetLayout'`) or was already on the `@/` alias.

**Enforcement:** None added — this is an isolated single-file straggler, not a recurring bug class in a directory that would benefit from a new `no-restricted-imports` rule.

**Behavior/visual preservation evidence:**
- Pure import-path rewrite, both paths resolve to the same module (`vite.config.ts`/`tsconfig.json`/`vitest.config.ts` all configure the `@/` alias to the repo root).
- Full `pnpm run validate` (type-check root+functions, lint root+functions, format-check, root tests 604 files/7321 tests, functions tests 41/785, test-count guard) — all green
- `pnpm run build` — client + SSR bundles + prerender all succeeded

**Risk tag:** `mechanical` — import-path-only change, zero runtime/behavior difference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGwddCRu51WiT1m6hciGyy)_