### PR TITLE
fix(settings-panel): reposition on board pan

### DIFF
--- a/components/common/SettingsPanel.tsx
+++ b/components/common/SettingsPanel.tsx
@@ -143,6 +143,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     updatePosition();
   }, [updatePosition, viewport, zoom]);
 
+  // Reposition on board pan (mirrors DraggableWindow's tool/snap menus) — pan doesn't touch widget.x/y, so the deps above never fire.
+  useEffect(() => {
+    window.addEventListener('board-pan', updatePosition);
+    return () => window.removeEventListener('board-pan', updatePosition);
+  }, [updatePosition]);
+
   // Animate in on mount (track both rAF handles for safe cleanup)
   useEffect(() => {
     let outerRaf = 0;

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -397,17 +397,7 @@ describe('SettingsPanel', () => {
     expect(leftValue).not.toBe(312);
   });
 
-  /**
-   * Regression: panning the board canvas (drag on empty space) translates the
-   * widget surface via a CSS transform WITHOUT changing widget.x/y — those
-   * are world coordinates, pan is purely visual. DashboardView dispatches a
-   * `board-pan` window event on every pan frame so floating popovers anchored
-   * to a widget's on-screen rect (DraggableWindow's tool menu, snap menu) can
-   * re-measure and follow. SettingsPanel positions itself the same way (via
-   * widgetRef.getBoundingClientRect()) but never listened for that event, so
-   * panning while settings are open left the panel visually stranded at its
-   * pre-pan screen position instead of following the widget.
-   */
+  // Regression: panning (CSS transform, doesn't touch widget.x/y) must re-measure the panel's position, mirroring DraggableWindow's board-pan listener.
   it('re-measures its position on a board-pan event', () => {
     // rect "moves" like a pan would, while widget.x/y (world coords) stay put.
     let rect = {

--- a/tests/components/common/SettingsPanel.test.tsx
+++ b/tests/components/common/SettingsPanel.test.tsx
@@ -398,6 +398,58 @@ describe('SettingsPanel', () => {
   });
 
   /**
+   * Regression: panning the board canvas (drag on empty space) translates the
+   * widget surface via a CSS transform WITHOUT changing widget.x/y — those
+   * are world coordinates, pan is purely visual. DashboardView dispatches a
+   * `board-pan` window event on every pan frame so floating popovers anchored
+   * to a widget's on-screen rect (DraggableWindow's tool menu, snap menu) can
+   * re-measure and follow. SettingsPanel positions itself the same way (via
+   * widgetRef.getBoundingClientRect()) but never listened for that event, so
+   * panning while settings are open left the panel visually stranded at its
+   * pre-pan screen position instead of following the widget.
+   */
+  it('re-measures its position on a board-pan event', () => {
+    // rect "moves" like a pan would, while widget.x/y (world coords) stay put.
+    let rect = {
+      left: 0,
+      top: 100,
+      right: 200,
+      bottom: 250,
+      width: 200,
+      height: 150,
+      x: 0,
+      y: 100,
+      toJSON: () => ({}),
+    };
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      () => rect
+    );
+
+    act(() => {
+      render(<Harness />);
+    });
+
+    const settingsContent = screen.getByTestId('settings-content');
+    const panelEl = findFixedAncestor(settingsContent);
+    expect(panelEl).not.toBeNull();
+    if (!panelEl) return;
+
+    // Pre-pan: panel sits to the right of the widget's screen rect.
+    expect(parseFloat(panelEl.style.left)).toBe(212); // 200 (rect.right) + 12
+
+    // Pan moves the widget 300px right on screen; widget.x/y are untouched.
+    rect = { ...rect, left: 300, right: 500 };
+    act(() => {
+      window.dispatchEvent(new CustomEvent('board-pan'));
+    });
+
+    // With the fix: the panel re-measures and follows the widget.
+    // With the bug: nothing listens for 'board-pan', so left stays at 212 —
+    // the panel is now floating over empty canvas, detached from the widget.
+    expect(parseFloat(panelEl.style.left)).toBe(512); // 500 (new rect.right) + 12
+  });
+
+  /**
    * Regression: pressing Escape inside a form field (input, textarea, select)
    * inside the settings panel must NOT close the panel.
    *


### PR DESCRIPTION
## Root cause

`SettingsPanel` anchors itself to `widgetRef.current.getBoundingClientRect()` and recomputes position on `[updatePosition, viewport, zoom]` changes only. Panning the board canvas (dragging on empty space) moves widgets on screen purely via a CSS `transform: translate()` on an ancestor container — it never touches `widget.x`/`widget.y` (world coordinates), so `SettingsPanel`'s position effect never fired.

`DashboardView` already dispatches a `board-pan` window event on every pan frame specifically so widget-anchored floating popovers can re-measure — `DraggableWindow`'s tool menu and snap menu both already subscribe to it. `SettingsPanel` never wired up the same listener, so opening a widget's settings and then panning the canvas left the settings panel visually stranded at its pre-pan screen position while the widget slid out from under it.

## Fix

Added a `useEffect` in `SettingsPanel.tsx` that subscribes to `window`'s `board-pan` event and calls the existing `updatePosition()` — mirroring the exact pattern already used by `DraggableWindow`'s sibling popovers. No new state, no architectural change.

**Band-aid rejected:** none needed — this is the minimal, correct wiring into an event bus that already exists for exactly this purpose.

## Regression test

`tests/components/common/SettingsPanel.test.tsx` — new test `'re-measures its position on a board-pan event'`: mocks `getBoundingClientRect`, renders the panel, confirms initial position, mutates the mocked rect (simulating a pan), dispatches `board-pan`, and asserts the panel follows.

**Fail-before / pass-after** (independently re-verified by the orchestrator): `212` vs expected `512` on unfixed dev-paul (1/1 fail); full test file passes (9/9) with the fix applied.

## Evidence

- `pnpm run validate` — clean (type-check, lint, format, full root + functions suites).
- `pnpm run build` — succeeds.
- Independently re-verified by the orchestrator via a stash/apply-patch cycle against dev-paul.

## Risk

**Contained.** Single component, additive event listener, matches an established sibling pattern already in production use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EriKAPCtWWF9uLVRrM6ikw)_