### PR TITLE
fix(plc): route usePlcBuildingDirectory snapshot errors through logError

### DIFF
--- a/hooks/usePlcBuildingDirectory.ts
+++ b/hooks/usePlcBuildingDirectory.ts
@@ -9,6 +9,7 @@ import {
 } from 'firebase/firestore';
 import { db, isAuthBypass } from '@/config/firebase';
 import { useAuth } from '@/context/useAuth';
+import { logError } from '@/utils/logError';
 import { shouldClearPlcDirectoryOnScopeChange } from '@/utils/plcDirectorySubscriptionKey';
 
 /**
@@ -214,7 +215,10 @@ export const usePlcBuildingDirectory = (
         setError(null);
       },
       (err) => {
-        console.error('PLC building-directory snapshot error:', err);
+        logError('usePlcBuildingDirectory.snapshot', err, {
+          orgId,
+          buildingId,
+        });
         setEntries(EMPTY_ENTRIES);
         setLoading(false);
         setError(err instanceof Error ? err : new Error(String(err)));

--- a/tests/hooks/usePlcBuildingDirectory.test.ts
+++ b/tests/hooks/usePlcBuildingDirectory.test.ts
@@ -33,6 +33,9 @@ import {
   where,
 } from 'firebase/firestore';
 import { usePlcBuildingDirectory } from '@/hooks/usePlcBuildingDirectory';
+import { logError } from '@/utils/logError';
+
+vi.mock('@/utils/logError', () => ({ logError: vi.fn() }));
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
@@ -65,6 +68,7 @@ const mockOnSnapshot = onSnapshot as Mock;
 const mockQuery = query as Mock;
 const mockWhere = where as Mock;
 const mockLimit = limit as Mock;
+const mockLogError = logError as unknown as Mock;
 
 const USER_UID = 'me-uid';
 const USER_EMAIL = 'me@example.com';
@@ -347,6 +351,38 @@ describe('usePlcBuildingDirectory — result filtering', () => {
     expect(result.current.entries).toEqual([]);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+});
+
+describe('usePlcBuildingDirectory — error path', () => {
+  it('routes snapshot errors through the structured logError seam, not raw console.error', () => {
+    let errorCb: (err: unknown) => void = () => {
+      throw new Error('error callback not captured');
+    };
+    mockOnSnapshot.mockImplementation((_q, _onNext, onError) => {
+      errorCb = onError;
+      return () => undefined;
+    });
+
+    const { result } = renderHook(() => usePlcBuildingDirectory());
+
+    const err = new Error('permission-denied');
+    act(() => {
+      errorCb(err);
+    });
+
+    // Every sibling usePlc* hook routes its snapshot-error path through the
+    // shared `logError` seam (single point where a future Sentry/Bugsnag
+    // backend gets wired in — see utils/logError.ts). A bare `console.error`
+    // here means this hook's failures are invisible to that pipeline.
+    expect(mockLogError).toHaveBeenCalledWith(
+      'usePlcBuildingDirectory.snapshot',
+      err,
+      { orgId: ORG_ID, buildingId: BUILDING_ID }
+    );
+    expect(result.current.error).toBe(err);
+    expect(result.current.entries).toEqual([]);
+    expect(result.current.loading).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Root cause

`hooks/usePlcBuildingDirectory.ts`'s `onSnapshot` error handler used a bare `console.error(...)` instead of the shared `logError()` seam every other `usePlc*` hook uses (confirmed via grep — this was the sole holdout among 20 sibling PLC hooks). `utils/logError.ts` documents this as the single required integration point for future error-reporting backends (Sentry/etc.); bypassing it means failures on this feature (the live `/plc` index hub's building-directory discovery feed, wired via `components/plc/PlcIndexHub.tsx`) are invisible to that pipeline.

## Fix

One-line swap from `console.error` to `logError('usePlcBuildingDirectory.snapshot', err, { orgId, buildingId })`, passing structured context matching the sibling hooks' convention.

## Rejected band-aid

None needed — root-cause fix is the one-line swap itself; there's no simpler or more targeted alternative.

## Regression test

`tests/hooks/usePlcBuildingDirectory.test.ts` — new test: "routes snapshot errors through the structured logError seam, not raw console.error."

## Evidence (fail-before / pass-after)

Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul`:
- Reverted the hook to `dev-paul`: new test **failed** (`expected "vi.fn()" to be called... Number of calls: 0`).
- Restored the fix: test **passed** (15/15 in the file).

## Validation

Independently re-ran on the branch:
- `pnpm run validate`: **GREEN** — 604/605 root test files (one unrelated `tests/components/plcMeetingMode.test.tsx` 5000ms timeout under concurrent-worktree CPU contention, re-ran in isolation and confirmed clean 4/4 — not a regression from this change), 7348/7349 tests; functions clean; `test:counts` guard passed.
- `pnpm run build`: passed.

## Risk

**Contained** — one-line observability fix in a single hook, no behavior change to the feature itself.

## Other backlog findings (not fixed, ruled out as stale/unreachable this run)

- `context/DialogContext.tsx`'s `openNext()` batching risk re-traced a 5th consecutive night — all `showPrompt()` call sites remain single/await-gated, no concurrent-trigger path found. Noted a related-but-still-unreached detail: `PromptDialog`'s un-keyed `useState(defaultValue)` in `DialogContainer.tsx` would leak stale input text across two same-kind consecutive prompts if the batching issue ever became reachable.
- `hooks/useRosters.ts`'s `assignPins()`/`utils/rosterPins.ts` — confirmed already collision-safe, no divergent path found.
- Dedup-fence sweep of recent commits (since 2026-07-23) found no new scoring/accumulation utility missing the established `Set<string>` fence.

---
Automated nightly code-health run (2026-08-11). See `docs/routines/debugger.md` for the standing routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByFq5e6u9i3GjYpp5PMGqv)_