### PR TITLE
fix(admin): stop Organization panel popovers from closing Admin Settings on Escape

### DIFF
--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -18,6 +18,10 @@ import {
 // before ANY bubble-phase `document` listener regardless of add order, so
 // stopImmediatePropagation() here reliably stops it. Same pattern as
 // `captureEscape` in components/common/Modal.tsx.
+// CONSTRAINT: same-target capture listeners run in add order, so if two of
+// these are ever open at once the OUTER (first-mounted) one wins — the
+// inverse of the LIFO dismissal users expect. No call site nests them today;
+// nesting one would need a depth counter or a topmost-layer registry.
 function useCaptureEscape(active: boolean, onEscape: () => void): void {
   const onEscapeRef = useRef(onEscape);
   // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync to avoid stale-closure without re-subscribing the effect (CLAUDE.md pattern)

--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -8,20 +8,8 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 
-// Closes on Escape without letting the key event reach AdminSettings' own
-// Escape-to-close-the-whole-panel listener. AdminSettings listens on
-// `document` in the bubble phase, registered on mount — i.e. before any of
-// these portalled popovers/menus/modals are ever opened — so a same-phase
-// `document` listener added later here can never pre-empt it via
-// stopPropagation (registration order decides same-target listener order,
-// not stopPropagation). Listening on `window` in the CAPTURE phase runs
-// before ANY bubble-phase `document` listener regardless of add order, so
-// stopImmediatePropagation() here reliably stops it. Same pattern as
-// `captureEscape` in components/common/Modal.tsx.
-// CONSTRAINT: same-target capture listeners run in add order, so if two of
-// these are ever open at once the OUTER (first-mounted) one wins — the
-// inverse of the LIFO dismissal users expect. No call site nests them today;
-// nesting one would need a depth counter or a topmost-layer registry.
+// Capture-phase + stopImmediatePropagation to pre-empt AdminSettings' bubble-phase document listener; mirrors captureEscape in components/common/Modal.tsx.
+// Constraint: first-mounted wins, so nesting two of these would dismiss the outer one — no call site does today.
 function useCaptureEscape(active: boolean, onEscape: () => void): void {
   const onEscapeRef = useRef(onEscape);
   // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync to avoid stale-closure without re-subscribing the effect (CLAUDE.md pattern)

--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -8,6 +8,34 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 
+// Closes on Escape without letting the key event reach AdminSettings' own
+// Escape-to-close-the-whole-panel listener. AdminSettings listens on
+// `document` in the bubble phase, registered on mount — i.e. before any of
+// these portalled popovers/menus/modals are ever opened — so a same-phase
+// `document` listener added later here can never pre-empt it via
+// stopPropagation (registration order decides same-target listener order,
+// not stopPropagation). Listening on `window` in the CAPTURE phase runs
+// before ANY bubble-phase `document` listener regardless of add order, so
+// stopImmediatePropagation() here reliably stops it. Same pattern as
+// `captureEscape` in components/common/Modal.tsx.
+function useCaptureEscape(active: boolean, onEscape: () => void): void {
+  const onEscapeRef = useRef(onEscape);
+  // eslint-disable-next-line react-hooks/refs -- intentional render-body ref sync to avoid stale-closure without re-subscribing the effect (CLAUDE.md pattern)
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.stopImmediatePropagation();
+      onEscapeRef.current();
+    };
+    window.addEventListener('keydown', handler, { capture: true });
+    return () =>
+      window.removeEventListener('keydown', handler, { capture: true });
+  }, [active]);
+}
+
 // Color palette for badges and role accents.
 export type AccentColor =
   | 'emerald'
@@ -419,16 +447,13 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
       if (triggerRef.current?.contains(target)) return;
       setOpen(false);
     };
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
-    };
     document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onEsc);
     return () => {
       document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onEsc);
     };
   }, [open]);
+
+  useCaptureEscape(open, () => setOpen(false));
 
   return (
     <div>
@@ -594,16 +619,13 @@ export const CellPopover: React.FC<{
       if (anchorRef.current?.contains(target)) return;
       onClose();
     };
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
     document.addEventListener('mousedown', onDocClick);
-    document.addEventListener('keydown', onEsc);
     return () => {
       document.removeEventListener('mousedown', onDocClick);
-      document.removeEventListener('keydown', onEsc);
     };
   }, [open, onClose, anchorRef]);
+
+  useCaptureEscape(open, onClose);
 
   if (!open || !pos || typeof document === 'undefined') return null;
   return createPortal(
@@ -770,14 +792,7 @@ export const LocalModal: React.FC<{
   footer?: React.ReactNode;
   size?: 'md' | 'lg' | 'xl';
 }> = ({ isOpen, onClose, title, icon, children, footer, size = 'md' }) => {
-  useEffect(() => {
-    if (!isOpen) return undefined;
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', onEsc);
-    return () => document.removeEventListener('keydown', onEsc);
-  }, [isOpen, onClose]);
+  useCaptureEscape(isOpen, onClose);
   if (!isOpen) return null;
   const widthClass =
     size === 'xl' ? 'max-w-4xl' : size === 'lg' ? 'max-w-2xl' : 'max-w-lg';

--- a/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
+++ b/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Regression test: RowMenu / CellPopover / LocalModal in
+ * components/admin/Organization/components/primitives.tsx are portalled to
+ * document.body and each register their own `document`-level `keydown`
+ * listener to close on Escape — but none of them call stopPropagation (or
+ * use capture phase). AdminSettings.tsx wraps the whole Organization panel
+ * in a modal that ALSO listens for Escape on `document` (registered on
+ * mount, i.e. before any of these are ever opened), so pressing Escape to
+ * dismiss a row's action menu / cell popover / nested "add building" style
+ * modal also closes the entire Admin Settings panel underneath it.
+ *
+ * Because both listeners are added to the SAME target (`document`) in the
+ * bubble phase, registration order — not stopPropagation() — decides who
+ * runs first. AdminSettings registers first (on mount, before the user can
+ * open any popover), so a same-phase stopPropagation() added later can never
+ * pre-empt it. The fix mirrors the already-established `captureEscape`
+ * pattern in components/common/Modal.tsx: listen on `window` in the CAPTURE
+ * phase and call stopImmediatePropagation(), which always runs before any
+ * bubble-phase `document` listener regardless of add order.
+ */
+import React, { useRef } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import {
+  RowMenu,
+  CellPopover,
+  LocalModal,
+} from '@/components/admin/Organization/components/primitives';
+
+afterEach(cleanup);
+
+// Mirrors AdminSettings.tsx's own Escape handler: a plain bubble-phase
+// `document` listener, registered before the panel under test ever opens
+// its popover/menu/modal — exactly like AdminSettings mounts before the
+// user can click into an Organization view.
+function installParentEscapeHandler() {
+  const onParentClose = vi.fn();
+  const handler = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') onParentClose();
+  };
+  document.addEventListener('keydown', handler);
+  return {
+    onParentClose,
+    uninstall: () => document.removeEventListener('keydown', handler),
+  };
+}
+
+function pressEscape() {
+  fireEvent.keyDown(document, { key: 'Escape' });
+}
+
+describe('Organization primitives — Escape does not leak to an outer document-level handler', () => {
+  it('RowMenu: closes itself without triggering the outer panel-close handler', () => {
+    const { onParentClose, uninstall } = installParentEscapeHandler();
+    try {
+      render(<RowMenu items={[{ label: 'Edit', onClick: vi.fn() }]} />);
+      fireEvent.click(screen.getByRole('button', { name: /row actions/i }));
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+
+      pressEscape();
+
+      expect(onParentClose).not.toHaveBeenCalled();
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('CellPopover: closes itself without triggering the outer panel-close handler', () => {
+    const { onParentClose, uninstall } = installParentEscapeHandler();
+    try {
+      const onClose = vi.fn();
+      const Harness: React.FC = () => {
+        const anchorRef = useRef<HTMLButtonElement>(null);
+        return (
+          <>
+            <button ref={anchorRef}>anchor</button>
+            <CellPopover open onClose={onClose} anchorRef={anchorRef}>
+              <div>popover content</div>
+            </CellPopover>
+          </>
+        );
+      };
+      render(<Harness />);
+      expect(screen.getByText('popover content')).toBeInTheDocument();
+
+      pressEscape();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onParentClose).not.toHaveBeenCalled();
+    } finally {
+      uninstall();
+    }
+  });
+
+  it('LocalModal: closes itself without triggering the outer panel-close handler', () => {
+    const { onParentClose, uninstall } = installParentEscapeHandler();
+    try {
+      const onClose = vi.fn();
+      render(
+        <LocalModal isOpen onClose={onClose} title="New building">
+          <div>modal content</div>
+        </LocalModal>
+      );
+      expect(screen.getByText('modal content')).toBeInTheDocument();
+
+      pressEscape();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(onParentClose).not.toHaveBeenCalled();
+    } finally {
+      uninstall();
+    }
+  });
+});

--- a/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
+++ b/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
@@ -60,6 +60,10 @@ describe('Organization primitives — Escape does not leak to an outer document-
       pressEscape();
 
       expect(onParentClose).not.toHaveBeenCalled();
+      // RowMenu has no onClose callback (it closes via internal setOpen
+      // state), so the DOM is the only observable proof the capture handler
+      // actually closed it rather than just swallowing the keydown.
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     } finally {
       uninstall();
     }

--- a/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
+++ b/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
@@ -1,23 +1,4 @@
-/**
- * Regression test: RowMenu / CellPopover / LocalModal in
- * components/admin/Organization/components/primitives.tsx are portalled to
- * document.body and each register their own `document`-level `keydown`
- * listener to close on Escape — but none of them call stopPropagation (or
- * use capture phase). AdminSettings.tsx wraps the whole Organization panel
- * in a modal that ALSO listens for Escape on `document` (registered on
- * mount, i.e. before any of these are ever opened), so pressing Escape to
- * dismiss a row's action menu / cell popover / nested "add building" style
- * modal also closes the entire Admin Settings panel underneath it.
- *
- * Because both listeners are added to the SAME target (`document`) in the
- * bubble phase, registration order — not stopPropagation() — decides who
- * runs first. AdminSettings registers first (on mount, before the user can
- * open any popover), so a same-phase stopPropagation() added later can never
- * pre-empt it. The fix mirrors the already-established `captureEscape`
- * pattern in components/common/Modal.tsx: listen on `window` in the CAPTURE
- * phase and call stopImmediatePropagation(), which always runs before any
- * bubble-phase `document` listener regardless of add order.
- */
+// Escape on a portalled RowMenu/CellPopover/LocalModal must not also close the whole Admin Settings panel underneath it.
 import React, { useRef } from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';


### PR DESCRIPTION
## Root cause

`RowMenu`, `CellPopover`, and `LocalModal` (used by every Organization admin view — Buildings, Users, Domains, Test Classes) are portalled to `document.body` and each registered their own `document`-level `keydown` Escape listener with no coordination against the panel around them. `AdminSettings.tsx` wraps the entire admin panel (including the Organization tab) in a modal that *also* listens for Escape on `document`, registered on mount — before the user can ever open a row menu/popover/modal inside it.

Because both listeners target the exact same node (`document`, bubble phase), **registration order decides which one runs first**, not `stopPropagation()`. `AdminSettings` always registers first, so it always fires first and unconditionally closes the entire Admin Settings panel — even before the popover's own handler runs. Net effect: pressing Escape to dismiss a small "..." row-action menu or a nested "Add building" modal also silently closed the whole Admin Settings panel underneath it.

This is the same "portalled popover doesn't stop Escape from propagating" bug class already fixed 10+ times elsewhere in this codebase (`RandomGroups.tsx`, `FolderItem.tsx`, `WidgetLibrary.tsx`), but a variant those fixes' pattern (bubble-phase `document.stopPropagation()`) doesn't actually solve here, since the pre-existing outer handler is also on `document` — same node, so ordering wins regardless.

## Fix

Added a shared `useCaptureEscape(active, onEscape)` hook and applied it to `RowMenu`, `CellPopover`, and `LocalModal` (all three had the identical bug). It listens on `window` in the **capture** phase and calls `stopImmediatePropagation()` — capture-phase `window` listeners always run before any bubble-phase `document` listener, regardless of registration order. This mirrors the `captureEscape` pattern already established in `components/common/Modal.tsx`.

## Band-aid rejected

Copy-pasting the existing bubble-phase `stopPropagation()` pattern from `WidgetLibrary.tsx`/`FolderItem.tsx`/`RandomGroups.tsx` — would not have fixed this. Those work because their outer handler (`DashboardView`) listens on `window`, a different/later node in the propagation path than `document`. Here both handlers are on `document`, so same-node registration order wins regardless of `stopPropagation()`.

## Regression test

`tests/components/admin/Organization/primitives.escapePropagation.test.tsx` (new) — mounts a fake outer `document`-level Escape listener mirroring `AdminSettings`'s registration timing, opens each of the three components, dispatches Escape, and asserts the outer handler is never called while the component itself does close.

**Before/after evidence:** independently re-verified by the orchestrator — reverting `primitives.tsx` to `dev-paul` fails all 3 cases (`expected vi.fn() to not be called at all, but actually been called 1 times`). Restoring the fix passes all 3. Also independently confirmed `AdminSettings.tsx`'s own Escape listener is registered on `document` without `{capture: true}`, matching the root-cause claim.

## Validation

`pnpm run validate` and `pnpm run build` — both green, independently re-run by the orchestrator on the final commit.

## Risk

**Contained** — new hook is additive and scoped to `components/admin/Organization/components/primitives.tsx`; no changes to `AdminSettings.tsx` or other Escape-handling code.

---
_Generated by [Claude Code](https://claude.ai/code/session_017noYuFMHKAK5uzaf9GNdEQ)_