### PR TITLE
fix(layout): use local-date helper for screenshot/annotation download filenames

### DIFF
--- a/components/common/DraggableWindow.test.tsx
+++ b/components/common/DraggableWindow.test.tsx
@@ -31,21 +31,48 @@ import {
 } from './modalStore';
 
 // Mock dependencies
-const { mockTakeScreenshot } = vi.hoisted(() => ({
+const { mockTakeScreenshot, mockUseScreenshot } = vi.hoisted(() => ({
   mockTakeScreenshot: vi.fn(),
+  mockUseScreenshot: vi.fn(),
 }));
 
 vi.mock('@/hooks/useScreenshot', () => ({
-  useScreenshot: () => ({
-    takeScreenshot: mockTakeScreenshot,
-    isFlashing: false,
-    isCapturing: false,
-  }),
+  // Records the (contentRef, fileName, options) args it's called with so
+  // tests can assert on the generated screenshot filename.
+  useScreenshot: (...args: unknown[]) => {
+    mockUseScreenshot(...args);
+    return {
+      takeScreenshot: mockTakeScreenshot,
+      isFlashing: false,
+      isCapturing: false,
+    };
+  },
 }));
 
 vi.mock('@/hooks/useClickOutside', () => ({
   useClickOutside: vi.fn(),
 }));
+
+// Controllable getLocalIsoDate for the UTC/local-date-divergence regression
+// test below. Mirrors the getTodayStr pattern in ScheduleWidget.test.tsx —
+// the test environment pins process.env.TZ to 'UTC' (see vitest.config.ts),
+// so real local getters can never diverge from toISOString() there; mocking
+// the helper directly is the only way to simulate the divergence a teacher
+// in a UTC-negative timezone actually sees.
+const { mockGetLocalIsoDate, defaultGetLocalIsoDate } = vi.hoisted(() => ({
+  mockGetLocalIsoDate: vi.fn<() => string>(),
+  defaultGetLocalIsoDate: { current: (() => '') as () => string },
+}));
+
+vi.mock('@/utils/localDate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/localDate')>();
+  defaultGetLocalIsoDate.current = actual.getLocalIsoDate;
+  mockGetLocalIsoDate.mockImplementation(actual.getLocalIsoDate);
+  return {
+    ...actual,
+    getLocalIsoDate: mockGetLocalIsoDate,
+  };
+});
 
 interface GlassCardProps {
   children: React.ReactNode;
@@ -202,6 +229,10 @@ describe('DraggableWindow', () => {
       return 0;
     });
     vi.clearAllMocks();
+    // Default: getLocalIsoDate returns the real local date so existing tests
+    // (which don't care about the screenshot filename) are unaffected.
+    mockGetLocalIsoDate.mockReset();
+    mockGetLocalIsoDate.mockImplementation(defaultGetLocalIsoDate.current);
     // Reset SettingsPanel render spy before each test
     settingsPanelRenderProps.length = 0;
     // Setup default spy to return null
@@ -1426,5 +1457,38 @@ describe('DraggableWindow', () => {
       'test-widget',
       expect.objectContaining({ minimized: true })
     );
+  });
+
+  // Regression: the screenshot filename was built from
+  // `new Date().toISOString().split('T')[0]` — the UTC calendar date — instead
+  // of the teacher's local date. For every timezone west of UTC (all of the
+  // Americas), the last few hours of the local day fall on the *next* UTC
+  // date, so a screenshot taken in the evening downloads with tomorrow's date
+  // baked into the filename. Fix: use the shared `getLocalIsoDate()` helper
+  // (utils/localDate.ts), already used elsewhere in the app for this exact
+  // class of bug (see ScheduleWidget's getTodayStr).
+  it('REGRESSION: screenshot filename uses the local date, not the UTC date', () => {
+    vi.useFakeTimers();
+    try {
+      // System clock: UTC 2026-03-06 02:00. A teacher at UTC-5 (e.g. US
+      // Central, DST) experiences this instant as 2026-03-05, 9:00 PM —
+      // still the evening before. Mock getLocalIsoDate to return that local
+      // date directly, since the test environment's TZ is pinned to UTC and
+      // real local getters can't diverge from toISOString() there.
+      vi.setSystemTime(new Date('2026-03-06T02:00:00Z'));
+      mockGetLocalIsoDate.mockReturnValue('2026-03-05');
+
+      renderComponent();
+
+      expect(mockUseScreenshot).toHaveBeenCalled();
+      const [, fileName] = mockUseScreenshot.mock.calls[0] as [unknown, string];
+      // BUG: toISOString-based code produces 'Classroom-Clock-2026-03-06'
+      // (tomorrow, from the teacher's perspective) — this assertion fails on
+      // the pre-fix implementation and passes once dateStr is sourced from
+      // getLocalIsoDate().
+      expect(fileName).toBe('Classroom-Clock-2026-03-05');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/components/common/DraggableWindow.tsx
+++ b/components/common/DraggableWindow.tsx
@@ -49,6 +49,7 @@ import { SNAP_LAYOUTS, SnapZone } from '@/config/snapLayouts';
 import { POSITION_AWARE_WIDGETS } from '@/config/widgetDefaults';
 import { calculateSnapBounds, SNAP_LAYOUT_CONSTANTS } from '@/utils/layoutMath';
 import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
+import { getLocalIsoDate } from '@/utils/localDate';
 import { clampWidgetToWorld, getWorldBounds } from '@/utils/zoomPanMath';
 import { useScreenshot } from '@/hooks/useScreenshot';
 import { useWindowSize } from '@/hooks/useWindowSize';
@@ -597,8 +598,10 @@ export const DraggableWindow: React.FC<DraggableWindowProps> = ({
   const innerEdgeStripsCacheRef = useRef<NodeListOf<HTMLElement> | null>(null);
 
   // Auto-generate filename: "Classroom-[WidgetType]-[Date]"
-  // Use ISO format YYYY-MM-DD
-  const dateStr = new Date().toISOString().split('T')[0];
+  // Use local ISO format YYYY-MM-DD (NOT toISOString(), which is UTC-based and
+  // shows tomorrow's date for the last few hours of a teacher's local day in
+  // every UTC-negative timezone — see utils/localDate.ts).
+  const dateStr = getLocalIsoDate();
   const fileName = `Classroom-${widget.type.charAt(0).toUpperCase() + widget.type.slice(1)}-${dateStr}`;
 
   const handleScreenshotSuccess = useCallback(() => {

--- a/components/layout/AnnotationOverlay.tsx
+++ b/components/layout/AnnotationOverlay.tsx
@@ -53,6 +53,7 @@ import { hitTestObject } from '@/components/widgets/DrawingWidget/hitTest';
 import { Button } from '@/components/common/Button';
 import { extractTextWithGemini } from '@/utils/ai';
 import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
+import { getLocalIsoDate } from '@/utils/localDate';
 import {
   DrawableObject,
   ImageObject,
@@ -504,7 +505,8 @@ export const AnnotationOverlay: React.FC = () => {
       const dataUrl = await capturePng();
       if (!dataUrl) return;
       const link = document.createElement('a');
-      link.download = `Annotation-${new Date().toISOString().split('T')[0]}.png`;
+      // Local date, not UTC (toISOString()) — see utils/localDate.ts.
+      link.download = `Annotation-${getLocalIsoDate()}.png`;
       link.href = dataUrl;
       link.click();
       addToast('Annotation downloaded!', 'success');

--- a/tests/components/layout/AnnotationOverlay.test.tsx
+++ b/tests/components/layout/AnnotationOverlay.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { AnnotationOverlay } from '@/components/layout/AnnotationOverlay';
 import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
+import { toPng } from 'html-to-image';
 import type {
   AnnotationState,
   DashboardContextValue,
@@ -24,6 +25,26 @@ vi.mock('@/hooks/useGoogleDrive', () => ({
 // html-to-image is only used by handlers we don't exercise here — stub so the
 // import doesn't load its canvas-heavy module graph under jsdom.
 vi.mock('html-to-image', () => ({ toPng: vi.fn().mockResolvedValue('') }));
+
+// Controllable getLocalIsoDate for the UTC/local-date-divergence regression
+// test below — see the matching mock in DraggableWindow.test.tsx for the
+// same pattern and rationale (TZ is pinned to 'UTC' in this test env, so real
+// local getters can never diverge from toISOString(); the helper itself must
+// be mocked to simulate what a non-UTC teacher would see).
+const { mockGetLocalIsoDate, defaultGetLocalIsoDate } = vi.hoisted(() => ({
+  mockGetLocalIsoDate: vi.fn<() => string>(),
+  defaultGetLocalIsoDate: { current: (() => '') as () => string },
+}));
+
+vi.mock('@/utils/localDate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/localDate')>();
+  defaultGetLocalIsoDate.current = actual.getLocalIsoDate;
+  mockGetLocalIsoDate.mockImplementation(actual.getLocalIsoDate);
+  return {
+    ...actual,
+    getLocalIsoDate: mockGetLocalIsoDate,
+  };
+});
 // The image-insertion hook does its own I/O; stub it so the overlay mounts
 // cleanly without needing a Firebase auth user or storage upload pipeline.
 vi.mock('@/components/widgets/DrawingWidget/useImageInsertion', () => ({
@@ -114,6 +135,10 @@ describe('AnnotationOverlay', () => {
     const root = document.createElement('div');
     root.id = 'dashboard-root';
     document.body.appendChild(root);
+    // Default: getLocalIsoDate returns the real local date so existing tests
+    // (which don't care about the download filename) are unaffected.
+    mockGetLocalIsoDate.mockReset();
+    mockGetLocalIsoDate.mockImplementation(defaultGetLocalIsoDate.current);
   });
 
   afterEach(() => {
@@ -223,5 +248,43 @@ describe('AnnotationOverlay', () => {
     expect(removeAnnotationObject).toHaveBeenCalledWith('txt-erase-me');
     expect(updateAnnotationState).not.toHaveBeenCalled();
     expect(addAnnotationObject).not.toHaveBeenCalled();
+  });
+
+  // Regression: the "Download PNG" filename was built from
+  // `new Date().toISOString().split('T')[0]` — the UTC calendar date —
+  // instead of the teacher's local date. For every timezone west of UTC (all
+  // of the Americas), the last few hours of the local day fall on the *next*
+  // UTC date, so an annotation downloaded in the evening gets tomorrow's date
+  // baked into the filename. Fix: use the shared `getLocalIsoDate()` helper
+  // (utils/localDate.ts).
+  it('REGRESSION: downloaded annotation filename uses the local date, not the UTC date', async () => {
+    setupContext();
+    (toPng as Mock).mockResolvedValueOnce('data:image/png;base64,abc');
+    // A teacher in a UTC-negative zone in the evening: their local calendar
+    // date has not yet caught up to UTC's. getLocalIsoDate is mocked directly
+    // (rather than the system clock) so the assertion below is deterministic
+    // regardless of when this suite actually runs.
+    mockGetLocalIsoDate.mockReturnValue('2026-03-05');
+
+    const anchors: HTMLAnchorElement[] = [];
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') anchors.push(el as HTMLAnchorElement);
+      return el;
+    });
+
+    const { getByTitle } = render(<AnnotationOverlay />);
+    fireEvent.click(getByTitle('Download PNG'));
+
+    await waitFor(() => {
+      expect(anchors.length).toBeGreaterThan(0);
+    });
+
+    // BUG: toISOString-based code names the file after today's real UTC date,
+    // not the mocked local date — this assertion fails on the pre-fix
+    // implementation and passes once the filename is sourced from
+    // getLocalIsoDate().
+    expect(anchors[0].download).toBe('Annotation-2026-03-05.png');
   });
 });


### PR DESCRIPTION
## Root cause

`components/common/DraggableWindow.tsx` (screenshot filename) and `components/layout/AnnotationOverlay.tsx` (annotation PNG download filename) both built their filenames with `new Date().toISOString().split('T')[0]` — the **UTC** calendar date — instead of the teacher's local date. For every timezone west of UTC (all of the Americas), the last several hours of the local day fall on the *next* UTC calendar date, so a screenshot or annotation saved in the evening downloads with tomorrow's date baked into the filename.

This is a known, previously-fixed bug class in this repo — `utils/localDate.ts`'s `getLocalIsoDate()` (and `Schedule/utils.ts`'s `getTodayStr()`) already exist specifically to prevent this (also just fixed twice in `CalendarConfigurationModal.tsx`). These two call sites were simply never migrated to the shared helper.

## Fix

Switched both call sites to the existing shared `getLocalIsoDate()` helper — no new logic invented, root cause fixed at the source.

## Band-aid rejected

Patching the string post-hoc (subtracting the local UTC offset from the `Date` before calling `toISOString()`) — rejected because the codebase already has a canonical, tested local-date helper; adding a second, divergent implementation of the same fix would just create more drift.

## Regression tests

- `components/common/DraggableWindow.test.tsx`: mocks `getLocalIsoDate` to diverge from the UTC-computed date and asserts the screenshot filename matches the local date, not `toISOString()`'s date.
- `tests/components/layout/AnnotationOverlay.test.tsx`: clicks "Download PNG" and asserts the generated filename matches the mocked local date.

Both mock the `getLocalIsoDate` helper directly (not the system clock) because `vitest.config.ts` pins `process.env.TZ = 'UTC'` for all tests, so real local/UTC getters can never diverge in-suite.

**Before/after evidence:** independently re-verified by the orchestrator — reverting both files to `dev-paul` and running the two regression tests fails both with the exact UTC-vs-local mismatch described (`expected 'Classroom-Clock-2026-03-06' to be 'Classroom-Clock-2026-03-05'`, `expected 'Annotation-2026-08-17.png' to be 'Annotation-2026-03-05.png'`). Restoring the fix passes all tests in both files.

## Validation

`pnpm run validate` and `pnpm run build` — both green, independently re-run by the orchestrator on the final commit.

## Risk

**Contained** — two call sites swapped to an existing, already-tested shared helper. No behavior change outside filename generation.

---
_Generated by [Claude Code](https://claude.ai/code/session_017noYuFMHKAK5uzaf9GNdEQ)_