### PR TITLE
fix(a11y): pair MaterialsWidget's orphaned settings labels with their controls

### DIFF
--- a/components/widgets/MaterialsWidget/Settings.test.tsx
+++ b/components/widgets/MaterialsWidget/Settings.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MaterialsSettings } from './Settings';
+import { useDashboard } from '@/context/useDashboard';
+import { useAuth } from '@/context/useAuth';
+import { useWidgetBuildingId } from '@/hooks/useWidgetBuildingId';
+import { WidgetData } from '@/types';
+
+vi.mock('@/context/useDashboard', () => ({
+  useDashboard: vi.fn(),
+}));
+vi.mock('@/context/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+vi.mock('@/hooks/useWidgetBuildingId', () => ({
+  useWidgetBuildingId: vi.fn(),
+}));
+
+const widget: WidgetData = {
+  id: 'materials-test-1',
+  type: 'materials',
+  x: 0,
+  y: 0,
+  w: 400,
+  h: 400,
+  z: 1,
+  flipped: true,
+  config: { selectedItems: [], activeItems: [] },
+};
+
+describe('MaterialsSettings — group heading associations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      updateWidget: vi.fn(),
+    });
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      featurePermissions: [],
+    });
+    (
+      useWidgetBuildingId as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue(undefined);
+  });
+
+  // These headings render as <span> (a bare <label> labelling nothing is
+  // ignored by screen readers), so the role=group + aria-labelledby pairing is
+  // the only thing giving each button group an accessible name.
+  it.each([['Typography'], ['Title Color'], ['Available Materials']])(
+    'names the %s button group from its heading',
+    (name) => {
+      render(<MaterialsSettings widget={widget} />);
+
+      expect(screen.getByRole('group', { name })).toBeInTheDocument();
+    }
+  );
+
+  it('names the title text input from its label', () => {
+    render(<MaterialsSettings widget={widget} />);
+
+    expect(screen.getByLabelText('Title Text')).toHaveAttribute('type', 'text');
+  });
+
+  it('renders the headings as spans, not orphaned labels', () => {
+    const { container } = render(<MaterialsSettings widget={widget} />);
+
+    const orphanedLabels = Array.from(
+      container.querySelectorAll('label')
+    ).filter((el) => !el.getAttribute('for') && !el.querySelector('input'));
+    expect(orphanedLabels).toHaveLength(0);
+  });
+});

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -16,6 +16,8 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   const buildingId = useWidgetBuildingId(widget);
   const config = widget.config as MaterialsConfig;
   const availableMaterialsLabelId = useId();
+  const typographyLabelId = useId();
+  const titleColorLabelId = useId();
   const {
     selectedItems = [],
     activeItems = [],
@@ -111,8 +113,14 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
 
         <div>
-          <SettingsLabel icon={Type}>Typography</SettingsLabel>
-          <div className="grid grid-cols-4 gap-2">
+          <SettingsLabel as="span" id={typographyLabelId} icon={Type}>
+            Typography
+          </SettingsLabel>
+          <div
+            className="grid grid-cols-4 gap-2"
+            role="group"
+            aria-labelledby={typographyLabelId}
+          >
             {fonts.map((f) => (
               <button
                 key={f.id}
@@ -139,8 +147,14 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
 
         <div>
-          <SettingsLabel icon={Palette}>Title Color</SettingsLabel>
-          <div className="flex flex-wrap gap-2">
+          <SettingsLabel as="span" id={titleColorLabelId} icon={Palette}>
+            Title Color
+          </SettingsLabel>
+          <div
+            className="flex flex-wrap gap-2"
+            role="group"
+            aria-labelledby={titleColorLabelId}
+          >
             {WIDGET_PALETTE.map((c) => (
               <button
                 key={c}

--- a/components/widgets/MaterialsWidget/Settings.tsx
+++ b/components/widgets/MaterialsWidget/Settings.tsx
@@ -17,6 +17,7 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
   const config = widget.config as MaterialsConfig;
   const availableMaterialsLabelId = useId();
   const typographyLabelId = useId();
+  const titleTextId = useId();
   const titleColorLabelId = useId();
   const {
     selectedItems = [],
@@ -98,8 +99,11 @@ export const MaterialsSettings: React.FC<{ widget: WidgetData }> = ({
       {/* Title Settings */}
       <div className="space-y-4">
         <div>
-          <SettingsLabel icon={Edit3}>Title Text</SettingsLabel>
+          <SettingsLabel htmlFor={titleTextId} icon={Edit3}>
+            Title Text
+          </SettingsLabel>
           <input
+            id={titleTextId}
             type="text"
             value={title}
             onChange={(e) =>


### PR DESCRIPTION
## Summary

Nightly consistency run (D3 — Settings Panel Label Primitives). Part of the long-running group-heading `SettingsLabel` retrofit series (runs 26–58, ~20 files).

**Canonical form:** `<SettingsLabel as="span" id="unique-id">Heading</SettingsLabel>` + `role="group" aria-labelledby="unique-id"` on the sibling-controls container — for a `SettingsLabel` that heads a *group* of sibling controls (button/chip/swatch group) rather than pairing 1:1 with one control, where a bare `<label>` (the default `as="label"`) is semantically orphaned.

**Instances unified (3, in 1 file):**
- `components/widgets/MaterialsWidget/Settings.tsx` — "Typography" heading over a 4-button font-picker grid → `as="span"` + `role="group"`
- `components/widgets/MaterialsWidget/Settings.tsx` — "Title Color" heading over a color-swatch button group → `as="span"` + `role="group"`
- `components/widgets/MaterialsWidget/Settings.tsx` — "Title Text" label over the title `<input>` was also orphaned (no `htmlFor`/`id` pairing) — a genuine 1:1 pairing, not a group heading, fixed with `htmlFor`/`id` instead of `as="span"`. Caught by an automated review follow-up pass; same underlying bug class (orphaned `<label>`) as the two group headings, just the 1:1 variant rather than the group variant.

All three missed by the file's earlier retrofit pass (run 49 fixed a fourth label, "Available Materials," in the same file). Group headings use `useId()`, matching the file's own pre-existing convention.

**Enforcement:** None added — this is a manual retrofit following an established repo-wide convention (no automated lint rule exists for this JSX shape; applied consistently by hand across ~20 files in this series per `docs/routines/unifier.md`).

**Behavior/visual-preservation evidence:**
- Read `components/common/SettingsLabel.tsx` source directly: `combinedClasses` is computed once (before the `as` branch check) and applied identically whether the component renders a `<span>` or a `<label>` — only the DOM tag and `htmlFor`/`aria-labelledby` wiring differ. Zero visual delta.
- `tsc --noEmit`: clean. `eslint --max-warnings 0`: clean. `prettier --check`: clean.
- New test file (`components/widgets/MaterialsWidget/Settings.test.tsx`) asserts accessible-name association for all three group headings plus the Title Text label, and asserts no orphaned `<label>` elements remain in the component.
- `pnpm run build`: succeeded (client + SSR + prerender) on the original 2-instance commit; CI re-verifying the full suite on the latest commit.

**Risk tag: mechanical** (pure DOM-tag + ARIA-attribute equivalence, no visual or behavioral change).

## Deferred to backlog / left alone
No new near-miss visual tiers or NEEDS-REVIEW candidates surfaced this run. Everything else encountered during the sweep matched an already-catalogued D3 exception or a previously-logged NEEDS-REVIEW row (the run-57/58 near-miss label tiers, the standing `role="group"` vs. `role="radiogroup"` architecture question, `Dock.tsx:1586`-style scope gaps) — none newly relevant here.

## Test plan
- [x] `tsc --noEmit`
- [x] `eslint . --max-warnings 0`
- [x] `prettier --check`
- [x] `pnpm run test` (includes new `Settings.test.tsx`)
- [x] `pnpm -C functions run test`
- [x] `pnpm run build`
- [ ] Optional: eyes-on check that MaterialsWidget's settings panel renders identically (change is DOM-tag/ARIA-only, not expected to affect rendering)