### PR TITLE
fix(imageWorker): check the alpha byte, not the whole pixel, when trimming

### DIFF
--- a/utils/imageWorker.test.ts
+++ b/utils/imageWorker.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { trimImageData } from './imageWorker';
+
+/**
+ * Builds an RGBA Uint8ClampedArray for a `width`x`height` image. Every pixel
+ * defaults to a fully-transparent pixel that still carries non-zero color
+ * channels (`bgColor`) — this mirrors real-world output from
+ * `removeBackgroundFloodFill`, which zeroes only the alpha byte
+ * (`data[offset + 3] = 0`) and leaves R/G/B untouched. `opaqueRect` paints an
+ * inclusive [x0,x1] x [y0,y1] block fully opaque with `fgColor`.
+ */
+function buildImage(
+  width: number,
+  height: number,
+  opaqueRect: { x0: number; x1: number; y0: number; y1: number },
+  bgColor: [number, number, number] = [100, 50, 25],
+  fgColor: [number, number, number] = [10, 10, 10]
+): Uint8ClampedArray {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const offset = (y * width + x) * 4;
+      const inRect =
+        x >= opaqueRect.x0 &&
+        x <= opaqueRect.x1 &&
+        y >= opaqueRect.y0 &&
+        y <= opaqueRect.y1;
+      if (inRect) {
+        data[offset] = fgColor[0];
+        data[offset + 1] = fgColor[1];
+        data[offset + 2] = fgColor[2];
+        data[offset + 3] = 255;
+      } else {
+        // Fully transparent, but NOT zeroed color channels — this is the
+        // shape flood-fill background removal actually produces.
+        data[offset] = bgColor[0];
+        data[offset + 1] = bgColor[1];
+        data[offset + 2] = bgColor[2];
+        data[offset + 3] = 0;
+      }
+    }
+  }
+  return data;
+}
+
+describe('trimImageData', () => {
+  it('trims to the opaque content, ignoring color data left behind under transparent pixels', () => {
+    // 10x10 image; only the 2x2 block at (4,4)-(5,5) is opaque. Every other
+    // pixel is transparent but still carries non-zero RGB — exactly what
+    // removeBackgroundFloodFill's alpha-only zeroing produces.
+    const width = 10;
+    const height = 10;
+    const data = buildImage(width, height, { x0: 4, x1: 5, y0: 4, y1: 5 });
+
+    const result = trimImageData(data, width, height);
+
+    expect(result.found).toBe(true);
+    // Content is at (4,4)-(5,5); padding of 2 clamped to the canvas gives
+    // [2,7] on both axes → a 6x6 trimmed box, not the full 10x10 canvas.
+    expect(result.minX).toBe(2);
+    expect(result.minY).toBe(2);
+    expect(result.width).toBe(6);
+    expect(result.height).toBe(6);
+  });
+
+  it('reports not-found for an image that is fully transparent, even with stray color data', () => {
+    const width = 5;
+    const height = 5;
+    // Rect outside the canvas bounds -> nothing opaque.
+    const data = buildImage(width, height, { x0: 99, x1: 99, y0: 99, y1: 99 });
+
+    const result = trimImageData(data, width, height);
+
+    expect(result.found).toBe(false);
+  });
+
+  it('still detects a fully-opaque image spanning the whole canvas', () => {
+    const width = 4;
+    const height = 4;
+    const data = buildImage(width, height, {
+      x0: 0,
+      x1: width - 1,
+      y0: 0,
+      y1: height - 1,
+    });
+
+    const result = trimImageData(data, width, height);
+
+    expect(result.found).toBe(true);
+    expect(result.minX).toBe(0);
+    expect(result.minY).toBe(0);
+    expect(result.width).toBe(width);
+    expect(result.height).toBe(height);
+  });
+});

--- a/utils/imageWorker.test.ts
+++ b/utils/imageWorker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { trimImageData } from './imageWorker';
+import { removeBackgroundFloodFill, trimImageData } from './imageWorker';
 
 /**
  * Builds an RGBA Uint8ClampedArray for a `width`x`height` image. Every pixel
@@ -91,5 +91,44 @@ describe('trimImageData', () => {
     expect(result.minY).toBe(0);
     expect(result.width).toBe(width);
     expect(result.height).toBe(height);
+  });
+});
+
+describe('removeBackgroundFloodFill -> trimImageData', () => {
+  it('trims to the content that survived background removal', () => {
+    // The interaction that actually broke: flood-fill zeroes only the alpha
+    // byte, so every cleared background pixel keeps its RGB. Feeding that
+    // straight into trim is the real pipeline, not a synthesized fixture.
+    const width = 10;
+    const height = 10;
+    const bg: [number, number, number] = [200, 200, 200];
+    const data = new Uint8ClampedArray(width * height * 4);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const offset = (y * width + x) * 4;
+        const inContent = x >= 4 && x <= 5 && y >= 4 && y <= 5;
+        const [r, g, b] = inContent ? [10, 10, 10] : bg;
+        data[offset] = r;
+        data[offset + 1] = g;
+        data[offset + 2] = b;
+        data[offset + 3] = 255;
+      }
+    }
+
+    const cleared = removeBackgroundFloodFill(data, width, height);
+
+    // Background cleared to alpha 0 but RGB retained; content untouched.
+    expect(cleared[0 * 4 + 3]).toBe(0);
+    expect(cleared[0 * 4]).toBe(bg[0]);
+    const contentOffset = (4 * width + 4) * 4;
+    expect(cleared[contentOffset + 3]).toBe(255);
+
+    const result = trimImageData(cleared, width, height);
+
+    expect(result.found).toBe(true);
+    expect(result.minX).toBe(2);
+    expect(result.minY).toBe(2);
+    expect(result.width).toBe(6);
+    expect(result.height).toBe(6);
   });
 });

--- a/utils/imageWorker.ts
+++ b/utils/imageWorker.ts
@@ -99,7 +99,7 @@ export function trimImageData(
 /**
  * Fallback background removal using flood fill from corners.
  */
-function removeBackgroundFloodFill(
+export function removeBackgroundFloodFill(
   data: Uint8ClampedArray,
   width: number,
   height: number,

--- a/utils/imageWorker.ts
+++ b/utils/imageWorker.ts
@@ -45,7 +45,11 @@ self.onmessage = (e: MessageEvent<WorkerMessage>) => {
  * Trims transparent whitespace from image data.
  * Returns the bounds of the non-transparent area.
  */
-function trimImageData(data: Uint8ClampedArray, width: number, height: number) {
+export function trimImageData(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number
+) {
   let minX = width;
   let minY = height;
   let maxX = 0;
@@ -57,10 +61,12 @@ function trimImageData(data: Uint8ClampedArray, width: number, height: number) {
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      // Check if alpha channel is non-zero
-      // In little-endian, alpha is the most significant byte (0xAA_BB_GG_RR)
-      // We just need to know if the entire pixel is NOT transparent
-      if (data32[y * width + x] !== 0) {
+      // Check if alpha channel is non-zero. In little-endian, alpha is the
+      // most significant byte (0xAA_BB_GG_RR), so isolate it with >>> 24 —
+      // checking the whole word (`!== 0`) is wrong whenever a transparent
+      // pixel still carries non-zero RGB (e.g. removeBackgroundFloodFill
+      // below zeroes only the alpha byte), which would count it as opaque.
+      if (data32[y * width + x] >>> 24 !== 0) {
         if (x < minX) minX = x;
         if (x > maxX) maxX = x;
         if (y < minY) minY = y;


### PR DESCRIPTION
## Root cause

`trimImageData()` in `utils/imageWorker.ts` (backs the "trim transparent whitespace" step run after every sticker/image upload, via `hooks/useImageUpload.ts`) tested opaqueness with `data32[i] !== 0` — checking whether the *entire* 32-bit RGBA word was non-zero, not whether the **alpha byte specifically** was non-zero. The adjacent comment correctly explained "alpha is the most significant byte" but then implemented the wrong check. A fully-transparent pixel (alpha = 0) that still carries non-zero R/G/B is counted as "found" content and pollutes the trim bounding box.

This isn't theoretical: `removeBackgroundFloodFill` (the flood-fill fallback for AI background removal, same file) explicitly zeroes only the alpha byte (`data[offset + 3] = 0`) and leaves R/G/B untouched — its own output is the exact shape that defeats the trim step. After the flood-fill fallback runs, `trimImageWhitespace` trims little to nothing, because the "background" pixels still register as opaque.

## Fix

One-line fix: isolate the alpha byte with `>>> 24` before comparing, instead of comparing the whole 32-bit word.

## Band-aid rejected

Patching only `removeBackgroundFloodFill` to also zero R/G/B when clearing alpha — rejected because the trim check is wrong in general. Any future producer of transparent-but-colored pixels (a different background-remover, a hand-edited PNG, browser decode quirks) would hit the same silent failure. Fixed the actual predicate instead.

## Regression test

`utils/imageWorker.test.ts` (new), 3 cases against the now-exported `trimImageData`:
1. Transparent-but-colored border pixels around an opaque block trim correctly to the opaque region, not the full canvas.
2. A fully-transparent image (even with stray RGB) reports `found: false`.
3. A fully-opaque image is unchanged (no regression on the normal path).

**Before/after evidence:** independently re-verified by the orchestrator — reverting the fix (keeping the function exported for testability) fails cases 1 and 2 with the exact predicted mismatch (`expected 0 to be 2`, `expected true to be false`). Restoring the fix passes all 3.

## Validation

`pnpm run validate` and `pnpm run build` — both green, independently re-run by the orchestrator on the final commit.

## Risk

**Contained** — one-line predicate fix in a single pure function, isolated to `utils/imageWorker.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_017noYuFMHKAK5uzaf9GNdEQ)_