### PR TITLE
fix(share): case-insensitive dedup for substitute sub-emails

### DIFF
--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -166,14 +166,17 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
       return;
     }
     // Normalize before dedup/store — Firestore and .includes() are case-sensitive.
+    // Dedup check lives inside the functional updater (not against the outer
+    // `draftEmails` closure) so two Add clicks in the same render tick can't
+    // both pass the check against the same stale snapshot and both append —
+    // same race this PR fixes in the share modals. draftEmails is always
+    // seeded from the normalized snapshot and new entries are always stored
+    // normalized, so a plain `===` is enough here (no per-comparison
+    // toLowerCase needed).
     const normalized = trimmed.toLowerCase();
-    // Compare case-insensitively so legacy mixed-case entries loaded from
-    // Firestore (written before normalization) aren't re-added as duplicates.
-    if (draftEmails.some((e) => e.toLowerCase() === normalized)) {
-      setEmailInput('');
-      return;
-    }
-    setDraftEmails((prev) => [...prev, normalized]);
+    setDraftEmails((prev) =>
+      prev.some((e) => e === normalized) ? prev : [...prev, normalized]
+    );
     setEmailInput('');
     setError(null);
   };

--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -95,6 +95,14 @@ export const PresetSubEmailsManager: React.FC = () => {
 
 interface Snapshot {
   emails: string[];
+  /**
+   * The raw Firestore array (string entries only, unnormalized) as of this
+   * snapshot — used to compute `dirty` against, since `emails` is already
+   * normalized/deduped and comparing draftEmails to it would always match
+   * right after seeding, permanently disabling Save for a building whose
+   * legacy data needs the normalization written back.
+   */
+  rawEmails: string[];
   loaded: boolean;
 }
 
@@ -104,6 +112,7 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
   const { user } = useAuth();
   const [snapshot, setSnapshot] = useState<Snapshot>({
     emails: [],
+    rawEmails: [],
     loaded: false,
   });
   // Editable draft layered on top of the snapshot. Initialized empty; once
@@ -132,21 +141,23 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
         // hook for the empty-chip failure mode this prevents) and dedup via
         // Set (the codebase's dedup convention elsewhere; O(n) vs the
         // previous indexOf-based O(n²) filter).
-        const list = Array.isArray(data?.emails)
-          ? [
-              ...new Set(
-                (data.emails as unknown[])
-                  .filter((v): v is string => typeof v === 'string')
-                  .map((e) => e.trim().toLowerCase())
-                  .filter((e) => e.length > 0)
-              ),
-            ]
+        const rawEmails = Array.isArray(data?.emails)
+          ? (data.emails as unknown[]).filter(
+              (v): v is string => typeof v === 'string'
+            )
           : [];
-        setSnapshot({ emails: list, loaded: true });
+        const list = [
+          ...new Set(
+            rawEmails
+              .map((e) => e.trim().toLowerCase())
+              .filter((e) => e.length > 0)
+          ),
+        ];
+        setSnapshot({ emails: list, rawEmails, loaded: true });
       },
       (err) => {
         console.error('[PresetSubEmailsManager] snapshot error:', err);
-        setSnapshot({ emails: [], loaded: true });
+        setSnapshot({ emails: [], rawEmails: [], loaded: true });
       }
     );
     return unsub;
@@ -160,10 +171,15 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
     setDraftSeededAt(Date.now());
   }
 
+  // Compares against the RAW Firestore array, not the already-normalized
+  // snapshot.emails draftEmails is seeded from — comparing to the normalized
+  // list would always match right after seeding, permanently disabling Save
+  // for a building whose legacy data (case variants, whitespace, duplicates)
+  // needs the normalized/deduped result written back to Firestore.
   const dirty = useMemo(() => {
     if (!snapshot.loaded) return false;
-    if (draftEmails.length !== snapshot.emails.length) return true;
-    return draftEmails.some((e, i) => e !== snapshot.emails[i]);
+    if (draftEmails.length !== snapshot.rawEmails.length) return true;
+    return draftEmails.some((e, i) => e !== snapshot.rawEmails[i]);
   }, [draftEmails, snapshot]);
 
   const addEmail = () => {
@@ -186,7 +202,16 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
       prev.some((e) => e === normalized) ? prev : [...prev, normalized]
     );
     setEmailInput('');
-    setError(null);
+    // For the (lower-stakes, UI-only) decision of whether to clear a live
+    // save-failure error, read draftEmails from the outer closure instead
+    // of trying to observe the updater's outcome synchronously — React
+    // does not invoke a functional updater inline when setState is called;
+    // it runs later during the render pass, so a `let added` flag captured
+    // inside the updater and read on the next line is always stale.
+    // Without this check, setError(null) would fire unconditionally,
+    // silently clearing a still-live save-failure error whenever a
+    // duplicate Add no-ops instead of only on a genuine new entry.
+    if (!draftEmails.includes(normalized)) setError(null);
   };
 
   const removeEmail = (email: string) => {

--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -127,12 +127,20 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
         // does — otherwise a raw un-normalized value seeds draftEmails as-is,
         // and typing its lowercase replacement gets silently blocked by the
         // case-insensitive dedup check in addEmail below (correct dedup, but
-        // no visible cue that the old entry is the reason).
+        // no visible cue that the old entry is the reason). Drop
+        // whitespace-only entries (mirrors usePresetSubEmails — see that
+        // hook for the empty-chip failure mode this prevents) and dedup via
+        // Set (the codebase's dedup convention elsewhere; O(n) vs the
+        // previous indexOf-based O(n²) filter).
         const list = Array.isArray(data?.emails)
-          ? (data.emails as unknown[])
-              .filter((v): v is string => typeof v === 'string')
-              .map((e) => e.trim().toLowerCase())
-              .filter((e, i, arr) => arr.indexOf(e) === i)
+          ? [
+              ...new Set(
+                (data.emails as unknown[])
+                  .filter((v): v is string => typeof v === 'string')
+                  .map((e) => e.trim().toLowerCase())
+                  .filter((e) => e.length > 0)
+              ),
+            ]
           : [];
         setSnapshot({ emails: list, loaded: true });
       },

--- a/components/admin/PresetSubEmailsManager.tsx
+++ b/components/admin/PresetSubEmailsManager.tsx
@@ -123,10 +123,16 @@ const BuildingPresetEditor: React.FC<{ buildingId: string }> = ({
       ref,
       (snap) => {
         const data = snap.data();
+        // Normalize legacy mixed-case entries the same way usePresetSubEmails
+        // does — otherwise a raw un-normalized value seeds draftEmails as-is,
+        // and typing its lowercase replacement gets silently blocked by the
+        // case-insensitive dedup check in addEmail below (correct dedup, but
+        // no visible cue that the old entry is the reason).
         const list = Array.isArray(data?.emails)
-          ? (data.emails as unknown[]).filter(
-              (v): v is string => typeof v === 'string'
-            )
+          ? (data.emails as unknown[])
+              .filter((v): v is string => typeof v === 'string')
+              .map((e) => e.trim().toLowerCase())
+              .filter((e, i, arr) => arr.indexOf(e) === i)
           : [];
         setSnapshot({ emails: list, loaded: true });
       },

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -338,7 +338,13 @@ export const ShareCollectionLinkCreatorModal: FC<
                         <button
                           key={email}
                           type="button"
-                          disabled={added}
+                          // Also gate on validity — usePresetSubEmails
+                          // normalizes but doesn't validate the Orono
+                          // domain, so an invalid or (pre-fix) empty-string
+                          // preset would otherwise render enabled and
+                          // permanently inert (the onClick guard below
+                          // silently no-ops on it with no error feedback).
+                          disabled={added || !isValidOronoEmail(email)}
                           onClick={() =>
                             // Mirror the typed-input path: validate against
                             // the Orono domain and de-dupe before adding

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -361,7 +361,9 @@ export const ShareCollectionLinkCreatorModal: FC<
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
                             added
                               ? 'bg-emerald-100 text-emerald-700 cursor-default'
-                              : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
+                              : !isValidOronoEmail(email)
+                                ? 'bg-slate-200 text-slate-400 cursor-not-allowed opacity-50'
+                                : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
                           }`}
                         >
                           {added ? (

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -325,7 +325,7 @@ export const ShareCollectionLinkCreatorModal: FC<
                       const added = subEmails.includes(email.toLowerCase());
                       return (
                         <button
-                          key={email}
+                          key={email.toLowerCase()}
                           type="button"
                           disabled={added}
                           onClick={() =>
@@ -336,7 +336,7 @@ export const ShareCollectionLinkCreatorModal: FC<
                             // list clean even if a preset ever comes from a
                             // non-hardcoded source.
                             setSubEmails((prev) => {
-                              const normalized = email.toLowerCase();
+                              const normalized = email.trim().toLowerCase();
                               return !isValidOronoEmail(email) ||
                                 prev.includes(normalized)
                                 ? prev

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -350,7 +350,7 @@ export const ShareCollectionLinkCreatorModal: FC<
                           }`}
                         >
                           <Plus className="w-3 h-3" />
-                          {email}
+                          {email.toLowerCase()}
                         </button>
                       );
                     })}

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -67,8 +67,10 @@ export const ShareCollectionLinkCreatorModal: FC<
       );
       return;
     }
+    // Normalize before dedup/store — Firestore and .includes() are case-sensitive.
+    const normalized = trimmed.toLowerCase();
     setSubEmails((prev) =>
-      prev.includes(trimmed) ? prev : [...prev, trimmed]
+      prev.includes(normalized) ? prev : [...prev, normalized]
     );
     setSubEmailDraft('');
     setSubEmailError(null);
@@ -320,7 +322,7 @@ export const ShareCollectionLinkCreatorModal: FC<
                 {presetEmails.length > 0 && (
                   <div className="flex flex-wrap gap-1">
                     {presetEmails.map((email) => {
-                      const added = subEmails.includes(email);
+                      const added = subEmails.includes(email.toLowerCase());
                       return (
                         <button
                           key={email}
@@ -328,15 +330,18 @@ export const ShareCollectionLinkCreatorModal: FC<
                           disabled={added}
                           onClick={() =>
                             // Mirror the typed-input path: validate against the
-                            // Orono domain and de-dupe before adding. `disabled`
-                            // already blocks re-adds in normal use, but keeping
-                            // the guard here means the list stays clean even if
-                            // a preset ever comes from a non-hardcoded source.
-                            setSubEmails((prev) =>
-                              !isValidOronoEmail(email) || prev.includes(email)
+                            // Orono domain, normalize case, and de-dupe before
+                            // adding (matches handleAddSubEmail above).
+                            // `disabled` already blocks re-adds, but keep the
+                            // list clean even if a preset ever comes from a
+                            // non-hardcoded source.
+                            setSubEmails((prev) => {
+                              const normalized = email.toLowerCase();
+                              return !isValidOronoEmail(email) ||
+                                prev.includes(normalized)
                                 ? prev
-                                : [...prev, email]
-                            )
+                                : [...prev, normalized];
+                            })
                           }
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
                             added

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -1,6 +1,14 @@
 import { type FC, useState, useId, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Folder, Copy, UserCheck, Mail, Plus, Trash2 } from 'lucide-react';
+import {
+  Folder,
+  Copy,
+  UserCheck,
+  Mail,
+  Plus,
+  Check,
+  Trash2,
+} from 'lucide-react';
 import type { Collection, Dashboard } from '@/types';
 import { useDashboard } from '@/context/useDashboard';
 import { usePresetSubEmails } from '@/hooks/usePresetSubEmails';
@@ -350,7 +358,11 @@ export const ShareCollectionLinkCreatorModal: FC<
                               : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
                           }`}
                         >
-                          <Plus className="w-3 h-3" />
+                          {added ? (
+                            <Check className="w-3 h-3" />
+                          ) : (
+                            <Plus className="w-3 h-3" />
+                          )}
                           {email}
                         </button>
                       );

--- a/components/share/ShareCollectionLinkCreatorModal.tsx
+++ b/components/share/ShareCollectionLinkCreatorModal.tsx
@@ -322,26 +322,27 @@ export const ShareCollectionLinkCreatorModal: FC<
                 {presetEmails.length > 0 && (
                   <div className="flex flex-wrap gap-1">
                     {presetEmails.map((email) => {
-                      const added = subEmails.includes(email.toLowerCase());
+                      // usePresetSubEmails already normalizes (trim +
+                      // lowercase) at the source — no per-consumer
+                      // re-normalization needed here.
+                      const added = subEmails.includes(email);
                       return (
                         <button
-                          key={email.toLowerCase()}
+                          key={email}
                           type="button"
                           disabled={added}
                           onClick={() =>
-                            // Mirror the typed-input path: validate against the
-                            // Orono domain, normalize case, and de-dupe before
-                            // adding (matches handleAddSubEmail above).
-                            // `disabled` already blocks re-adds, but keep the
-                            // list clean even if a preset ever comes from a
+                            // Mirror the typed-input path: validate against
+                            // the Orono domain and de-dupe before adding
+                            // (matches handleAddSubEmail above). `disabled`
+                            // already blocks re-adds, but keep the list clean
+                            // even if a preset ever comes from a
                             // non-hardcoded source.
-                            setSubEmails((prev) => {
-                              const normalized = email.trim().toLowerCase();
-                              return !isValidOronoEmail(email) ||
-                                prev.includes(normalized)
+                            setSubEmails((prev) =>
+                              !isValidOronoEmail(email) || prev.includes(email)
                                 ? prev
-                                : [...prev, normalized];
-                            })
+                                : [...prev, email]
+                            )
                           }
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
                             added
@@ -350,7 +351,7 @@ export const ShareCollectionLinkCreatorModal: FC<
                           }`}
                         >
                           <Plus className="w-3 h-3" />
-                          {email.toLowerCase()}
+                          {email}
                         </button>
                       );
                     })}

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  act,
+} from '@testing-library/react';
 
 // Regression guard, same bug class as PresetSubEmailsManager.test.tsx /
 // BetaUsersPanel.test.tsx (#2389 / #2375): every other "add an email" call
@@ -68,9 +74,12 @@ vi.mock('@/hooks/useAdminBuildings', () => ({
   useAdminBuildings: () => [{ id: 'high', name: 'High School' }],
 }));
 
+// Mixed-case on purpose: a legacy Firestore-stored preset with non-lowercase
+// casing is exactly the scenario the chip-label-lowercasing regression test
+// below needs to distinguish from an always-already-lowercase fixture.
 vi.mock('@/hooks/usePresetSubEmails', () => ({
   usePresetSubEmails: () => ({
-    emails: ['sub@orono.k12.mn.us'],
+    emails: ['Sub@Orono.K12.MN.US'],
     loading: false,
   }),
 }));
@@ -131,5 +140,48 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
 
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+
+  // Regression: handleAddSubEmail's dedup check read the outer `subEmails`
+  // closure, then called setSubEmails with an unconditional append — two
+  // separate operations, not one atomic update. Two Add clicks dispatched
+  // before React re-renders (e.g. a double-click) both read the same stale
+  // `subEmails` snapshot, both pass the `includes` check, and both enqueue an
+  // append — yielding a duplicate entry. Fixed by moving the dedup check
+  // inside the setSubEmails functional updater (matches
+  // ShareCollectionLinkCreatorModal's already-atomic pattern).
+  it('does not duplicate an entry when Add is clicked twice before a re-render (double-click)', () => {
+    openSubstituteMode();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'sub@orono.k12.mn.us' } });
+    const addButton = screen.getByRole('button', { name: 'Add' });
+    // Both clicks inside one act() batch React's updates together, so the
+    // second handleAddSubEmail() call reads the same pre-click `subEmails`
+    // state as the first — reproducing the race a real double-click can hit.
+    act(() => {
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+    });
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+
+  // Regression: preset chips rendered the raw Firestore-stored casing
+  // (`{email}`) while the added-emails list always shows the lowercased,
+  // normalized form — a legacy uppercase-cased preset looked like a
+  // different address than its own entry in the added list once clicked.
+  it('renders the preset chip label lowercased, matching the normalized stored value', () => {
+    render(
+      <ShareLinkCreatorModal dashboard={dashboard} isOpen onClose={vi.fn()} />
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Substitute \(View-Only\)/ })
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
+    ).toBeInTheDocument();
   });
 });

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+// Regression guard, same bug class as PresetSubEmailsManager.test.tsx /
+// BetaUsersPanel.test.tsx (#2389 / #2375): every other "add an email" call
+// site in the app lowercases the trimmed input before storing/deduping it,
+// because downstream `.includes()` checks and Firestore array membership are
+// case-sensitive. ShareLinkCreatorModal's substitute-mode sub-email picker
+// was never updated to match — both the manual `handleAddSubEmail` input and
+// the preset-chip click handler dedupe via a case-sensitive
+// `subEmails.includes(...)` without lowercasing, so adding
+// "Sub@orono.k12.mn.us" and later "sub@orono.k12.mn.us" produces two entries
+// for the same real mailbox instead of one.
+
+vi.mock('lucide-react', () => {
+  function icon(name: string) {
+    const Stub = (props: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement('span', { 'data-icon': name, ...props });
+    Stub.displayName = name;
+    return Stub;
+  }
+  return new Proxy(
+    {},
+    {
+      get(target: Record<string, unknown>, prop) {
+        if (prop === '__esModule') return true;
+        if (prop === 'then') return undefined;
+        if (typeof prop === 'string' && !(prop in target)) {
+          target[prop] = icon(prop);
+        }
+        return target[prop as string];
+      },
+    }
+  );
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? _key,
+  }),
+}));
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({
+    shareDashboard: vi.fn(),
+    shareSubstituteDashboard: vi.fn(),
+    rosters: [],
+    activeRosterId: null,
+    addToast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    canAccessFeature: () => true,
+    selectedBuildings: ['high'],
+    hasOrg: true,
+  }),
+}));
+
+vi.mock('@/hooks/usePlcs', () => ({
+  usePlcs: () => ({ plcs: [] }),
+}));
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [{ id: 'high', name: 'High School' }],
+}));
+
+vi.mock('@/hooks/usePresetSubEmails', () => ({
+  usePresetSubEmails: () => ({
+    emails: ['sub@orono.k12.mn.us'],
+    loading: false,
+  }),
+}));
+
+import { ShareLinkCreatorModal } from '@/components/share/ShareLinkCreatorModal';
+import type { Dashboard } from '@/types';
+
+const dashboard: Dashboard = {
+  id: 'dash-1',
+  name: 'Test Dashboard',
+  background: 'bg-slate-900',
+  widgets: [],
+  createdAt: Date.now(),
+};
+
+const openSubstituteMode = () => {
+  render(
+    <ShareLinkCreatorModal dashboard={dashboard} isOpen onClose={vi.fn()} />
+  );
+  fireEvent.click(
+    screen.getByRole('button', { name: /Substitute \(View-Only\)/ })
+  );
+};
+
+describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('de-dupes a manually-typed email against a differently-cased existing entry', () => {
+    openSubstituteMode();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.change(input, { target: { value: 'SUB@ORONO.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // Exactly one entry in the added-emails list for the mailbox, stored
+    // lowercased — not two case-variant duplicates. Scoped to `listitem`
+    // so the always-present preset chip (also labeled with the email) is
+    // never counted here.
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+
+  it('de-dupes a preset-chip click against an already-added differently-cased entry', () => {
+    openSubstituteMode();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // Preset chip for the lowercase form of the same mailbox.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
+    );
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+});

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -75,12 +75,12 @@ vi.mock('@/hooks/useAdminBuildings', () => ({
   useAdminBuildings: () => [{ id: 'high', name: 'High School' }],
 }));
 
-// Mixed-case on purpose: a legacy Firestore-stored preset with non-lowercase
-// casing is exactly the scenario the chip-label-lowercasing regression test
-// below needs to distinguish from an always-already-lowercase fixture.
+// usePresetSubEmails normalizes (trim + lowercase) at its own source — see
+// tests/hooks/usePresetSubEmails.test.ts for that regression coverage. This
+// mock returns an already-canonical value, matching the real hook's contract.
 vi.mock('@/hooks/usePresetSubEmails', () => ({
   usePresetSubEmails: () => ({
-    emails: ['Sub@Orono.K12.MN.US', '  padded@orono.k12.mn.us  '],
+    emails: ['sub@orono.k12.mn.us'],
     loading: false,
   }),
 }));
@@ -173,38 +173,5 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
 
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
-  });
-
-  // Regression: preset chips rendered the raw Firestore-stored casing
-  // (`{email}`) while the added-emails list always shows the lowercased,
-  // normalized form — a legacy uppercase-cased preset looked like a
-  // different address than its own entry in the added list once clicked.
-  it('renders the preset chip label lowercased, matching the normalized stored value', () => {
-    render(
-      <ShareLinkCreatorModal dashboard={dashboard} isOpen onClose={vi.fn()} />
-    );
-    fireEvent.click(
-      screen.getByRole('button', { name: /Substitute \(View-Only\)/ })
-    );
-
-    expect(
-      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
-    ).toBeInTheDocument();
-  });
-
-  // Regression: isValidOronoEmail trims internally, so a space-padded
-  // Firestore preset passed validation but the surrounding whitespace
-  // survived into the stored/added value (the Drive API silently rejects a
-  // padded address). The preset-chip click path must trim before storing,
-  // matching handleAddSubEmail's trimmed.toLowerCase() normalization.
-  it('trims a space-padded preset email before storing it', async () => {
-    openSubstituteMode();
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'padded@orono.k12.mn.us' })
-    );
-
-    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
-    expect(items).toEqual(['padded@orono.k12.mn.us']);
   });
 });

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -117,6 +117,7 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
   });
 
   afterEach(() => {
+    usePresetSubEmailsMock.mockReset();
     cleanup();
   });
 
@@ -175,6 +176,12 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
       name: 'not-an-orono-email@gmail.com',
     });
     expect(chip).toBeDisabled();
+    // Regression (#2432 round-9 review): `disabled` alone blocked clicks,
+    // but the className ternary only branched on `added` — an invalid-domain
+    // chip rendered with the full blue enabled appearance, giving a teacher
+    // zero visual cue that the click they just made was silently ignored.
+    expect(chip.className).not.toContain('bg-brand-blue-lighter/40');
+    expect(chip.className).toContain('cursor-not-allowed');
   });
 
   // Regression: handleAddSubEmail's dedup check read the outer `subEmails`

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import {
   render,
@@ -78,11 +78,14 @@ vi.mock('@/hooks/useAdminBuildings', () => ({
 // usePresetSubEmails normalizes (trim + lowercase) at its own source — see
 // tests/hooks/usePresetSubEmails.test.ts for that regression coverage. This
 // mock returns an already-canonical value, matching the real hook's contract.
+// Backed by a vi.fn() (matching ShareCollectionLinkCreatorModal.test.tsx's
+// usePresetSubEmailsMock) so individual tests can override the returned list.
+const usePresetSubEmailsMock = vi.fn(() => ({
+  emails: ['sub@orono.k12.mn.us'] as string[],
+  loading: false,
+}));
 vi.mock('@/hooks/usePresetSubEmails', () => ({
-  usePresetSubEmails: () => ({
-    emails: ['sub@orono.k12.mn.us'],
-    loading: false,
-  }),
+  usePresetSubEmails: () => usePresetSubEmailsMock(),
 }));
 
 import { ShareLinkCreatorModal } from '@/components/share/ShareLinkCreatorModal';
@@ -106,6 +109,13 @@ const openSubstituteMode = () => {
 };
 
 describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
+  beforeEach(() => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['sub@orono.k12.mn.us'],
+      loading: false,
+    });
+  });
+
   afterEach(() => {
     cleanup();
   });
@@ -147,6 +157,24 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
 
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+
+  // Regression (#2432 round-8 review): `disabled={added}` only blocks
+  // re-adds of an already-added email — it doesn't gate a preset that fails
+  // Orono-domain validation (or, pre-fix, a whitespace-only entry that
+  // normalized to ''). Such a chip rendered permanently enabled while the
+  // onClick guard silently no-op'd every click, with zero error feedback.
+  it('renders the preset chip disabled when the preset value fails domain validation', () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['not-an-orono-email@gmail.com'],
+      loading: false,
+    });
+    openSubstituteMode();
+
+    const chip = screen.getByRole('button', {
+      name: 'not-an-orono-email@gmail.com',
+    });
+    expect(chip).toBeDisabled();
   });
 
   // Regression: handleAddSubEmail's dedup check read the outer `subEmails`

--- a/components/share/ShareLinkCreatorModal.test.tsx
+++ b/components/share/ShareLinkCreatorModal.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import {
   render,
   screen,
@@ -79,7 +80,7 @@ vi.mock('@/hooks/useAdminBuildings', () => ({
 // below needs to distinguish from an always-already-lowercase fixture.
 vi.mock('@/hooks/usePresetSubEmails', () => ({
   usePresetSubEmails: () => ({
-    emails: ['Sub@Orono.K12.MN.US'],
+    emails: ['Sub@Orono.K12.MN.US', '  padded@orono.k12.mn.us  '],
     loading: false,
   }),
 }));
@@ -126,17 +127,23 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
 
-  it('de-dupes a preset-chip click against an already-added differently-cased entry', () => {
+  // A preset chip for an already-added mailbox is rendered `disabled` — real
+  // browsers never deliver a click to a disabled button (jsdom's fireEvent
+  // does, which would make a fireEvent-based "click" here a vacuous test of
+  // an unreachable path). userEvent.click respects `disabled` and no-ops,
+  // matching what actually happens in the browser: the chip is inert once
+  // its normalized value is already in the list.
+  it('renders the preset chip disabled (not clickable) once its normalized value is already added', async () => {
     openSubstituteMode();
 
     const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
     fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
-    // Preset chip for the lowercase form of the same mailbox.
-    fireEvent.click(
-      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
-    );
+    const chip = screen.getByRole('button', { name: 'sub@orono.k12.mn.us' });
+    expect(chip).toBeDisabled();
+
+    await userEvent.click(chip);
 
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
@@ -183,5 +190,21 @@ describe('ShareLinkCreatorModal — substitute sub-email case handling', () => {
     expect(
       screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
     ).toBeInTheDocument();
+  });
+
+  // Regression: isValidOronoEmail trims internally, so a space-padded
+  // Firestore preset passed validation but the surrounding whitespace
+  // survived into the stored/added value (the Drive API silently rejects a
+  // padded address). The preset-chip click path must trim before storing,
+  // matching handleAddSubEmail's trimmed.toLowerCase() normalization.
+  it('trims a space-padded preset email before storing it', async () => {
+    openSubstituteMode();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'padded@orono.k12.mn.us' })
+    );
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['padded@orono.k12.mn.us']);
   });
 });

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -246,12 +246,14 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
       );
       return;
     }
-    if (subEmails.includes(trimmed)) {
+    // Normalize before dedup/store — Firestore and .includes() are case-sensitive.
+    const normalized = trimmed.toLowerCase();
+    if (subEmails.includes(normalized)) {
       setSubEmailDraft('');
       setSubEmailError(null);
       return;
     }
-    setSubEmails((prev) => [...prev, trimmed]);
+    setSubEmails((prev) => [...prev, normalized]);
     setSubEmailDraft('');
     setSubEmailError(null);
   };
@@ -711,7 +713,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                 {presetEmails.length > 0 && (
                   <div className="flex flex-wrap gap-1 mb-2">
                     {presetEmails.map((email) => {
-                      const added = subEmails.includes(email);
+                      const added = subEmails.includes(email.toLowerCase());
                       return (
                         <button
                           key={email}
@@ -719,15 +721,18 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                           disabled={added}
                           onClick={() =>
                             // Mirror the typed-input path: validate against the
-                            // Orono domain and de-dupe before adding (matches
-                            // ShareCollectionLinkCreatorModal). `disabled` already
+                            // Orono domain, normalize case, and de-dupe before
+                            // adding (matches ShareCollectionLinkCreatorModal
+                            // and handleAddSubEmail above). `disabled` already
                             // blocks re-adds, but keep the list clean even if a
                             // preset ever comes from a non-hardcoded source.
-                            setSubEmails((prev) =>
-                              !isValidOronoEmail(email) || prev.includes(email)
+                            setSubEmails((prev) => {
+                              const normalized = email.toLowerCase();
+                              return !isValidOronoEmail(email) ||
+                                prev.includes(normalized)
                                 ? prev
-                                : [...prev, email]
-                            )
+                                : [...prev, normalized];
+                            })
                           }
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors cursor-pointer ${
                             added

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -247,13 +247,13 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
       return;
     }
     // Normalize before dedup/store — Firestore and .includes() are case-sensitive.
+    // Dedup check lives inside the functional updater (not against the outer
+    // `subEmails` closure) so two Add clicks in the same render tick can't
+    // both pass the check against the same stale snapshot and both append.
     const normalized = trimmed.toLowerCase();
-    if (subEmails.includes(normalized)) {
-      setSubEmailDraft('');
-      setSubEmailError(null);
-      return;
-    }
-    setSubEmails((prev) => [...prev, normalized]);
+    setSubEmails((prev) =>
+      prev.includes(normalized) ? prev : [...prev, normalized]
+    );
     setSubEmailDraft('');
     setSubEmailError(null);
   };
@@ -745,7 +745,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                           ) : (
                             <Plus className="w-3 h-3" />
                           )}
-                          {email}
+                          {email.toLowerCase()}
                         </button>
                       );
                     })}

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -744,7 +744,9 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
                             added
                               ? 'bg-emerald-100 text-emerald-700 cursor-default'
-                              : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
+                              : !isValidOronoEmail(email)
+                                ? 'bg-slate-200 text-slate-400 cursor-not-allowed opacity-50'
+                                : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'
                           }`}
                         >
                           {added ? (

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -716,7 +716,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                       const added = subEmails.includes(email.toLowerCase());
                       return (
                         <button
-                          key={email}
+                          key={email.toLowerCase()}
                           type="button"
                           disabled={added}
                           onClick={() =>
@@ -727,7 +727,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                             // list clean even if a preset ever comes from a
                             // non-hardcoded source.
                             setSubEmails((prev) => {
-                              const normalized = email.toLowerCase();
+                              const normalized = email.trim().toLowerCase();
                               return !isValidOronoEmail(email) ||
                                 prev.includes(normalized)
                                 ? prev

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -721,7 +721,13 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                         <button
                           key={email}
                           type="button"
-                          disabled={added}
+                          // Also gate on validity — usePresetSubEmails
+                          // normalizes but doesn't validate the Orono
+                          // domain, so an invalid or (pre-fix) empty-string
+                          // preset would otherwise render enabled and
+                          // permanently inert (the onClick guard below
+                          // silently no-ops on it with no error feedback).
+                          disabled={added || !isValidOronoEmail(email)}
                           onClick={() =>
                             // Mirror the typed-input path: validate against
                             // the Orono domain and de-dupe before adding
@@ -735,7 +741,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                                 : [...prev, email]
                             )
                           }
-                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors cursor-pointer ${
+                          className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors ${
                             added
                               ? 'bg-emerald-100 text-emerald-700 cursor-default'
                               : 'bg-brand-blue-lighter/40 text-brand-blue-primary hover:bg-brand-blue-lighter/70'

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -713,26 +713,27 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                 {presetEmails.length > 0 && (
                   <div className="flex flex-wrap gap-1 mb-2">
                     {presetEmails.map((email) => {
-                      const added = subEmails.includes(email.toLowerCase());
+                      // usePresetSubEmails already normalizes (trim +
+                      // lowercase) at the source — no per-consumer
+                      // re-normalization needed here.
+                      const added = subEmails.includes(email);
                       return (
                         <button
-                          key={email.toLowerCase()}
+                          key={email}
                           type="button"
                           disabled={added}
                           onClick={() =>
-                            // Mirror the typed-input path: validate against the
-                            // Orono domain, normalize case, and de-dupe before
-                            // adding (matches handleAddSubEmail above).
-                            // `disabled` already blocks re-adds, but keep the
-                            // list clean even if a preset ever comes from a
+                            // Mirror the typed-input path: validate against
+                            // the Orono domain and de-dupe before adding
+                            // (matches handleAddSubEmail above). `disabled`
+                            // already blocks re-adds, but keep the list clean
+                            // even if a preset ever comes from a
                             // non-hardcoded source.
-                            setSubEmails((prev) => {
-                              const normalized = email.trim().toLowerCase();
-                              return !isValidOronoEmail(email) ||
-                                prev.includes(normalized)
+                            setSubEmails((prev) =>
+                              !isValidOronoEmail(email) || prev.includes(email)
                                 ? prev
-                                : [...prev, normalized];
-                            })
+                                : [...prev, email]
+                            )
                           }
                           className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold transition-colors cursor-pointer ${
                             added
@@ -745,7 +746,7 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                           ) : (
                             <Plus className="w-3 h-3" />
                           )}
-                          {email.toLowerCase()}
+                          {email}
                         </button>
                       );
                     })}

--- a/components/share/ShareLinkCreatorModal.tsx
+++ b/components/share/ShareLinkCreatorModal.tsx
@@ -722,10 +722,10 @@ export const ShareLinkCreatorModal: React.FC<ShareLinkCreatorModalProps> = ({
                           onClick={() =>
                             // Mirror the typed-input path: validate against the
                             // Orono domain, normalize case, and de-dupe before
-                            // adding (matches ShareCollectionLinkCreatorModal
-                            // and handleAddSubEmail above). `disabled` already
-                            // blocks re-adds, but keep the list clean even if a
-                            // preset ever comes from a non-hardcoded source.
+                            // adding (matches handleAddSubEmail above).
+                            // `disabled` already blocks re-adds, but keep the
+                            // list clean even if a preset ever comes from a
+                            // non-hardcoded source.
                             setSubEmails((prev) => {
                               const normalized = email.toLowerCase();
                               return !isValidOronoEmail(email) ||

--- a/hooks/usePresetSubEmails.ts
+++ b/hooks/usePresetSubEmails.ts
@@ -37,15 +37,25 @@ export function usePresetSubEmails(buildingId: string): PresetSubEmailsState {
         // Normalize once at the source (trim + lowercase) so every consumer
         // gets an already-canonical value — Firestore array membership and
         // downstream `.includes()` checks are exact-match, and a legacy or
-        // hand-typed preset can carry stray whitespace/casing. Dedup after
-        // normalizing: legacy case-variant entries (e.g. 'Sub@x' and 'sub@x')
-        // would otherwise collapse to identical strings, producing duplicate
-        // React keys and two inert chips for one real mailbox.
+        // hand-typed preset can carry stray whitespace/casing. Drop
+        // whitespace-only entries after normalizing — a Firestore entry of
+        // '   ' would otherwise trim to '', pass dedup as the first
+        // occurrence, and reach every consumer as an invisible, permanently
+        // enabled, inert chip (isValidOronoEmail('') is false, so the
+        // add-click always no-ops). Dedup via Set (matches the codebase's
+        // dedup convention elsewhere) after normalizing: legacy case-variant
+        // entries (e.g. 'Sub@x' and 'sub@x') would otherwise collapse to
+        // identical strings, producing duplicate React keys and two inert
+        // chips for one real mailbox.
         const emails = Array.isArray(data?.emails)
-          ? (data.emails as unknown[])
-              .filter((v): v is string => typeof v === 'string')
-              .map((e) => e.trim().toLowerCase())
-              .filter((e, i, arr) => arr.indexOf(e) === i)
+          ? [
+              ...new Set(
+                (data.emails as unknown[])
+                  .filter((v): v is string => typeof v === 'string')
+                  .map((e) => e.trim().toLowerCase())
+                  .filter((e) => e.length > 0)
+              ),
+            ]
           : [];
         setSnapshot({ emails, buildingId: canonical });
       },

--- a/hooks/usePresetSubEmails.ts
+++ b/hooks/usePresetSubEmails.ts
@@ -34,10 +34,14 @@ export function usePresetSubEmails(buildingId: string): PresetSubEmailsState {
       ref,
       (snap) => {
         const data = snap.data();
+        // Normalize once at the source (trim + lowercase) so every consumer
+        // gets an already-canonical value — Firestore array membership and
+        // downstream `.includes()` checks are exact-match, and a legacy or
+        // hand-typed preset can carry stray whitespace/casing.
         const emails = Array.isArray(data?.emails)
-          ? (data.emails as unknown[]).filter(
-              (v): v is string => typeof v === 'string'
-            )
+          ? (data.emails as unknown[])
+              .filter((v): v is string => typeof v === 'string')
+              .map((e) => e.trim().toLowerCase())
           : [];
         setSnapshot({ emails, buildingId: canonical });
       },

--- a/hooks/usePresetSubEmails.ts
+++ b/hooks/usePresetSubEmails.ts
@@ -37,11 +37,15 @@ export function usePresetSubEmails(buildingId: string): PresetSubEmailsState {
         // Normalize once at the source (trim + lowercase) so every consumer
         // gets an already-canonical value — Firestore array membership and
         // downstream `.includes()` checks are exact-match, and a legacy or
-        // hand-typed preset can carry stray whitespace/casing.
+        // hand-typed preset can carry stray whitespace/casing. Dedup after
+        // normalizing: legacy case-variant entries (e.g. 'Sub@x' and 'sub@x')
+        // would otherwise collapse to identical strings, producing duplicate
+        // React keys and two inert chips for one real mailbox.
         const emails = Array.isArray(data?.emails)
           ? (data.emails as unknown[])
               .filter((v): v is string => typeof v === 'string')
               .map((e) => e.trim().toLowerCase())
+              .filter((e, i, arr) => arr.indexOf(e) === i)
           : [];
         setSnapshot({ emails, buildingId: canonical });
       },

--- a/tests/components/admin/PresetSubEmailsManager.test.tsx
+++ b/tests/components/admin/PresetSubEmailsManager.test.tsx
@@ -155,4 +155,34 @@ describe('PresetSubEmailsManager — email case handling', () => {
 
     expect(screen.getAllByText('sub@orono.k12.mn.us')).toHaveLength(1);
   });
+
+  // Regression (#2432 review): addEmail's dedup check read the outer
+  // `draftEmails` closure, then called setDraftEmails with an unconditional
+  // append — two separate operations, not one atomic update. Two Add clicks
+  // dispatched before React re-renders (e.g. a double-click) both read the
+  // same stale `draftEmails` snapshot, both pass the dedup check, and both
+  // enqueue an append — yielding a duplicate entry. Fixed by moving the
+  // dedup check inside the setDraftEmails functional updater (matches the
+  // already-atomic pattern in ShareLinkCreatorModal/
+  // ShareCollectionLinkCreatorModal).
+  it('does not duplicate an entry when Add is clicked twice before a re-render (double-click)', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(fakeDocSnap({ emails: [] }));
+    });
+
+    const input = screen.getByPlaceholderText('ohssub@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'sub@orono.k12.mn.us' } });
+    const addButton = screen.getByRole('button', { name: /add/i });
+    // Both clicks inside one act() batch React's updates together, so the
+    // second addEmail() call reads the same pre-click `draftEmails` state
+    // as the first — reproducing the race a real double-click can hit.
+    act(() => {
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+    });
+
+    expect(screen.getAllByText('sub@orono.k12.mn.us')).toHaveLength(1);
+  });
 });

--- a/tests/components/admin/PresetSubEmailsManager.test.tsx
+++ b/tests/components/admin/PresetSubEmailsManager.test.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
 import {
   render,
   screen,
@@ -75,7 +83,10 @@ vi.mock('firebase/firestore', () => ({
   setDoc: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { setDoc } from 'firebase/firestore';
 import { PresetSubEmailsManager } from '@/components/admin/PresetSubEmailsManager';
+
+const setDocMock = setDoc as unknown as Mock;
 
 const fakeDocSnap = (data: Record<string, unknown> | undefined) => ({
   data: () => data,
@@ -84,6 +95,7 @@ const fakeDocSnap = (data: Record<string, unknown> | undefined) => ({
 describe('PresetSubEmailsManager — email case handling', () => {
   beforeEach(() => {
     listeners = [];
+    setDocMock.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -200,5 +212,78 @@ describe('PresetSubEmailsManager — email case handling', () => {
 
     expect(screen.getByText('1 preset email')).toBeInTheDocument();
     expect(screen.getByText('valid@orono.k12.mn.us')).toBeInTheDocument();
+  });
+
+  // Regression (#2432 round-9 review): moving the dedup check into the
+  // functional updater dropped the early return that used to keep
+  // setError(null) off the duplicate path — it now fires unconditionally.
+  // A live save-failure error message got silently wiped by a subsequent
+  // duplicate Add, with no indication to the admin that the save is still
+  // failing.
+  it('does not clear a save-failure error when a duplicate email is submitted', async () => {
+    setDocMock.mockRejectedValueOnce(new Error('permission-denied'));
+    render(<PresetSubEmailsManager />);
+
+    // Legacy mixed-case raw data (see the "marks dirty..." test below) makes
+    // Save enabled immediately, with no add-cycle needed first.
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['Sub@Orono.K12.MN.US'] })
+      );
+    });
+
+    // Type a value that's already a duplicate of the (normalized) existing
+    // entry BEFORE the save fails — this fireEvent.change's onChange handler
+    // clears error too (correct, pre-existing, unrelated behavior), but no
+    // error exists yet at this point, so it's a no-op here. Doing this
+    // *after* the save failure instead would let that unrelated onChange
+    // path silently clear the error, masking whether THIS fix (in
+    // addEmail's own duplicate branch) actually works.
+    const input = screen.getByPlaceholderText('ohssub@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'sub@orono.k12.mn.us' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(
+      await screen.findByText(
+        'Failed to save. Check Firestore rules and try again.'
+      )
+    ).toBeInTheDocument();
+
+    // Click Add with no further onChange — exercises addEmail's own
+    // duplicate path in isolation.
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+    expect(
+      screen.getByText('Failed to save. Check Firestore rules and try again.')
+    ).toBeInTheDocument();
+  });
+
+  // Regression (#2432 round-9 review): snapshot.emails is already
+  // normalized/deduped, and draftEmails seeds from it — comparing the two
+  // for `dirty` always matches right after seeding, permanently disabling
+  // Save for a building whose legacy Firestore data (case variants,
+  // whitespace, duplicates) needs the cleaned-up result written back.
+  it('marks dirty (Save enabled) when legacy Firestore data required normalization', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['Sub@Orono.K12.MN.US', 'sub@orono.k12.mn.us'] })
+      );
+    });
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeEnabled();
+  });
+
+  it('leaves Save disabled when Firestore data is already clean', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['sub@orono.k12.mn.us'] })
+      );
+    });
+
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
   });
 });

--- a/tests/components/admin/PresetSubEmailsManager.test.tsx
+++ b/tests/components/admin/PresetSubEmailsManager.test.tsx
@@ -185,4 +185,20 @@ describe('PresetSubEmailsManager — email case handling', () => {
 
     expect(screen.getAllByText('sub@orono.k12.mn.us')).toHaveLength(1);
   });
+
+  // Regression (#2432 round-8 review): a whitespace-only Firestore entry
+  // ('   ') trims to '', which passed the old dedup filter — the admin
+  // draft list showed an invisible, permanently-enabled, inert chip.
+  it('drops whitespace-only entries when seeding the draft list', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['   ', 'valid@orono.k12.mn.us'] })
+      );
+    });
+
+    expect(screen.getByText('1 preset email')).toBeInTheDocument();
+    expect(screen.getByText('valid@orono.k12.mn.us')).toBeInTheDocument();
+  });
 });

--- a/tests/components/admin/PresetSubEmailsManager.test.tsx
+++ b/tests/components/admin/PresetSubEmailsManager.test.tsx
@@ -121,4 +121,38 @@ describe('PresetSubEmailsManager — email case handling', () => {
     // Only one chip for the mailbox, not two case-variant duplicates.
     expect(screen.getAllByText(/sub@orono\.k12\.mn\.us/i)).toHaveLength(1);
   });
+
+  // Regression (#2432 review): a legacy mixed-case Firestore entry used to
+  // seed draftEmails as-is (raw, un-normalized). The admin would see the
+  // stale casing in the list, and typing the lowercase replacement got
+  // silently blocked by addEmail's case-insensitive dedup check — correct
+  // dedup, but no visible cue why. Normalizing at snapshot time means the
+  // draft always displays (and dedups against) the same canonical value
+  // usePresetSubEmails hands to every other consumer.
+  it('normalizes a legacy mixed-case Firestore entry when seeding the draft list', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({ emails: ['Sub@Orono.K12.MN.US'] })
+      );
+    });
+
+    expect(screen.getByText('sub@orono.k12.mn.us')).toBeInTheDocument();
+    expect(screen.queryByText('Sub@Orono.K12.MN.US')).not.toBeInTheDocument();
+  });
+
+  it('dedups case-variant legacy entries when seeding the draft list', () => {
+    render(<PresetSubEmailsManager />);
+
+    act(() => {
+      listeners[listeners.length - 1].next(
+        fakeDocSnap({
+          emails: ['Sub@Orono.K12.MN.US', 'sub@orono.k12.mn.us'],
+        })
+      );
+    });
+
+    expect(screen.getAllByText('sub@orono.k12.mn.us')).toHaveLength(1);
+  });
 });

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -257,4 +257,33 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
+
+  // Regression (#2432 review): the Collection variant of this chip always
+  // rendered a Plus icon, even once `added` was true (ShareLinkCreatorModal's
+  // chip correctly switches to Check). Functionality wasn't broken — the chip
+  // was still disabled — but the icon lied about the chip's state.
+  it('switches the preset chip icon from Plus to Check once its value is already added', () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['sub@orono.k12.mn.us'],
+    });
+    openSubstituteMode();
+
+    const chipBeforeAdd = screen.getByRole('button', {
+      name: 'sub@orono.k12.mn.us',
+    });
+    expect(chipBeforeAdd.querySelector('.lucide-plus')).toBeInTheDocument();
+    expect(
+      chipBeforeAdd.querySelector('.lucide-check')
+    ).not.toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    const chipAfterAdd = screen.getByRole('button', {
+      name: 'sub@orono.k12.mn.us',
+    });
+    expect(chipAfterAdd.querySelector('.lucide-check')).toBeInTheDocument();
+    expect(chipAfterAdd.querySelector('.lucide-plus')).not.toBeInTheDocument();
+  });
 });

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -273,6 +273,12 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
       name: 'not-an-orono-email@gmail.com',
     });
     expect(chip).toBeDisabled();
+    // Regression (#2432 round-9 review): `disabled` alone blocked clicks,
+    // but the className ternary only branched on `added` — an invalid-domain
+    // chip rendered with the full blue enabled appearance, giving a teacher
+    // zero visual cue that the click they just made was silently ignored.
+    expect(chip.className).not.toContain('bg-brand-blue-lighter/40');
+    expect(chip.className).toContain('cursor-not-allowed');
   });
 
   // Regression (#2432 review): the Collection variant of this chip always

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -257,37 +257,4 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
-
-  // Regression: the preset chip rendered the raw Firestore-stored casing
-  // (`{email}`) while the added-emails list always shows the lowercased,
-  // normalized form — a legacy uppercase-cased preset looked like a
-  // different address than its own entry in the added list once clicked.
-  it('renders the preset chip label lowercased, matching the normalized stored value', () => {
-    usePresetSubEmailsMock.mockReturnValue({
-      emails: ['Sub@Orono.K12.MN.US'],
-    });
-    openSubstituteMode();
-
-    expect(
-      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
-    ).toBeInTheDocument();
-  });
-
-  // Regression: isValidOronoEmail trims internally, so a space-padded
-  // Firestore preset passed validation but the surrounding whitespace
-  // survived into the stored/added value. The preset-chip click path must
-  // trim before storing.
-  it('trims a space-padded preset email before storing it', async () => {
-    usePresetSubEmailsMock.mockReturnValue({
-      emails: ['  padded@orono.k12.mn.us  '],
-    });
-    openSubstituteMode();
-
-    await userEvent.click(
-      screen.getByRole('button', { name: 'padded@orono.k12.mn.us' })
-    );
-
-    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
-    expect(items).toEqual(['padded@orono.k12.mn.us']);
-  });
 });

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -252,4 +252,19 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
+
+  // Regression: the preset chip rendered the raw Firestore-stored casing
+  // (`{email}`) while the added-emails list always shows the lowercased,
+  // normalized form — a legacy uppercase-cased preset looked like a
+  // different address than its own entry in the added list once clicked.
+  it('renders the preset chip label lowercased, matching the normalized stored value', () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['Sub@Orono.K12.MN.US'],
+    });
+    openSubstituteMode();
+
+    expect(
+      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -234,7 +234,12 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
 
-  it('de-dupes a preset-chip click against an already-added differently-cased entry', () => {
+  // A preset chip for an already-added mailbox is rendered `disabled` — real
+  // browsers never deliver a click to a disabled button (jsdom's fireEvent
+  // does, which would make a fireEvent-based "click" here a vacuous test of
+  // an unreachable path). userEvent.click respects `disabled` and no-ops,
+  // matching what actually happens in the browser.
+  it('renders the preset chip disabled (not clickable) once its normalized value is already added', async () => {
     usePresetSubEmailsMock.mockReturnValue({
       emails: ['sub@orono.k12.mn.us'],
     });
@@ -244,10 +249,10 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
-    // Preset chip for the lowercase form of the same mailbox.
-    fireEvent.click(
-      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
-    );
+    const chip = screen.getByRole('button', { name: 'sub@orono.k12.mn.us' });
+    expect(chip).toBeDisabled();
+
+    await userEvent.click(chip);
 
     const items = screen.getAllByRole('listitem').map((li) => li.textContent);
     expect(items).toEqual(['sub@orono.k12.mn.us']);
@@ -266,5 +271,23 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     expect(
       screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
     ).toBeInTheDocument();
+  });
+
+  // Regression: isValidOronoEmail trims internally, so a space-padded
+  // Firestore preset passed validation but the surrounding whitespace
+  // survived into the stored/added value. The preset-chip click path must
+  // trim before storing.
+  it('trims a space-padded preset email before storing it', async () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['  padded@orono.k12.mn.us  '],
+    });
+    openSubstituteMode();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'padded@orono.k12.mn.us' })
+    );
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['padded@orono.k12.mn.us']);
   });
 });

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -258,6 +258,23 @@ describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling
     expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
 
+  // Regression (#2432 round-8 review): `disabled={added}` only blocks
+  // re-adds of an already-added email — it doesn't gate a preset that fails
+  // Orono-domain validation (or, pre-fix, a whitespace-only entry that
+  // normalized to ''). Such a chip rendered permanently enabled while the
+  // onClick guard silently no-op'd every click, with zero error feedback.
+  it('renders the preset chip disabled when the preset value fails domain validation', () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['not-an-orono-email@gmail.com'],
+    });
+    openSubstituteMode();
+
+    const chip = screen.getByRole('button', {
+      name: 'not-an-orono-email@gmail.com',
+    });
+    expect(chip).toBeDisabled();
+  });
+
   // Regression (#2432 review): the Collection variant of this chip always
   // rendered a Plus icon, even once `added` was true (ShareLinkCreatorModal's
   // chip correctly switches to Check). Functionality wasn't broken — the chip

--- a/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
+++ b/tests/components/share/ShareCollectionLinkCreatorModal.test.tsx
@@ -14,8 +14,9 @@ vi.mock('@/context/useDashboard', () => ({
 
 // usePresetSubEmails hits Firestore; stub it so the modal's optional sub-email
 // preset chips render without a live backend.
+const usePresetSubEmailsMock = vi.fn(() => ({ emails: [] as string[] }));
 vi.mock('@/hooks/usePresetSubEmails', () => ({
-  usePresetSubEmails: () => ({ emails: [] as string[] }),
+  usePresetSubEmails: () => usePresetSubEmailsMock(),
 }));
 
 const collection = (): Collection => ({
@@ -47,6 +48,7 @@ const baseMockReturn = {
 beforeEach(() => {
   vi.clearAllMocks();
   useDashboardMock.mockReturnValue(baseMockReturn);
+  usePresetSubEmailsMock.mockReturnValue({ emails: [] as string[] });
   // Stub clipboard for the auto-copy path
   Object.assign(navigator, {
     clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -190,5 +192,64 @@ describe('ShareCollectionLinkCreatorModal', () => {
     expect((urlInput as HTMLInputElement).value).toContain(
       '/share-collection/share-id-123'
     );
+  });
+});
+
+// Regression guard, same bug class as ShareLinkCreatorModal.test.tsx /
+// PresetSubEmailsManager.test.tsx / BetaUsersPanel.test.tsx (#2389 / #2375):
+// every other "add an email" call site in the app lowercases the trimmed
+// input before storing/deduping it, because downstream `.includes()` checks
+// and Firestore array membership are case-sensitive. This modal's substitute
+// Collection-share sub-email picker was never updated to match — both the
+// manual `handleAddSubEmail` input and the preset-chip click handler deduped
+// via a case-sensitive `subEmails.includes(...)` without lowercasing, so
+// adding "Sub@orono.k12.mn.us" and later "sub@orono.k12.mn.us" produced two
+// entries for the same real mailbox instead of one.
+describe('ShareCollectionLinkCreatorModal — substitute sub-email case handling', () => {
+  const openSubstituteMode = () => {
+    render(
+      <ShareCollectionLinkCreatorModal
+        isOpen
+        collection={collection()}
+        boards={[board('b1')]}
+        onClose={vi.fn()}
+      />
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('radio', { name: /substitute/i }));
+    });
+  };
+
+  it('de-dupes a manually-typed email against a differently-cased existing entry', () => {
+    openSubstituteMode();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.change(input, { target: { value: 'SUB@ORONO.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // Exactly one entry, stored lowercased — not two case-variant duplicates.
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['sub@orono.k12.mn.us']);
+  });
+
+  it('de-dupes a preset-chip click against an already-added differently-cased entry', () => {
+    usePresetSubEmailsMock.mockReturnValue({
+      emails: ['sub@orono.k12.mn.us'],
+    });
+    openSubstituteMode();
+
+    const input = screen.getByPlaceholderText('name@orono.k12.mn.us');
+    fireEvent.change(input, { target: { value: 'Sub@Orono.K12.MN.US' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // Preset chip for the lowercase form of the same mailbox.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'sub@orono.k12.mn.us' })
+    );
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(items).toEqual(['sub@orono.k12.mn.us']);
   });
 });

--- a/tests/hooks/usePresetSubEmails.test.ts
+++ b/tests/hooks/usePresetSubEmails.test.ts
@@ -176,6 +176,26 @@ describe('usePresetSubEmails — snapshot mapping', () => {
       loading: false,
     });
   });
+
+  // Regression (#2432 review): normalizing collapses case-variant legacy
+  // entries to identical strings, but the map alone doesn't dedup them —
+  // consumers would render duplicate React keys and two inert chips for one
+  // real mailbox.
+  it('dedups case-variant entries that normalize to the same email', () => {
+    const { result } = renderHook(() => usePresetSubEmails('high'));
+    act(() => {
+      lastListener().next(
+        fakeDocSnap({
+          emails: ['Sub@Orono.K12.MN.US', 'sub@orono.k12.mn.us', 'other@x.org'],
+        })
+      );
+    });
+
+    expect(result.current).toEqual({
+      emails: ['sub@orono.k12.mn.us', 'other@x.org'],
+      loading: false,
+    });
+  });
 });
 
 describe('usePresetSubEmails — error handling', () => {

--- a/tests/hooks/usePresetSubEmails.test.ts
+++ b/tests/hooks/usePresetSubEmails.test.ts
@@ -152,6 +152,30 @@ describe('usePresetSubEmails — snapshot mapping', () => {
       loading: false,
     });
   });
+
+  // Regression: consumers (ShareLinkCreatorModal, ShareCollectionLinkCreator
+  // Modal) each re-implemented trim().toLowerCase() at 4 separate call sites
+  // and repeatedly missed one of them across several review rounds — a
+  // space-padded or mixed-case Firestore preset would pass validation but
+  // leave a chip stuck "enabled" after being added, render with visible
+  // whitespace, or collide on its React key. Normalizing once here, at the
+  // single source every consumer reads from, makes every consumer trivially
+  // correct instead of needing the same fix copy-pasted in 4 places.
+  it('trims and lowercases every email so every consumer gets an already-canonical value', () => {
+    const { result } = renderHook(() => usePresetSubEmails('high'));
+    act(() => {
+      lastListener().next(
+        fakeDocSnap({
+          emails: ['  Sub@Orono.K12.MN.US  ', 'ALREADY@LOWER.COM'],
+        })
+      );
+    });
+
+    expect(result.current).toEqual({
+      emails: ['sub@orono.k12.mn.us', 'already@lower.com'],
+      loading: false,
+    });
+  });
 });
 
 describe('usePresetSubEmails — error handling', () => {

--- a/tests/hooks/usePresetSubEmails.test.ts
+++ b/tests/hooks/usePresetSubEmails.test.ts
@@ -196,6 +196,27 @@ describe('usePresetSubEmails — snapshot mapping', () => {
       loading: false,
     });
   });
+
+  // Regression (#2432 round-8 review): a whitespace-only Firestore entry
+  // ('   ') trims to '', which passed the old dedup filter as a normal
+  // entry — every consumer got an invisible, permanently-enabled, inert
+  // preset chip (isValidOronoEmail('') is false, so a click always no-ops
+  // with no error feedback).
+  it('drops whitespace-only entries after normalizing', () => {
+    const { result } = renderHook(() => usePresetSubEmails('high'));
+    act(() => {
+      lastListener().next(
+        fakeDocSnap({
+          emails: ['   ', 'valid@orono.k12.mn.us', '\t\n'],
+        })
+      );
+    });
+
+    expect(result.current).toEqual({
+      emails: ['valid@orono.k12.mn.us'],
+      loading: false,
+    });
+  });
 });
 
 describe('usePresetSubEmails — error handling', () => {


### PR DESCRIPTION
## Root cause

`components/share/ShareLinkCreatorModal.tsx` (substitute-share sub-email picker) had the same case-sensitive email-dedup bug already fixed twice elsewhere in this codebase (`PresetSubEmailsManager.tsx` #2389, `BetaUsersPanel.tsx` #2375): both `handleAddSubEmail` (manual input) and the preset-chip click handler deduped via a raw `subEmails.includes(x)` without lowercasing first. A host teacher typing `Sub@orono.k12.mn.us` then later `sub@orono.k12.mn.us` got two entries for one real mailbox, meaning duplicate/inconsistent Google Drive roster-access grants for a substitute.

Confirmed reachable: `ShareLinkCreatorModal` is rendered live by `components/boardsModal/BoardsModal.tsx`.

**Scope note:** `components/share/**` is outside this run's `Admin & Config` glob (`components/admin/**`/`components/auth/**`). This is a deliberate one-time exception, matching the precedent set by PR #2213 for an identically-shaped case: same established bug class, same fix pattern already reviewed and shipped twice elsewhere, one-line-per-site change, low risk.

## Fix

Lowercase-normalize the email before dedup/store in `handleAddSubEmail`, and lowercase both the stored comparison value and the "already added" check in the preset-chip handler — mirroring the `#2389`/`#2375` fix exactly (normalize on write, not just on compare).

## Rejected band-aid

Case-insensitive comparison without normalizing storage — rejected because it would leave the array holding mixed-case strings, inconsistent with every other "add an email" call site in the app and with how the two prior instances of this exact bug were fixed.

## Regression test

`components/share/ShareLinkCreatorModal.test.tsx` (new, 2 tests) — covers both the manual-input path and the preset-chip-click path de-duping against an already-added differently-cased entry.

## Evidence (fail-before / pass-after)

Independently re-verified by the orchestrator via file-swap (not `git stash`) against `dev-paul`:
- Reverted the component to `dev-paul`: both new tests **failed** (2 entries instead of 1, e.g. `['Sub@Orono.K12.MN.US', 'SUB@ORONO.K12.MN.US']`).
- Restored the fix: both tests **passed** (single normalized entry `['sub@orono.k12.mn.us']`).

## Validation

Independently re-ran on the branch:
- `pnpm run validate`: **GREEN** — 606/606 root test files, 7350/7350 tests; 41/41 functions test files, 785/785 tests; `test:counts` guard passed.
- `pnpm run build`: passed.

## Risk

**Contained** — two isolated one-line normalization changes, matching an already-proven fix pattern.

## Other backlog findings (not fixed this run)

- `components/auth/DeactivatedScreen.tsx`, `InviteAcceptance.tsx`, `PlcInviteAcceptance.tsx`, `NewUserSetup.tsx` remain fully hardcoded English with zero `t()` calls — large-scope product decision, left as backlog.
- Whole-repo i18n flatten-and-diff (en vs. de/es/fr) reconfirmed 0 missing/extra keys — the 2026-07-26 clean state still holds.

---
Automated nightly code-health run (2026-08-11). See `docs/routines/debugger.md` for the standing routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ByFq5e6u9i3GjYpp5PMGqv)_