### PR TITLE
fix(admin): stop Organization panel popover Escape from leaking to DashboardView

### DIFF
--- a/components/admin/Organization/components/primitives.tsx
+++ b/components/admin/Organization/components/primitives.tsx
@@ -7,6 +7,7 @@ import {
   Info,
   AlertTriangle,
 } from 'lucide-react';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 
 // Color palette for badges and role accents.
 export type AccentColor =
@@ -420,7 +421,11 @@ export const RowMenu: React.FC<{ items: MenuItem[]; label?: string }> = ({
       setOpen(false);
     };
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      // Portalled outside any `.widget` ancestor — stop Escape reaching DashboardView's global handler (see ToolDockItem).
+      e.stopPropagation();
+      setOpen(false);
     };
     document.addEventListener('mousedown', onDocClick);
     document.addEventListener('keydown', onEsc);
@@ -595,7 +600,11 @@ export const CellPopover: React.FC<{
       onClose();
     };
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      // Portalled outside any `.widget` ancestor — stop Escape reaching DashboardView's global handler (see ToolDockItem).
+      e.stopPropagation();
+      onClose();
     };
     document.addEventListener('mousedown', onDocClick);
     document.addEventListener('keydown', onEsc);
@@ -773,7 +782,11 @@ export const LocalModal: React.FC<{
   useEffect(() => {
     if (!isOpen) return undefined;
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      // Rendered over live dashboard widgets — stop Escape reaching DashboardView's global handler (see ToolDockItem).
+      e.stopPropagation();
+      onClose();
     };
     document.addEventListener('keydown', onEsc);
     return () => document.removeEventListener('keydown', onEsc);

--- a/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
+++ b/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Regression test: `RowMenu`, `CellPopover`, and `LocalModal`
+ * (components/admin/Organization/components/primitives.tsx) closed on
+ * Escape but never called stopPropagation(). All three are rendered inside
+ * AdminSettings' full-screen overlay while live dashboard widgets sit behind
+ * it (opened via the Sidebar gear icon), and are portalled outside any
+ * `.widget` ancestor. The unstopped keydown bubbled to DashboardView's
+ * global `window`-level Escape handler, which falls back to minimizing the
+ * topmost dashboard widget — a completely unrelated widget disappearing
+ * just because an admin dismissed a row menu, cell popover, or nested
+ * modal. Same recurring bug class fixed 13+ times elsewhere (ToolDockItem,
+ * ClassRosterMenu, ActiveClassChip, FolderItem, WidgetLibrary, etc.).
+ *
+ * FIX: all three handlers now call event.stopPropagation() before closing,
+ * matching the established sibling pattern.
+ */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import {
+  RowMenu,
+  CellPopover,
+  LocalModal,
+} from '@/components/admin/Organization/components/primitives';
+
+afterEach(cleanup);
+
+function withWindowKeydownSpy(run: () => void) {
+  const spy = vi.fn();
+  window.addEventListener('keydown', spy);
+  try {
+    run();
+    return spy;
+  } finally {
+    window.removeEventListener('keydown', spy);
+  }
+}
+
+describe('Organization primitives — Escape does not leak to window-level handlers', () => {
+  it('RowMenu closes on Escape and stops propagation', () => {
+    render(<RowMenu items={[{ label: 'Delete', onClick: vi.fn() }]} />);
+    fireEvent.click(screen.getByRole('button', { name: /row actions/i }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    const spy = withWindowKeydownSpy(() => {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    });
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('CellPopover closes on Escape and stops propagation', () => {
+    const onClose = vi.fn();
+    const AnchorHarness: React.FC = () => {
+      const anchorRef = React.useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={anchorRef}>anchor</button>
+          <CellPopover open onClose={onClose} anchorRef={anchorRef}>
+            <div>popover content</div>
+          </CellPopover>
+        </>
+      );
+    };
+    render(<AnchorHarness />);
+    expect(screen.getByText('popover content')).toBeInTheDocument();
+
+    const spy = withWindowKeydownSpy(() => {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('LocalModal closes on Escape and stops propagation', () => {
+    const onClose = vi.fn();
+    render(
+      <LocalModal isOpen onClose={onClose} title="Test modal">
+        <div>modal content</div>
+      </LocalModal>
+    );
+    expect(
+      screen.getByRole('dialog', { name: /test modal/i })
+    ).toBeInTheDocument();
+
+    const spy = withWindowKeydownSpy(() => {
+      fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
+++ b/tests/components/admin/Organization/primitives.escapePropagation.test.tsx
@@ -1,19 +1,4 @@
-/**
- * Regression test: `RowMenu`, `CellPopover`, and `LocalModal`
- * (components/admin/Organization/components/primitives.tsx) closed on
- * Escape but never called stopPropagation(). All three are rendered inside
- * AdminSettings' full-screen overlay while live dashboard widgets sit behind
- * it (opened via the Sidebar gear icon), and are portalled outside any
- * `.widget` ancestor. The unstopped keydown bubbled to DashboardView's
- * global `window`-level Escape handler, which falls back to minimizing the
- * topmost dashboard widget — a completely unrelated widget disappearing
- * just because an admin dismissed a row menu, cell popover, or nested
- * modal. Same recurring bug class fixed 13+ times elsewhere (ToolDockItem,
- * ClassRosterMenu, ActiveClassChip, FolderItem, WidgetLibrary, etc.).
- *
- * FIX: all three handlers now call event.stopPropagation() before closing,
- * matching the established sibling pattern.
- */
+// Regression: RowMenu/CellPopover/LocalModal Escape handlers must stopPropagation() so it doesn't leak to DashboardView's global handler.
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';


### PR DESCRIPTION
## Root cause

`RowMenu`, `CellPopover`, and `LocalModal` in `components/admin/Organization/components/primitives.tsx` (used throughout Admin Settings → Organization: `AllOrganizationsView`, `DomainsView`, `BuildingsView`, `TestClassesView`, `RolesView`, `UsersView`) each registered a `document`-level `keydown` Escape handler that closed the popover/menu/modal but never called `stopPropagation()`.

All three are portalled outside any `.widget` ancestor, and `AdminSettings` is a full-screen overlay opened while live dashboard widgets sit behind it (not a shared `Modal`, so `useHasOpenModal()` doesn't shield it). The unstopped keydown bubbled to `DashboardView`'s global Escape handler, which falls back to minimizing the topmost dashboard widget — e.g. silently closing an unrelated running timer just because an admin dismissed a row menu.

Same recurring bug class already fixed 13+ times elsewhere (`ToolDockItem`, `ClassRosterMenu`, `ActiveClassChip`, `FolderItem`, `WidgetLibrary`, etc.), but never ported to this file — flagged as an open, unverified backlog lead on 2026-08-14 and re-confirmed live-reachable before fixing.

## Fix

Applied the established `stopPropagation()` + `isEscapeFromWidgetInput()` guard idiom to all three handlers, matching every prior fix of this class exactly.

**Band-aid rejected:** none — this is the established root-cause fix pattern, not a symptom patch.

## Regression test

`tests/components/admin/Organization/primitives.escapePropagation.test.tsx` (new), 3 tests — one per component — rendering, opening, firing Escape on `document`, and asserting a `window`-level keydown spy was **not** called (plus that the component actually closed).

**Fail-before / pass-after** (independently re-verified by the orchestrator): 3/3 fail against dev-paul (unfixed) — spy called once each; 3/3 pass with the fix applied.

## Evidence

- `pnpm run validate` — clean (type-check, lint, format, 621 root test files / 7432 tests, 41 functions files / 804 tests).
- `pnpm run build` — succeeds.
- Independently re-verified by the orchestrator via a stash/apply-patch cycle against dev-paul.

## Risk

**Contained.** Three handlers in one file, additive guard matching an established idiom used 13+ times elsewhere in the codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EriKAPCtWWF9uLVRrM6ikw)_