### PR TITLE
fix(i18n): unify DE meeting-agenda terminology to "Tagesordnung"

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -620,7 +620,7 @@
         "label": "Meeting-Notizen",
         "newMeetingNote": "Neue Meeting-Notiz",
         "newMeetingNoteShort": "Meeting",
-        "agenda": "Agenda",
+        "agenda": "Tagesordnung",
         "decisions": "Entscheidungen",
         "actionItems": "Maßnahmen"
       }

--- a/tests/i18n/deMeetingAgendaTerminologyLocales.test.ts
+++ b/tests/i18n/deMeetingAgendaTerminologyLocales.test.ts
@@ -1,0 +1,44 @@
+// DE locale used two different words for the identical "meeting agenda" concept in the PLC
+// feature: plcDashboard.notes.meeting.agenda (Wave 2, #510e534) kept the English loanword
+// "Agenda", while plcDashboard.meeting.record.agenda (Wave 3, #eb38a69) correctly used the
+// established formal German term "Tagesordnung" — the two keys were translated independently
+// in separate feature waves and drifted. ES and FR are each internally consistent across both
+// keys (ES: "Agenda"/"Agenda", FR: "Ordre du jour"/"Ordre du jour"); only DE split.
+
+import { describe, it, expect } from 'vitest';
+import en from '@/locales/en.json';
+import de from '@/locales/de.json';
+
+/** Dotted path walker — returns the leaf string or undefined. */
+function getLeaf(root: unknown, path: string): string | undefined {
+  let node: unknown = root;
+  for (const segment of path.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return typeof node === 'string' ? node : undefined;
+}
+
+const NOTES_KEY = 'plcDashboard.notes.meeting.agenda';
+const RECORD_KEY = 'plcDashboard.meeting.record.agenda';
+
+describe('EN locale — both agenda keys represent the same concept', () => {
+  it('en.plcDashboard.notes.meeting.agenda and en.plcDashboard.meeting.record.agenda are both "Agenda"', () => {
+    expect(getLeaf(en, NOTES_KEY)).toBe('Agenda');
+    expect(getLeaf(en, RECORD_KEY)).toBe('Agenda');
+  });
+});
+
+describe('DE locale — "Agenda"/"Tagesordnung" terminology drift fixed', () => {
+  it('de.plcDashboard.notes.meeting.agenda matches de.plcDashboard.meeting.record.agenda', () => {
+    expect(getLeaf(de, NOTES_KEY)).toBe(getLeaf(de, RECORD_KEY));
+  });
+
+  it('de.plcDashboard.notes.meeting.agenda is "Tagesordnung", not the English loanword "Agenda"', () => {
+    expect(getLeaf(de, NOTES_KEY)).toBe('Tagesordnung');
+  });
+
+  it('de.plcDashboard.meeting.record.agenda stays "Tagesordnung"', () => {
+    expect(getLeaf(de, RECORD_KEY)).toBe('Tagesordnung');
+  });
+});


### PR DESCRIPTION
## Root cause

`locales/de.json` used two different German words for the identical "meeting agenda" concept in the PLC feature:

- `plcDashboard.notes.meeting.agenda` (added in an earlier feature wave) = `"Agenda"` (English loanword)
- `plcDashboard.meeting.record.agenda` (added in a later feature wave) = `"Tagesordnung"` (established formal German term)

Both keys render as a UI heading for the same "meeting agenda" concept (`NotesBody.tsx`'s meeting-note template header vs. `PlcMeetingRecordView.tsx`'s section title). ES and FR are each internally consistent across both keys (ES: "Agenda"/"Agenda", FR: "Ordre du jour"/"Ordre du jour") — only DE drifted, because the two keys were translated independently in separate feature waves. This matches the codebase's established "translated but inconsistent terminology" bug class (see the DE Board→Tafel precedent, #2149).

A German user creating a meeting note and later viewing its formal record would see two different words for the same thing on the same feature.

## Fix

Canonicalized `plcDashboard.notes.meeting.agenda` to `"Tagesordnung"`, matching the more formal/precise term already used in the officially-exported meeting record view.

## Rejected band-aid

Leaving `notes.meeting.agenda` as `"Agenda"` — a technically valid German loanword on its own — would mask the inconsistency rather than fix it.

## Regression test

`tests/i18n/deMeetingAgendaTerminologyLocales.test.ts` (new file) — asserts both keys match, and that the canonical value is `"Tagesordnung"` not the English loanword.

- **Fail-before** (independently re-verified by the orchestrator via file-swap against `dev-paul`): 2/4 tests fail — `expected 'Agenda' to be 'Tagesordnung'`.
- **Pass-after**: 4/4 tests pass.

## Evidence

- Full `tests/i18n/` suite — 40 files / 1563 tests, green (no regressions).
- `pnpm run validate` — full run — green.
- `pnpm run build` — succeeded.
- Orchestrator independently re-ran fail-before/pass-after in isolation.

## Risk

**Contained** — single locale-string change plus a new scoped regression test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YGutrWaS8VoNbuEJ8Bh7)_