### PR TITLE
fix(widgets): close Randomizer group color-picker popover on Escape

### DIFF
--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -189,15 +189,7 @@ describe('GroupDropZone — rename input', () => {
   });
 });
 
-// ─── Regression: color-picker popover had no local Escape handling ─────────
-//
-// The color-picker popover is portalled to document.body, outside the
-// widget's `.widget` ancestor. Before the fix it had an outside-pointerdown
-// listener but no keydown listener at all, so pressing Escape while it was
-// open did nothing locally and bubbled unimpeded to DashboardView's
-// window-level Escape handler — which minimizes/closes the top-most (or
-// focused) widget. Opening a color swatch picker should never make the
-// whole RandomWidget disappear.
+// Regression: portalled color-picker popover had no local Escape handling at all.
 describe('GroupDropZone — color picker Escape', () => {
   const groups = makeGroups({ g1: ['Alice', 'Bob'], g2: ['Carol'] });
   const sharedGroups = [{ id: 'g1', name: 'Team Alpha' }];
@@ -225,12 +217,10 @@ describe('GroupDropZone — color picker Escape', () => {
     try {
       fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
 
-      // The popover must close locally...
       expect(
         screen.queryByLabelText('Reset to default color')
       ).not.toBeInTheDocument();
-      // ...and the Escape must never reach DashboardView's window listener
-      // (which would otherwise minimize/close an unrelated widget).
+      // Must never reach DashboardView's window handler (would minimize an unrelated widget).
       expect(windowKeydownSpy).not.toHaveBeenCalled();
     } finally {
       window.removeEventListener('keydown', windowKeydownSpy);

--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -188,3 +188,52 @@ describe('GroupDropZone — rename input', () => {
     expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Good Name');
   });
 });
+
+// ─── Regression: color-picker popover had no local Escape handling ─────────
+//
+// The color-picker popover is portalled to document.body, outside the
+// widget's `.widget` ancestor. Before the fix it had an outside-pointerdown
+// listener but no keydown listener at all, so pressing Escape while it was
+// open did nothing locally and bubbled unimpeded to DashboardView's
+// window-level Escape handler — which minimizes/closes the top-most (or
+// focused) widget. Opening a color swatch picker should never make the
+// whole RandomWidget disappear.
+describe('GroupDropZone — color picker Escape', () => {
+  const groups = makeGroups({ g1: ['Alice', 'Bob'], g2: ['Carol'] });
+  const sharedGroups = [{ id: 'g1', name: 'Team Alpha' }];
+
+  it('REGRESSION: closes the color picker on Escape and stops it reaching window-level handlers', () => {
+    const onChangeGroupColor = vi.fn();
+    render(
+      <RandomGroups
+        displayResult={groups}
+        sharedGroups={sharedGroups}
+        editable
+        onToggleLock={vi.fn()}
+        onChangeGroupColor={onChangeGroupColor}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Change Team Alpha color/i })
+    );
+    expect(screen.getByLabelText('Reset to default color')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+
+      // The popover must close locally...
+      expect(
+        screen.queryByLabelText('Reset to default color')
+      ).not.toBeInTheDocument();
+      // ...and the Escape must never reach DashboardView's window listener
+      // (which would otherwise minimize/close an unrelated widget).
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -226,4 +226,31 @@ describe('GroupDropZone — color picker Escape', () => {
       window.removeEventListener('keydown', windowKeydownSpy);
     }
   });
+
+  // isEscapeFromWidgetInput() needs a [data-draggable-window] ancestor to fire, which DraggableWindow supplies in the real tree.
+  it('leaves the color picker open when Escape comes from the rename input', () => {
+    render(
+      <div data-draggable-window="">
+        <RandomGroups
+          displayResult={groups}
+          sharedGroups={sharedGroups}
+          editable
+          onToggleLock={vi.fn()}
+          onRenameGroup={vi.fn()}
+          onChangeGroupColor={vi.fn()}
+        />
+      </div>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Change Team Alpha color/i })
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Rename Team Alpha/i }));
+    const input = screen.getByRole('textbox', { name: /Rename Team Alpha/i });
+
+    fireEvent.keyDown(input, { key: 'Escape', bubbles: true });
+
+    // Escape belongs to the input (cancel the rename); the picker must not consume it.
+    expect(screen.getByLabelText('Reset to default color')).toBeInTheDocument();
+  });
 });

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -157,11 +157,7 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [colorPickerOpen]);
 
-  // Close color picker on Escape. Portalled to document.body, outside any
-  // `.widget` ancestor, so without stopPropagation an Escape here bubbles
-  // unimpeded to DashboardView's window-level handler, which minimizes/closes
-  // the top-most (or focused) widget — an unrelated widget disappearing just
-  // because the color picker was open.
+  // Portalled outside .widget — stop Escape from bubbling to DashboardView's global handler.
   useEffect(() => {
     if (!colorPickerOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -6,6 +6,7 @@ import { RandomGroup, SharedGroup } from '@/types';
 import { StudentChip } from './StudentChip';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 
 interface RandomGroupsProps {
   displayResult: string | string[] | string[][] | RandomGroup[] | null;
@@ -154,6 +155,23 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
     };
     document.addEventListener('pointerdown', handlePointerDown);
     return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [colorPickerOpen]);
+
+  // Close color picker on Escape. Portalled to document.body, outside any
+  // `.widget` ancestor, so without stopPropagation an Escape here bubbles
+  // unimpeded to DashboardView's window-level handler, which minimizes/closes
+  // the top-most (or focused) widget — an unrelated widget disappearing just
+  // because the color picker was open.
+  useEffect(() => {
+    if (!colorPickerOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      e.stopPropagation();
+      setColorPickerOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
   }, [colorPickerOpen]);
 
   // Recompute popover anchor on open + window resize / scroll so it tracks


### PR DESCRIPTION
## Root cause

`GroupDropZone` in `components/widgets/random/RandomGroups.tsx` renders its group color-picker popover via `createPortal(..., document.body)` — outside any `.widget` ancestor. It closed on outside-pointerdown, but had no `keydown` handling at all. Pressing Escape while the popover was open did nothing locally, so the event bubbled unimpeded to `DashboardView`'s global Escape handler, which minimizes/closes the topmost (or focused) widget with no `.widget` ancestor to anchor to. Net effect: opening the color swatch picker on a Randomizer widget and pressing Escape could silently minimize an unrelated widget on the board (e.g. a running timer).

This is the same recurring "portalled popover, no local Escape handling at all" bug class already fixed in `CatalystSetPickerPopover.tsx` (#2439) and, more generally (missing-`stopPropagation()` variant), 11 other times across this codebase — `RandomGroups.tsx`'s color-picker popover was the last flagged-but-unfixed instance (backlog since 2026-08-12).

Confirmed live: `RandomWidget.tsx` renders `<RandomGroups editable onChangeGroupColor={...} .../>` in both `jigsaw` and default group modes.

## Fix

Added a `document`-level `keydown` effect, scoped to the popover's open state, guarded by `isEscapeFromWidgetInput` (so Escape typed into the adjacent group-rename input isn't intercepted), that calls `stopPropagation()` and closes the popover — mirroring the established, already-reviewed pattern from `CatalystSetPickerPopover.tsx`/`ClassRosterMenu.tsx`.

## Rejected band-aid

Adding `stopPropagation()` inside the existing outside-pointerdown handler — wrong event type, would do nothing. The popover had no keydown listener at all, so the fix requires adding one from scratch, not patching an existing one.

## Regression test

`components/widgets/random/RandomGroups.test.tsx`, new `describe('GroupDropZone — color picker Escape')` block: opens the color picker, fires Escape on `document`, asserts (a) the popover unmounts and (b) a `window`-level `keydown` spy is never invoked.
- **Before fix:** fails — popover swatch (`Reset to default color`) still in the document after Escape.
- **After fix:** all 9 tests in the file pass.

Independently re-verified by the orchestrator via file-swap (pre-fix `dev-paul` source swapped in, confirmed the new test fails with the exact assertion above; restored, confirmed 9/9 pass) — no `git stash` used, per this repo's shared-stash-ref caution for concurrent worktrees.

## Evidence

- `pnpm run validate` (type-check:all, lint, format-check, root tests 614 files/7403 tests, functions tests 41 files/803 tests, `test:counts` guard) — all green.
- `pnpm run build` — succeeded (pre-existing chunk-size advisory warnings only, unrelated to this change).

## Risk

**Contained.** Single widget, single popover, adding a well-precedented fix pattern already shipped and reviewed 12 times elsewhere in this codebase.

---
Part of the nightly automated code-health run (run 39, 2026-08-14). See `docs/routines/debugger.md` for the recurring-bug-class history.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxAYe67FQWLBonUXfXeEmc)_