### PR TITLE
fix(functions): paginate gcPlcOrphans version-overflow scan

### DIFF
--- a/functions/src/gcPlcOrphans.test.ts
+++ b/functions/src/gcPlcOrphans.test.ts
@@ -63,6 +63,7 @@ import {
   PLC_PAGE_SIZE,
   GROUP_PAGE_SIZE,
   CATEGORY_PAGE_SIZE,
+  MAX_VERSIONS_SCAN_PER_GROUP,
 } from './gcPlcOrphans';
 
 // ===========================================================================
@@ -555,6 +556,109 @@ describe('runGcPlcOrphans — version overflow scan must paginate (pagination cl
         (a, b) => a - b
       )
     );
+  });
+});
+
+describe('runGcPlcOrphans — version history past MAX_VERSIONS_SCAN_PER_GROUP', () => {
+  // The scan is capped at MAX_VERSIONS_SCAN_PER_GROUP in lexicographic
+  // documentId() order, which does NOT track the numeric version order the
+  // trim step sorts by. Past the ceiling the scanned sample can therefore
+  // exclude real versions. These tests pin the contract the constant's
+  // docblock claims: never over-delete, converge across runs.
+  //
+  // With ids "1".."5001", the lexicographic maximum is "999" ('9' > '5'), so
+  // "999" is the one doc pushed outside the 5000-doc scan window.
+  const total = MAX_VERSIONS_SCAN_PER_GROUP + 1;
+  const excludedByLexOrder = '999';
+
+  const seedGroup = () =>
+    makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: {
+            versions: Array.from({ length: total }, (_, i) => ({
+              id: String(i + 1),
+              data: { version: i + 1 },
+            })),
+          },
+        },
+      ],
+    });
+
+  it('never deletes a version the capped scan could not see', async () => {
+    const { db, root } = seedGroup();
+
+    await runGcPlcOrphans(db, NOW);
+
+    const remaining = root.synced_quizzes[0].sub!.versions.map((d) => d.id);
+    // Unscanned, and outside the kept-newest set — but still present.
+    expect(remaining).toContain(excludedByLexOrder);
+    // The genuinely-newest version is kept.
+    expect(remaining).toContain(String(total));
+  });
+
+  it('does not converge to VERSION_HISTORY_LIMIT in one run, but does on the next', async () => {
+    const { db, root } = seedGroup();
+
+    const first = await runGcPlcOrphans(db, NOW);
+
+    // One run trims the scanned sample only, leaving the skewed doc behind.
+    expect(first.versionOverflow).toBe(
+      MAX_VERSIONS_SCAN_PER_GROUP - VERSION_HISTORY_LIMIT
+    );
+    expect(root.synced_quizzes[0].sub!.versions).toHaveLength(
+      VERSION_HISTORY_LIMIT + 1
+    );
+
+    const second = await runGcPlcOrphans(db, NOW);
+
+    expect(second.versionOverflow).toBe(1);
+    const converged = root.synced_quizzes[0]
+      .sub!.versions.map((d) => Number(d.id))
+      .sort((a, b) => a - b);
+    expect(converged).toHaveLength(VERSION_HISTORY_LIMIT);
+    expect(converged).toEqual(
+      Array.from({ length: VERSION_HISTORY_LIMIT }, (_, i) => total - i).sort(
+        (a, b) => a - b
+      )
+    );
+  });
+
+  it('warns when the ceiling actually truncated, not when the collection merely fills it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { db } = seedGroup();
+    await runGcPlcOrphans(db, NOW);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes('hit scan ceiling'))
+    ).toBe(true);
+
+    warn.mockClear();
+
+    // Exactly MAX_VERSIONS_SCAN_PER_GROUP docs: the scan sees everything, so
+    // the ceiling warning would be a false alarm.
+    const exact = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: {
+            versions: Array.from(
+              { length: MAX_VERSIONS_SCAN_PER_GROUP },
+              (_, i) => ({ id: String(i + 1), data: { version: i + 1 } })
+            ),
+          },
+        },
+      ],
+    });
+    await runGcPlcOrphans(exact.db, NOW);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes('hit scan ceiling'))
+    ).toBe(false);
+
+    warn.mockRestore();
   });
 });
 

--- a/functions/src/gcPlcOrphans.test.ts
+++ b/functions/src/gcPlcOrphans.test.ts
@@ -211,6 +211,14 @@ interface StubDoc {
  * returns) and slice past the cursor doc — this is what actually exercises
  * cross-page pagination in the regression tests below.
  */
+/**
+ * Any un-paginated (no `.limit()`) `.get()` over a backing array larger than
+ * this simulates a real Firestore unbounded-read cliff (see `get()` below).
+ * Comfortably above every VERSION_HISTORY_LIMIT-sized fixture used elsewhere
+ * in this file, so only a deliberately huge collection trips it.
+ */
+const UNBOUNDED_READ_SAFETY_THRESHOLD = 1000;
+
 function makeStubDb(seed: {
   plcs?: StubDoc[];
   synced_quizzes?: StubDoc[];
@@ -260,6 +268,20 @@ function makeStubDb(seed: {
     startAfter: (cursor: DocSnap) =>
       makeCollectionRef(backing, { ...opts, afterId: cursor.id }),
     get: () => {
+      // Simulated pagination cliff: a real Firestore `.get()` over a huge
+      // subcollection with no `.limit()` risks a function-memory/timeout
+      // blowout (this is a scheduled function pinned to 256MiB). This stub
+      // can't reproduce an actual OOM, so it stands in for one — any
+      // unbounded read over UNBOUNDED_READ_SAFETY_THRESHOLD docs throws,
+      // forcing the sweep to always page through `.limit()`.
+      if (
+        opts.lim === undefined &&
+        backing.length > UNBOUNDED_READ_SAFETY_THRESHOLD
+      ) {
+        throw new Error(
+          `[stub] unbounded .get() over ${backing.length} docs — real Firestore would risk a memory/timeout blowout; the sweep must paginate with .limit()`
+        );
+      }
       let rows = opts.ordered
         ? [...backing].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
         : [...backing];
@@ -487,6 +509,52 @@ describe('runGcPlcOrphans — version overflow (category e)', () => {
 
     expect(counts.versionOverflow).toBe(0);
     expect(root.synced_quizzes[0].sub!.versions).toHaveLength(5);
+  });
+});
+
+describe('runGcPlcOrphans — version overflow scan must paginate (pagination cliff)', () => {
+  // Before the fix, `sweepVersionOverflow` read a single un-paginated
+  // `groupRef.collection('versions').get()` with no `.limit()` at all —
+  // unlike every sibling sweep in this module (PLC iteration, group
+  // iteration, per-PLC category scans), which were already fixed for this
+  // exact bug class. A group whose `versions` subcollection grows very large
+  // (e.g. client-side pruning failed for a stretch, or abuse) would blow the
+  // single Firestore call up to an unbounded size on a function pinned to
+  // 256MiB — the stub's `get()` simulates that risk by throwing on any
+  // unbounded read past UNBOUNDED_READ_SAFETY_THRESHOLD docs.
+  it('trims overflow for a group whose version history is much larger than a single page, without an unbounded read', async () => {
+    // Comfortably past UNBOUNDED_READ_SAFETY_THRESHOLD (the stub's simulated
+    // cliff), but well under the production MAX_VERSIONS_SCAN_PER_GROUP
+    // ceiling — a realistic "this group's history grew huge" scenario, not
+    // an edge-of-ceiling one.
+    const total = 1500;
+    const versions: StubDoc[] = Array.from({ length: total }, (_, i) => ({
+      id: String(i + 1),
+      data: { version: i + 1 },
+    }));
+    const { db, root } = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: { versions },
+        },
+      ],
+    });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    expect(counts.versionOverflow).toBe(total - VERSION_HISTORY_LIMIT);
+    const remaining = root.synced_quizzes[0]
+      .sub!.versions.map((d) => Number(d.id))
+      .sort((a, b) => a - b);
+    expect(remaining).toHaveLength(VERSION_HISTORY_LIMIT);
+    // Newest VERSION_HISTORY_LIMIT versions (by numeric id) are kept.
+    expect(remaining).toEqual(
+      Array.from({ length: VERSION_HISTORY_LIMIT }, (_, i) => total - i).sort(
+        (a, b) => a - b
+      )
+    );
   });
 });
 

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -119,6 +119,27 @@ export const MAX_CATEGORY_SCAN_PER_PLC = 5000;
 /** Page size for the paginated per-PLC category sweeps (startAfter cursor on document id). */
 export const CATEGORY_PAGE_SIZE = 500;
 
+/**
+ * Overall safety ceiling on version-history snapshots scanned PER GROUP PER
+ * RUN — same rationale as `MAX_CATEGORY_SCAN_PER_PLC`, one level deeper still:
+ * a single synced group's own `versions` subcollection. Version doc ids are
+ * the bare version number as a string, which does NOT sort numerically under
+ * Firestore's lexicographic `FieldPath.documentId()` ordering (e.g. `"10"` <
+ * `"9"`), so this sweep still fetches every candidate page-by-page and does
+ * the real numeric sort in memory afterward — pagination here bounds the size
+ * of each individual Firestore response (memory/time per call), the same way
+ * it does for `fetchCategoryPaginated`, rather than reducing total docs read.
+ * Without this, `sweepVersionOverflow` issued a single un-paginated `.get()`
+ * over the entire `versions` subcollection — the same unbounded-read bug
+ * already fixed for cross-PLC iteration (`MAX_PLCS_PER_RUN`), the
+ * synced-group sweep (`MAX_GROUPS_PER_RUN`), and per-PLC category scans
+ * (`MAX_CATEGORY_SCAN_PER_PLC`), just missed one level deeper still.
+ */
+export const MAX_VERSIONS_SCAN_PER_GROUP = 5000;
+
+/** Page size for the paginated version-overflow scan (startAfter cursor on document id). */
+export const VERSIONS_PAGE_SIZE = 500;
+
 /** Firestore caps a batch at 500 ops; chunk below that defensively. */
 const BATCH_CHUNK = 250;
 
@@ -256,6 +277,42 @@ async function deleteRefs(
 }
 
 /**
+ * Paginates an arbitrary collection ref up to `maxScan`, `pageSize` docs at a
+ * time, via a `startAfter` cursor on `orderBy(FieldPath.documentId())`. Used
+ * for both per-PLC category subcollections (`activity` / `presence` /
+ * soft-delete subs) and, separately, a single group's `versions`
+ * subcollection — see `MAX_CATEGORY_SCAN_PER_PLC` / `MAX_VERSIONS_SCAN_PER_GROUP`
+ * for why a single un-paginated page silently strands docs outside an
+ * effectively-arbitrary doc-id window once a collection grows past one page.
+ */
+async function fetchPaginated(
+  collectionRef: admin.firestore.CollectionReference,
+  maxScan: number,
+  pageSize: number
+): Promise<QueryDocSnap[]> {
+  const results: QueryDocSnap[] = [];
+  let lastDoc: QueryDocSnap | undefined;
+  while (results.length < maxScan) {
+    const pageLimit = Math.min(pageSize, maxScan - results.length);
+    let query = collectionRef
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(pageLimit);
+    if (lastDoc) query = query.startAfter(lastDoc);
+    const page = await query.get();
+    if (page.size === 0) break;
+    results.push(...page.docs);
+    lastDoc = page.docs[page.docs.length - 1];
+    if (page.size < pageLimit) break;
+  }
+  if (results.length >= maxScan) {
+    console.warn(
+      `[gcPlcOrphans] hit scan ceiling (${maxScan}) on ${collectionRef.path} — raise it or shard the sweep`
+    );
+  }
+  return results;
+}
+
+/**
  * Reap empty synced groups across both canonical collections. A group is
  * deleted only when its `participants` map is empty (no teacher still shares
  * it). Paginated (startAfter cursor on document id) so every group up to
@@ -303,17 +360,23 @@ async function sweepEmptyGroups(db: Firestore): Promise<number> {
  * Trim version-history overflow under a single synced group. Keeps the newest
  * `VERSION_HISTORY_LIMIT` snapshots (by numeric doc id = version number) and
  * deletes the rest. Defensive: the client prunes after each publish, so this
- * usually finds nothing.
+ * usually finds nothing. Paginated (startAfter cursor on document id, up to
+ * `MAX_VERSIONS_SCAN_PER_GROUP`) — see that constant for why a single
+ * un-paginated `.get()` on this subcollection was an unbounded-read cliff.
  */
 async function sweepVersionOverflow(
   db: Firestore,
   groupRef: admin.firestore.DocumentReference
 ): Promise<number> {
-  const versionsSnap = await groupRef.collection('versions').get();
-  if (versionsSnap.size <= VERSION_HISTORY_LIMIT) return 0;
+  const versionDocs = await fetchPaginated(
+    groupRef.collection('versions'),
+    MAX_VERSIONS_SCAN_PER_GROUP,
+    VERSIONS_PAGE_SIZE
+  );
+  if (versionDocs.length <= VERSION_HISTORY_LIMIT) return 0;
   // Newest-first by version number (doc id). Non-numeric ids sort last (NaN →
   // treated as oldest) so malformed snapshots are pruned first.
-  const sorted = [...versionsSnap.docs].sort((a, b) => {
+  const sorted = [...versionDocs].sort((a, b) => {
     const av = Number(a.id);
     const bv = Number(b.id);
     const an = Number.isFinite(av) ? av : -Infinity;
@@ -325,38 +388,20 @@ async function sweepVersionOverflow(
 }
 
 /**
- * Paginates an arbitrary subcollection up to `MAX_CATEGORY_SCAN_PER_PLC`,
- * `CATEGORY_PAGE_SIZE` docs at a time, via a `startAfter` cursor on
- * `orderBy(FieldPath.documentId())`. See `MAX_CATEGORY_SCAN_PER_PLC` for why
- * a single un-paginated page silently stranded docs outside an
- * effectively-arbitrary doc-id window once a subcollection grew past one page.
+ * Paginates an arbitrary PLC subcollection (activity / presence / a
+ * soft-delete sub) up to `MAX_CATEGORY_SCAN_PER_PLC`. Thin wrapper around
+ * `fetchPaginated` — see `MAX_CATEGORY_SCAN_PER_PLC` for why a single
+ * un-paginated page silently stranded docs outside an effectively-arbitrary
+ * doc-id window once a subcollection grew past one page.
  */
-async function fetchCategoryPaginated(
+function fetchCategoryPaginated(
   collectionRef: admin.firestore.CollectionReference
 ): Promise<QueryDocSnap[]> {
-  const results: QueryDocSnap[] = [];
-  let lastDoc: QueryDocSnap | undefined;
-  while (results.length < MAX_CATEGORY_SCAN_PER_PLC) {
-    const pageLimit = Math.min(
-      CATEGORY_PAGE_SIZE,
-      MAX_CATEGORY_SCAN_PER_PLC - results.length
-    );
-    let query = collectionRef
-      .orderBy(admin.firestore.FieldPath.documentId())
-      .limit(pageLimit);
-    if (lastDoc) query = query.startAfter(lastDoc);
-    const page = await query.get();
-    if (page.size === 0) break;
-    results.push(...page.docs);
-    lastDoc = page.docs[page.docs.length - 1];
-    if (page.size < pageLimit) break;
-  }
-  if (results.length >= MAX_CATEGORY_SCAN_PER_PLC) {
-    console.warn(
-      `[gcPlcOrphans] hit MAX_CATEGORY_SCAN_PER_PLC ceiling (${MAX_CATEGORY_SCAN_PER_PLC}) on ${collectionRef.path} — raise it or shard the sweep`
-    );
-  }
-  return results;
+  return fetchPaginated(
+    collectionRef,
+    MAX_CATEGORY_SCAN_PER_PLC,
+    CATEGORY_PAGE_SIZE
+  );
 }
 
 /**

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -314,10 +314,19 @@ async function fetchPaginated(
     lastDoc = page.docs[page.docs.length - 1];
     if (page.size < pageLimit) break;
   }
-  if (results.length >= maxScan) {
-    console.warn(
-      `[gcPlcOrphans] hit scan ceiling (${maxScan}) on ${collectionRef.path} — raise it or shard the sweep`
-    );
+  // A full last page at the ceiling is ambiguous — an exactly-maxScan collection
+  // strands nothing. One 1-doc probe distinguishes the two, warn only if truncated.
+  if (results.length >= maxScan && lastDoc) {
+    const probe = await collectionRef
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .startAfter(lastDoc)
+      .limit(1)
+      .get();
+    if (probe.size > 0) {
+      console.warn(
+        `[gcPlcOrphans] hit scan ceiling (${maxScan}) on ${collectionRef.path} — raise it or shard the sweep`
+      );
+    }
   }
   return results;
 }

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -122,18 +122,28 @@ export const CATEGORY_PAGE_SIZE = 500;
 /**
  * Overall safety ceiling on version-history snapshots scanned PER GROUP PER
  * RUN — same rationale as `MAX_CATEGORY_SCAN_PER_PLC`, one level deeper still:
- * a single synced group's own `versions` subcollection. Version doc ids are
- * the bare version number as a string, which does NOT sort numerically under
- * Firestore's lexicographic `FieldPath.documentId()` ordering (e.g. `"10"` <
- * `"9"`), so this sweep still fetches every candidate page-by-page and does
- * the real numeric sort in memory afterward — pagination here bounds the size
- * of each individual Firestore response (memory/time per call), the same way
- * it does for `fetchCategoryPaginated`, rather than reducing total docs read.
- * Without this, `sweepVersionOverflow` issued a single un-paginated `.get()`
- * over the entire `versions` subcollection — the same unbounded-read bug
- * already fixed for cross-PLC iteration (`MAX_PLCS_PER_RUN`), the
- * synced-group sweep (`MAX_GROUPS_PER_RUN`), and per-PLC category scans
+ * a single synced group's own `versions` subcollection. Without this,
+ * `sweepVersionOverflow` issued a single un-paginated `.get()` over the
+ * entire `versions` subcollection — the same unbounded-read bug already
+ * fixed for cross-PLC iteration (`MAX_PLCS_PER_RUN`), the synced-group sweep
+ * (`MAX_GROUPS_PER_RUN`), and per-PLC category scans
  * (`MAX_CATEGORY_SCAN_PER_PLC`), just missed one level deeper still.
+ *
+ * CAVEAT (unlike the category scans, where scan order doesn't matter):
+ * version doc ids are the bare version number as a string, which does NOT
+ * sort numerically under Firestore's lexicographic `FieldPath.documentId()`
+ * ordering (e.g. `"6"` sorts after `"5999"`). `sweepVersionOverflow` sorts
+ * numerically in memory, but only across whatever this scan actually
+ * fetched — for a group whose history has grown past this ceiling, the
+ * lexicographically-first 5000 doc ids are not guaranteed to include the
+ * true highest version numbers, so the "keep newest 10" step can operate on
+ * a skewed sample rather than the actual newest versions. This never
+ * over-deletes a version genuinely worth keeping (an excluded doc is simply
+ * not read this run, not wrongly deleted) and never reintroduces the
+ * unbounded-read risk this constant exists to bound, but full convergence to
+ * `VERSION_HISTORY_LIMIT` for a group past this ceiling may take several
+ * nightly runs rather than one. See docs/routines/debugger.md Backlog for a
+ * proper fix (order by a numeric field instead of lexicographic doc id).
  */
 export const MAX_VERSIONS_SCAN_PER_GROUP = 5000;
 


### PR DESCRIPTION
## Root cause

`sweepVersionOverflow()` (the nightly PLC-GC sweep's version-history trimmer) issued a single un-paginated `groupRef.collection('versions').get()` with no `.limit()`. Every sibling scan in this same file (`sweepEmptyGroups`, the per-PLC category scans for activity/presence/tombstones, and PLC/group top-level iteration) had already been fixed for exactly this "pagination cliff" bug class — this call was missed one level deeper, inside a single synced group's own `versions` subcollection.

A group whose version history grew very large (client-side pruning stalled, or abuse) would hit an unbounded Firestore read on a scheduled function pinned to `memory: '256MiB'`, risking an OOM/timeout that would abort the *entire* nightly GC run (activity/presence/tombstone sweeps for every other PLC included), since nothing downstream catches the error.

## Fix

Extracted the existing paginated-scan logic into a shared `fetchPaginated(collectionRef, maxScan, pageSize)` helper (used by both the per-PLC category sweep and the new version-overflow sweep — `fetchCategoryPaginated` is now a thin wrapper over it). Added `MAX_VERSIONS_SCAN_PER_GROUP` (5000) / `VERSIONS_PAGE_SIZE` (500) so `sweepVersionOverflow` pages through `startAfter` cursors like every other sweep in the module, instead of one unbounded call.

## Band-aid rejected

Wrapping the existing unbounded `.get()` in a try/catch to stop one bad group from crashing the whole run — rejected because that would silently give up on trimming that group's overflow forever and hide the underlying risk rather than removing it. The sustainable fix follows the codebase's own established pattern (`MAX_CATEGORY_SCAN_PER_PLC` / `MAX_GROUPS_PER_RUN` / `MAX_PLCS_PER_RUN`): bound and paginate the read.

## Regression test

`functions/src/gcPlcOrphans.test.ts` — the stub Firestore's `.get()` was extended to simulate a real unbounded-read cliff (throws if any collection larger than a safety threshold is read without a preceding `.limit()`). A new test seeds a group with 1500 version snapshots and asserts the sweep correctly trims to `VERSION_HISTORY_LIMIT`, keeping the newest versions.

**Before/after evidence:** independently re-verified by the orchestrator — reverting `gcPlcOrphans.ts` to `dev-paul` throws `[stub] unbounded .get() over 1500 docs...` at the exact flagged line. Restoring the fix passes all 36 tests in the file.

## Validation

`pnpm run validate` (root + functions) and `pnpm run build:all` — both green, independently re-run by the orchestrator on the final commit. `firestore.rules` untouched, so `test:rules` was not required.

## Risk

**Contained** — refactor + one new bounded scan path in a single Cloud Function file (`functions/src/gcPlcOrphans.ts`), following an existing, already-battle-tested pagination pattern from the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_017noYuFMHKAK5uzaf9GNdEQ)_