### PR TITLE
D4: use @/ alias in stress-reference spike import

### DIFF
--- a/scripts/spikes/stress-reference/reference.test.ts
+++ b/scripts/spikes/stress-reference/reference.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import nucleiData from '../stress-detection/nuclei.json';
+import nucleiData from '@/scripts/spikes/stress-detection/nuclei.json';
 import {
   type Lang,
   type StressReading,

--- a/scripts/spikes/stress-reference/reference.ts
+++ b/scripts/spikes/stress-reference/reference.ts
@@ -15,7 +15,7 @@
  * the map and `ˌ` is discarded everywhere below.
  */
 
-import nucleiData from '../stress-detection/nuclei.json';
+import nucleiData from '@/scripts/spikes/stress-detection/nuclei.json';
 
 /** The 244 nucleus-bearing tokens, derived from the model's own vocabulary. */
 const NUCLEUS_TOKENS: readonly string[] = [...nucleiData.nuclei].sort(


### PR DESCRIPTION
## Nightly Unifier — D4 Import Path Convention

**Canonical form:** `@/` alias for all cross-directory imports (repo root alias, configured in `tsconfig.json` `paths` and `vite.config.ts` `resolve.alias`). Relative `'../foo'` is only acceptable for true same-directory/direct-parent-sibling imports.

**Instance unified:** `scripts/spikes/stress-reference/reference.ts` and its `reference.test.ts` each imported `nucleiData` from the sibling `scripts/spikes/stress-detection/` directory via a relative `'../stress-detection/nuclei.json'` escape — the same cross-subdirectory-relative-import anti-pattern already fixed repo-wide in `components/plc/**` and `components/widgets/**`. Both now import via `@/scripts/spikes/stress-detection/nuclei.json`.

This file predates this run (added 2026-08-04) and had never been touched by a D4 sweep before.

**Enforcement:** None added this run — the existing `no-restricted-imports` ESLint rules are scoped to `components/plc/**` and `components/widgets/**` (the two directories where this bug class has recurred repeatedly). `scripts/**` is excluded from ESLint entirely (see `eslint.config.js` `ignores`), so this directory is enforced by convention/review rather than a lint rule. As part of this run we re-verified the existing plc `no-restricted-imports` regex is still fully in sync with the live `PLC_SECTIONS` list and the actual `components/plc/` subdirectory listing — no drift found there.

**Behavior-preservation evidence (mechanical, zero logic change):**
- `@/*` → `./*` is configured identically in `tsconfig.json` and `vite.config.ts`; `vitest.config.ts` merges `vite.config.ts` and does not exclude `scripts/**`, so the alias resolves identically for the app build, `tsc`, and the test run — this file is only ever exercised via its own `reference.test.ts` under vitest (per its own doc comment: "SPIKE / DECISION HARNESS. Not wired into the app... See reference.test.ts").
- `pnpm run type-check` — clean
- `pnpm run lint` (`--max-warnings 0`, app + functions) — clean
- `pnpm run format:check` — clean
- `pnpm run test` — 607 files / 7381 tests passing (targeted re-run of `reference.test.ts` alone: 50/50 passing)
- `pnpm run build` — client bundle + SSR bundle + prerender all succeed

**Risk tag:** mechanical (pure import-path equivalence, two-line diff, no behavior or visual change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ9odAcJi4nR4ZCyXEikHg)_