### PR TITLE
fix(a11y): pair orphaned group-heading labels with their radiogroups

### DIFF
--- a/components/admin/TimeToolConfigurationPanel.tsx
+++ b/components/admin/TimeToolConfigurationPanel.tsx
@@ -83,6 +83,10 @@ export const TimeToolConfigurationPanel: React.FC<
     useBuildingSelection(BUILDINGS);
   const accentColorLabelId = useId();
   const trafficLightColorLabelId = useId();
+  const defaultModeLabelId = useId();
+  const displayStyleLabelId = useId();
+  const numberStyleLabelId = useId();
+  const defaultAlertSoundLabelId = useId();
 
   const buildingDefaults = config.buildingDefaults ?? {};
   const currentBuildingConfig: BuildingTimeToolDefaults = buildingDefaults[
@@ -184,11 +188,13 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Default Mode */}
         <div>
-          <SettingsLabel className="mb-1">Default Mode</SettingsLabel>
+          <SettingsLabel as="span" id={defaultModeLabelId} className="mb-1">
+            Default Mode
+          </SettingsLabel>
           <div
             className="flex gap-1.5"
             role="radiogroup"
-            aria-label="Default Mode"
+            aria-labelledby={defaultModeLabelId}
           >
             {MODES.map(({ value, label }) => (
               <button
@@ -208,11 +214,13 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Display Style */}
         <div>
-          <SettingsLabel className="mb-1">Display Style</SettingsLabel>
+          <SettingsLabel as="span" id={displayStyleLabelId} className="mb-1">
+            Display Style
+          </SettingsLabel>
           <div
             className="flex gap-1.5"
             role="radiogroup"
-            aria-label="Display Style"
+            aria-labelledby={displayStyleLabelId}
           >
             {VISUAL_TYPES.map(({ value, label }) => (
               <button
@@ -234,11 +242,13 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Number Style */}
         <div>
-          <SettingsLabel className="mb-1">Number Style</SettingsLabel>
+          <SettingsLabel as="span" id={numberStyleLabelId} className="mb-1">
+            Number Style
+          </SettingsLabel>
           <div
             className="flex gap-1.5"
             role="radiogroup"
-            aria-label="Number Style"
+            aria-labelledby={numberStyleLabelId}
           >
             {CLOCK_STYLES.map(({ value, label }) => (
               <button
@@ -260,11 +270,17 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Alert Sound */}
         <div>
-          <SettingsLabel className="mb-1">Default Alert Sound</SettingsLabel>
+          <SettingsLabel
+            as="span"
+            id={defaultAlertSoundLabelId}
+            className="mb-1"
+          >
+            Default Alert Sound
+          </SettingsLabel>
           <div
             className="flex gap-1.5"
             role="radiogroup"
-            aria-label="Default Alert Sound"
+            aria-labelledby={defaultAlertSoundLabelId}
           >
             {SOUNDS.map((sound) => (
               <button

--- a/components/widgets/Scoreboard/Settings.tsx
+++ b/components/widgets/Scoreboard/Settings.tsx
@@ -176,14 +176,18 @@ export const ScoreboardSettings: React.FC<{ widget: WidgetData }> = ({
     addToast('All scores reset to 0', 'info');
   };
 
+  const layoutLabelId = `scoreboard-layout-label-${widget.id}`;
+
   return (
     <div className="space-y-6">
       <div>
-        <SettingsLabel>Layout</SettingsLabel>
+        <SettingsLabel as="span" id={layoutLabelId}>
+          Layout
+        </SettingsLabel>
         <div
           className="flex items-center bg-slate-200/80 rounded-lg p-0.5"
           role="radiogroup"
-          aria-label="Scoreboard layout"
+          aria-labelledby={layoutLabelId}
         >
           <button
             type="button"

--- a/components/widgets/Scoreboard/Widget.test.tsx
+++ b/components/widgets/Scoreboard/Widget.test.tsx
@@ -400,6 +400,25 @@ describe('ScoreboardSettings', () => {
     mockAddToast.mockClear();
   });
 
+  // Pins the aria-labelledby ↔ SettingsLabel id pairing; dropping the id leaves the group unnamed with nothing else failing.
+  it('names the layout radiogroup from its visible heading', () => {
+    const widget: WidgetData = {
+      id: 'scoreboard-id',
+      type: 'scoreboard',
+      config: { teams: [] } as ScoreboardConfig,
+      x: 0,
+      y: 0,
+      w: 100,
+      h: 100,
+      z: 1,
+      flipped: true,
+    };
+
+    render(<ScoreboardSettings widget={widget} />);
+
+    expect(screen.getByRole('radiogroup')).toHaveAccessibleName('Layout');
+  });
+
   it('imports groups from random widget', () => {
     const widget: WidgetData = {
       id: 'scoreboard-id',

--- a/tests/components/admin/TimeToolConfigurationPanel.labels.test.tsx
+++ b/tests/components/admin/TimeToolConfigurationPanel.labels.test.tsx
@@ -1,0 +1,37 @@
+// Pins each radiogroup's aria-labelledby ↔ SettingsLabel id pairing; dropping an id leaves the group unnamed with nothing else failing.
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { TimeToolGlobalConfig } from '@/types';
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [{ id: 'b1', name: 'Test School' }],
+}));
+
+import { TimeToolConfigurationPanel } from '@/components/admin/TimeToolConfigurationPanel';
+
+afterEach(cleanup);
+
+const RADIOGROUP_NAMES = [
+  'Default Mode',
+  'Display Style',
+  'Number Style',
+  'Default Alert Sound',
+];
+
+describe('TimeToolConfigurationPanel — radiogroup accessible names', () => {
+  it.each(RADIOGROUP_NAMES)(
+    'names the %s radiogroup from its visible heading',
+    (name) => {
+      render(
+        <TimeToolConfigurationPanel
+          config={{} as TimeToolGlobalConfig}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(screen.getByRole('radiogroup', { name })).toBeInTheDocument();
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Nightly consistency run (D3 — Settings Panel Label Primitives). Part of the long-running group-heading `SettingsLabel` retrofit series (runs 26-55).

**Canonical form:** `<SettingsLabel as="span" id="unique-id">Heading</SettingsLabel>` + `role="group"|"radiogroup" aria-labelledby="unique-id"` on the sibling-control container — replacing an orphaned `<label>` (default `as="label"`, no `htmlFor`) whose radiogroup carried its own redundant `aria-label` duplicating the visible heading text instead of pointing at it via `aria-labelledby`. Matches the convention already established in 12+ other radiogroup instances repo-wide (`TextSizePresetSettings`, `SurfaceColorSettings`, `TimeTool/Settings.tsx` ×6, `SpecialistSchedule/Settings.tsx`, `MusicWidget/Settings.tsx` ×2, and the two already-fixed groups within `TimeToolConfigurationPanel.tsx` itself).

**Instances unified (5, across 2 files):**
- `components/widgets/Scoreboard/Settings.tsx` — "Layout" radiogroup (Cards/List toggle)
- `components/admin/TimeToolConfigurationPanel.tsx` — "Default Mode", "Display Style", "Number Style", "Default Alert Sound"

**Enforcement:** None added — this fix is a manual retrofit following the established repo-wide convention (no automated lint rule exists for this shape; the pattern has been applied consistently by hand across ~20 files in this series).

**Behavior/visual-preservation evidence:**
- Read `components/common/SettingsLabel.tsx` source directly: `combinedClasses` is computed once and applied identically in both the `<span>` and `<label>` render branches — only the DOM tag differs. Zero visual delta.
- The `aria-label` → `aria-labelledby` swap changes only accessible-name computation, not layout/paint.
- `tsc --noEmit`: 0 errors. `eslint . --max-warnings 0`: clean on changed files (also independently re-verified by the orchestrator). `prettier --check`: clean on changed files (independently re-verified). Full `pnpm run test`: 614 root test files / 7402 tests passed; `pnpm -C functions run test`: 41 files / 803 tests passed. `pnpm run build`: succeeded (client + SSR + prerender). Orchestrator additionally ran a targeted `vitest` pass covering `components/widgets/Scoreboard/**` and `components/admin/TimeToolConfigurationPanel*` (200 files / 1530 tests, all passing).

**Risk tag: mechanical** (pure DOM-tag + ARIA-attribute equivalence, no visual or behavioral change).

## Deferred to backlog / left alone
- `DrawingWidget/Settings.tsx:115,190`, `RevealGrid/Settings.tsx:624,648` — each heads exactly one control, not a group; not a fit.
- `ClockConfigurationPanel.tsx:123` "Default Theme Color" — heterogeneous composite row (swatch + text input + button), same declined shape as prior `Stations/Settings.tsx` case.
- `SurfaceColorSettings.tsx` inner `aria-label` — nested sub-radiogroup with no visible heading of its own; `aria-label` is correct there, not a mismatch.
- Re-confirmed the 3 candidates already declined in a prior run (`MathToolsConfigurationPanel.tsx` grid headers, `Stations/Settings.tsx` composite rows, `NumberLine/Settings.tsx` individually-labeled sub-fields) are still correctly out of mechanical scope.
- Standing NEEDS-REVIEW items (undocumented 3rd label-weight tier; `role="group"`+`aria-pressed` vs. full `role="radiogroup"` architecture question) intentionally left untouched — both require a human decision, not a mechanical fix.

## Test plan
- [x] `tsc --noEmit`
- [x] `eslint . --max-warnings 0`
- [x] `prettier --check`
- [x] `pnpm run test` (root)
- [x] `pnpm -C functions run test`
- [x] `pnpm run build`
- [ ] Optional: eyes-on check that Scoreboard/TimeTool admin config settings panels render identically (change is DOM-tag/ARIA-only, not expected to affect rendering)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsQHVe9MfQ9BDFzJbZ7NqQ)_