### PR TITLE
fix(drawing): retrofit orphaned Background group heading to SettingsLabel span pattern

### DIFF
--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -137,7 +137,13 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
       </div>
 
       <div>
-        <SettingsLabel icon={LayoutGrid}>Background</SettingsLabel>
+        <SettingsLabel
+          icon={LayoutGrid}
+          as="span"
+          id={`drawing-background-label-${widget.id}`}
+        >
+          Background
+        </SettingsLabel>
         {/* Toggle-button group (not radiogroup) — selecting a background is a
             mode toggle. The button + aria-pressed pattern gives us native
             Tab/Space/Enter without the roving-tabindex machinery that a true
@@ -145,7 +151,7 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
             AnnotationOverlay.tsx (PR 1685 round-1 fix). */}
         <div
           role="group"
-          aria-label="Background template"
+          aria-labelledby={`drawing-background-label-${widget.id}`}
           className="flex gap-2 px-2"
         >
           {BACKGROUND_OPTIONS.map(({ value, label }) => {


### PR DESCRIPTION
## Nightly Unifier — D3 Settings Panel Label Primitives (run 55)

**Canonical form:** `<SettingsLabel as="span" id="unique-id">Group Heading</SettingsLabel>` + `role="group" aria-labelledby="unique-id"` on the sibling controls container — the group-heading form of `SettingsLabel` established over runs 26-53 for labels that head a group of controls rather than pairing 1:1 with a single input.

**Instance unified:** `components/widgets/DrawingWidget/Settings.tsx:140-157` — the "Background" group heading. This file already had the *correct* pattern for its "Color Presets" group (lines 84-93, shipped run 32) but the "Background" group 20 lines later was left on the old shape: a bare `<SettingsLabel>` (rendered as an orphaned `<label>` with no `htmlFor`) duplicated by a separate `aria-label="Background template"` on the sibling `role="group"` container. Converted to `as="span" id={`drawing-background-label-${widget.id}`}` (instance-scoped, matching this file's own established convention for the Color Presets fix) and pointed the group's `aria-labelledby` at it, removing the now-redundant `aria-label`.

Found via a targeted sweep for `role="group"` + `aria-label` (instead of `aria-labelledby`) pairs inside `Settings.tsx`/`*ConfigurationPanel.tsx` files — a previously-undocumented instance, not on any prior run's backlog.

**Investigated and correctly left untouched** (open candidates carried over from run 53/PR #2424):
- `components/admin/MathToolsConfigurationPanel.tsx:141,143,147` — confirmed these are CSS-grid `<div>` column headers over independent per-row content, not a real `<table>` and not a flat sibling-control group; neither `SettingsLabel` form fits. Needs a structural change (real `<table>`/`<th scope="col">`) outside this routine's mechanical scope — left as a backlog item for a future dedicated pass.
- `components/widgets/Stations/Settings.tsx:232,271` — heading over heterogeneous composite rows / a single conditional block, not a flat button/checkbox group. Correctly out of scope.
- `components/widgets/NumberLine/Settings.tsx:106,264,345` — sections whose sub-fields already have their own individual `<label htmlFor>` pairings. Correctly out of scope.

**Enforcement:** N/A — applying an existing, already-enforced-by-convention shared component; the "second instance in the same file" class this closes is caught by review discipline (reading the whole file, not just historical diffs), not automatable via lint.

**Behavior-preservation evidence:** `SettingsLabel.tsx`'s `combinedClasses` confirmed identical for `as="label"` vs `as="span"` (read directly, not trusted from precedent citation) — zero visual delta.
- `pnpm exec tsc --noEmit` → exit 0
- `pnpm run lint` (app + functions) → exit 0
- `pnpm run format:check` → exit 0
- `pnpm run test` → 614 test files / 7402 tests passed
- `pnpm -C functions test` → 41/41 files, 803 tests passed
- `pnpm run build` (client + SSR + prerender) → exit 0
- All independently re-run by the orchestrator directly in the worktree after the subagent hit the stuck-background-wait pattern partway through its own verification; orchestrator reviewed the diff, the surrounding file (confirming "Brush Thickness"/"Shape Fill" are genuine 1:1 pairings correctly left as `as="label"`), and the `SettingsLabel.tsx` source before running its own full `pnpm run validate` + `pnpm run build` (both green) and shipping.

**Risk tag:** `mechanical` — pure equivalence, single-file, already-proven pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiLP8NERPUhPEEsgzUqtSZ)_