### PR TITLE
fix(widgets): key Stations assignments by student id, not display name

### DIFF
--- a/components/widgets/Stations/Widget.test.tsx
+++ b/components/widgets/Stations/Widget.test.tsx
@@ -133,4 +133,31 @@ describe('StationsWidget', () => {
     expect(updatePayload.config.assignments).not.toHaveProperty('John Doe');
     expect(updatePayload.config.assignments.s1).toBeNull();
   });
+
+  it('persists an assignment write for custom-roster students (id equals name in custom mode)', async () => {
+    // Regression test: in custom-list mode there's no backing student record,
+    // so `activeRoster` maps { id: name, name } — id and name are literally
+    // the same string. setAssignment's legacy-key cleanup must not delete
+    // the very key it just wrote (legacyName === studentId here), or every
+    // write to a custom-roster student's assignment silently reverts to
+    // nothing once persisted, breaking assignment for the entire roster mode.
+    const widget = createWidget({
+      rosterMode: 'custom',
+      customRoster: ['Alex Kim'],
+      assignments: { 'Alex Kim': 'station-a' },
+    });
+
+    render(<StationsWidget widget={widget} />);
+
+    const chip = await screen.findByText('Alex Kim');
+    fireEvent.click(chip);
+
+    const [, updatePayload] = mockDashboardContext.updateWidget.mock.calls.at(
+      -1
+    ) as [string, { config: StationsConfig }];
+    // Must retain the key with an explicit null, not delete it outright — the
+    // pre-fix bug deleted it unconditionally (on both assign AND unassign),
+    // so this asserts the write actually lands rather than silently vanishing.
+    expect(updatePayload.config.assignments).toHaveProperty('Alex Kim', null);
+  });
 });

--- a/components/widgets/Stations/Widget.test.tsx
+++ b/components/widgets/Stations/Widget.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StationsWidget } from './Widget';
+import { useDashboard } from '@/context/useDashboard';
+import { WidgetData, StationsConfig } from '@/types';
+import { mockPointerEvent } from '@/tests/testHelpers/mocks';
+
+vi.mock('@/context/useDashboard');
+
+const mockDashboardContext = {
+  updateWidget: vi.fn(),
+  addToast: vi.fn(),
+  rosters: [
+    {
+      id: 'roster-1',
+      name: 'Class 1A',
+      students: [
+        { id: 's1', firstName: 'John', lastName: 'Doe' },
+        { id: 's2', firstName: 'Jane', lastName: 'Smith' },
+      ],
+    },
+  ],
+  activeRosterId: 'roster-1',
+  activeDashboard: { widgets: [{ id: 'stations-1' }] },
+};
+
+describe('StationsWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockDashboardContext
+    );
+    if (!global.PointerEvent) {
+      global.PointerEvent = mockPointerEvent();
+    }
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const createWidget = (config: Partial<StationsConfig> = {}): WidgetData => {
+    return {
+      id: 'stations-1',
+      type: 'stations',
+      x: 0,
+      y: 0,
+      w: 500,
+      h: 400,
+      z: 1,
+      config: {
+        rosterMode: 'class',
+        assignments: {},
+        stations: [
+          { id: 'station-a', title: 'Station A', color: '#10b981', order: 0 },
+          { id: 'station-b', title: 'Station B', color: '#3b82f6', order: 1 },
+        ],
+        ...config,
+      },
+    } as WidgetData;
+  };
+
+  it('keeps two same-name students independently assigned (no name-collision)', async () => {
+    // Regression test: assignments must be keyed by the roster student `id`,
+    // not the display name. Two students who share a name (e.g. two "Emma
+    // Smith"s) previously collided on the same `assignments` key, so an
+    // id-keyed assignment map like this one was never read at all and both
+    // students silently fell back to "unassigned" no matter what the config
+    // said. Each station's count badge (`aria-label="N students assigned..."`)
+    // must show exactly one member per station, with nobody left unassigned.
+    (useDashboard as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      ...mockDashboardContext,
+      rosters: [
+        {
+          id: 'roster-1',
+          name: 'Class 1A',
+          students: [
+            { id: 's1', firstName: 'Emma', lastName: 'Smith' },
+            { id: 's2', firstName: 'Emma', lastName: 'Smith' },
+          ],
+        },
+      ],
+    });
+
+    const widget = createWidget({
+      assignments: { s1: 'station-a', s2: 'station-b' },
+    });
+
+    render(<StationsWidget widget={widget} />);
+
+    expect(await screen.findAllByText('Emma Smith')).toHaveLength(2);
+    expect(screen.getAllByLabelText('1 students assigned')).toHaveLength(2);
+    expect(screen.getByText('Unassigned (0)')).toBeInTheDocument();
+  });
+
+  it('still honors a legacy name-keyed assignment saved before the id-keying fix', async () => {
+    // Regression test: dashboards saved before assignments were keyed by
+    // student id (and station names imported via the Randomizer nexus, which
+    // has no student ids) store the assignment under the display name
+    // instead (e.g. "John Doe": "station-a"). The widget must still honor a
+    // name-keyed entry when no id-keyed one exists rather than treating the
+    // student as unassigned.
+    const widget = createWidget({
+      assignments: { 'John Doe': 'station-a' },
+    });
+
+    render(<StationsWidget widget={widget} />);
+
+    expect(await screen.findByText('John Doe')).toBeInTheDocument();
+    // Only John Doe has an assignment (legacy-name-keyed); Jane Smith (the
+    // other default roster member) has none and stays unassigned.
+    expect(screen.getByLabelText('1 students assigned')).toBeInTheDocument();
+    expect(screen.getByText('Unassigned (1)')).toBeInTheDocument();
+  });
+
+  it('can unassign a student whose assignment only exists under the legacy name key', async () => {
+    // Regression test: the read-path fallback (previous test) keeps legacy
+    // assignments visible, but a write path that only ever deletes
+    // `assignments[id]` is a no-op when the entry lives under the name key —
+    // so a legacy-keyed student could never actually be unassigned by click.
+    const widget = createWidget({
+      assignments: { 'John Doe': 'station-a' },
+    });
+
+    render(<StationsWidget widget={widget} />);
+
+    const chip = await screen.findByText('John Doe');
+    fireEvent.click(chip);
+
+    const [, updatePayload] = mockDashboardContext.updateWidget.mock.calls.at(
+      -1
+    ) as [string, { config: StationsConfig }];
+    expect(updatePayload.config.assignments).not.toHaveProperty('John Doe');
+    expect(updatePayload.config.assignments.s1).toBeNull();
+  });
+});

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -146,11 +146,14 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   // Always clear a legacy name-keyed entry for this student when writing —
   // otherwise it either keeps re-surfacing via the read-path fallback above
   // after an unassign, or lingers as orphaned data after a direct reassignment.
+  // Guard legacyName !== studentId: in custom-list mode id and name are the
+  // same string (id: name), so without this guard the delete would remove
+  // the very key `next[studentId] = value` just set two lines above.
   const setAssignment = useCallback(
     (studentId: string, value: string | null) => {
       const next = { ...assignments, [studentId]: value };
       const legacyName = activeRoster.find((s) => s.id === studentId)?.name;
-      if (legacyName) delete next[legacyName];
+      if (legacyName && legacyName !== studentId) delete next[legacyName];
       persistAssignments(next);
     },
     [assignments, activeRoster, persistAssignments]

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -82,8 +82,16 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
     [config.rosterMode, rosters, activeRosterId]
   );
 
-  const activeRoster = useMemo((): string[] => {
-    if (config.rosterMode === 'custom') return config.customRoster ?? [];
+  // Each entry pairs a stable identity (`id`) with the display `name`.
+  // `assignments` is keyed by `id` — class-roster students use their roster
+  // `id` so two students who share a display name (e.g. two "Emma Smith"s)
+  // get independent assignments instead of colliding on the same key.
+  // Custom-list mode has no backing student record, so the typed name is the
+  // only identity available there (matches LunchCount's identical carveout).
+  const activeRoster = useMemo((): { id: string; name: string }[] => {
+    if (config.rosterMode === 'custom') {
+      return (config.customRoster ?? []).map((name) => ({ id: name, name }));
+    }
     if (!currentRoster) return [];
 
     const today = getLocalIsoDate();
@@ -94,27 +102,33 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
 
     // Absent students drop out of the source list entirely — they don't appear
     // in any station card or the unassigned bucket. Their stored assignment in
-    // `config.assignments` is preserved (keyed by display name), so they snap
-    // back to the same station automatically once un-marked.
+    // `config.assignments` is preserved, so they snap back to the same
+    // station automatically once un-marked.
     return currentRoster.students
       .filter((s) => !absentIds.has(s.id))
-      .map((s) => `${s.firstName} ${s.lastName}`.trim());
+      .map((s) => ({
+        id: s.id,
+        name: `${s.firstName} ${s.lastName}`.trim(),
+      }));
   }, [config.rosterMode, config.customRoster, currentRoster]);
 
   // Group students by station id (for chip lists) plus an unassigned bucket.
   // Stale assignments (students no longer in roster) survive silently — we
   // only render chips for roster members so missing-from-roster keys don't
-  // appear, but they remain in `assignments` until the next reset.
+  // appear, but they remain in `assignments` until the next reset. Falls back
+  // to a legacy name-keyed entry when no id-keyed one exists, so dashboards
+  // saved before this fix (and station names imported from the Randomizer,
+  // which has no student ids to give us) don't lose their assignments.
   const grouped = useMemo(() => {
-    const byStation: Record<string, string[]> = {};
+    const byStation: Record<string, { id: string; name: string }[]> = {};
     for (const station of orderedStations) byStation[station.id] = [];
-    const unassigned: string[] = [];
-    for (const name of activeRoster) {
-      const value = assignments[name];
+    const unassigned: { id: string; name: string }[] = [];
+    for (const student of activeRoster) {
+      const value = assignments[student.id] ?? assignments[student.name];
       if (value && byStation[value]) {
-        byStation[value].push(name);
+        byStation[value].push(student);
       } else {
-        unassigned.push(name);
+        unassigned.push(student);
       }
     }
     return { byStation, unassigned };
@@ -127,6 +141,19 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
       });
     },
     [widget.id, config, updateWidget]
+  );
+
+  // Always clear a legacy name-keyed entry for this student when writing —
+  // otherwise it either keeps re-surfacing via the read-path fallback above
+  // after an unassign, or lingers as orphaned data after a direct reassignment.
+  const setAssignment = useCallback(
+    (studentId: string, value: string | null) => {
+      const next = { ...assignments, [studentId]: value };
+      const legacyName = activeRoster.find((s) => s.id === studentId)?.name;
+      if (legacyName) delete next[legacyName];
+      persistAssignments(next);
+    },
+    [assignments, activeRoster, persistAssignments]
   );
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
@@ -145,12 +172,15 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
       setActiveId(null);
       const { active, over } = event;
       if (!over) return;
-      const studentName = String(active.id);
+      const studentId = String(active.id);
       const overId = String(over.id);
+      const legacyName = activeRoster.find((s) => s.id === studentId)?.name;
+      const current =
+        assignments[studentId] ??
+        (legacyName ? assignments[legacyName] : undefined);
 
       if (overId === UNASSIGNED_DROP_ID) {
-        const next = { ...assignments, [studentName]: null };
-        persistAssignments(next);
+        setAssignment(studentId, null);
         return;
       }
       if (overId.startsWith(STATION_DROP_PREFIX)) {
@@ -159,7 +189,7 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
         if (!station) return;
         // Capacity guard: refuse and toast if full (and the student isn't
         // already there — moving within the same station is a no-op).
-        if (assignments[studentName] === stationId) return;
+        if (current === stationId) return;
         if (
           station.maxStudents != null &&
           stationCount(assignments, stationId) >= station.maxStudents
@@ -167,15 +197,14 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
           addToast(`${station.title || 'Station'} is full.`, 'info');
           return;
         }
-        const next = { ...assignments, [studentName]: stationId };
-        persistAssignments(next);
+        setAssignment(studentId, stationId);
       }
     },
-    [assignments, orderedStations, persistAssignments, addToast]
+    [assignments, activeRoster, orderedStations, setAssignment, addToast]
   );
 
   const handleResetAll = useCallback(() => {
-    persistAssignments(resetAllAssignments(activeRoster));
+    persistAssignments(resetAllAssignments(activeRoster.map((s) => s.id)));
   }, [persistAssignments, activeRoster]);
 
   const handleResetStation = useCallback(
@@ -209,7 +238,10 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
       addToast('No students in the active class.', 'info');
       return;
     }
-    const result = shuffleStudentsIntoStations(orderedStations, activeRoster);
+    const result = shuffleStudentsIntoStations(
+      orderedStations,
+      activeRoster.map((s) => s.id)
+    );
     persistAssignments(result.assignments);
     if (result.overflowStudents.length > 0) {
       addToast(
@@ -242,6 +274,13 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
       styles: { active: { opacity: '0.5' } },
     }),
   };
+
+  // `activeId` is now the dragged student's stable id, not their display
+  // name — resolve it back to a name for the drag overlay label.
+  const draggingStudentName = useMemo(
+    () => activeRoster.find((s) => s.id === activeId)?.name ?? activeId,
+    [activeId, activeRoster]
+  );
 
   // Empty state when the teacher hasn't configured any stations yet.
   if (orderedStations.length === 0) {
@@ -419,10 +458,7 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
                     key={station.id}
                     station={station}
                     members={members}
-                    onUnassign={(student) => {
-                      const next = { ...assignments, [student]: null };
-                      persistAssignments(next);
-                    }}
+                    onUnassign={(studentId) => setAssignment(studentId, null)}
                     onResetStation={() => handleResetStation(station.id)}
                     isFull={isFull}
                     fontClassName={fontClassName}
@@ -479,9 +515,9 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
                   >
                     {grouped.unassigned.map((student) => (
                       <DraggableStudent
-                        key={student}
-                        id={student}
-                        name={student}
+                        key={student.id}
+                        id={student.id}
+                        name={student.name}
                         className={studentChipClass}
                         style={{
                           ...studentChipStyle,
@@ -510,7 +546,7 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
               fontSize: 'min(14px, 6cqmin)',
             }}
           >
-            {activeId}
+            {draggingStudentName}
           </div>
         ) : null}
       </DragOverlay>

--- a/components/widgets/Stations/components/StationCard.tsx
+++ b/components/widgets/Stations/components/StationCard.tsx
@@ -12,8 +12,8 @@ import { studentChipClass, studentChipStyle } from './studentChip';
 
 interface StationCardProps {
   station: Station;
-  members: string[];
-  onUnassign: (student: string) => void;
+  members: { id: string; name: string }[];
+  onUnassign: (studentId: string) => void;
   onResetStation: () => void;
   isFull: boolean;
   /** Active typography class (from `getFontClass`) inherited from widget config. */
@@ -259,10 +259,10 @@ export const StationCard: React.FC<StationCardProps> = ({
             >
               {members.map((student) => (
                 <DraggableStudent
-                  key={student}
-                  id={student}
-                  name={student}
-                  onClick={() => onUnassign(student)}
+                  key={student.id}
+                  id={student.id}
+                  name={student.name}
+                  onClick={() => onUnassign(student.id)}
                   className={`${studentChipClass} justify-center text-center`}
                   style={{
                     // Override studentChipStyle's widget-relative cqmin values

--- a/types.ts
+++ b/types.ts
@@ -5716,7 +5716,12 @@ export interface SavedStationsPreset {
 export interface StationsConfig {
   /** Teacher-defined stations. Sorted by `order` for rotation/display. */
   stations: Station[];
-  /** Map: studentName -> stationId, or null/missing for unassigned. */
+  /**
+   * Map: studentId -> stationId, or null/missing for unassigned. Custom-list
+   * mode keys by the typed name (no backing student id). May also contain
+   * legacy name-keyed entries from pre-migration dashboards or a Randomizer
+   * import — read sites fall back to the name key when no id-keyed entry exists.
+   */
   assignments: Record<string, string | null>;
   rosterMode?: 'class' | 'custom';
   customRoster?: string[];


### PR DESCRIPTION
## Root cause

`components/widgets/Stations/Widget.tsx` built its roster as an array of derived display-name strings (`${firstName} ${lastName}`) and used that string as the key into `config.assignments` throughout drag-and-drop, shuffle, rotate, and reset. Two students sharing a display name (siblings, twins, common names) collide on the same key, so assigning one silently overwrites or moves the other's station assignment.

This is the same bug class already fixed for `LunchCount/Widget.tsx` in #2247. Stations was explicitly deferred at the time because a full fix also had to account for `Stations/nexus.ts`'s `buildStationsFromRandomGroups`, which imports groups from the Randomizer widget and can only key by name (`RandomGroup.names` has no student ids).

## Fix

Mirrors LunchCount's proven pattern. Class-roster mode now keys `activeRoster`/`assignments` by the roster student's stable `id`; every read site falls back to the legacy name key when no id-keyed entry exists (`assignments[id] ?? assignments[name]`), and every write site clears any stale legacy-name entry for that student. This transparently covers both pre-migration dashboards *and* the Randomizer-nexus import path (which is inherently name-keyed) — no changes to `nexus.ts` or the Randomizer widget were needed. Custom-list mode (no backing student record) is unchanged — still keyed by name, matching LunchCount's identical carve-out.

## Band-aid rejected

Adding `assignments` to `utils/dashboardPII.ts`'s scrub allowlist (the original backlog framing) — rejected because that field name is shared with `SeatingChart` (already ID-keyed) and would blanket-strip legitimate non-PII data. The only sustainable fix is at the widget level.

## Regression test

`components/widgets/Stations/Widget.test.tsx` (new), 3 cases:
1. Two same-name students stay independently assigned (collision case).
2. A legacy name-keyed assignment saved before this fix is still honored (backward compat).
3. Unassigning a student whose assignment only exists under the legacy name key actually clears it, not leaves a stale `null`-valued legacy key.

**Before/after evidence:** independently re-verified by the orchestrator — reverting `Widget.tsx`/`StationCard.tsx` to `dev-paul` and running the new test file fails 2 of 3 cases for the reported reasons (`expected 'Emma Smith' collision to leave 1 unassigned` / `expected { 'John Doe': null } to not have property`). Restoring the fix passes all 3, plus the existing `stationsActions.test.ts` (14 tests) untouched.

## Validation

`pnpm run validate` (type-check:all, lint zero-warnings, format:check, root + functions tests, test:counts) and `pnpm run build` — both green, independently re-run by the orchestrator on the final commit.

## Risk

**Contained** — localized to `components/widgets/Stations/**` and `types.ts`'s doc comment, with a name-key fallback for backward compatibility.

---
_Generated by [Claude Code](https://claude.ai/code/session_017noYuFMHKAK5uzaf9GNdEQ)_