### PR TITLE
fix(dashboard): resolve widget-keyboard-action target through settings-panel portals

### DIFF
--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -213,6 +213,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     <div
       ref={panelRef}
       data-widget-portal=""
+      data-widget-id={widget.id}
       className={`font-${globalStyle.fontFamily}`}
       style={{
         position: 'fixed',

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -934,12 +934,12 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // Use the focused element if it's a widget, otherwise target top widget.
-          // Call getAttribute on the .widget ancestor (from closest()), NOT on
-          // document.activeElement — the focused element may be a child button or
-          // input inside the widget and would not carry data-widget-id itself.
-          const widgetAncestor =
-            document.activeElement?.closest<HTMLElement>('.widget');
+          // [data-widget-portal] covers SettingsPanel, which portals to document.body
+          // outside its owning widget's .widget subtree — without it, focus on a
+          // non-form settings control falls through to topWidget instead.
+          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
+            '.widget, [data-widget-portal]'
+          );
           const targetId = widgetAncestor
             ? widgetAncestor.getAttribute('data-widget-id')
             : topWidget.id;
@@ -1004,8 +1004,11 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          const widgetAncestor =
-            document.activeElement?.closest<HTMLElement>('.widget');
+          // [data-widget-portal] covers SettingsPanel, portalled to document.body
+          // outside its owning widget's .widget subtree.
+          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
+            '.widget, [data-widget-portal]'
+          );
           const targetId = widgetAncestor
             ? widgetAncestor.getAttribute('data-widget-id')
             : topWidget.id;
@@ -1042,8 +1045,11 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          const widgetAncestor =
-            document.activeElement?.closest<HTMLElement>('.widget');
+          // [data-widget-portal] covers SettingsPanel, portalled to document.body
+          // outside its owning widget's .widget subtree.
+          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
+            '.widget, [data-widget-portal]'
+          );
           const targetId = widgetAncestor
             ? widgetAncestor.getAttribute('data-widget-id')
             : topWidget.id;

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -219,6 +219,14 @@ const ShellPlaceholder: React.FC = () => {
   );
 };
 
+// [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree — but only SettingsPanel carries data-widget-id, so any other portal falls back to topWidgetId.
+function resolveTargetWidgetId(topWidgetId: string): string {
+  const widgetAncestor = document.activeElement?.closest<HTMLElement>(
+    '.widget, [data-widget-portal]'
+  );
+  return widgetAncestor?.getAttribute('data-widget-id') ?? topWidgetId;
+}
+
 export const DashboardView: React.FC = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -934,13 +942,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
-          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
-            '.widget, [data-widget-portal]'
-          );
-          const targetId = widgetAncestor
-            ? widgetAncestor.getAttribute('data-widget-id')
-            : topWidget.id;
+          const targetId = resolveTargetWidgetId(topWidget.id);
 
           if (!targetId) return;
 
@@ -1002,13 +1004,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
-          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
-            '.widget, [data-widget-portal]'
-          );
-          const targetId = widgetAncestor
-            ? widgetAncestor.getAttribute('data-widget-id')
-            : topWidget.id;
+          const targetId = resolveTargetWidgetId(topWidget.id);
 
           if (targetId) {
             const event = new CustomEvent('widget-keyboard-action', {
@@ -1042,13 +1038,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
-          const widgetAncestor = document.activeElement?.closest<HTMLElement>(
-            '.widget, [data-widget-portal]'
-          );
-          const targetId = widgetAncestor
-            ? widgetAncestor.getAttribute('data-widget-id')
-            : topWidget.id;
+          const targetId = resolveTargetWidgetId(topWidget.id);
 
           if (targetId) {
             const event = new CustomEvent('widget-keyboard-action', {

--- a/components/layout/DashboardView.tsx
+++ b/components/layout/DashboardView.tsx
@@ -934,9 +934,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, which portals to document.body
-          // outside its owning widget's .widget subtree — without it, focus on a
-          // non-form settings control falls through to topWidget instead.
+          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
           const widgetAncestor = document.activeElement?.closest<HTMLElement>(
             '.widget, [data-widget-portal]'
           );
@@ -1004,8 +1002,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, portalled to document.body
-          // outside its owning widget's .widget subtree.
+          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
           const widgetAncestor = document.activeElement?.closest<HTMLElement>(
             '.widget, [data-widget-portal]'
           );
@@ -1045,8 +1042,7 @@ export const DashboardView: React.FC = () => {
           const sorted = [...activeDashboard.widgets].sort((a, b) => b.z - a.z);
           const topWidget = sorted[0];
 
-          // [data-widget-portal] covers SettingsPanel, portalled to document.body
-          // outside its owning widget's .widget subtree.
+          // [data-widget-portal] covers SettingsPanel, which portals outside its widget's .widget subtree.
           const widgetAncestor = document.activeElement?.closest<HTMLElement>(
             '.widget, [data-widget-portal]'
           );

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -1026,6 +1026,103 @@ describe('DashboardView Gestures & Navigation', () => {
     });
   });
 
+  describe('widget-keyboard-action falls back to the topmost widget when focus is inside a portal with no data-widget-id', () => {
+    const TOP_WIDGET_ID = 'widget-topmost';
+
+    let portalRoot: HTMLDivElement;
+    let portalButton: HTMLButtonElement;
+
+    beforeEach(() => {
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: {
+          ...mockDashboards[1],
+          widgets: [
+            {
+              id: TOP_WIDGET_ID,
+              type: 'clock',
+              x: 0,
+              y: 0,
+              w: 200,
+              h: 200,
+              z: 1,
+              flipped: false,
+              config: {},
+            },
+          ],
+        },
+        dashboards: mockDashboards,
+        toasts: [],
+        addWidget: mockAddWidget,
+        loadDashboard: mockLoadDashboard,
+        removeToast: vi.fn(),
+        updateWidget: vi.fn(),
+        removeWidget: vi.fn(),
+        duplicateWidget: vi.fn(),
+        bringToFront: vi.fn(),
+        addToast: vi.fn(),
+        minimizeAllWidgets: vi.fn(),
+        restoreAllWidgets: vi.fn(),
+        deleteAllWidgets: vi.fn(),
+        setSelectedWidgetId: vi.fn(),
+        updateDashboardSettings: vi.fn(),
+        zoom: 1,
+        setZoom: vi.fn(),
+        collectionsApi: {
+          collections: [],
+          loading: false,
+          error: null,
+          createCollection: vi.fn(),
+          renameCollection: vi.fn(),
+          moveCollection: vi.fn(),
+          deleteCollection: vi.fn(),
+          reorderSiblings: vi.fn(),
+          setCollectionMetadata: vi.fn(),
+          setCollectionDefaultBoard: vi.fn(),
+        },
+      });
+
+      // Simulate a non-SettingsPanel [data-widget-portal] consumer (e.g. a
+      // Drawing tool popover or TextWidget formatting toolbar) — these carry
+      // the portal marker but no data-widget-id, unlike SettingsPanel.
+      portalRoot = document.createElement('div');
+      portalRoot.setAttribute('data-widget-portal', '');
+
+      portalButton = document.createElement('button');
+      portalButton.setAttribute('type', 'button');
+      portalButton.textContent = 'Bold';
+      portalRoot.appendChild(portalButton);
+
+      document.body.appendChild(portalRoot);
+      portalButton.focus();
+    });
+
+    afterEach(() => {
+      if (portalRoot.parentNode) {
+        portalRoot.parentNode.removeChild(portalRoot);
+      }
+    });
+
+    it('REGRESSION: still dispatches Delete to the topmost widget instead of silently no-oping', () => {
+      renderView();
+
+      const dispatched: CustomEvent[] = [];
+      const handler = (e: Event) => dispatched.push(e as CustomEvent);
+      window.addEventListener('widget-keyboard-action', handler);
+
+      expect(document.activeElement).toBe(portalButton);
+
+      fireEvent.keyDown(window, { key: 'Delete' });
+
+      window.removeEventListener('widget-keyboard-action', handler);
+
+      expect(dispatched).toHaveLength(1);
+      const detail = (
+        dispatched[0] as CustomEvent<{ widgetId: string; key: string }>
+      ).detail;
+      expect(detail.widgetId).toBe(TOP_WIDGET_ID);
+    });
+  });
+
   // Toast accessibility: the ToastContainer must expose live-region roles so
   // screen readers announce toasts (assertive for errors, polite otherwise) and
   // provide an explicit Dismiss control so SR/keyboard users can close a toast

--- a/tests/components/layout/DashboardView.test.tsx
+++ b/tests/components/layout/DashboardView.test.tsx
@@ -868,6 +868,164 @@ describe('DashboardView Gestures & Navigation', () => {
     });
   });
 
+  // Regression: SettingsPanel is portalled to document.body via
+  // createPortal, tagged data-widget-portal="" but (until this fix) with no
+  // data-widget-id — so focus landing on a non-form control inside an open
+  // settings panel (a Toggle/SegmentedControl button, not an INPUT/
+  // TEXTAREA/SELECT) can't be resolved back to its owning widget via
+  // closest('.widget'). The fallback silently targets whatever widget is
+  // topmost by z-index instead — which is a DIFFERENT widget than the one
+  // whose settings panel is actually open whenever that widget isn't also
+  // the top one. Escape then dispatches to the wrong widget (e.g. silently
+  // minimizing an unrelated widget instead of just closing the settings
+  // panel already closing via SettingsPanel's own document-level handler).
+  describe('widget-keyboard-action targets the owning widget when focus is inside a settings-panel portal', () => {
+    const TOP_WIDGET_ID = 'widget-topmost';
+    const SETTINGS_WIDGET_ID = 'widget-settings-open';
+
+    let portalRoot: HTMLDivElement;
+    let portalButton: HTMLButtonElement;
+
+    beforeEach(() => {
+      (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+        activeDashboard: {
+          ...mockDashboards[1],
+          widgets: [
+            {
+              id: TOP_WIDGET_ID,
+              type: 'clock',
+              x: 0,
+              y: 0,
+              w: 200,
+              h: 200,
+              z: 2,
+              flipped: false,
+              config: {},
+            },
+            {
+              id: SETTINGS_WIDGET_ID,
+              type: 'clock',
+              x: 300,
+              y: 0,
+              w: 200,
+              h: 200,
+              z: 1,
+              flipped: true,
+              config: {},
+            },
+          ],
+        },
+        dashboards: mockDashboards,
+        toasts: [],
+        addWidget: mockAddWidget,
+        loadDashboard: mockLoadDashboard,
+        removeToast: vi.fn(),
+        updateWidget: vi.fn(),
+        removeWidget: vi.fn(),
+        duplicateWidget: vi.fn(),
+        bringToFront: vi.fn(),
+        addToast: vi.fn(),
+        minimizeAllWidgets: vi.fn(),
+        restoreAllWidgets: vi.fn(),
+        deleteAllWidgets: vi.fn(),
+        setSelectedWidgetId: vi.fn(),
+        updateDashboardSettings: vi.fn(),
+        zoom: 1,
+        setZoom: vi.fn(),
+        collectionsApi: {
+          collections: [],
+          loading: false,
+          error: null,
+          createCollection: vi.fn(),
+          renameCollection: vi.fn(),
+          moveCollection: vi.fn(),
+          deleteCollection: vi.fn(),
+          reorderSiblings: vi.fn(),
+          setCollectionMetadata: vi.fn(),
+          setCollectionDefaultBoard: vi.fn(),
+        },
+      });
+
+      // Simulate SettingsPanel's portal: appended directly to document.body
+      // (outside any .widget ancestor), tagged data-widget-portal="" like
+      // the real component, holding a non-form control (e.g. a Toggle) that
+      // receives focus when the teacher interacts with a setting.
+      portalRoot = document.createElement('div');
+      portalRoot.setAttribute('data-widget-portal', '');
+      portalRoot.setAttribute('data-widget-id', SETTINGS_WIDGET_ID);
+
+      portalButton = document.createElement('button');
+      portalButton.setAttribute('type', 'button');
+      portalButton.textContent = 'Show seconds';
+      portalRoot.appendChild(portalButton);
+
+      document.body.appendChild(portalRoot);
+      portalButton.focus();
+    });
+
+    afterEach(() => {
+      if (portalRoot.parentNode) {
+        portalRoot.parentNode.removeChild(portalRoot);
+      }
+    });
+
+    it('dispatches Escape to the widget whose settings panel owns the focused control, not the topmost widget', () => {
+      renderView();
+
+      const dispatched: CustomEvent[] = [];
+      const handler = (e: Event) => dispatched.push(e as CustomEvent);
+      window.addEventListener('widget-keyboard-action', handler);
+
+      expect(document.activeElement).toBe(portalButton);
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+
+      window.removeEventListener('widget-keyboard-action', handler);
+
+      expect(dispatched).toHaveLength(1);
+      const detail = (
+        dispatched[0] as CustomEvent<{ widgetId: string; key: string }>
+      ).detail;
+      expect(detail.widgetId).toBe(SETTINGS_WIDGET_ID);
+    });
+
+    it('dispatches Delete to the widget whose settings panel owns the focused control, not the topmost widget', () => {
+      renderView();
+
+      const dispatched: CustomEvent[] = [];
+      const handler = (e: Event) => dispatched.push(e as CustomEvent);
+      window.addEventListener('widget-keyboard-action', handler);
+
+      fireEvent.keyDown(window, { key: 'Delete' });
+
+      window.removeEventListener('widget-keyboard-action', handler);
+
+      expect(dispatched).toHaveLength(1);
+      const detail = (
+        dispatched[0] as CustomEvent<{ widgetId: string; key: string }>
+      ).detail;
+      expect(detail.widgetId).toBe(SETTINGS_WIDGET_ID);
+    });
+
+    it('dispatches Pin (Alt+P) to the widget whose settings panel owns the focused control, not the topmost widget', () => {
+      renderView();
+
+      const dispatched: CustomEvent[] = [];
+      const handler = (e: Event) => dispatched.push(e as CustomEvent);
+      window.addEventListener('widget-keyboard-action', handler);
+
+      fireEvent.keyDown(window, { key: 'p', altKey: true });
+
+      window.removeEventListener('widget-keyboard-action', handler);
+
+      expect(dispatched).toHaveLength(1);
+      const detail = (
+        dispatched[0] as CustomEvent<{ widgetId: string; key: string }>
+      ).detail;
+      expect(detail.widgetId).toBe(SETTINGS_WIDGET_ID);
+    });
+  });
+
   // Toast accessibility: the ToastContainer must expose live-region roles so
   // screen readers announce toasts (assertive for errors, polite otherwise) and
   // provide an explicit Dismiss control so SR/keyboard users can close a toast


### PR DESCRIPTION
## Root cause

`components/layout/DashboardView.tsx`'s global keydown handler resolves which widget Escape/Delete/Alt+P should target via `document.activeElement?.closest('.widget')`, falling back to the topmost-by-z-index widget when that lookup returns `null`.

`SettingsPanel.tsx` renders via `createPortal` to `document.body`, **outside** its owning widget's `.widget` DOM subtree. Focusing any non-form control inside an open settings panel (a `Toggle`, `SegmentedControl`, preset button — very common in widget settings UIs) makes `closest('.widget')` return `null`. The handler then silently falls back to whatever widget is currently topmost by z-index — which, whenever that's a *different* widget than the one whose settings are open, means Escape/Delete/Alt+P act on the wrong widget, including silently deleting or minimizing an unrelated one.

## Fix

Extended the ancestor lookup to also match `[data-widget-portal]` (`'.widget, [data-widget-portal]'`), and tagged `SettingsPanel`'s portal root with `data-widget-id={widget.id}` so it resolves to the correct owning widget regardless of where in the DOM tree focus currently sits. Applied identically to all three call sites (Escape, Delete, Alt+P) since they share the same duplicated resolution logic — fixing only Escape would have left Delete (the more severe consequence) and Alt+P with the identical gap.

## Rejected band-aid

Considered adding `stopPropagation()` in `SettingsPanel`'s own Escape handler instead. Rejected: PR #2430's history already showed this exact approach causes 3 regressions (blocks Shift+Escape minimize-all, group-build-mode exit, and `AnnotationOverlay`'s own Escape handler whenever a settings panel happens to be open). The correct fix belongs in the ancestor-resolution logic itself, not in suppressing propagation.

## Regression test

`tests/components/layout/DashboardView.test.tsx` — new `describe('widget-keyboard-action targets the owning widget when focus is inside a settings-panel portal')`, covering Escape, Delete, and Alt+P.

- **Fail-before** (independently re-verified by the orchestrator via file-swap against `dev-paul`): all 3 new tests fail — `expected 'widget-topmost' to be 'widget-settings-open'`.
- **Pass-after**: 34/34 tests in the file pass.

## Evidence

- `pnpm run validate` — full run — green.
- `pnpm run build` — succeeded.
- Adjacent Escape/settings test suites (`SettingsPanel.test.tsx`, `DraggableWindow.test.tsx`) also re-run clean (85/85) to confirm no regression in the surrounding machinery.
- Orchestrator independently re-ran fail-before/pass-after in isolation.

## Risk

**Contained** — touches only the widget-identity resolution used by 3 keyboard shortcuts and adds one data attribute to `SettingsPanel`'s portal root; no behavior change for the non-portal case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YGutrWaS8VoNbuEJ8Bh7)_