### PR TITLE
fix(settings): stop mid-drag transparency writes from landing on the wrong board

### DIFF
--- a/hooks/useGlobalStyleEditor.ts
+++ b/hooks/useGlobalStyleEditor.ts
@@ -53,10 +53,16 @@ export function useGlobalStyleEditor(): GlobalStyleEditor {
   // changes so a different read-only board re-notifies. Adjusting state during
   // render avoids the extra round-trip an effect would cost.
   const [readOnlyToastShown, setReadOnlyToastShown] = useState(false);
+  // In-flight values so the thumb follows the cursor before the debounce fires.
+  const [pendingWindow, setPendingWindow] = useState<number | null>(null);
+  const [pendingDock, setPendingDock] = useState<number | null>(null);
   const [prevBoardId, setPrevBoardId] = useState(activeDashboard?.id);
   if (activeDashboard?.id !== prevBoardId) {
     setPrevBoardId(activeDashboard?.id);
     setReadOnlyToastShown(false);
+    // Clear in-flight drag values so a switched-to board shows its own committed value, not a carried-over one.
+    setPendingWindow(null);
+    setPendingDock(null);
   }
 
   const commit = useCallback(
@@ -85,20 +91,21 @@ export function useGlobalStyleEditor(): GlobalStyleEditor {
     [commit]
   );
 
-  // Each slider gets its own debounced commit so rapid cross-slider drags don't
-  // share a timer and overwrite each other's pending values.
+  // originBoardId is re-checked against the active board when the debounce fires, so a board switch mid-drag can't write onto the wrong board.
   const commitWindowTransparency = useDebouncedCallback(
-    (value: number) => commit({ windowTransparency: value }),
+    (originBoardId: string | undefined, value: number) => {
+      if (originBoardId !== activeDashboard?.id) return;
+      commit({ windowTransparency: value });
+    },
     200
   );
   const commitDockTransparency = useDebouncedCallback(
-    (value: number) => commit({ dockTransparency: value }),
+    (originBoardId: string | undefined, value: number) => {
+      if (originBoardId !== activeDashboard?.id) return;
+      commit({ dockTransparency: value });
+    },
     200
   );
-
-  // In-flight values so the thumb follows the cursor before the debounce fires.
-  const [pendingWindow, setPendingWindow] = useState<number | null>(null);
-  const [pendingDock, setPendingDock] = useState<number | null>(null);
 
   // Clear each pending value once the committed state catches up.
   const [prevCommittedWindow, setPrevCommittedWindow] = useState(
@@ -130,14 +137,14 @@ export function useGlobalStyleEditor(): GlobalStyleEditor {
       value: pendingWindow ?? currentStyle.windowTransparency,
       onChange: (value: number) => {
         setPendingWindow(value);
-        commitWindowTransparency(value);
+        commitWindowTransparency(activeDashboard?.id, value);
       },
     },
     dockTransparency: {
       value: pendingDock ?? currentStyle.dockTransparency,
       onChange: (value: number) => {
         setPendingDock(value);
-        commitDockTransparency(value);
+        commitDockTransparency(activeDashboard?.id, value);
       },
     },
   };

--- a/tests/hooks/useGlobalStyleEditor.test.tsx
+++ b/tests/hooks/useGlobalStyleEditor.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * useGlobalStyleEditor — regression coverage for the board-switch-mid-drag
+ * race. See hooks/useGlobalStyleEditor.ts for the full mechanism writeup.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
+
+const setGlobalStyle = vi.fn();
+const addToast = vi.fn();
+
+interface MockDashboardState {
+  activeDashboard: { id: string; globalStyle: typeof DEFAULT_GLOBAL_STYLE };
+  setGlobalStyle: typeof setGlobalStyle;
+  isActiveBoardReadOnly: boolean;
+  addToast: typeof addToast;
+}
+
+const mockState: MockDashboardState = {
+  activeDashboard: {
+    id: 'board-a',
+    globalStyle: { ...DEFAULT_GLOBAL_STYLE, windowTransparency: 0.2 },
+  },
+  setGlobalStyle,
+  isActiveBoardReadOnly: false,
+  addToast,
+};
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => mockState,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_k: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? _k,
+  }),
+}));
+
+import { useGlobalStyleEditor } from '@/hooks/useGlobalStyleEditor';
+
+describe('useGlobalStyleEditor — board switch mid-drag', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setGlobalStyle.mockClear();
+    mockState.activeDashboard = {
+      id: 'board-a',
+      globalStyle: { ...DEFAULT_GLOBAL_STYLE, windowTransparency: 0.2 },
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not write a stale dragged value onto a different board switched to before the debounce fires', () => {
+    const { result, rerender } = renderHook(() => useGlobalStyleEditor());
+
+    // Drag the windowTransparency slider on board-a. The debounced commit is
+    // now armed to fire in 200ms with value 0.5.
+    act(() => {
+      result.current.windowTransparency.onChange(0.5);
+    });
+    expect(result.current.windowTransparency.value).toBe(0.5);
+
+    // Board switches to board-b (e.g. via a keyboard shortcut) before the
+    // debounce fires. board-b's own committed transparency is 0.9.
+    mockState.activeDashboard = {
+      id: 'board-b',
+      globalStyle: { ...DEFAULT_GLOBAL_STYLE, windowTransparency: 0.9 },
+    };
+    rerender();
+
+    // The slider must reflect board-b's real value, not the stale in-flight
+    // drag value carried over from board-a.
+    expect(result.current.windowTransparency.value).toBe(0.9);
+
+    // Let the originally-armed debounce fire.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // The debounced commit from board-a's drag must NOT land on board-b.
+    expect(setGlobalStyle).not.toHaveBeenCalledWith({
+      windowTransparency: 0.5,
+    });
+  });
+});

--- a/tests/hooks/useGlobalStyleEditor.test.tsx
+++ b/tests/hooks/useGlobalStyleEditor.test.tsx
@@ -85,4 +85,31 @@ describe('useGlobalStyleEditor — board switch mid-drag', () => {
       windowTransparency: 0.5,
     });
   });
+
+  it('applies the same board-switch guard to dockTransparency', () => {
+    mockState.activeDashboard = {
+      id: 'board-a',
+      globalStyle: { ...DEFAULT_GLOBAL_STYLE, dockTransparency: 0.2 },
+    };
+    const { result, rerender } = renderHook(() => useGlobalStyleEditor());
+
+    act(() => {
+      result.current.dockTransparency.onChange(0.5);
+    });
+    expect(result.current.dockTransparency.value).toBe(0.5);
+
+    mockState.activeDashboard = {
+      id: 'board-b',
+      globalStyle: { ...DEFAULT_GLOBAL_STYLE, dockTransparency: 0.9 },
+    };
+    rerender();
+
+    expect(result.current.dockTransparency.value).toBe(0.9);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(setGlobalStyle).not.toHaveBeenCalledWith({ dockTransparency: 0.5 });
+  });
 });


### PR DESCRIPTION
## Root cause

`hooks/useGlobalStyleEditor.ts`'s debounced window/dock transparency commits (`commitWindowTransparency`/`commitDockTransparency`, 200ms debounce) weren't scoped to the board the drag started on. `setGlobalStyle` always writes to `activeIdRef.current` — whichever board is active when the debounced write actually fires, not whichever board was active when the drag started.

If the active board changes before the 200ms debounce elapses (reachable in production: `DashboardView.tsx`'s global `Alt+ArrowLeft/Right` board-switch shortcut isn't gated behind the shared modal-open tracker), the old board's dragged value silently lands on the new board's `GlobalStyle`, corrupting it. A parallel display bug meant the slider itself could also keep showing the stale value from the board just left, since `pendingWindow`/`pendingDock` weren't reset on board switch (unlike the existing `readOnlyToastShown` reset).

## Fix summary

Capture the origin board id (`activeDashboard?.id`) at drag time, thread it through the debounced callback, and skip the commit if the active board no longer matches when the timer fires. Also reset `pendingWindow`/`pendingDock` in the existing board-switch reset block so a switched-to board immediately shows its own real values.

## Rejected band-aid

Just resetting `pendingWindow`/`pendingDock` on board switch (matching the existing `readOnlyToastShown` reset) would fix the *visual* staleness but not the actual data corruption — the already-armed `setTimeout` from the debounce fires regardless of React state and would still call `setGlobalStyle` against whatever board is current at that moment. The real fix has to guard the write site itself.

## Regression test

`tests/hooks/useGlobalStyleEditor.test.tsx` — drags `windowTransparency` on board-a, switches the mocked `activeDashboard` to board-b before advancing fake timers, asserts the displayed value reflects board-b (not the stale drag) and that `setGlobalStyle` is never called with the stale board-a value.

**Before/after evidence:** independently re-verified by the orchestrator — reverted only the source fix (kept the test) and confirmed it fails on `dev-paul` (`expected 0.5 to be 0.9`), then restored the fix and confirmed it passes.

## Validation

`pnpm run validate` (type-check:all → lint → format:check → root tests [615 files / 7403 tests] → functions tests [41 files / 803 tests] → test:counts) and `pnpm run build` both pass clean.

## Risk

**contained** — single hook, guard added at the debounced-write boundary, no change to the public `GlobalStyleEditor` API surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YUarrDbieRDDFebRJMrJp)_