### PR TITLE
fix(widgets): stop Escape leaking from RandomGroups color picker to DashboardView

### DIFF
--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -188,3 +188,56 @@ describe('GroupDropZone — rename input', () => {
     expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Good Name');
   });
 });
+
+// ─── Regression: color-picker popover Escape does not leak to window ──────
+//
+// BEFORE the fix: the color-picker popover (portalled to document.body, with
+// no `.widget` ancestor) had no local Escape handling at all. Pressing
+// Escape while it was open left it stuck open AND fell through to
+// DashboardView's global window-level keydown handler, which acts on the
+// topmost widget (e.g. dispatches a minimize/close action) — an unrelated
+// side effect the user never intended while just trying to dismiss a color
+// swatch popover.
+//
+// AFTER the fix: a document-level keydown handler closes the popover and
+// calls stopPropagation() before the event can reach window listeners.
+describe('GroupDropZone — color picker popover Escape handling', () => {
+  const groups = makeGroups({ g1: ['Alice', 'Bob'] });
+  const sharedGroups = [{ id: 'g1', name: 'Team Alpha' }];
+
+  function renderWithColorPicker() {
+    return render(
+      <RandomGroups
+        displayResult={groups}
+        sharedGroups={sharedGroups}
+        editable
+        onRenameGroup={vi.fn()}
+        onToggleLock={vi.fn()}
+        onChangeGroupColor={vi.fn()}
+      />
+    );
+  }
+
+  it('REGRESSION: closes on Escape and stops propagation before it reaches window listeners', () => {
+    renderWithColorPicker();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Change Team Alpha color/i })
+    );
+    expect(screen.getByLabelText('Reset to default color')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(
+        screen.queryByLabelText('Reset to default color')
+      ).not.toBeInTheDocument();
+      // Without stopPropagation this would reach DashboardView's global handler.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -156,8 +156,7 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [colorPickerOpen]);
 
-  // Close color picker on Escape. Portalled outside any .widget ancestor, so
-  // without this it falls through to DashboardView's global handler instead.
+  // Portalled outside any .widget ancestor; without this, Escape falls through to DashboardView's global handler.
   useEffect(() => {
     if (!colorPickerOpen) return;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -156,6 +156,19 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
     return () => document.removeEventListener('pointerdown', handlePointerDown);
   }, [colorPickerOpen]);
 
+  // Close color picker on Escape. Portalled outside any .widget ancestor, so
+  // without this it falls through to DashboardView's global handler instead.
+  useEffect(() => {
+    if (!colorPickerOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopPropagation();
+      setColorPickerOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [colorPickerOpen]);
+
   // Recompute popover anchor on open + window resize / scroll so it tracks
   // the palette button when the user pans the dashboard.
   useEffect(() => {


### PR DESCRIPTION
## Root cause

`components/widgets/random/RandomGroups.tsx`'s `GroupDropZone` color-picker popover (`colorPickerOpen`/`colorPickerRef`) is portalled via `createPortal` to `document.body`, outside any `.widget` ancestor. It already had `useEffect`s for outside-pointerdown-close and resize/scroll repositioning, but **no Escape handling at all**.

This is the "portalled popover, no local Escape handling" variant of a well-precedented recurring bug class (12+ prior fixes, most recently `CatalystSetPickerPopover.tsx` in #2439). Because the popover has no local Escape handler, pressing Escape while it's open falls through to `DashboardView`'s global `window`-level keydown handler, which dispatches a `widget-keyboard-action` Escape at the topmost/focused widget — an unrelated side effect — while the color picker itself stays stuck open.

## Fix

Added a `document`-level `keydown` listener (active only while `colorPickerOpen`) that closes the popover and calls `stopPropagation()` before the event can reach `window` listeners — mirroring the exact idiom already used in `CatalystSetPickerPopover.tsx` (#2439).

## Rejected band-aid

None needed — this bug class already has a single well-precedented correct fix (document-level handler + `stopPropagation()`, same as 10+ prior instances), so the established idiom was applied directly rather than inventing a new approach.

## Regression test

`components/widgets/random/RandomGroups.test.tsx` — new `describe('GroupDropZone — color picker popover Escape handling')` / `REGRESSION: closes on Escape and stops propagation before it reaches window listeners`.

- **Fail-before** (independently re-verified by the orchestrator via file-swap against `dev-paul`): `expect(screen.queryByLabelText('Reset to default color')).not.toBeInTheDocument()` fails — popover stays open.
- **Pass-after**: 9/9 tests in the file pass.

## Evidence

- `pnpm run validate` — full run (type-check:all, lint, format:check, root tests, functions tests, test:counts guard) — green.
- `pnpm run build` — succeeded.
- Orchestrator independently re-ran fail-before/pass-after in isolation (source file swapped against `dev-paul`'s version, test re-run each way).

## Risk

**Contained** — single component, single new Escape handler, no changes to shared primitives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YGutrWaS8VoNbuEJ8Bh7)_