### PR TITLE
fix(admin): use local date, not UTC, when writing calendar blocked/default dates

### DIFF
--- a/components/admin/CalendarConfigurationModal.tsx
+++ b/components/admin/CalendarConfigurationModal.tsx
@@ -31,6 +31,11 @@ import { DockDefaultsPanel } from './DockDefaultsPanel';
 import { SettingsLabel } from '@/components/common/SettingsLabel';
 import { useDashboard } from '@/context/useDashboard';
 
+// Local Y-M-D, not toISOString() (UTC-shifts across the day boundary) — mirrors Calendar/Widget.tsx's isBlocked fix.
+function getLocalDateISO(date: Date = new Date()): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
 interface CalendarConfigurationModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -230,7 +235,7 @@ export const CalendarConfigurationModal: React.FC<
   };
 
   const addBlockedDate = () => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getLocalDateISO();
     if (!config.blockedDates.includes(today)) {
       updateGlobal({ blockedDates: [...config.blockedDates, today] });
     }
@@ -238,7 +243,7 @@ export const CalendarConfigurationModal: React.FC<
 
   const addDefaultEvent = () => {
     const newEvent: CalendarEvent = {
-      date: new Date().toISOString().split('T')[0],
+      date: getLocalDateISO(),
       title: 'New Default Event',
     };
     updateBuilding({

--- a/tests/components/admin/CalendarConfigurationModal.localDate.test.tsx
+++ b/tests/components/admin/CalendarConfigurationModal.localDate.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Regression guard: "Add Date" (district blocked dates) and "Add Event"
+// (building default events) must stamp the ADMIN'S LOCAL calendar day, not
+// the UTC day. `new Date().toISOString().split('T')[0]` shifts to UTC and
+// rolls to the next day for any evening hour in a negative-UTC-offset
+// timezone (e.g. US Central) — the exact bug already fixed on the read side
+// in components/widgets/Calendar/Widget.tsx (see its `isBlocked` comment).
+// A blocked-date add made this way silently blocks the WRONG day.
+
+vi.mock('@/context/useAuth', () => ({
+  useAuth: () => ({ ensureGoogleScope: vi.fn().mockResolvedValue(null) }),
+}));
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useAdminBuildings', () => ({
+  useAdminBuildings: () => [{ id: 'b1', name: 'Building One' }],
+}));
+
+vi.mock('@/config/firebase', () => ({ db: {}, isAuthBypass: false }));
+
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(() => ({})),
+  getDoc: vi.fn().mockResolvedValue({ exists: () => false, data: () => ({}) }),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils/googleCalendarService', () => ({
+  GoogleCalendarService: class {
+    getEvents = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+import { CalendarConfigurationModal } from '@/components/admin/CalendarConfigurationModal';
+
+describe('CalendarConfigurationModal — local-date write path', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    // US Central (UTC-5 in August, DST). 9:30 PM local on Aug 16 is already
+    // 2:30 AM UTC on Aug 17 — the exact evening window where the bug bites.
+    process.env.TZ = 'America/Chicago';
+    // Mock only the Date value (not timer functions) so testing-library's
+    // async polling (findBy*/waitFor), which relies on real setTimeout,
+    // keeps working normally.
+    vi.setSystemTime(new Date('2026-08-17T02:30:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = originalTz;
+  });
+
+  it('"Add Date" stamps the admin\'s local today, not the UTC-shifted day', async () => {
+    const user = userEvent.setup();
+    render(<CalendarConfigurationModal isOpen onClose={() => undefined} />);
+
+    const addDateButton = await screen.findByText(/Add Date/i);
+    await user.click(addDateButton);
+
+    const dateInputs = await screen.findAllByDisplayValue('2026-08-16');
+    expect(dateInputs.length).toBeGreaterThan(0);
+    // Confirms this is actually exercising the bug window: naive
+    // toISOString() would have produced the UTC day instead.
+    expect(screen.queryByDisplayValue('2026-08-17')).not.toBeInTheDocument();
+  });
+
+  it('"Add Event" defaults a new building event to the admin\'s local today', async () => {
+    const user = userEvent.setup();
+    render(<CalendarConfigurationModal isOpen onClose={() => undefined} />);
+
+    const addEventButton = await screen.findByText(/Add Event/i);
+    await user.click(addEventButton);
+
+    const dateInputs = await screen.findAllByDisplayValue('2026-08-16');
+    expect(dateInputs.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Root cause

`components/admin/CalendarConfigurationModal.tsx`'s "Add Date" (district blocked dates) and "Add Event" (building default events) buttons stamped new dates with `new Date().toISOString().split('T')[0]`. `toISOString()` converts to UTC before formatting, so it rolls to the next (or previous) calendar day depending on the admin's timezone offset — e.g. any evening hour in a US timezone produces tomorrow's date instead of today's.

The read side (`components/widgets/Calendar/Widget.tsx`'s `isBlocked` computation) was already fixed for this exact bug class and documents why via an inline comment; the admin write path was never brought in line with that fix, so write and read used different day-boundary math. A blocked date added in the evening would silently block the wrong day for every teacher's Calendar widget district-wide.

## Fix summary

Added a `getLocalDateISO()` helper (Y-M-D via `getFullYear()`/`getMonth()`/`getDate()`, mirroring the widget's already-correct approach) and used it at both write sites.

## Rejected band-aid

Clamping/validating the date after computation, or only fixing `addBlockedDate` and leaving `addDefaultEvent`'s copy of the same bug — rejected because both call sites share the identical root cause and the correct fix is the same one-line swap at each site.

## Regression test

`tests/components/admin/CalendarConfigurationModal.localDate.test.tsx` — pins `TZ=America/Chicago` and system time to `2026-08-17T02:30:00Z` (9:30pm local Aug 16, already Aug 17 in UTC), clicks "Add Date" / "Add Event", and asserts the resulting date input shows `2026-08-16`, not `2026-08-17`.

**Before/after evidence:** independently re-verified by the orchestrator — reverted only the source fix (kept the test) and confirmed both assertions fail on `dev-paul` (2/2 fail — the `2026-08-16` value never appears), then restored the fix and confirmed both pass.

## Validation

`pnpm run validate` (type-check:all → lint → format:check → root tests [615 files / 7404 tests] → functions tests [41 files / 803 tests] → test:counts) and `pnpm run build` both pass clean.

## Risk

**contained** — single component, one small pure helper function, no shared/cross-cutting surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YUarrDbieRDDFebRJMrJp)_