### PR TITLE
fix(admin): case-insensitive beta-user dedup in GlobalPermissionsManager

### DIFF
--- a/components/admin/GlobalPermissionsManager.test.tsx
+++ b/components/admin/GlobalPermissionsManager.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+} from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { GlobalPermissionsManager } from './GlobalPermissionsManager';
+
+// Minimal lucide-react stub — avoids loading the full ~25,000-line bundle.
+vi.mock('lucide-react', () => {
+  function icon(name: string) {
+    const Stub = (props: React.HTMLAttributes<HTMLSpanElement>) =>
+      React.createElement('span', { 'data-icon': name, ...props });
+    Stub.displayName = name;
+    return Stub;
+  }
+  const mocks: Record<string, unknown> = {};
+  return new Proxy(mocks, {
+    get(target, prop) {
+      if (prop === '__esModule') return true;
+      if (prop === 'then') return undefined;
+      if (typeof prop === 'string' && !(prop in target)) {
+        target[prop] = icon(prop);
+      }
+      return target[prop as string];
+    },
+  });
+});
+
+vi.mock('@/config/firebase', () => ({ db: {} }));
+
+const existingPermission = {
+  featureId: 'live-session',
+  accessLevel: 'beta',
+  betaUsers: ['Teacher@School.ORG'],
+  enabled: true,
+  buildings: [],
+  config: {},
+};
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  doc: vi.fn(),
+  setDoc: vi.fn(),
+  addDoc: vi.fn(),
+  serverTimestamp: vi.fn(),
+  getDocs: vi.fn(() => ({
+    forEach: (cb: (doc: { data: () => unknown }) => void) => {
+      cb({ data: () => existingPermission });
+    },
+  })),
+}));
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({
+    user: { email: 'admin@test.com' },
+    appSettings: {},
+    updateAppSettings: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useStorage', () => ({
+  useStorage: () => ({
+    uploadAdminLogo: vi.fn(),
+    deleteAdminLogo: vi.fn(),
+    uploading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useIsMobile', () => ({ useIsMobile: () => false }));
+
+describe('GlobalPermissionsManager', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // A pre-existing legacy mixed-case entry must not produce a duplicate on re-add.
+  it('does not re-add a beta user whose email differs only by case from an existing entry', async () => {
+    render(<GlobalPermissionsManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Live Sessions')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Teacher@School.ORG')).toBeInTheDocument();
+
+    const input = screen.getByPlaceholderText('user@example.com');
+    fireEvent.change(input, { target: { value: 'teacher@school.org' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Still exactly one chip for this user — no duplicate was added.
+    expect(screen.getAllByText(/teacher@school\.org/i)).toHaveLength(1);
+  });
+});

--- a/components/admin/GlobalPermissionsManager.tsx
+++ b/components/admin/GlobalPermissionsManager.tsx
@@ -645,7 +645,8 @@ export const GlobalPermissionsManager: React.FC = () => {
     }
 
     const permission = getPermission(featureId);
-    if (!permission.betaUsers.includes(trimmedEmail)) {
+    // Case-insensitive: catches a legacy mixed-case entry pre-dating normalization.
+    if (!permission.betaUsers.some((e) => e.toLowerCase() === trimmedEmail)) {
       updatePermission(featureId, {
         betaUsers: [...permission.betaUsers, trimmedEmail],
       });


### PR DESCRIPTION
## Root cause

`GlobalPermissionsManager.tsx`'s `addBetaUser` lowercases the new email before storing it (`email.trim().toLowerCase()`), but deduped it against the existing `betaUsers` array via a case-sensitive `.includes()`. A legacy mixed-case entry — written before this normalization existed, or edited directly via the Firestore console — doesn't match the lowercased candidate, so re-adding "the same" email in a different case created a second chip for the same person.

This is the identical bug class already fixed in the sibling components `BetaUsersPanel.tsx` (#2375) and `PresetSubEmailsManager.tsx` (#2389) — `GlobalPermissionsManager.tsx`'s own `addBetaUser` (a separate implementation for the *global* feature-permissions editor) still had the case-sensitive membership check.

## Fix

Changed the membership check to case-insensitive:
```ts
if (!permission.betaUsers.some((e) => e.toLowerCase() === trimmedEmail)) {
```

## Rejected band-aid

Lowercasing existing array entries at render/load time instead of fixing the comparison — rejected because it doesn't fix the actual dedup check (a future write path using the same `.includes()`-style comparison would still misbehave), and it would silently rewrite admin-authored data.

## Regression test

`components/admin/GlobalPermissionsManager.test.tsx`: seeds a `live-session` permission with beta user `Teacher@School.ORG`, then adds `teacher@school.org`.
- **Before fix:** `AssertionError: expected [...] to have a length of 1 but got 2` — duplicate chip created.
- **After fix:** exactly one chip.

## Evidence

- `pnpm run validate` (type-check, lint, format-check, root tests 608 files/7382 tests, functions tests 41 files/798 tests, test:counts guard) — all green.
- `pnpm run build` — succeeded (pre-existing >500kB chunk-size warnings, unrelated to this change).

## Risk

**Contained.** Single component, single comparison change matching an already-established sibling pattern; no change to write-time normalization or data shape.

---
Part of the nightly automated code-health run (run 38, 2026-08-12). See `docs/routines/debugger.md` for the recurring-bug-class history.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Brjs1LPzANLKtdhNJUye8u)_