### PR TITLE
fix(dashboard): clear pending long-press timer on unmount

### DIFF
--- a/hooks/useLongPress.test.ts
+++ b/hooks/useLongPress.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useLongPress } from './useLongPress';
+
+const fakePointerEvent = (x = 0, y = 0) =>
+  ({ clientX: x, clientY: y }) as unknown as React.PointerEvent;
+
+describe('useLongPress', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires onLongPress after the hold delay while still mounted', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    result.current.onPointerDown(fakePointerEvent());
+    vi.advanceTimersByTime(600);
+
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending timer when the pointer moves past the threshold', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    result.current.onPointerDown(fakePointerEvent(0, 0));
+    result.current.onPointerMove(fakePointerEvent(50, 50));
+    vi.advanceTimersByTime(600);
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending timer on pointer up', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+
+    result.current.onPointerDown(fakePointerEvent());
+    result.current.onPointerUp();
+    vi.advanceTimersByTime(600);
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onLongPress after the owning component unmounts mid-press', () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result, unmount } = renderHook(() => useLongPress(onLongPress));
+
+    result.current.onPointerDown(fakePointerEvent());
+    unmount();
+    vi.advanceTimersByTime(600);
+
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/hooks/useLongPress.ts
+++ b/hooks/useLongPress.ts
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 
 /** Distance in px the pointer can move before cancelling the long press. */
 const MOVE_THRESHOLD = 15;
@@ -58,6 +58,9 @@ export function useLongPress(
     },
     [clear]
   );
+
+  // Unmount mid-press must cancel the pending timer — no pointerup/cancel will ever arrive.
+  useEffect(() => clear, [clear]);
 
   return {
     onPointerDown: handlePointerDown,


### PR DESCRIPTION
## Root cause

`hooks/useLongPress.ts` schedules a 600ms hold timer in `handlePointerDown` but never cleared it on unmount. This hook backs 4 dock components (`ToolDockItem`, `FolderItem`, `SortableFolderWidget`, `SavedWidgetDockItem`). If the pressed element unmounts mid-press — e.g. an item removed from the dock via real-time Firestore sync, or a parent re-render — with no `pointerup`/`pointercancel` ever reaching the hook, the pending timer still fires `onLongPress` 600ms later against a stale target, triggering edit-mode/widget-library state changes for a press the user can no longer see or intended.

## Fix

Added `useEffect(() => clear, [clear])`, using the hook's existing memoized `clear` callback, so the pending timer is always torn down on unmount.

## Rejected band-aid

Guarding `onLongPress` itself with an `isMountedRef` check (swallow the callback instead of cancelling the timer) — rejected because it leaves the stale timer running instead of tearing it down, and doesn't generalize to the unmount-cleanup pattern already used elsewhere in this codebase for the same class of resource leak.

## Regression test

`hooks/useLongPress.test.ts` (4 tests total, including the new one):
- **Before fix:** `does not fire onLongPress after the owning component unmounts mid-press` failed — `expected "vi.fn()" to not be called at all, but actually been called 1 times`.
- **After fix:** `4 passed (4)`.

## Evidence

- `pnpm run validate` (type-check, lint, format-check, root tests 608 files/7385 tests, functions tests 41 files/798 tests, test:counts guard) — all green.
- `pnpm run build` — succeeded (pre-existing >500kB chunk-size warnings, unrelated to this change).

## Risk

**Contained.** Single hook, additive cleanup effect using an already-memoized callback; no change to call-site behavior while mounted.

---
Part of the nightly automated code-health run (run 38, 2026-08-12). See `docs/routines/debugger.md` for the recurring-bug-class history.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brjs1LPzANLKtdhNJUye8u)_