### PR TITLE
fix(widgets): stop Escape leaking from Catalyst set picker to DashboardView

### DIFF
--- a/components/widgets/Catalyst/CatalystSetPickerPopover.test.tsx
+++ b/components/widgets/Catalyst/CatalystSetPickerPopover.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { CatalystSetPickerPopover } from './CatalystSetPickerPopover';
+import { useCatalystSets } from '@/hooks/useCatalystSets';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
+
+vi.mock('@/hooks/useCatalystSets', () => ({
+  useCatalystSets: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+const anchorRect = {
+  left: 10,
+  right: 50,
+  top: 10,
+  bottom: 40,
+  width: 40,
+  height: 30,
+} as DOMRect;
+
+describe('CatalystSetPickerPopover — Escape does not leak to window-level handlers', () => {
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    (useCatalystSets as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      sets: [],
+      loading: false,
+    });
+    const onClose = vi.fn();
+    render(
+      <CatalystSetPickerPopover
+        anchorRect={anchorRect}
+        globalStyle={DEFAULT_GLOBAL_STYLE}
+        onSelectRoutine={vi.fn()}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('No sets configured.')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(onClose).toHaveBeenCalled();
+      // Without stopPropagation this would reach DashboardView's global window-level handler.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/components/widgets/Catalyst/CatalystSetPickerPopover.tsx
+++ b/components/widgets/Catalyst/CatalystSetPickerPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, RefObject, useState } from 'react';
+import React, { useEffect, useMemo, useRef, RefObject, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ImageOff } from 'lucide-react';
 import { useCatalystSets } from '@/hooks/useCatalystSets';
@@ -10,6 +10,7 @@ import {
   renderCatalystIcon,
 } from '@/components/widgets/Catalyst/catalystHelpers';
 import { Z_INDEX } from '@/config/zIndex';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 
 interface Props {
   anchorRect: DOMRect;
@@ -31,6 +32,18 @@ export const CatalystSetPickerPopover: React.FC<Props> = ({
   const [selectedSetId, setSelectedSetId] = useState<string | null>(null);
 
   useClickOutside(menuRef, onClose, buttonRef ? [buttonRef] : []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(event)) return;
+      // Portalled outside any `.widget` ancestor — stop it reaching DashboardView's global handler.
+      event.stopPropagation();
+      onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const bottom = window.innerHeight - anchorRect.top + 10;
   const left = anchorRect.left + anchorRect.width / 2;


### PR DESCRIPTION
## Root cause

`components/widgets/Catalyst/CatalystSetPickerPopover.tsx` (rendered from `Dock.tsx`, portalled to `document.body` outside any `.widget` ancestor) had **no local Escape handling at all** — its only dismissal path was `useClickOutside`, which listens for `pointerdown`, never `keydown`. Pressing Escape while the picker is open falls through untouched to `DashboardView`'s global `window`-level Escape handler, which finds no `.widget` ancestor for the popover and falls back to minimizing the topmost z-index widget on the board — an unrelated widget disappearing just from dismissing the set picker.

This is a fresh instance of the recurring "portalled popover Escape doesn't stopPropagation" bug class already fixed 10x elsewhere in this codebase (`ActiveClassChip`, `FolderPickerPopover`, `RandomClassContextButton`, `LiveControl`, `PageStrip`, `SettingsPanel`, etc.) — but a *missing-handler* variant rather than a *missing-stopPropagation* variant.

## Fix

Added a `document`-level `keydown` listener (mirroring `ClassRosterMenu`'s established pattern) that closes the popover and calls `event.stopPropagation()` on Escape, guarded by `isEscapeFromWidgetInput` so it doesn't swallow Escape meant for a widget's own text input.

## Rejected band-aid

None needed — this is the same well-precedented root-cause fix already applied repo-wide for this bug class; there was no narrower symptom-only fix available.

## Regression test

`components/widgets/Catalyst/CatalystSetPickerPopover.test.tsx`:
- **Before fix:** `AssertionError: expected "vi.fn()" to be called at least once` (`onClose` never called on Escape).
- **After fix:** `Test Files 1 passed (1) / Tests 1 passed (1)` — `onClose` fires and the `window`-level keydown spy is never called (propagation stopped).

## Evidence

- `pnpm run validate` (type-check, lint, format-check, root tests 608 files/7382 tests, functions tests 41 files/798 tests, test:counts guard) — all green.
- `pnpm run build` — succeeded (pre-existing >500kB chunk-size warnings, unrelated to this change).

## Risk

**Contained.** Single component, additive `useEffect` mirroring an existing established pattern used by many sibling components; no change to any other widget or shared primitive.

---
Part of the nightly automated code-health run (run 38, 2026-08-12). See `docs/routines/debugger.md` for the recurring-bug-class history.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brjs1LPzANLKtdhNJUye8u)_