### PR TITLE
fix(settings-panel): stop Escape from double-triggering DashboardView's global handler

### DIFF
--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -562,6 +562,19 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync for stale-closure prevention (CLAUDE.md pattern); false positive from react-hooks/refs v7
   stateRef.current = { isEditingTitle, saveTitle };
 
+  // Set to true by SettingsPanel's onClose, synchronously, before it calls
+  // updateWidget. DashboardView's global Escape handler always dispatches a
+  // widget-keyboard-action event (it can't see this component's local
+  // showConfirm state, so it must not skip the dispatch — see DashboardView.tsx).
+  // Without this ref, handleCustomKeyboard's Escape branch would read the
+  // still-stale `widget.flipped === true` prop (React hasn't re-rendered yet
+  // within the same synchronous keydown dispatch) and call updateWidget a
+  // second, redundant time. Reset every render — the ref only needs to
+  // survive the brief window between onClose firing and the next commit.
+  const justClosedSettingsRef = useRef(false);
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref reset for stale-flag prevention (CLAUDE.md pattern); false positive from react-hooks/refs v7
+  justClosedSettingsRef.current = false;
+
   const handleCloseTools = useCallback(() => {
     setSelectedWidgetId(null);
     const { isEditingTitle, saveTitle } = stateRef.current;
@@ -1935,6 +1948,12 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         // If you add a new Escape branch here, mirror it in handleKeyDown and vice-versa.
         if (showConfirm) {
           setShowConfirm(false);
+        } else if (justClosedSettingsRef.current) {
+          // SettingsPanel's own Escape handler already closed the panel in
+          // this same keydown dispatch (see the ref's declaration comment) —
+          // nothing left to do. A plain `&&` guard on the branch below would
+          // instead fall through to the minimize branch, which is worse than
+          // the original redundant write it was meant to prevent.
         } else if (widget.flipped && !isActiveBoardReadOnly) {
           // Allow closing an already-open settings panel for per-widget-locked
           // widgets; isActiveBoardReadOnly blocks all writes on shared boards.
@@ -3348,7 +3367,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           settings={settings}
           appearanceSettings={appearanceSettings}
           shouldRenderSettings={shouldRenderSettings}
-          onClose={() => updateWidget(widget.id, { flipped: false })}
+          onClose={() => {
+            justClosedSettingsRef.current = true;
+            updateWidget(widget.id, { flipped: false });
+          }}
           updateWidget={updateWidget}
           globalStyle={globalStyle}
           title={title}

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -205,6 +205,13 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const isActiveBoardReadOnly = useDashboardCanvasSelector(
     (s) => s.isActiveBoardReadOnly
   );
+  // Mirrors updateWidget's `!activeIdRef.current` early return (activeDashboard
+  // is derived from activeId — see DashboardContext.tsx). Read by
+  // SettingsPanel's onClose below so justClosedSettingsRef is only set when
+  // updateWidget's write will actually land and re-render to reset it.
+  const hasActiveDashboard = useDashboardCanvasSelector(
+    (s) => s.activeDashboard !== null
+  );
   const zoom = useDashboardCanvasSelector((s) => s.zoom);
   const groupBuildMode = useDashboardCanvasSelector((s) => s.groupBuildMode);
   // Event-handler-time canvas reads (no render subscription).
@@ -3368,15 +3375,19 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           appearanceSettings={appearanceSettings}
           shouldRenderSettings={shouldRenderSettings}
           onClose={() => {
-            // On a read-only board, updateWidget below returns early (never
-            // calls setDashboards), so no re-render fires to reset this ref
-            // in the render body — it would otherwise stay stuck `true` for
-            // the widget's lifetime, permanently no-op'ing every subsequent
-            // Escape in handleCustomKeyboard's priority chain (including
-            // setIsAnnotating(false), a purely local write NOT blocked by
-            // the read-only guard). Only set it when the write will actually
-            // land and trigger the reset.
-            justClosedSettingsRef.current = !isActiveBoardReadOnly;
+            // updateWidget (DashboardContext.tsx) returns early — without
+            // calling setDashboards, so no re-render fires to reset this ref
+            // in the render body — on a read-only board OR when there's no
+            // active dashboard (activeIdRef.current null; a very narrow race
+            // where a dashboard switch clears activeId while this widget is
+            // still mounted). Either way the ref would otherwise stay stuck
+            // `true` for the widget's lifetime, permanently no-op'ing every
+            // subsequent Escape in handleCustomKeyboard's priority chain
+            // (including setIsAnnotating(false), a purely local write NOT
+            // blocked by either guard). Only set it when the write will
+            // actually land and trigger the reset.
+            justClosedSettingsRef.current =
+              !isActiveBoardReadOnly && hasActiveDashboard;
             updateWidget(widget.id, { flipped: false });
           }}
           updateWidget={updateWidget}

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -205,13 +205,6 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const isActiveBoardReadOnly = useDashboardCanvasSelector(
     (s) => s.isActiveBoardReadOnly
   );
-  // Mirrors updateWidget's `!activeIdRef.current` early return (activeDashboard
-  // is derived from activeId — see DashboardContext.tsx). Read by
-  // SettingsPanel's onClose below so justClosedSettingsRef is only set when
-  // updateWidget's write will actually land and re-render to reset it.
-  const hasActiveDashboard = useDashboardCanvasSelector(
-    (s) => s.activeDashboard !== null
-  );
   const zoom = useDashboardCanvasSelector((s) => s.zoom);
   const groupBuildMode = useDashboardCanvasSelector((s) => s.groupBuildMode);
   // Event-handler-time canvas reads (no render subscription).
@@ -3386,8 +3379,16 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
             // (including setIsAnnotating(false), a purely local write NOT
             // blocked by either guard). Only set it when the write will
             // actually land and trigger the reset.
+            //
+            // Read via getCanvasState() (event-fire time) rather than the
+            // render-closure values above — this callback can fire after a
+            // stale render commit, and reading at event time closes that
+            // window entirely instead of risking acting on a value that's
+            // already out of date by the time onClose runs.
+            const canvasState = getCanvasState();
             justClosedSettingsRef.current =
-              !isActiveBoardReadOnly && hasActiveDashboard;
+              !canvasState.isActiveBoardReadOnly &&
+              canvasState.activeDashboard !== null;
             updateWidget(widget.id, { flipped: false });
           }}
           updateWidget={updateWidget}

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -3368,7 +3368,15 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
           appearanceSettings={appearanceSettings}
           shouldRenderSettings={shouldRenderSettings}
           onClose={() => {
-            justClosedSettingsRef.current = true;
+            // On a read-only board, updateWidget below returns early (never
+            // calls setDashboards), so no re-render fires to reset this ref
+            // in the render body — it would otherwise stay stuck `true` for
+            // the widget's lifetime, permanently no-op'ing every subsequent
+            // Escape in handleCustomKeyboard's priority chain (including
+            // setIsAnnotating(false), a purely local write NOT blocked by
+            // the read-only guard). Only set it when the write will actually
+            // land and trigger the reset.
+            justClosedSettingsRef.current = !isActiveBoardReadOnly;
             updateWidget(widget.id, { flipped: false });
           }}
           updateWidget={updateWidget}

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -1948,20 +1948,24 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
         // If you add a new Escape branch here, mirror it in handleKeyDown and vice-versa.
         if (showConfirm) {
           setShowConfirm(false);
-        } else if (justClosedSettingsRef.current) {
+        } else if (!justClosedSettingsRef.current) {
+          // Wrapped (rather than an early empty `else if` branch) so a new
+          // sub-case added below is mechanically guarded by the ref check —
           // SettingsPanel's own Escape handler already closed the panel in
-          // this same keydown dispatch (see the ref's declaration comment) —
-          // nothing left to do. A plain `&&` guard on the branch below would
-          // instead fall through to the minimize branch, which is worse than
-          // the original redundant write it was meant to prevent.
-        } else if (widget.flipped && !isActiveBoardReadOnly) {
-          // Allow closing an already-open settings panel for per-widget-locked
-          // widgets; isActiveBoardReadOnly blocks all writes on shared boards.
-          updateWidget(widget.id, { flipped: false });
-        } else if (isAnnotating) {
-          setIsAnnotating(false);
-        } else if (!isLocked) {
-          updateWidget(widget.id, { minimized: true, flipped: false });
+          // this same keydown dispatch (see the ref's declaration comment)
+          // when justClosedSettingsRef.current is true, so nothing here
+          // should run in that case. A plain `&&` on just the widget.flipped
+          // branch would instead fall through to the minimize branch, which
+          // is worse than the original redundant write this ref prevents.
+          if (widget.flipped && !isActiveBoardReadOnly) {
+            // Allow closing an already-open settings panel for per-widget-locked
+            // widgets; isActiveBoardReadOnly blocks all writes on shared boards.
+            updateWidget(widget.id, { flipped: false });
+          } else if (isAnnotating) {
+            setIsAnnotating(false);
+          } else if (!isLocked) {
+            updateWidget(widget.id, { minimized: true, flipped: false });
+          }
         }
       } else if (key === 'Pin') {
         if (!isLocked) {

--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -172,12 +172,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           target.tagName === 'SELECT' ||
           target.isContentEditable);
       if (isFormField) return;
-      // Portalled to <body>, outside any `.widget` ancestor — without
-      // stopping propagation an Escape here also bubbles up to
-      // DashboardView's global window-level Escape handler, which then
-      // dispatches a redundant widget-keyboard-action Escape at this same
-      // widget (a second, unnecessary updateWidget/Firestore write).
-      e.stopPropagation();
       onCloseRef.current();
     };
     document.addEventListener('keydown', handleKeyDown);

--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -172,6 +172,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           target.tagName === 'SELECT' ||
           target.isContentEditable);
       if (isFormField) return;
+      // Portalled to <body>, outside any `.widget` ancestor — without
+      // stopping propagation an Escape here also bubbles up to
+      // DashboardView's global window-level Escape handler, which then
+      // dispatches a redundant widget-keyboard-action Escape at this same
+      // widget (a second, unnecessary updateWidget/Firestore write).
+      e.stopPropagation();
       onCloseRef.current();
     };
     document.addEventListener('keydown', handleKeyDown);

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -946,15 +946,15 @@ export const DashboardView: React.FC = () => {
 
           if (!targetId) return;
 
-          // If the target widget's settings panel is already open, SettingsPanel's
-          // own document-level Escape handler already closes it (document fires
-          // before window in the bubble phase) — dispatching here too would be a
-          // redundant flip-back / extra Firestore write for the same widget.
-          const targetWidget = activeDashboard.widgets.find(
-            (w) => w.id === targetId
-          );
-          if (targetWidget?.flipped) return;
-
+          // Always dispatch — even when the target widget's settings panel is
+          // already open (SettingsPanel's own document-level handler may have
+          // just closed it in this same event). DashboardView can't see
+          // DraggableWindow's local `showConfirm` state, so skipping the
+          // dispatch here would also swallow Escape for an open delete-confirm
+          // dialog on a flipped widget, leaving it stuck. DraggableWindow's
+          // handleCustomKeyboard avoids the resulting redundant flip-back
+          // write itself, via a ref set synchronously by SettingsPanel's
+          // onClose (see justClosedSettingsRef).
           // Dispatch custom event to notify the specific widget
           const event = new CustomEvent('widget-keyboard-action', {
             detail: { widgetId: targetId, key: 'Escape', shiftKey: e.shiftKey },

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -946,6 +946,15 @@ export const DashboardView: React.FC = () => {
 
           if (!targetId) return;
 
+          // If the target widget's settings panel is already open, SettingsPanel's
+          // own document-level Escape handler already closes it (document fires
+          // before window in the bubble phase) — dispatching here too would be a
+          // redundant flip-back / extra Firestore write for the same widget.
+          const targetWidget = activeDashboard.widgets.find(
+            (w) => w.id === targetId
+          );
+          if (targetWidget?.flipped) return;
+
           // Dispatch custom event to notify the specific widget
           const event = new CustomEvent('widget-keyboard-action', {
             detail: { widgetId: targetId, key: 'Escape', shiftKey: e.shiftKey },

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -958,6 +958,62 @@ describe('DraggableWindow (Tests folder)', () => {
 
       expect(container.querySelector('canvas')).not.toBeInTheDocument();
     });
+
+    // Regression (#2430 round-6 review): the read-only-board fix above only
+    // accounted for one of updateWidget's two early returns
+    // (isActiveBoardReadOnlyRef.current). The other — `!activeIdRef.current`
+    // — hits on a narrow race (e.g. a dashboard switch clears activeId while
+    // this widget is still mounted). Without also guarding on that, the ref
+    // would get stuck the same way: set unconditionally true, updateWidget
+    // no-ops with no re-render, nothing ever resets it.
+    it('does not permanently suppress Escape when there is no active dashboard (activeId race)', () => {
+      render(
+        <DashboardContext.Provider
+          value={
+            {
+              ...mockContext,
+              selectedWidgetId: mockWidget.id,
+              isActiveBoardReadOnly: false,
+              activeDashboard: null,
+            } as unknown as DashboardContextValue
+          }
+        >
+          <DraggableWindow
+            widget={{ ...mockWidget, flipped: true }}
+            settings={<div>Mock Settings Content</div>}
+            title="Test Widget"
+            globalStyle={mockGlobalStyle}
+          >
+            <div data-testid="widget-content">Content</div>
+          </DraggableWindow>
+        </DashboardContext.Provider>
+      );
+      expect(screen.getByText('Mock Settings Content')).toBeInTheDocument();
+
+      // First Escape: SettingsPanel's onClose fires. With the fix, the ref
+      // stays `false` here since there's no active dashboard to write to.
+      act(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+      });
+
+      // A later, independent Escape must still reach the widget.flipped
+      // branch and call updateWidget a second time — proving the ref did
+      // not leak past this widget's one settings-close.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('widget-keyboard-action', {
+            detail: { widgetId: 'test-widget', key: 'Escape', shiftKey: false },
+          })
+        );
+      });
+
+      const flipCalls = mockContext.updateWidget.mock.calls.filter(
+        ([, patch]) => (patch as { flipped?: boolean })?.flipped === false
+      );
+      expect(flipCalls).toHaveLength(2);
+    });
   });
 
   describe('Toolbar button lock guards', () => {

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -792,6 +792,91 @@ describe('DraggableWindow (Tests folder)', () => {
     });
   });
 
+  // Regression (#2430 review): DashboardView's global Escape handler always
+  // dispatches widget-keyboard-action — it can't see this component's local
+  // showConfirm state, so it must not skip the dispatch just because the
+  // widget is flipped. These tests exercise handleCustomKeyboard's own
+  // priority chain and the justClosedSettingsRef redundant-write guard.
+  describe('handleCustomKeyboard Escape priority (showConfirm vs. flipped)', () => {
+    const renderFlipped = () =>
+      render(
+        <DashboardContext.Provider
+          value={
+            {
+              ...mockContext,
+              selectedWidgetId: mockWidget.id,
+            } as unknown as DashboardContextValue
+          }
+        >
+          <DraggableWindow
+            widget={{ ...mockWidget, flipped: true }}
+            settings={<div>Settings</div>}
+            title="Test Widget"
+            globalStyle={mockGlobalStyle}
+          >
+            <div data-testid="widget-content">Content</div>
+          </DraggableWindow>
+        </DashboardContext.Provider>
+      );
+
+    it('dismisses an open delete-confirm dialog via Escape even while the settings panel is also open (flipped)', () => {
+      renderFlipped();
+
+      // Delete → showConfirm(true), reproducing the compound state from the
+      // review: settings open (flipped) AND a confirm dialog open.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('widget-keyboard-action', {
+            detail: { widgetId: 'test-widget', key: 'Delete', shiftKey: false },
+          })
+        );
+      });
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('widget-keyboard-action', {
+            detail: { widgetId: 'test-widget', key: 'Escape', shiftKey: false },
+          })
+        );
+      });
+
+      // showConfirm takes priority in handleCustomKeyboard's Escape branch —
+      // the dialog must dismiss, and this dismissal must NOT also flip the
+      // widget back (that branch is only reached when showConfirm is false).
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      expect(mockContext.updateWidget).not.toHaveBeenCalledWith('test-widget', {
+        flipped: false,
+      });
+    });
+
+    it('does not call updateWidget a second time when SettingsPanel already closed the panel via its own Escape handler', () => {
+      renderFlipped();
+
+      // SettingsPanel's own document-level Escape handler and DashboardView's
+      // window-level widget-keyboard-action dispatch both fire within the
+      // same synchronous keydown dispatch in the real app — reproduce that by
+      // firing the real Escape on document (triggers SettingsPanel's onClose,
+      // which sets justClosedSettingsRef before calling updateWidget) and the
+      // CustomEvent DashboardView would dispatch, inside one act() batch.
+      act(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+        window.dispatchEvent(
+          new CustomEvent('widget-keyboard-action', {
+            detail: { widgetId: 'test-widget', key: 'Escape', shiftKey: false },
+          })
+        );
+      });
+
+      const flipCalls = mockContext.updateWidget.mock.calls.filter(
+        ([, patch]) => (patch as { flipped?: boolean })?.flipped === false
+      );
+      expect(flipCalls).toHaveLength(1);
+    });
+  });
+
   describe('Toolbar button lock guards', () => {
     // Regression suite for the toolbar `disabled={isLocked}` + `if (isLocked) return`
     // defense-in-depth pattern. `disabled` alone doesn't stop programmatic

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -810,7 +810,7 @@ describe('DraggableWindow (Tests folder)', () => {
         >
           <DraggableWindow
             widget={{ ...mockWidget, flipped: true }}
-            settings={<div>Settings</div>}
+            settings={<div>Mock Settings Content</div>}
             title="Test Widget"
             globalStyle={mockGlobalStyle}
           >
@@ -853,6 +853,15 @@ describe('DraggableWindow (Tests folder)', () => {
     it('does not call updateWidget a second time when SettingsPanel already closed the panel via its own Escape handler', () => {
       renderFlipped();
 
+      // Guard against a vacuous pass: confirm SettingsPanel actually mounted
+      // and rendered its content BEFORE dispatching Escape below. Testing
+      // Library's render() flushes all passive effects synchronously (via its
+      // own act() wrapper), so if this assertion holds, SettingsPanel's
+      // `useEffect(() => { document.addEventListener('keydown', ...) }, [])`
+      // has already registered — the document dispatch below is guaranteed
+      // to reach a live listener, not a race against effect timing.
+      expect(screen.getByText('Mock Settings Content')).toBeInTheDocument();
+
       // SettingsPanel's own document-level Escape handler and DashboardView's
       // window-level widget-keyboard-action dispatch both fire within the
       // same synchronous keydown dispatch in the real app — reproduce that by
@@ -873,7 +882,81 @@ describe('DraggableWindow (Tests folder)', () => {
       const flipCalls = mockContext.updateWidget.mock.calls.filter(
         ([, patch]) => (patch as { flipped?: boolean })?.flipped === false
       );
+      // Exactly one call, from SettingsPanel's own onClose — proves the
+      // justClosedSettingsRef guard actually suppressed handleCustomKeyboard's
+      // would-be second write, not just that only one path happened to fire.
       expect(flipCalls).toHaveLength(1);
+    });
+
+    // Regression (#2430 round-5 review): justClosedSettingsRef was set
+    // unconditionally to `true` in onClose, but updateWidget returns early on
+    // a read-only board (never calls setDashboards), so no re-render fires to
+    // reset the ref in the render body. The ref stayed stuck `true` for the
+    // widget's lifetime, permanently no-op'ing handleCustomKeyboard's Escape
+    // priority chain — including setIsAnnotating(false), a purely local write
+    // NOT blocked by the read-only guard, leaving a read-only viewer unable
+    // to exit annotation mode via keyboard for the rest of the session.
+    it('does not permanently suppress Escape after closing settings on a read-only board (isAnnotating still toggles)', () => {
+      // isAnnotating is local component state (useState), not a widget field,
+      // and the normal UI paths to set it true (Alt+D, the Annotate toolbar
+      // button) are gated by isLocked = widget.isLocked || isActiveBoardReadOnly.
+      // So to reproduce "already annotating when the board flips to read-only
+      // mid-session", start writable, enter annotation mode via the real Alt+D
+      // shortcut, then rerender the same instance with isActiveBoardReadOnly
+      // flipped to true — local state survives the rerender.
+      const tree = (isActiveBoardReadOnly: boolean) => (
+        <DashboardContext.Provider
+          value={
+            {
+              ...mockContext,
+              selectedWidgetId: mockWidget.id,
+              isActiveBoardReadOnly,
+            } as unknown as DashboardContextValue
+          }
+        >
+          <DraggableWindow
+            widget={{ ...mockWidget, flipped: true }}
+            settings={<div>Mock Settings Content</div>}
+            title="Test Widget"
+            globalStyle={mockGlobalStyle}
+          >
+            <div data-testid="widget-content">Content</div>
+          </DraggableWindow>
+        </DashboardContext.Provider>
+      );
+
+      const { rerender, container } = render(tree(false));
+
+      const widgetEl = screen.getByTestId('widget-content').closest('.widget');
+      if (!widgetEl) throw new Error('.widget element not found');
+      fireEvent.keyDown(widgetEl, { key: 'd', altKey: true });
+      expect(container.querySelector('canvas')).toBeInTheDocument();
+
+      // Board becomes read-only mid-session.
+      rerender(tree(true));
+      expect(screen.getByText('Mock Settings Content')).toBeInTheDocument();
+
+      // First Escape: SettingsPanel's onClose fires. With the fix, the ref is
+      // only set when the board is writable, so it stays `false` here —
+      // updateWidget no-ops on this read-only board (no re-render either way).
+      act(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+      });
+
+      // A later, independent Escape must still be able to reach the
+      // isAnnotating branch — proving the ref did not leak past this widget's
+      // one settings-close.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent('widget-keyboard-action', {
+            detail: { widgetId: 'test-widget', key: 'Escape', shiftKey: false },
+          })
+        );
+      });
+
+      expect(container.querySelector('canvas')).not.toBeInTheDocument();
     });
   });
 

--- a/tests/components/common/DraggableWindow.test.tsx
+++ b/tests/components/common/DraggableWindow.test.tsx
@@ -841,10 +841,13 @@ describe('DraggableWindow (Tests folder)', () => {
         );
       });
 
-      // showConfirm takes priority in handleCustomKeyboard's Escape branch —
-      // the dialog must dismiss, and this dismissal must NOT also flip the
-      // widget back (that branch is only reached when showConfirm is false).
       expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      // showConfirm takes priority in handleCustomKeyboard's Escape branch.
+      // The flipped-back write is blocked by showConfirm returning early —
+      // justClosedSettingsRef is NOT exercised here (no real keydown was
+      // dispatched, only the widget-keyboard-action CustomEvent, so
+      // SettingsPanel's own document-level Escape listener never fires).
+      // See the next test in this suite for the ref guard itself.
       expect(mockContext.updateWidget).not.toHaveBeenCalledWith('test-widget', {
         flipped: false,
       });

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -519,10 +519,11 @@ describe('SettingsPanel', () => {
    * same widget — but that also silenced every OTHER window-level Escape
    * listener while a settings panel was open: Shift+Escape (minimize all),
    * group-build-mode exit, and AnnotationOverlay's own close-on-Escape. The
-   * redundant-dispatch bug is fixed instead in DashboardView (skip the
-   * widget-keyboard-action dispatch when the target widget is already
-   * flipped) — see tests/components/layout/DashboardView.test.tsx. Escape
-   * must keep propagating past this panel's document-level handler.
+   * redundant-dispatch bug is instead prevented inside DraggableWindow itself
+   * via justClosedSettingsRef — a ref set synchronously in the onClose lambda
+   * before updateWidget fires, then read in handleCustomKeyboard's Escape
+   * priority chain to skip the redundant flip-back write. Escape must keep
+   * propagating past this panel's document-level handler.
    */
   it('does not stop Escape from reaching a window-level handler', () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -513,18 +513,18 @@ describe('SettingsPanel', () => {
   });
 
   /**
-   * Regression: SettingsPanel's Escape handler is a document-level listener
-   * on a portal rendered outside any `.widget` ancestor (createPortal to
-   * document.body). Without calling stopPropagation(), the same Escape
-   * keypress continues bubbling past document to the window, where
-   * DashboardView's global keydown handler also reacts to it — dispatching
-   * a redundant 'widget-keyboard-action' Escape event at the same widget
-   * (an extra, unnecessary updateWidget/Firestore write on every settings
-   * close). This mirrors the "portalled popover Escape doesn't
-   * stopPropagation()" bug class fixed elsewhere (see ClassRosterMenu.tsx,
-   * FolderTree.tsx, ActiveClassChip.tsx, etc.) — SettingsPanel was missed.
+   * Regression guard against re-introducing a blanket stopPropagation() here.
+   * An earlier version of this fix called e.stopPropagation() on Escape to
+   * avoid a redundant DashboardView-dispatched widget-keyboard-action for the
+   * same widget — but that also silenced every OTHER window-level Escape
+   * listener while a settings panel was open: Shift+Escape (minimize all),
+   * group-build-mode exit, and AnnotationOverlay's own close-on-Escape. The
+   * redundant-dispatch bug is fixed instead in DashboardView (skip the
+   * widget-keyboard-action dispatch when the target widget is already
+   * flipped) — see tests/components/layout/DashboardView.test.tsx. Escape
+   * must keep propagating past this panel's document-level handler.
    */
-  it('stops propagation on Escape so a window-level handler (DashboardView) does not also fire', () => {
+  it('does not stop Escape from reaching a window-level handler', () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
       left: 0,
       top: 100,
@@ -572,7 +572,7 @@ describe('SettingsPanel', () => {
       });
 
       expect(onClose).toHaveBeenCalledTimes(1);
-      expect(windowHandler).not.toHaveBeenCalled();
+      expect(windowHandler).toHaveBeenCalledTimes(1);
     } finally {
       window.removeEventListener('keydown', windowHandler);
     }

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -511,4 +511,70 @@ describe('SettingsPanel', () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * Regression: SettingsPanel's Escape handler is a document-level listener
+   * on a portal rendered outside any `.widget` ancestor (createPortal to
+   * document.body). Without calling stopPropagation(), the same Escape
+   * keypress continues bubbling past document to the window, where
+   * DashboardView's global keydown handler also reacts to it — dispatching
+   * a redundant 'widget-keyboard-action' Escape event at the same widget
+   * (an extra, unnecessary updateWidget/Firestore write on every settings
+   * close). This mirrors the "portalled popover Escape doesn't
+   * stopPropagation()" bug class fixed elsewhere (see ClassRosterMenu.tsx,
+   * FolderTree.tsx, ActiveClassChip.tsx, etc.) — SettingsPanel was missed.
+   */
+  it('stops propagation on Escape so a window-level handler (DashboardView) does not also fire', () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 100,
+      right: 200,
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    });
+
+    const onClose = vi.fn();
+    const windowHandler = vi.fn();
+
+    const HarnessSimple: React.FC = () => {
+      const widgetRef = React.useRef<HTMLDivElement>(null);
+      return (
+        <>
+          <div ref={widgetRef} data-testid="fake-widget" />
+          <SettingsPanel
+            widget={MOCK_WIDGET}
+            widgetRef={widgetRef}
+            settings={<div data-testid="no-input">No form fields</div>}
+            shouldRenderSettings
+            onClose={onClose}
+            updateWidget={vi.fn()}
+            globalStyle={MOCK_GLOBAL_STYLE}
+            title="Test Widget"
+          />
+        </>
+      );
+    };
+
+    window.addEventListener('keydown', windowHandler);
+    try {
+      act(() => {
+        render(<HarnessSimple />);
+      });
+
+      act(() => {
+        document.body.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+        );
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(windowHandler).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowHandler);
+    }
+  });
 });

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -1150,6 +1150,102 @@ describe('DashboardView Gestures & Navigation', () => {
     });
   });
 
+  // Regression: SettingsPanel.tsx's own document-level Escape handler already
+  // closes an open settings panel (document fires before window in the bubble
+  // phase). Without this guard, DashboardView's window-level fallback also
+  // dispatched a widget-keyboard-action Escape at the SAME widget, causing
+  // DraggableWindow to flip it back a second, redundant time — an extra
+  // Firestore write on every settings-panel Escape-close. An earlier fix
+  // attempt solved this by calling stopPropagation() inside SettingsPanel
+  // itself, but that also silenced Shift+Escape (minimize all), group-build
+  // mode exit, and AnnotationOverlay's own Escape handler whenever a settings
+  // panel happened to be open — all legitimate co-active states. The correct
+  // fix instead skips the dispatch here, only for the specific already-open
+  // widget, leaving every other window-level Escape listener untouched.
+  describe('global Escape defers to an already-open widget settings panel', () => {
+    const widgetsWithFlipped = (flipped: boolean) => [
+      {
+        id: 'widget-1',
+        type: 'clock',
+        x: 100,
+        y: 100,
+        w: 200,
+        h: 200,
+        z: 1,
+        flipped,
+        config: {},
+      },
+    ];
+
+    const mockReturnWithWidget = (flipped: boolean, extra = {}) => ({
+      activeDashboard: {
+        ...mockDashboards[1],
+        widgets: widgetsWithFlipped(flipped),
+      },
+      dashboards: mockDashboards,
+      toasts: [],
+      addWidget: vi.fn(),
+      minimizeAllWidgets: vi.fn(),
+      restoreAllWidgets: vi.fn(),
+      loadDashboard: mockLoadDashboard,
+      zoom: 1,
+      setZoom: vi.fn(),
+      collectionsApi: {
+        collections: [],
+        loading: false,
+        error: null,
+        createCollection: vi.fn(),
+        renameCollection: vi.fn(),
+        moveCollection: vi.fn(),
+        deleteCollection: vi.fn(),
+        reorderSiblings: vi.fn(),
+        setCollectionMetadata: vi.fn(),
+        setCollectionDefaultBoard: vi.fn(),
+      },
+      ...extra,
+    });
+
+    it('does not dispatch a widget-keyboard-action Escape when the target widget is already flipped (settings open)', () => {
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        mockReturnWithWidget(true)
+      );
+      const handler = vi.fn();
+      window.addEventListener('widget-keyboard-action', handler);
+      try {
+        renderView();
+        fireEvent.keyDown(window, { key: 'Escape' });
+        expect(handler).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('widget-keyboard-action', handler);
+      }
+    });
+
+    it('still dispatches a widget-keyboard-action Escape when the target widget is not flipped', () => {
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        mockReturnWithWidget(false)
+      );
+      const handler = vi.fn();
+      window.addEventListener('widget-keyboard-action', handler);
+      try {
+        renderView();
+        fireEvent.keyDown(window, { key: 'Escape' });
+        expect(handler).toHaveBeenCalled();
+      } finally {
+        window.removeEventListener('widget-keyboard-action', handler);
+      }
+    });
+
+    it('Shift+Escape still minimizes all widgets even when the top widget is flipped (settings open)', () => {
+      const minimizeAllWidgets = vi.fn();
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+        mockReturnWithWidget(true, { minimizeAllWidgets })
+      );
+      renderView();
+      fireEvent.keyDown(window, { key: 'Escape', shiftKey: true });
+      expect(minimizeAllWidgets).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // Regression: Ctrl+/ (Open Cheat Sheet) lacked a typing-field guard.
   //
   // Bug: the `if ((e.ctrlKey || e.metaKey) && e.key === '/')` branch in the

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -1150,19 +1150,26 @@ describe('DashboardView Gestures & Navigation', () => {
     });
   });
 
-  // Regression: SettingsPanel.tsx's own document-level Escape handler already
-  // closes an open settings panel (document fires before window in the bubble
-  // phase). Without this guard, DashboardView's window-level fallback also
-  // dispatched a widget-keyboard-action Escape at the SAME widget, causing
-  // DraggableWindow to flip it back a second, redundant time — an extra
-  // Firestore write on every settings-panel Escape-close. An earlier fix
-  // attempt solved this by calling stopPropagation() inside SettingsPanel
-  // itself, but that also silenced Shift+Escape (minimize all), group-build
-  // mode exit, and AnnotationOverlay's own Escape handler whenever a settings
-  // panel happened to be open — all legitimate co-active states. The correct
-  // fix instead skips the dispatch here, only for the specific already-open
-  // widget, leaving every other window-level Escape listener untouched.
-  describe('global Escape defers to an already-open widget settings panel', () => {
+  // Regression history (#2430): SettingsPanel.tsx's own document-level
+  // Escape handler already closes an open settings panel (document fires
+  // before window in the bubble phase). An earlier fix attempt called
+  // stopPropagation() inside SettingsPanel to stop DashboardView's
+  // window-level fallback from ALSO dispatching a redundant
+  // widget-keyboard-action Escape at the same widget — but that also
+  // silenced Shift+Escape (minimize all), group-build mode exit, and
+  // AnnotationOverlay's own Escape handler whenever a settings panel
+  // happened to be open. A second attempt skipped the dispatch here in
+  // DashboardView specifically when the target widget was flipped — but
+  // DashboardView can't see DraggableWindow's local `showConfirm` state, so
+  // that also left an open delete-confirm dialog on a flipped widget stuck
+  // (Escape blocked before it could reach handleCustomKeyboard's
+  // showConfirm branch). The correct fix: DashboardView ALWAYS dispatches;
+  // DraggableWindow avoids the redundant write itself via a ref set
+  // synchronously by SettingsPanel's onClose (see
+  // justClosedSettingsRef in DraggableWindow.tsx, and
+  // "handleCustomKeyboard Escape priority" in DraggableWindow.test.tsx for
+  // that side of the fix).
+  describe('global Escape always dispatches widget-keyboard-action, even when a widget is flipped (settings open)', () => {
     const widgetsWithFlipped = (flipped: boolean) => [
       {
         id: 'widget-1',
@@ -1190,6 +1197,13 @@ describe('DashboardView Gestures & Navigation', () => {
       loadDashboard: mockLoadDashboard,
       zoom: 1,
       setZoom: vi.fn(),
+      removeToast: vi.fn(),
+      updateWidget: vi.fn(),
+      removeWidget: vi.fn(),
+      duplicateWidget: vi.fn(),
+      bringToFront: vi.fn(),
+      addToast: vi.fn(),
+      deleteAllWidgets: vi.fn(),
       collectionsApi: {
         collections: [],
         loading: false,
@@ -1205,7 +1219,7 @@ describe('DashboardView Gestures & Navigation', () => {
       ...extra,
     });
 
-    it('does not dispatch a widget-keyboard-action Escape when the target widget is already flipped (settings open)', () => {
+    it('still dispatches a widget-keyboard-action Escape when the target widget is already flipped (settings open)', () => {
       (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
         mockReturnWithWidget(true)
       );
@@ -1214,7 +1228,7 @@ describe('DashboardView Gestures & Navigation', () => {
       try {
         renderView();
         fireEvent.keyDown(window, { key: 'Escape' });
-        expect(handler).not.toHaveBeenCalled();
+        expect(handler).toHaveBeenCalled();
       } finally {
         window.removeEventListener('widget-keyboard-action', handler);
       }


### PR DESCRIPTION
## Root cause

`components/common/SettingsPanel.tsx` — the widget settings panel used by **every widget in the app** — is `createPortal`'d to `document.body`, outside any `.widget` ancestor, and registers its Escape-to-close handler on `document`. That handler closed the panel but never called `stopPropagation()`, so the same Escape keypress continued on to `DashboardView`'s global `window`-level Escape handler, which (since opening settings always calls `bringToFront`) dispatched a redundant `widget-keyboard-action` Escape at the *same* widget, causing `DraggableWindow` to flip it back a second, unnecessary time — an extra Firestore write on every settings-panel Escape-close.

This is the same recurring "portalled popover Escape doesn't stopPropagation" bug class already fixed 8x elsewhere — `SettingsPanel.tsx` was the one instance missed, and by far the highest-traffic one since every widget uses it.

## Fix (as actually committed — see review history below for two rejected intermediate attempts)

**`SettingsPanel.tsx` is unchanged from `dev-paul`** — it still does not call `stopPropagation()`, and a regression test guards against ever reintroducing that.

The actual fix lives in `components/common/DraggableWindow.tsx`: a new `justClosedSettingsRef`, set synchronously inside the `onClose` lambda passed to `SettingsPanel` (before it calls `updateWidget`), and read inside `handleCustomKeyboard`'s Escape priority chain:

```
if (showConfirm) { ... }                      // unchanged, always wins
else if (justClosedSettingsRef.current) { }    // no-op: SettingsPanel already closed this tick
else if (widget.flipped && !isActiveBoardReadOnly) { updateWidget(...) }
else if (isAnnotating) { ... }
else if (!isLocked) { ... }                    // minimize fallback
```

`DashboardView`'s global Escape handler **always dispatches** `widget-keyboard-action` — it does not (and cannot) special-case a flipped widget, because it has no visibility into `DraggableWindow`'s local `showConfirm` state.

### Two rejected approaches (kept here for anyone bisecting a future regression)

1. **`e.stopPropagation()` inside `SettingsPanel.tsx`** — mechanically stopped the redundant dispatch, but since it blocked the event from ever reaching `window`, it also silenced `DashboardView`'s Shift+Escape (minimize all), group-build-mode exit, and `AnnotationOverlay`'s own close-on-Escape handler whenever a settings panel happened to be open — all legitimate co-active states.
2. **Skip the dispatch in `DashboardView` when `targetWidget.flipped`** — fixed the double-write, but `DashboardView` can't see `DraggableWindow`'s local `showConfirm` state. Pressing Delete while settings is open sets `showConfirm=true` (no `flipped` guard on that path); the next Escape then hit the flipped-guard and returned early, so `handleCustomKeyboard`'s `showConfirm` branch never ran — a delete-confirm dialog on a flipped widget got permanently stuck.

The final design fixes the redundant write at its actual source (`DraggableWindow`, which owns both the write and the `showConfirm` state) instead of trying to have an unrelated ancestor guess at component-local state it can't observe.

## Regression tests

- `tests/components/common/SettingsPanel.test.tsx` — asserts Escape does **not** stop propagation (guards against reintroducing attempt #1).
- `tests/components/layout/DashboardView.test.tsx` — asserts Escape always dispatches regardless of flipped state, and that Shift+Escape still works when the top widget is flipped (guards against reintroducing attempt #2).
- `tests/components/common/DraggableWindow.test.tsx` — new "handleCustomKeyboard Escape priority (showConfirm vs. flipped)" suite: (a) an open delete-confirm dialog on a flipped widget dismisses correctly via Escape, (b) `updateWidget` is called exactly once (not twice) when `SettingsPanel`'s own Escape handler and the dispatched `widget-keyboard-action` both fire in the same synchronous keydown.

## Evidence (fail-before / pass-after)

Independently re-verified by the orchestrator at each of the 3 rounds via file-swap (not `git stash`) against the prior committed state — every new/changed assertion failed on the reverted code and passed after restoring the fix (see commit history for round-by-round detail).

## Validation

Final state independently re-run by the orchestrator: `pnpm run validate` **GREEN** — 605/605 root test files, 7354/7354 tests; 41/41 functions test files, 785/785 tests; `test:counts` guard passed. `pnpm run build` passed.

## Risk

**Contained** — the actual write path changed is a single `else if` branch inside one component's existing Escape handler; `SettingsPanel.tsx` (the 50+-widget-shared component) ends up completely unmodified from `dev-paul`.

## Other backlog findings (not fixed, out of scope)

- `components/common/library/PeriodSelector.tsx` has the same missing-guard bug but zero live consumers (dead/staged code) — revisit if/when wired up.
- `components/layout/sidebar/SidebarWidgets.tsx` has a missing permission gate but zero live consumers — needs a delete-or-wire-up decision.

---
Automated nightly code-health run (2026-08-11). See `docs/routines/debugger.md` for the standing routine.
