### PR TITLE
fix(dock): stop Escape from leaking out of the Widget Library overlay

### DIFF
--- a/components/layout/dock/WidgetLibrary.tsx
+++ b/components/layout/dock/WidgetLibrary.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef, useCallback, useMemo } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 import {
   Bookmark,
   FolderPlus,
@@ -185,6 +186,18 @@ export const WidgetLibrary = forwardRef<HTMLDivElement, WidgetLibraryProps>(
       onClose,
       triggerRef ? [triggerRef] : []
     );
+
+    // Portalled outside any `.widget`/Modal ancestor — stop Escape reaching DashboardView's global handler.
+    useEffect(() => {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Escape') return;
+        if (isEscapeFromWidgetInput(event)) return;
+        event.stopPropagation();
+        onClose();
+      };
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [onClose]);
 
     const handleResetDock = useCallback(async () => {
       const confirmed = await showConfirm(

--- a/tests/components/layout/WidgetLibrary.escapePropagation.test.tsx
+++ b/tests/components/layout/WidgetLibrary.escapePropagation.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Regression test: WidgetLibrary (the "Add Widget" library overlay opened
+ * from the Dock) is portalled to document.body but has NO Escape-key
+ * handler at all — only useClickOutside. Because it never uses the shared
+ * `Modal` component, `useHasOpenModal()` (which DashboardView's global
+ * Escape handler checks to bail out) never registers it as open. Pressing
+ * Escape while the library is open therefore falls through to
+ * DashboardView's global `window`-level Escape handler, which — finding no
+ * typing field and no `.widget` ancestor for the library overlay — falls
+ * back to targeting the topmost z-index widget on the board and
+ * closing/minimizing it, all while the library overlay stays open and
+ * unaffected.
+ *
+ * FIX: WidgetLibrary now closes itself on Escape and calls
+ * stopPropagation(), matching the same fix already applied to
+ * ToolDockItem, ClassRosterMenu, RemoteControlMenu, ActiveClassChip, and
+ * FolderPickerPopover.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('@/context/useDialog', () => ({
+  useDialog: () => ({ showConfirm: vi.fn() }),
+}));
+vi.mock('@/context/useToolVisibility', () => ({
+  useToolVisibility: () => ({ resetDockToDefaults: vi.fn() }),
+}));
+
+import { WidgetLibrary } from '@/components/layout/dock/WidgetLibrary';
+import { DEFAULT_GLOBAL_STYLE } from '@/types';
+
+afterEach(cleanup);
+
+describe('WidgetLibrary — Escape does not leak to window-level handlers', () => {
+  it('closes on Escape and stops propagation before it reaches window listeners', () => {
+    const onClose = vi.fn();
+    render(
+      <WidgetLibrary
+        onToggle={vi.fn()}
+        visibleTools={[]}
+        canAccess={() => true}
+        onClose={onClose}
+        globalStyle={DEFAULT_GLOBAL_STYLE}
+        libraryOrder={[]}
+        onReorderLibrary={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Widget Library')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+      expect(onClose).toHaveBeenCalled();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

`components/layout/dock/WidgetLibrary.tsx` (the "Add Widget" library overlay opened from the Dock) is `createPortal`-ed to `document.body`, but never uses the shared `Modal` component, so `useHasOpenModal()` never sees it as open and had no local Escape handling. Pressing Escape while the library overlay was open fell through unobstructed to `DashboardView`'s global window-level Escape handler, which closed/minimized an unrelated widget on the board while the library overlay itself stayed open.

This is a fresh, previously-unfixed instance of the recurring "portalled popover, Escape doesn't stopPropagation" bug class already fixed repeatedly elsewhere in this codebase (`ToolDockItem`, `ClassRosterMenu`, `RemoteControlMenu`, `ActiveClassChip`, `FolderPickerPopover`).

## Fix summary

Added the same document-level Escape + `stopPropagation()` handler already used by the components above, guarded with the shared `isEscapeFromWidgetInput` helper.

## Rejected band-aid

Wiring `WidgetLibrary` through `incrementOpenModalCount`/`decrementOpenModalCount` (so `useHasOpenModal()` sees it) would have been a bigger behavioral change than needed — that counter also gates other things like `DraggableWindow`'s floating toolbar — and diverges from the established fix pattern for this exact bug class. The minimal, precedented fix (local Escape handler + stopPropagation) was used instead.

## Regression test

`tests/components/layout/WidgetLibrary.escapePropagation.test.tsx` — new test mirroring the existing `ClassRosterMenu.escapePropagation.test.tsx`/`RemoteControlMenu.escapePropagation.test.tsx` pattern.

**Before/after evidence:** independently re-verified by the orchestrator — reverted only the source fix (kept the test) and confirmed it fails on `dev-paul` (`onClose` never called), then restored the fix and confirmed it passes.

## Validation

`pnpm run validate` (type-check:all → lint → format:check → root tests [615 files / 7403 tests] → functions tests [41 files / 803 tests] → test:counts) and `pnpm run build` both pass clean.

## Risk

**contained** — single component, single new effect, no shared/cross-cutting surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YUarrDbieRDDFebRJMrJp)_