### PR TITLE
fix(rosters): sync pin_index sidecar for students migrated off Firestore

### DIFF
--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -507,6 +507,13 @@ export const useRosters = (user: User | null) => {
               studentCount: withPins.length,
             };
           }
+          // Phase 3 — mirrors addRoster/updateRoster's pin_index sync, which this migration path was missing.
+          const rosterName =
+            typeof raw.name === 'string'
+              ? raw.name
+              : (metaListRef.current[idx]?.name ?? '');
+          if (rosterName)
+            void syncRosterPinIndex(docSnap.id, rosterName, withPins);
           didMigrate = true;
           console.warn(
             `[PII Migration] Moved students for roster ${docSnap.id} to Drive`

--- a/hooks/useRosters.ts
+++ b/hooks/useRosters.ts
@@ -512,8 +512,14 @@ export const useRosters = (user: User | null) => {
             typeof raw.name === 'string'
               ? raw.name
               : (metaListRef.current[idx]?.name ?? '');
-          if (rosterName)
+          if (rosterName) {
             void syncRosterPinIndex(docSnap.id, rosterName, withPins);
+          } else {
+            // syncRosterPinIndex keys pin_index entries by roster name; without one there is nothing to bridge PIN login against.
+            console.warn(
+              `[PII Migration] Roster ${docSnap.id} has no name — skipped pin_index sync; re-save the roster to bridge PIN login`
+            );
+          }
           didMigrate = true;
           console.warn(
             `[PII Migration] Moved students for roster ${docSnap.id} to Drive`

--- a/tests/hooks/useRosters.test.ts
+++ b/tests/hooks/useRosters.test.ts
@@ -759,6 +759,45 @@ describe('useRosters — PII migration', () => {
     );
   });
 
+  it('syncs the pin-index sidecar for ClassLink students freshly pinned during migration', async () => {
+    localStorage.removeItem(migrationKey(TEACHER_UID));
+    currentDriveService = makeDriveService();
+
+    renderHook(() => useRosters(mockUser));
+    emitSnapshot(0, [
+      metaDoc('r1', {
+        studentCount: 1,
+        // Legacy ClassLink doc: no `pin` field yet, so migration's
+        // assignPins() hands out a fresh one.
+        students: [
+          {
+            id: 's1',
+            firstName: 'Ada',
+            lastName: 'L',
+            classLinkSourcedId: 'cl-a',
+          },
+        ],
+      }),
+    ]);
+
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(lastCallableName).toBe('commitRosterPinIndexV1')
+    );
+    const payload = lastCallablePayload as {
+      rosterId: string;
+      entries: Array<{
+        period: string;
+        pin: string;
+        classlinkSourcedId: string;
+      }>;
+    };
+    expect(payload.rosterId).toBe('r1');
+    expect(payload.entries).toEqual([
+      { period: 'Roster r1', pin: '01', classlinkSourcedId: 'cl-a' },
+    ]);
+  });
+
   it('does not re-run migration once the per-user flag is set', async () => {
     // Flag is set in beforeEach; a legacy doc with students[] should be ignored.
     const { result } = renderHook(() => useRosters(mockUser));

--- a/tests/hooks/useRosters.test.ts
+++ b/tests/hooks/useRosters.test.ts
@@ -798,6 +798,58 @@ describe('useRosters — PII migration', () => {
     ]);
   });
 
+  it('skips the pin-index callable entirely for a migrated roster with no ClassLink students', async () => {
+    localStorage.removeItem(migrationKey(TEACHER_UID));
+    currentDriveService = makeDriveService();
+
+    renderHook(() => useRosters(mockUser));
+    emitSnapshot(0, [
+      metaDoc('r1', {
+        studentCount: 1,
+        // Local roster — no classLinkSourcedId, so there is no SSO bridge to write.
+        students: [{ id: 's1', firstName: 'Ada', lastName: 'L' }],
+      }),
+    ]);
+
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(localStorage.getItem(migrationKey(TEACHER_UID))).toBe('1')
+    );
+    expect(lastCallableName).toBeNull();
+  });
+
+  it('warns instead of syncing silently when a migrated roster has no name', async () => {
+    localStorage.removeItem(migrationKey(TEACHER_UID));
+    currentDriveService = makeDriveService();
+
+    renderHook(() => useRosters(mockUser));
+    emitSnapshot(0, [
+      // No `name` on the doc and no matching meta entry, so rosterName resolves to ''.
+      {
+        id: 'r1',
+        data: () => ({
+          studentCount: 1,
+          students: [
+            {
+              id: 's1',
+              firstName: 'Ada',
+              lastName: 'L',
+              classLinkSourcedId: 'cl-a',
+            },
+          ],
+        }),
+      },
+    ]);
+
+    await waitFor(() => expect(mockUpdateDoc).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(vi.mocked(console.warn)).toHaveBeenCalledWith(
+        expect.stringContaining('skipped pin_index sync')
+      )
+    );
+    expect(lastCallableName).toBeNull();
+  });
+
   it('does not re-run migration once the per-user flag is set', async () => {
     // Flag is set in beforeEach; a legacy doc with students[] should be ignored.
     const { result } = renderHook(() => useRosters(mockUser));


### PR DESCRIPTION
## Root cause

`hooks/useRosters.ts`'s `runMigrationIfNeeded()` (the one-time PII migration that moves a legacy roster's `students[]` out of Firestore into a Drive file) calls `assignPins()` to mint fresh PINs for any ClassLink-sourced student that doesn't already have one — but, unlike `addRoster()` and `updateRoster()`, it never calls `syncRosterPinIndex()` afterward.

`syncRosterPinIndex()` is what posts `(period, pin, classlinkSourcedId)` tuples to the `commitRosterPinIndexV1` cloud function, writing the `pin_index` sidecar docs that `pinLoginV1` reads to bridge a PIN-joining student to their ClassLink SSO uid. Any legacy ClassLink roster whose students didn't already have a `pin` field gets freshly-minted PINs during this one-time migration with **no accompanying pin_index write** — those students' PIN login fails to SSO-bridge until an unrelated future `updateRoster()` call happens to resync it (an indeterminate window, potentially days).

## Fix

Added the same `syncRosterPinIndex(docSnap.id, rosterName, withPins)` call (fire-and-forget, matching the existing best-effort pattern) right after the successful Drive upload + Firestore patch in the migration loop, with the same name-fallback logic `updateRoster()` already uses.

## Rejected band-aid

Relying on the next `updateRoster()` call to eventually resync the sidecar — this leaves an indeterminate window where affected students can't SSO-bridge via PIN. It's not a fix, just hoping a later unrelated action happens to mask it.

## Regression test

`tests/hooks/useRosters.test.ts` — new test `syncs the pin-index sidecar for ClassLink students freshly pinned during migration` under `describe('useRosters — PII migration')`.

- **Fail-before** (independently re-verified by the orchestrator via file-swap against `dev-paul`): `expected null to be 'commitRosterPinIndexV1'`.
- **Pass-after**: 36/36 tests in the file pass.

## Evidence

- `pnpm run validate` — full run — green.
- `pnpm run build` — succeeded.
- Orchestrator independently re-ran fail-before/pass-after in isolation.

## Risk

**Contained** — one additional fire-and-forget call in an existing migration path, mirroring an already-proven pattern used by two sibling write paths in the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YGutrWaS8VoNbuEJ8Bh7)_