### PR TITLE
fix(random): close group color-picker popover on Escape

### DIFF
--- a/components/widgets/random/RandomGroups.test.tsx
+++ b/components/widgets/random/RandomGroups.test.tsx
@@ -188,3 +188,38 @@ describe('GroupDropZone — rename input', () => {
     expect(onRenameGroup).toHaveBeenCalledWith('g1', 'Good Name');
   });
 });
+
+// ─── Regression: color-picker popover has no Escape handling ────────────────
+//
+// The color-picker popover is portalled to document.body (outside any
+// `.widget` / `[data-draggable-window]` ancestor) but only closed on
+// outside-pointerdown — it had no document-level keydown listener at all, so
+// pressing Escape while it was open did nothing locally and instead reached
+// DashboardView's global Escape handler unobstructed (which minimizes the
+// topmost widget), leaving the popover stuck open. This mirrors the fix
+// pattern in CatalystSetPickerPopover.tsx (PR #2439) and ActiveClassChip.tsx.
+describe('GroupDropZone — color picker popover', () => {
+  it('REGRESSION: closes the color picker when Escape is pressed', () => {
+    render(
+      <RandomGroups
+        displayResult={makeGroups({ g1: ['Alice', 'Bob'] })}
+        editable
+        onToggleLock={vi.fn()}
+        onChangeGroupColor={vi.fn()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Change Group 1 color/i })
+    );
+    expect(
+      screen.getByRole('button', { name: /Change Group 1 color/i })
+    ).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(
+      screen.getByRole('button', { name: /Change Group 1 color/i })
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/components/widgets/random/RandomGroups.tsx
+++ b/components/widgets/random/RandomGroups.tsx
@@ -6,6 +6,7 @@ import { RandomGroup, SharedGroup } from '@/types';
 import { StudentChip } from './StudentChip';
 import { SCOREBOARD_COLORS } from '@/config/scoreboard';
 import { ScaledEmptyState } from '@/components/common/ScaledEmptyState';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 
 interface RandomGroupsProps {
   displayResult: string | string[] | string[][] | RandomGroup[] | null;
@@ -154,6 +155,20 @@ const GroupDropZone: React.FC<GroupDropZoneProps> = ({
     };
     document.addEventListener('pointerdown', handlePointerDown);
     return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [colorPickerOpen]);
+
+  // Close color picker on Escape.
+  useEffect(() => {
+    if (!colorPickerOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      // Portalled outside any `.widget` ancestor — stop it reaching DashboardView's global handler.
+      e.stopPropagation();
+      setColorPickerOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
   }, [colorPickerOpen]);
 
   // Recompute popover anchor on open + window resize / scroll so it tracks


### PR DESCRIPTION
## Root cause

`RandomGroups.tsx`'s `GroupDropZone` sub-component (used by the Randomizer widget's group-build mode) renders its per-group color-picker popover via `createPortal(..., document.body)`, outside any `.widget` ancestor. It had an outside-`pointerdown` listener to close on click-away, but **zero Escape-key handling**. Pressing Escape while the picker was open did nothing locally, so the keypress fell through unobstructed to `DashboardView`'s global document-level Escape handler, which minimizes the topmost widget — leaving the color picker visibly stuck open with no keyboard way to dismiss it.

This is a fresh, previously-unfixed instance of the recurring "portalled popover, zero local Escape handling" bug class in this codebase (same family as `CatalystSetPickerPopover.tsx` fixed in #2439, `ActiveClassChip.tsx`, etc.).

## Fix summary

Added a `document`-level `keydown` effect, scoped to while `colorPickerOpen` is true, that closes the picker on Escape and calls `stopPropagation()` so it doesn't also trigger the global widget-minimize fallback — mirroring the precedented pattern used elsewhere in the codebase.

## Rejected band-aid

None needed — this is already the minimal root-cause fix (one effect, same shape as prior fixes for this exact bug class). No larger architectural issue underlies it.

## Regression test

`components/widgets/random/RandomGroups.test.tsx` — new test asserting `aria-expanded` flips from `"true"` to `"false"` on the palette button after `fireEvent.keyDown(document, { key: 'Escape' })`.

**Before/after evidence:** independently re-verified by the orchestrator — reverted only the source fix (kept the test) and confirmed the test fails on `dev-paul` (`aria-expanded` stays `"true"`), then restored the fix and confirmed it passes (9/9 tests in the file).

## Validation

`pnpm run validate` (type-check:all → lint → format:check → root tests [614 files / 7403 tests] → functions tests [41 files / 803 tests] → test:counts) and `pnpm run build` both pass clean.

## Risk

**contained** — single component, single new effect, no shared/cross-cutting surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YUarrDbieRDDFebRJMrJp)_