### PR TITLE
fix(dashboard): unify beta-widget access check between AuthContext and DashboardContext

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -2283,10 +2283,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, []);
 
-  // Helper for checking if a user has beta access. Delegates to the shared
-  // `utils/betaAccess.isBetaUser` (single source of truth — see LO2
-  // harmonization note there) so every consumer of beta-gated permissions
-  // agrees on who counts as a beta user.
+  // Helper for checking if a user has beta access — delegates to the shared utils/betaAccess.isBetaUser.
   const isBetaUser = useCallback(
     (betaUsers: string[], email: string | null | undefined) =>
       isBetaUserShared(betaUsers, email, userRoles, roleId),

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -78,6 +78,7 @@ import {
   stampLastActive,
 } from '@/utils/lastActiveThrottle';
 import { deriveUserTier, meetsMinTier } from '@/utils/userTier';
+import { isBetaUser as isBetaUserShared } from '@/utils/betaAccess';
 
 // The operator's own organization. Two narrow uses remain after dynamic
 // org resolution shipped:
@@ -2282,24 +2283,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, []);
 
-  // Helper for checking if a user has beta access
+  // Helper for checking if a user has beta access. Delegates to the shared
+  // `utils/betaAccess.isBetaUser` (single source of truth — see LO2
+  // harmonization note there) so every consumer of beta-gated permissions
+  // agrees on who counts as a beta user.
   const isBetaUser = useCallback(
-    (betaUsers: string[], email: string | null | undefined) => {
-      const lowerEmail = email?.toLowerCase() ?? '';
-      return (
-        betaUsers.some((e) => e.toLowerCase() === lowerEmail) ||
-        (userRoles?.betaTeachers?.some((e) => e.toLowerCase() === lowerEmail) ??
-          false) ||
-        // LO2 harmonization: super admins get beta access from EITHER source —
-        // the legacy admin_settings/user_roles.superAdmins[] list OR a member
-        // doc with roleId 'super_admin'. The legacy list is KEPT as an
-        // additional accepted source (a Paul-gated migration retires it later);
-        // this mirrors OrganizationPanel.resolveActorRole, which reads both.
-        (userRoles?.superAdmins?.some((e) => e.toLowerCase() === lowerEmail) ??
-          false) ||
-        roleId === 'super_admin'
-      );
-    },
+    (betaUsers: string[], email: string | null | undefined) =>
+      isBetaUserShared(betaUsers, email, userRoles, roleId),
     [userRoles, roleId]
   );
 

--- a/context/DashboardContext.betaDockDefaults.test.tsx
+++ b/context/DashboardContext.betaDockDefaults.test.tsx
@@ -1,23 +1,4 @@
-/**
- * Regression coverage for `getDefaultDockTools` / `resetDockToDefaults`'s
- * beta-access check.
- *
- * `DashboardContext` re-derives "is this beta-gated widget accessible to the
- * current user" independently of `AuthContext.canAccessWidget`, and the two
- * had drifted: the real gate (`AuthContext.isBetaUser`) compares emails
- * case-insensitively and also accepts `userRoles.betaTeachers` /
- * `userRoles.superAdmins` / `roleId === 'super_admin'` as beta-access
- * sources, while `DashboardContext`'s copy only did a case-SENSITIVE
- * `.includes()` against the permission's own `betaUsers` array. A beta user
- * who could access a widget via `canAccessWidget()` (e.g. an admin-lowercased
- * `betaUsers` entry against a mixed-case sign-in email, or account-wide
- * `betaTeachers` access) would silently never get that widget seeded into
- * their default dock, nor restored via the "Reset to defaults" action.
- *
- * Mocking strategy mirrors `context/toolVisibility.test.tsx` (the sibling
- * DashboardProvider test harness), with `useAuth` backed by a `vi.fn()` so
- * each test can drive its own user/permission fixture.
- */
+// Regression coverage for getDefaultDockTools/resetDockToDefaults's beta-access check staying in sync with AuthContext.isBetaUser.
 import React, { useEffect } from 'react';
 import { render, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/context/DashboardContext.betaDockDefaults.test.tsx
+++ b/context/DashboardContext.betaDockDefaults.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * Regression coverage for `getDefaultDockTools` / `resetDockToDefaults`'s
+ * beta-access check.
+ *
+ * `DashboardContext` re-derives "is this beta-gated widget accessible to the
+ * current user" independently of `AuthContext.canAccessWidget`, and the two
+ * had drifted: the real gate (`AuthContext.isBetaUser`) compares emails
+ * case-insensitively and also accepts `userRoles.betaTeachers` /
+ * `userRoles.superAdmins` / `roleId === 'super_admin'` as beta-access
+ * sources, while `DashboardContext`'s copy only did a case-SENSITIVE
+ * `.includes()` against the permission's own `betaUsers` array. A beta user
+ * who could access a widget via `canAccessWidget()` (e.g. an admin-lowercased
+ * `betaUsers` entry against a mixed-case sign-in email, or account-wide
+ * `betaTeachers` access) would silently never get that widget seeded into
+ * their default dock, nor restored via the "Reset to defaults" action.
+ *
+ * Mocking strategy mirrors `context/toolVisibility.test.tsx` (the sibling
+ * DashboardProvider test harness), with `useAuth` backed by a `vi.fn()` so
+ * each test can drive its own user/permission fixture.
+ */
+import React, { useEffect } from 'react';
+import { render, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DashboardProvider } from './DashboardContext';
+import { useToolVisibility } from './useToolVisibility';
+import type { FeaturePermission, UserRolesConfig } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Mocks (mirrors context/toolVisibility.test.tsx)
+// ---------------------------------------------------------------------------
+
+interface AuthMockShape {
+  user: { uid: string; displayName: string; email: string };
+  isAdmin: boolean;
+  roleId: string | null;
+  userRoles: UserRolesConfig | null;
+  featurePermissions: FeaturePermission[];
+  selectedBuildings: string[];
+  savedWidgetConfigs: Record<string, unknown>;
+  saveWidgetConfig: ReturnType<typeof vi.fn>;
+  refreshGoogleToken: ReturnType<typeof vi.fn>;
+  remoteControlEnabled: boolean;
+  profileLoaded: boolean;
+  setupCompleted: boolean;
+}
+
+function baseAuthMock(): AuthMockShape {
+  return {
+    user: {
+      uid: 'test-user',
+      displayName: 'Test User',
+      email: 'test@example.com',
+    },
+    isAdmin: false,
+    roleId: null,
+    userRoles: null,
+    featurePermissions: [],
+    selectedBuildings: [],
+    savedWidgetConfigs: {},
+    saveWidgetConfig: vi.fn(),
+    refreshGoogleToken: vi.fn(),
+    remoteControlEnabled: true,
+    profileLoaded: true,
+    setupCompleted: true,
+  };
+}
+
+let authMock: AuthMockShape = baseAuthMock();
+const useAuthMock = vi.fn(() => authMock);
+vi.mock('./useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('@/hooks/useGoogleDrive', () => ({
+  useGoogleDrive: () => ({
+    driveService: null,
+    userDomain: 'example.com',
+    isConnected: false,
+  }),
+}));
+
+vi.mock('@/hooks/useFirestore', () => {
+  const value = {
+    saveDashboard: vi.fn().mockResolvedValue(Date.now()),
+    saveDashboards: vi.fn().mockResolvedValue(undefined),
+    deleteDashboard: vi.fn().mockResolvedValue(undefined),
+    // This suite never needs a loaded dashboard — resetDockToDefaults only
+    // reads featurePermissions/user, so the snapshot callback is unused.
+    subscribeToDashboards: vi.fn(() => () => undefined),
+    shareDashboard: vi.fn(),
+    loadSharedDashboard: vi.fn().mockResolvedValue(null),
+    rosters: [],
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    activeRosterId: null,
+  };
+  return { useFirestore: () => value };
+});
+
+vi.mock('@/hooks/useRosters', () => {
+  const value = {
+    rosters: [],
+    activeRosterId: null,
+    addRoster: vi.fn(),
+    updateRoster: vi.fn(),
+    deleteRoster: vi.fn(),
+    setActiveRoster: vi.fn(),
+    setAbsentStudents: vi.fn(),
+  };
+  return { useRosters: () => value };
+});
+
+vi.mock('@/hooks/useCollections', () => {
+  const value = {
+    collections: [],
+    loading: false,
+    error: null,
+    createCollection: vi.fn(),
+    renameCollection: vi.fn(),
+    moveCollection: vi.fn(),
+    deleteCollection: vi.fn(),
+    reorderSiblings: vi.fn(),
+    setCollectionMetadata: vi.fn(),
+    setCollectionDefaultBoard: vi.fn(),
+  };
+  return { useCollections: () => value };
+});
+
+vi.mock('@/hooks/useSharedCollection', () => {
+  const value = {
+    shareCollection: vi.fn().mockResolvedValue('mock-collection-share-id'),
+    shareSubstituteCollection: vi
+      .fn()
+      .mockResolvedValue('mock-collection-sub-share-id'),
+    loadSharedCollection: vi
+      .fn()
+      .mockResolvedValue({ ok: false, reason: 'not-found' }),
+    loadSharedCollectionBoards: vi.fn().mockResolvedValue([]),
+  };
+  return { useSharedCollection: () => value };
+});
+
+vi.mock('firebase/firestore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('firebase/firestore')>();
+  return {
+    ...actual,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({
+      __path: segments.join('/'),
+    })),
+    getDoc: vi.fn().mockResolvedValue({
+      exists: () => false,
+      data: () => undefined,
+    }),
+    setDoc: vi.fn().mockResolvedValue(undefined),
+    updateDoc: vi.fn().mockResolvedValue(undefined),
+    writeBatch: vi.fn(() => ({
+      update: vi.fn(),
+      delete: vi.fn(),
+      set: vi.fn(),
+      commit: vi.fn().mockResolvedValue(undefined),
+    })),
+    onSnapshot: vi.fn(() => () => undefined),
+    serverTimestamp: vi.fn(() => ({ __serverTimestamp: true })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const captured: { toolVis: ReturnType<typeof useToolVisibility> | null } = {
+  toolVis: null,
+};
+
+const CaptureProbe: React.FC = () => {
+  const toolVis = useToolVisibility();
+  useEffect(() => {
+    captured.toolVis = toolVis;
+  });
+  return null;
+};
+
+function getToolVis(): ReturnType<typeof useToolVisibility> {
+  if (!captured.toolVis)
+    throw new Error('Tool-visibility context not captured');
+  return captured.toolVis;
+}
+
+function betaPermission(
+  overrides: Partial<FeaturePermission> = {}
+): FeaturePermission {
+  return {
+    widgetType: 'clock',
+    enabled: true,
+    accessLevel: 'beta',
+    betaUsers: [],
+    ...overrides,
+  } as FeaturePermission;
+}
+
+function setup(): void {
+  render(
+    <DashboardProvider>
+      <CaptureProbe />
+    </DashboardProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  captured.toolVis = null;
+  authMock = baseAuthMock();
+  useAuthMock.mockImplementation(() => authMock);
+});
+
+describe('DashboardContext getDefaultDockTools beta-access parity', () => {
+  it('includes a beta widget whose betaUsers entry is lowercase but the sign-in email is mixed-case', () => {
+    // Mirrors real post-#2375 data: the admin panel normalizes betaUsers to
+    // lowercase on write, but Firebase Auth / Google Workspace does not
+    // guarantee a lowercase `user.email` on sign-in.
+    authMock.user.email = 'Teacher@School.org';
+    authMock.featurePermissions = [
+      betaPermission({ betaUsers: ['teacher@school.org'] }),
+    ];
+
+    setup();
+
+    act(() => {
+      getToolVis().resetDockToDefaults();
+    });
+
+    expect(getToolVis().visibleTools).toContain('clock');
+  });
+
+  it('includes a beta widget granted via userRoles.betaTeachers rather than the permission betaUsers list', () => {
+    authMock.user.email = 'roster-beta@school.org';
+    authMock.userRoles = {
+      students: [],
+      teachers: [],
+      betaTeachers: ['roster-beta@school.org'],
+      admins: [],
+      superAdmins: [],
+    };
+    authMock.featurePermissions = [betaPermission({ betaUsers: [] })];
+
+    setup();
+
+    act(() => {
+      getToolVis().resetDockToDefaults();
+    });
+
+    expect(getToolVis().visibleTools).toContain('clock');
+  });
+
+  it('still excludes a beta widget for a user who is not a beta user by any source', () => {
+    authMock.user.email = 'not-a-beta-user@school.org';
+    authMock.featurePermissions = [
+      betaPermission({ betaUsers: ['teacher@school.org'] }),
+    ];
+
+    setup();
+
+    act(() => {
+      getToolVis().resetDockToDefaults();
+    });
+
+    expect(getToolVis().visibleTools).not.toContain('clock');
+  });
+});

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -96,6 +96,7 @@ import {
 import { ToolVisibilityContext } from './ToolVisibilityContextValue';
 import { validateGridConfig, sanitizeAIConfig } from '@/utils/ai_security';
 import { getAdminBuildingConfig as getAdminBuildingConfigPure } from '@/utils/adminBuildingConfig';
+import { isBetaUser } from '@/utils/betaAccess';
 import { AnnotationState } from './DashboardContextValue';
 import { DRAWING_DEFAULTS } from '@/components/widgets/DrawingWidget/constants';
 import { STANDARD_COLORS } from '@/config/colors';
@@ -231,6 +232,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     user,
     isAdmin,
     roleId,
+    userRoles,
     isStudentRole,
     roleResolved,
     refreshGoogleToken,
@@ -745,6 +747,10 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     /**
      * Checks whether a given FeaturePermission record is accessible to the
      * current user (enabled, correct access level, in beta list if required).
+     * Delegates the beta check to the shared `isBetaUser` helper — the same
+     * one `AuthContext.canAccessWidget` uses — so this stays in lockstep
+     * with the real gate instead of re-deriving its own (previously
+     * case-sensitive, role-list-blind) copy.
      */
     const isPermAccessible = (perm: FeaturePermission): boolean => {
       const isEnabled = perm.enabled !== false;
@@ -752,7 +758,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
         perm.accessLevel !== 'admin' || isAdmin === true;
       const isBetaAccessible =
         perm.accessLevel !== 'beta' ||
-        perm.betaUsers.includes(user?.email ?? '');
+        isBetaUser(perm.betaUsers, user?.email, userRoles, roleId);
       return isEnabled && isAccessibleByRole && isBetaAccessible;
     };
 
@@ -811,7 +817,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     }
 
     return tools;
-  }, [featurePermissions, selectedBuildings, isAdmin, user]);
+  }, [featurePermissions, selectedBuildings, isAdmin, user, userRoles, roleId]);
 
   // Empty-dock recovery: whenever the dock is empty after hydration,
   // refill it with building-aware defaults. Earlier iterations of this

--- a/context/DashboardContext.tsx
+++ b/context/DashboardContext.tsx
@@ -744,14 +744,7 @@ export const DashboardProvider: React.FC<{ children: React.ReactNode }> = ({
     | WidgetType
     | InternalToolType
   )[] => {
-    /**
-     * Checks whether a given FeaturePermission record is accessible to the
-     * current user (enabled, correct access level, in beta list if required).
-     * Delegates the beta check to the shared `isBetaUser` helper — the same
-     * one `AuthContext.canAccessWidget` uses — so this stays in lockstep
-     * with the real gate instead of re-deriving its own (previously
-     * case-sensitive, role-list-blind) copy.
-     */
+    // Checks whether a FeaturePermission is accessible to the current user; beta check delegates to the shared isBetaUser helper.
     const isPermAccessible = (perm: FeaturePermission): boolean => {
       const isEnabled = perm.enabled !== false;
       const isAccessibleByRole =

--- a/utils/betaAccess.test.ts
+++ b/utils/betaAccess.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { isBetaUser } from './betaAccess';
+import type { UserRolesConfig } from '@/types';
+
+const roles = (overrides: Partial<UserRolesConfig> = {}): UserRolesConfig => ({
+  students: [],
+  teachers: [],
+  betaTeachers: [],
+  admins: [],
+  superAdmins: [],
+  ...overrides,
+});
+
+describe('isBetaUser', () => {
+  it('grants access via a case-insensitive betaUsers match', () => {
+    expect(isBetaUser(['teacher@school.edu'], 'Teacher@School.edu')).toBe(true);
+  });
+
+  it('grants access via userRoles.betaTeachers, independent of betaUsers', () => {
+    expect(
+      isBetaUser(
+        [],
+        'teacher@school.edu',
+        roles({ betaTeachers: ['teacher@school.edu'] })
+      )
+    ).toBe(true);
+  });
+
+  it('grants access via userRoles.superAdmins, independent of betaUsers', () => {
+    expect(
+      isBetaUser(
+        [],
+        'admin@school.edu',
+        roles({ superAdmins: ['admin@school.edu'] })
+      )
+    ).toBe(true);
+  });
+
+  it('grants access via roleId === "super_admin", independent of any list', () => {
+    expect(isBetaUser([], 'admin@school.edu', null, 'super_admin')).toBe(true);
+  });
+
+  it('denies access when the user matches none of the four sources', () => {
+    expect(
+      isBetaUser(
+        ['other@school.edu'],
+        'teacher@school.edu',
+        roles({ betaTeachers: ['other@school.edu'] }),
+        'teacher'
+      )
+    ).toBe(false);
+  });
+
+  it('denies access for a null/undefined email even with a non-empty betaUsers list', () => {
+    expect(isBetaUser(['teacher@school.edu'], null)).toBe(false);
+    expect(isBetaUser(['teacher@school.edu'], undefined)).toBe(false);
+  });
+});

--- a/utils/betaAccess.ts
+++ b/utils/betaAccess.ts
@@ -12,6 +12,7 @@ export function isBetaUser(
     betaUsers.some((e) => e.toLowerCase() === lowerEmail) ||
     (userRoles?.betaTeachers?.some((e) => e.toLowerCase() === lowerEmail) ??
       false) ||
+    // LO2 harmonization: legacy admin_settings/user_roles.superAdmins[] is kept as an accepted source alongside roleId==='super_admin' until a Paul-gated migration retires it.
     (userRoles?.superAdmins?.some((e) => e.toLowerCase() === lowerEmail) ??
       false) ||
     roleId === 'super_admin'

--- a/utils/betaAccess.ts
+++ b/utils/betaAccess.ts
@@ -1,13 +1,4 @@
-/**
- * Shared beta-access check for `FeaturePermission.accessLevel === 'beta'`.
- *
- * Single source of truth so every consumer (AuthContext.canAccessWidget /
- * canAccessFeature, DashboardContext.getDefaultDockTools) grants beta access
- * identically. A user is a beta user if their (case-insensitively compared)
- * email appears in the permission's own `betaUsers` list, OR in the account-
- * wide `userRoles.betaTeachers` / `userRoles.superAdmins` lists, OR they hold
- * the `super_admin` role.
- */
+// Single source of truth for beta-widget access — shared by AuthContext and DashboardContext.
 import type { UserRolesConfig } from '@/types';
 
 export function isBetaUser(

--- a/utils/betaAccess.ts
+++ b/utils/betaAccess.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared beta-access check for `FeaturePermission.accessLevel === 'beta'`.
+ *
+ * Single source of truth so every consumer (AuthContext.canAccessWidget /
+ * canAccessFeature, DashboardContext.getDefaultDockTools) grants beta access
+ * identically. A user is a beta user if their (case-insensitively compared)
+ * email appears in the permission's own `betaUsers` list, OR in the account-
+ * wide `userRoles.betaTeachers` / `userRoles.superAdmins` lists, OR they hold
+ * the `super_admin` role.
+ */
+import type { UserRolesConfig } from '@/types';
+
+export function isBetaUser(
+  betaUsers: string[],
+  email: string | null | undefined,
+  userRoles?: UserRolesConfig | null,
+  roleId?: string | null
+): boolean {
+  const lowerEmail = email?.toLowerCase() ?? '';
+  return (
+    betaUsers.some((e) => e.toLowerCase() === lowerEmail) ||
+    (userRoles?.betaTeachers?.some((e) => e.toLowerCase() === lowerEmail) ??
+      false) ||
+    (userRoles?.superAdmins?.some((e) => e.toLowerCase() === lowerEmail) ??
+      false) ||
+    roleId === 'super_admin'
+  );
+}


### PR DESCRIPTION
## Root cause

`DashboardContext.getDefaultDockTools` (seeds a new user's dock and backs the "Reset to defaults" action) re-derived beta-access eligibility independently of `AuthContext.canAccessWidget`, and the two had drifted:

- **Authoritative gate** (`AuthContext.isBetaUser`): case-insensitive email comparison, plus fallback access via `userRoles.betaTeachers`, `userRoles.superAdmins`, or `roleId === 'super_admin'`.
- **DashboardContext's copy**: `perm.betaUsers.includes(user?.email ?? '')` — case-sensitive, and blind to the role-list fallback sources entirely.

A beta user who could access a widget via `canAccessWidget()` (e.g. an admin-lowercased `betaUsers` entry vs. a mixed-case sign-in email, or account-wide `betaTeachers` access) would never get that widget seeded into their default dock, nor restored by "Reset to defaults" — a silent, confusing inconsistency. PR #2375 partially addressed this by normalizing `betaUsers` on write but explicitly left this read site's gap open, and never covered the role-list sources at all.

## Fix

Extracted the check into a shared `utils/betaAccess.ts` (single source of truth) and pointed both `AuthContext.isBetaUser` and `DashboardContext.getDefaultDockTools` at it.

**Band-aid rejected:** just adding `.toLowerCase()` to the DashboardContext read site — would still miss the `betaTeachers`/`superAdmins`/`super_admin` sources and could re-drift the next time either side changes independently.

## Regression test

`context/DashboardContext.betaDockDefaults.test.tsx` (new), 3 tests: mixed-case email vs. lowercase `betaUsers` entry, access granted only via `userRoles.betaTeachers`, and a negative control (non-beta user correctly excluded).

**Fail-before / pass-after** (independently re-verified by the orchestrator): 2/3 fail against dev-paul (unfixed) — `'clock'` missing from `visibleTools` — 3/3 pass with the fix applied. Also independently type-checked clean.

## Evidence

- `pnpm run validate` — clean (type-check, lint, format, 621 root test files / 7432 tests, 41 functions files / 804 tests).
- `pnpm run build` — succeeds.
- Independently re-verified by the orchestrator via a stash/apply-patch cycle against dev-paul, plus a standalone `tsc --noEmit`.

## Risk

**Contained.** New shared utility + two call-site swaps; no behavior change for any already-correctly-gated user.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EriKAPCtWWF9uLVRrM6ikw)_