### PR TITLE
fix(widgets): stop Escape propagation in LiveControl and PageStrip popovers

### DIFF
--- a/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.InlineTitle.test.tsx
@@ -92,3 +92,91 @@ describe('InlineTitle (via PageStrip) — Escape-cancel stale onBlur guard', () 
     expect(onRenamePage).toHaveBeenCalledWith(0, 'Enter Name');
   });
 });
+
+// Regression (#2429 round-2 review): the popover's dismiss-on-Escape listener
+// is registered on `document`, while InlineTitle cancels a rename from a React
+// synthetic `onKeyDown` that calls `e.stopPropagation()`. The concern raised in
+// review was that React 17+ delegates to the root container rather than
+// `document`, so the native keydown would still reach the document listener and
+// close the whole popover when the user only meant to cancel the rename.
+//
+// It does not, and these tests pin that. React 17+ calls `preparePortalMount`
+// on every portal container, so the popover's delegated listeners live on
+// `document.body` (the portal target — see `createPortal(..., document.body)`
+// in PageStrip.tsx). React's SyntheticEvent.stopPropagation() also calls
+// `nativeEvent.stopPropagation()`, which halts native bubbling at `body`,
+// one hop before `document`. So the popover's document-level `onKey` never
+// runs for a keydown originating inside the portal.
+//
+// This is load-bearing: if InlineTitle's `stopPropagation()` is ever removed
+// (it also exists to stop the widget wrapper's Backspace/Delete/arrow nudge
+// handlers), Escape-to-cancel-rename would start tearing down the whole
+// popover. These tests fail in that case.
+describe('InlineTitle (via PageStrip) — Escape-cancel does not dismiss the popover', () => {
+  const multiPages = [
+    { id: 'p1', objects: [], title: 'Page 1' },
+    { id: 'p2', objects: [], title: 'Page 2' },
+  ];
+
+  const openPopoverAndEditRow = (
+    onRenamePage: (index: number, title: string) => void
+  ) => {
+    render(
+      <PageStrip
+        pages={multiPages}
+        onRenamePage={onRenamePage}
+        {...baseProps}
+      />
+    );
+    // Open the pages popover (portalled to document.body).
+    fireEvent.click(screen.getByRole('button', { name: /manage pages/i }));
+    expect(screen.getByTestId('drawing-page-popover')).toBeInTheDocument();
+
+    // Enter row-edit mode for page 2, which mounts an InlineTitle input
+    // INSIDE the portal.
+    fireEvent.click(screen.getByRole('button', { name: /rename page 2/i }));
+    return screen.getByRole('textbox', { name: /page title/i });
+  };
+
+  it('keeps the popover open when Escape cancels an in-popover rename', () => {
+    const onRenamePage = vi.fn();
+    const input = openPopoverAndEditRow(onRenamePage);
+
+    fireEvent.change(input, { target: { value: 'Discarded' } });
+    act(() => {
+      fireEvent.keyDown(input, { key: 'Escape' });
+    });
+
+    // The rename is cancelled...
+    expect(onRenamePage).not.toHaveBeenCalled();
+    // ...and the popover is still open — Escape did not reach the
+    // document-level dismiss handler.
+    expect(screen.getByTestId('drawing-page-popover')).toBeInTheDocument();
+    // Edit mode exited, so the row renders its static label again.
+    expect(
+      screen.queryByRole('textbox', { name: /page title/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('still dismisses the popover on Escape when no rename is in progress', () => {
+    // Complement to the test above: the document-level handler must remain
+    // functional for Escape presses that do NOT originate inside a portalled
+    // input, otherwise "the popover never closes" would pass the test above
+    // for the wrong reason.
+    render(
+      <PageStrip pages={multiPages} onRenamePage={vi.fn()} {...baseProps} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /manage pages/i }));
+    expect(screen.getByTestId('drawing-page-popover')).toBeInTheDocument();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+
+    expect(
+      screen.queryByTestId('drawing-page-popover')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/widgets/DrawingWidget/PageStrip.escapePropagation.test.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.escapePropagation.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PageStrip } from './PageStrip';
+
+/**
+ * Regression: PageStrip's "manage pages" popover is portalled to
+ * document.body, outside any `.widget` DraggableWindow ancestor. Its Escape
+ * handler closed the popover but never called stopPropagation(), so the
+ * keydown kept bubbling to DashboardView's global window-level Escape
+ * handler, which falls back to minimizing the topmost z-index widget. Net
+ * effect: dismissing the pages popover with Escape could also silently
+ * minimize an unrelated widget on the live board.
+ *
+ * FIX: the handler now calls event.stopPropagation() before closing,
+ * matching the same fix already applied to ActiveClassChip and other
+ * portalled popovers for this exact bug class.
+ */
+const makePages = () => [
+  { id: 'p1', objects: [], title: 'Page 1' },
+  { id: 'p2', objects: [], title: 'Page 2' },
+];
+
+const baseProps = {
+  currentPage: 0,
+  onSelectPage: vi.fn(),
+  onAddPage: vi.fn(),
+  onDeletePage: vi.fn(),
+  onRenamePage: vi.fn(),
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PageStrip popover — Escape does not leak to window-level handlers', () => {
+  it('closes the pages popover on Escape and stops propagation before it reaches window listeners', () => {
+    render(<PageStrip pages={makePages()} {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /manage pages/i }));
+    expect(screen.getByTestId('drawing-page-popover')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      });
+
+      expect(
+        screen.queryByTestId('drawing-page-popover')
+      ).not.toBeInTheDocument();
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If the popover's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the topmost widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/components/widgets/DrawingWidget/PageStrip.tsx
+++ b/components/widgets/DrawingWidget/PageStrip.tsx
@@ -133,7 +133,13 @@ export const PageStrip: React.FC<PageStripProps> = ({
       close();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
+      if (e.key !== 'Escape') return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopPropagation the keydown bubbles to DashboardView's global
+      // Escape handler, which minimizes the topmost widget (see
+      // ActiveClassChip's fix for the same bug class).
+      e.stopPropagation();
+      close();
     };
     document.addEventListener('pointerdown', onDocPointerDown);
     document.addEventListener('keydown', onKey);

--- a/components/widgets/LiveControl.tsx
+++ b/components/widgets/LiveControl.tsx
@@ -95,6 +95,11 @@ export const LiveControl: React.FC<LiveControlProps> = ({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        // Portalled to <body>, outside any `.widget` ancestor — without
+        // stopPropagation the keydown bubbles to DashboardView's global
+        // Escape handler, which minimizes the topmost widget (see
+        // ActiveClassChip's fix for the same bug class).
+        event.stopPropagation();
         setShowMenu(false);
         buttonRef.current?.focus();
         return;

--- a/components/widgets/LiveControl.tsx
+++ b/components/widgets/LiveControl.tsx
@@ -126,7 +126,7 @@ export const LiveControl: React.FC<LiveControlProps> = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [showMenu]);
+  }, [showMenu, isLive]);
 
   // BUTTON UI (extracted for consistency)
   const ActionButtons = (

--- a/components/widgets/LiveControl.tsx
+++ b/components/widgets/LiveControl.tsx
@@ -76,6 +76,24 @@ export const LiveControl: React.FC<LiveControlProps> = ({
     if (showMenu) setShowMenu(false);
   }, [buttonRef]);
 
+  // Reset the menu when the live session ends — adjusting state while
+  // rendering (CLAUDE.md pattern; mirrors InlineTitle's prevValue sync
+  // below) rather than an effect, since this synchronizes local state to a
+  // prop change rather than an external system. Without this, showMenu and
+  // menuPosition survive isLive→false (the portal unmounts via the render
+  // guard below, but neither piece of state is cleared) — if a new session
+  // starts before the teacher closes the menu, the render guard passes
+  // again and the portal re-mounts at stale coordinates, re-running the
+  // focus-trap effect and stealing focus with no user gesture.
+  const [prevIsLive, setPrevIsLive] = useState(isLive);
+  if (prevIsLive !== isLive) {
+    setPrevIsLive(isLive);
+    if (!isLive) {
+      setShowMenu(false);
+      setMenuPosition(null);
+    }
+  }
+
   // Trap focus within the menu when open
   useEffect(() => {
     if (!showMenu || !menuRef.current) return undefined;

--- a/tests/components/widgets/LiveControl.test.tsx
+++ b/tests/components/widgets/LiveControl.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { LiveControl } from '@/components/widgets/LiveControl';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { LiveStudent } from '@/types';
@@ -177,7 +177,9 @@ describe('LiveControl', () => {
     window.addEventListener('keydown', windowKeydownSpy);
 
     try {
-      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      });
 
       expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
       // This is the crux of the regression: DashboardView's global Escape
@@ -185,6 +187,38 @@ describe('LiveControl', () => {
       // handler doesn't stopPropagation, the event still reaches window
       // and DashboardView falls back to minimizing the topmost widget.
       expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+
+  // Regression: the focus-trap effect's stopPropagation() Escape handler is
+  // registered on `document` with a dep array of only [showMenu]. Ending a
+  // live session (isLive: true -> false) while the menu is open unmounts the
+  // popout-menu portal (the render guard also checks `!isLive`) without
+  // `showMenu` itself changing, so the effect never re-runs its cleanup and
+  // the listener leaks. Before stopPropagation() was added this leak was
+  // harmless; after, the stale listener would swallow every future Escape
+  // press site-wide, since setShowMenu(false) is a no-op once the popover is
+  // already unmounted and stopPropagation() still runs regardless. Fixed by
+  // adding `isLive` to the effect's dependency array so ending the session
+  // tears down the listener even though `showMenu` never flips back to false.
+  it('cleans up the Escape listener when isLive flips to false while the menu is open, so a later Escape still reaches window', () => {
+    const { rerender, props } = renderLiveControl();
+    fireEvent.click(screen.getByLabelText(/connected students/));
+    expect(screen.getByText('Classroom (2)')).toBeInTheDocument();
+
+    act(() => {
+      rerender(<LiveControl {...props} isLive={false} />);
+    });
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+    try {
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      });
+      expect(windowKeydownSpy).toHaveBeenCalledTimes(1);
     } finally {
       window.removeEventListener('keydown', windowKeydownSpy);
     }

--- a/tests/components/widgets/LiveControl.test.tsx
+++ b/tests/components/widgets/LiveControl.test.tsx
@@ -224,6 +224,34 @@ describe('LiveControl', () => {
     }
   });
 
+  // Regression (#2429 round-2 review): fixing the stale-listener leak above
+  // by adding `isLive` to the focus-trap effect's deps left a second bug —
+  // showMenu/menuPosition were never reset when isLive went false. The
+  // portal unmounts via the render guard (`!isLive` short-circuits it), but
+  // showMenu stays true. If a *new* live session starts before the teacher
+  // reopens the menu, the render guard passes again, the portal re-mounts
+  // at stale coordinates, and the focus-trap effect re-runs — stealing
+  // focus with no user gesture. Fixed by resetting both pieces of state in
+  // a dedicated effect keyed on isLive.
+  it('does not silently reopen the menu when a new live session starts after the previous one ended while the menu was open', () => {
+    const { rerender, props } = renderLiveControl();
+    fireEvent.click(screen.getByLabelText(/connected students/));
+    expect(screen.getByText('Classroom (2)')).toBeInTheDocument();
+
+    // Session ends while the menu is open.
+    act(() => {
+      rerender(<LiveControl {...props} isLive={false} />);
+    });
+    expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
+
+    // A new session starts. Without the fix, showMenu was still `true` from
+    // before, so the portal silently re-mounts here.
+    act(() => {
+      rerender(<LiveControl {...props} isLive={true} />);
+    });
+    expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
+  });
+
   it('renders Preview link with preview=1 appended when joinUrl is present', () => {
     renderLiveControl();
     fireEvent.click(screen.getByLabelText(/connected students/));

--- a/tests/components/widgets/LiveControl.test.tsx
+++ b/tests/components/widgets/LiveControl.test.tsx
@@ -231,8 +231,11 @@ describe('LiveControl', () => {
   // showMenu stays true. If a *new* live session starts before the teacher
   // reopens the menu, the render guard passes again, the portal re-mounts
   // at stale coordinates, and the focus-trap effect re-runs — stealing
-  // focus with no user gesture. Fixed by resetting both pieces of state in
-  // a dedicated effect keyed on isLive.
+  // focus with no user gesture. Fixed by resetting both pieces of state via
+  // the adjusting-state-while-rendering pattern (LiveControl.tsx:88-95;
+  // CLAUDE.md "useEffect is an escape hatch, not a default") — not an
+  // effect, which would cost an extra render pass for what's really a
+  // render-time prop-change reaction.
   it('does not silently reopen the menu when a new live session starts after the previous one ended while the menu was open', () => {
     const { rerender, props } = renderLiveControl();
     fireEvent.click(screen.getByLabelText(/connected students/));

--- a/tests/components/widgets/LiveControl.test.tsx
+++ b/tests/components/widgets/LiveControl.test.tsx
@@ -155,6 +155,41 @@ describe('LiveControl', () => {
     expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
   });
 
+  /**
+   * Regression: the classroom menu is portalled to document.body, outside
+   * any `.widget` DraggableWindow ancestor. Its Escape handler closed the
+   * menu but never called stopPropagation(), so the keydown kept bubbling to
+   * DashboardView's global window-level Escape handler, which falls back to
+   * minimizing the topmost z-index widget. Net effect: dismissing this menu
+   * with Escape during a live session could also silently minimize an
+   * unrelated widget on the live board.
+   *
+   * FIX: the handler now calls event.stopPropagation() before closing,
+   * matching the same fix already applied to ActiveClassChip and other
+   * portalled popovers for this exact bug class.
+   */
+  it('stops propagation on Escape so it does not reach window-level handlers', () => {
+    renderLiveControl();
+    fireEvent.click(screen.getByLabelText(/connected students/));
+    expect(screen.getByText('Classroom (2)')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+      expect(screen.queryByText('Classroom (2)')).not.toBeInTheDocument();
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If the menu's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the topmost widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+
   it('renders Preview link with preview=1 appended when joinUrl is present', () => {
     renderLiveControl();
     fireEvent.click(screen.getByLabelText(/connected students/));


### PR DESCRIPTION
## Root cause

`components/widgets/LiveControl.tsx` and `components/widgets/DrawingWidget/PageStrip.tsx` both render a popover/menu via `createPortal(..., document.body)`, outside any `.widget` `DraggableWindow` ancestor. Each registers its own `document`-level `keydown` listener to close on Escape, but neither called `stopPropagation()`. The event therefore bubbled to `DashboardView`'s global `window`-level Escape handler, which — finding no `.widget` ancestor for the focused portal content — falls back to minimizing the topmost z-index widget on the board.

Concrete impact: dismissing the "connected students" menu during a live session, or the "manage pages" popover in the Drawing widget, could silently minimize an unrelated widget on the live board (e.g. a running timer).

This is the same recurring bug class already fixed 8x elsewhere in the codebase (`ActiveClassChip.tsx`, `ToolDockItem.tsx`, `RemoteControlMenu.tsx`, `ClassRosterMenu.tsx`, `FolderPickerPopover.tsx`, `BoardNavFab.tsx`/`CollectionSwitcherMenu.tsx`/`BoardActionsFab.tsx`, `OverflowMenu.tsx`, `RandomClassContextButton.tsx`). `LiveControl` and `PageStrip` were the two remaining confirmed-live-reachable instances flagged in the nightly debugger's backlog.

Both components are confirmed live/reachable: `LiveControl` is mounted by `WidgetRenderer.tsx` as `headerActions` on any widget with an active live session; `PageStrip` is mounted directly in `DrawingWidget`'s toolbar whenever a drawing has ≥2 pages.

## Fix

Added `event.stopPropagation()` before closing the popover in both components' Escape handlers, mirroring the established fix pattern used at every prior instance of this bug class.

## Rejected band-aid

Special-casing `DraggableWindow`'s Escape handler to ignore Escape whenever "some portal" is open — rejected as fragile (requires tracking global portal-open state) and doesn't fix the actual defect: the component that consumes an event should own stopping its propagation, not a downstream fallback handler guessing at intent.

## Regression tests

- `components/widgets/DrawingWidget/PageStrip.escapePropagation.test.tsx` (new)
- `tests/components/widgets/LiveControl.test.tsx` (new test added)

Both mirror the existing `ActiveClassChip.escapePropagation.test.tsx` pattern: open the popover, attach a `window`-level keydown spy, fire Escape, assert the popover closed AND the window spy was never called.

## Evidence (fail-before / pass-after)

Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul`:
- Reverted both source files to `dev-paul`: both new tests **failed** (window-level spy called once — event leaked to `window`).
- Restored the fix: both tests **passed**, plus the pre-existing `ActiveClassChip`/`PageStrip.InlineTitle` tests still green (19/19 total across the 4 files).

## Validation

Independently re-ran on the branch (not just trusting the subagent's own run):
- `pnpm run validate`: **GREEN** — 606/606 root test files, 7350/7350 tests; 41/41 functions test files, 785/785 tests; `test:counts` guard passed.
- `pnpm run build`: passed (app bundle + SSR/prerender).

## Risk

**Contained** — two isolated one-line changes (plus tests), no shared/blast-radius primitive touched.

---
Automated nightly code-health run (2026-08-11). See `docs/routines/debugger.md` for the standing routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByFq5e6u9i3GjYpp5PMGqv)_