### PR TITLE
fix(lti): dedup OneRoster roster emails before scoring class-link overlap

### DIFF
--- a/functions/src/lti/courseLinkEndpoints.test.ts
+++ b/functions/src/lti/courseLinkEndpoints.test.ts
@@ -348,6 +348,42 @@ describe('ltiSuggestClassLinkMatchV1', () => {
     expect(res.suggestion?.overlap).toBe(3);
   });
 
+  it('does not let duplicate roster entries for the same student inflate overlap past a genuinely-better match', async () => {
+    seenSession();
+    fetchNrpsMembersMock.mockResolvedValue([
+      {
+        userId: 's1',
+        givenName: '',
+        familyName: '',
+        email: 'a@s.edu',
+        roles: [],
+        status: '',
+      },
+      {
+        userId: 's2',
+        givenName: '',
+        familyName: '',
+        email: 'b@s.edu',
+        roles: [],
+        status: '',
+      },
+    ]);
+    fetchClassStudentsMock.mockImplementation(
+      async (_t, _i, _s, classId: string) =>
+        // cl-A's OneRoster response lists the SAME student 3x (a data-quality
+        // duplicate, e.g. a merged/cross-listed enrollment) — 1 true unique
+        // match. cl-B has 2 distinct students, both matching — the genuinely
+        // better class.
+        classId === 'cl-A'
+          ? [{ email: 'a@s.edu' }, { email: 'a@s.edu' }, { email: 'a@s.edu' }]
+          : [{ email: 'a@s.edu' }, { email: 'b@s.edu' }]
+    );
+
+    const res = await callSuggest({ auth: TEACHER, data: base });
+    expect(res.suggestion?.classlinkClassId).toBe('cl-B');
+    expect(res.suggestion?.overlap).toBe(2);
+  });
+
   it('returns null (no-emails-released) when the platform withholds NRPS email', async () => {
     seenSession();
     fetchNrpsMembersMock.mockResolvedValue([

--- a/functions/src/lti/courseLinkEndpoints.ts
+++ b/functions/src/lti/courseLinkEndpoints.ts
@@ -410,7 +410,7 @@ export const ltiSuggestClassLinkMatchV1 = onCall(
     let best: MatchSuggestion | null = null;
     let secondOverlap = 0;
     for (const classlinkClassId of ownedCandidates) {
-      let rosterEmails: string[];
+      let rosterEmails: Set<string>;
       try {
         const students = await classroomAddonNet.fetchClassStudents(
           tenantUrl,
@@ -418,9 +418,15 @@ export const ltiSuggestClassLinkMatchV1 = onCall(
           clClientSecret,
           classlinkClassId
         );
-        rosterEmails = students
-          .map((s) => (s.email ?? '').toLowerCase())
-          .filter((e) => e.length > 0);
+        // Dedup fence: OneRoster can list the same student twice (merged /
+        // cross-listed enrollments), which would otherwise double-count that
+        // one student's match and let a class with duplicate roster rows
+        // out-rank a class with more genuinely distinct matching students.
+        rosterEmails = new Set(
+          students
+            .map((s) => (s.email ?? '').toLowerCase())
+            .filter((e) => e.length > 0)
+        );
       } catch (err) {
         console.warn(
           `[ltiSuggestMatch] OneRoster fetch failed for class ${classlinkClassId}:`,
@@ -428,11 +434,11 @@ export const ltiSuggestClassLinkMatchV1 = onCall(
         );
         continue;
       }
-      if (rosterEmails.length === 0) continue;
+      if (rosterEmails.size === 0) continue;
       let overlap = 0;
       for (const e of rosterEmails) if (sectionEmails.has(e)) overlap += 1;
       if (overlap === 0) continue;
-      const ratio = overlap / Math.min(rosterEmails.length, sectionEmails.size);
+      const ratio = overlap / Math.min(rosterEmails.size, sectionEmails.size);
       if (!best || overlap > best.overlap) {
         if (best) secondOverlap = best.overlap;
         best = { classlinkClassId, overlap, ratio };

--- a/functions/src/lti/courseLinkEndpoints.ts
+++ b/functions/src/lti/courseLinkEndpoints.ts
@@ -418,10 +418,7 @@ export const ltiSuggestClassLinkMatchV1 = onCall(
           clClientSecret,
           classlinkClassId
         );
-        // Dedup fence: OneRoster can list the same student twice (merged /
-        // cross-listed enrollments), which would otherwise double-count that
-        // one student's match and let a class with duplicate roster rows
-        // out-rank a class with more genuinely distinct matching students.
+        // Dedup fence: OneRoster can list the same student twice (merged/cross-listed enrollments).
         rosterEmails = new Set(
           students
             .map((s) => (s.email ?? '').toLowerCase())


### PR DESCRIPTION
## Root cause

`functions/src/lti/courseLinkEndpoints.ts`'s `ltiSuggestClassLinkMatchV1` (the Schoology↔ClassLink class-link auto-match suggester, live-wired via `utils/ltiCourseLinks.ts` → `components/classes/LinkSchoologyModal.tsx`) iterated a Firestore/OneRoster-sourced `students` array into a plain `rosterEmails: string[]` with no dedup fence, then used that un-deduped array for both the `overlap` count and the `ratio` denominator.

This is the same dedup-fence bug class fixed 6+ times already for scoring utilities (`videoActivityGrading.ts`, `plcContributions.ts`, `useVideoActivityAssignments.ts`, `useQuizAssignments.ts`, `quizScoreboard`, `classroomGradePush`) — just in a matching/ranking context instead of a scoring context. OneRoster can list the same student twice (a documented, real data-quality pattern for merged/cross-listed enrollments). A duplicate roster row inflates `overlap` for that class, letting a class with duplicate rows out-rank a class with more genuinely distinct matching students — i.e., the wrong Schoology section gets suggested/linked.

## Fix

`rosterEmails` is now reduced through a `Set<string>` immediately after fetch (mirroring `sectionEmails`, which was already correctly a `Set`), so both `overlap` and `ratio` are computed over distinct students.

## Rejected band-aid

Filtering duplicates only at the final `overlap` count while leaving `rosterEmails.length` un-deduped for `ratio` — this would still poison the `ratio`/`ambiguous` fields the caller relies on.

## Regression test

`functions/src/lti/courseLinkEndpoints.test.ts` — new test `does not let duplicate roster entries for the same student inflate overlap past a genuinely-better match` under `describe('ltiSuggestClassLinkMatchV1')`.

- **Fail-before** (independently re-verified by the orchestrator via file-swap against `dev-paul`): `expected 'cl-A' to be 'cl-B'` — the class with 3 duplicate rows (1 unique student) incorrectly beats the class with 2 unique matching students.
- **Pass-after**: 18/18 tests in the file pass.

## Evidence

- Full `functions/src/lti/**` suite — 122/122 pass.
- `pnpm -C functions run lint` / `pnpm -C functions run build` (tsc) — clean.
- `pnpm run validate` — full run (root: 614 files/7402+ tests; functions: 41 files/804 tests; test:counts guard) — green.
- `pnpm run build` — succeeded.
- Orchestrator independently re-ran fail-before/pass-after in isolation. Also independently re-swept this run's stated SSRF-guard, pagination-cliff, and `firestore.rules` sibling-cutoff leads — all confirmed clean, no new gap.

## Risk

**Contained** — single file, single dedup fence, mirrors an already-proven pattern (`sectionEmails` in the same function) and 6 prior fixes of the identical bug class.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5YGutrWaS8VoNbuEJ8Bh7)_