### PR TITLE
fix(functions): bound gcPlcOrphans version-overflow sweep per group

### DIFF
--- a/functions/src/gcPlcOrphans.test.ts
+++ b/functions/src/gcPlcOrphans.test.ts
@@ -63,6 +63,7 @@ import {
   PLC_PAGE_SIZE,
   GROUP_PAGE_SIZE,
   CATEGORY_PAGE_SIZE,
+  MAX_VERSIONS_SCAN_PER_GROUP,
 } from './gcPlcOrphans';
 
 // ===========================================================================
@@ -231,8 +232,9 @@ function makeStubDb(seed: {
   }
   interface CollectionRef {
     limit: (n: number) => CollectionRef;
-    orderBy: (field: unknown) => CollectionRef;
+    orderBy: (field: unknown, direction?: 'asc' | 'desc') => CollectionRef;
     startAfter: (cursor: DocSnap) => CollectionRef;
+    offset: (n: number) => CollectionRef;
     get: () => Promise<{ docs: DocSnap[]; size: number }>;
   }
   interface DocSnap {
@@ -253,19 +255,54 @@ function makeStubDb(seed: {
 
   const makeCollectionRef = (
     backing: StubDoc[],
-    opts: { lim?: number; ordered?: boolean; afterId?: string } = {}
+    opts: {
+      lim?: number;
+      ordered?: boolean;
+      afterId?: string;
+      offsetN?: number;
+      orderField?: unknown;
+      orderDir?: 'asc' | 'desc';
+    } = {}
   ): CollectionRef => ({
     limit: (n: number) => makeCollectionRef(backing, { ...opts, lim: n }),
-    orderBy: () => makeCollectionRef(backing, { ...opts, ordered: true }),
+    orderBy: (field: unknown, direction?: 'asc' | 'desc') =>
+      makeCollectionRef(backing, {
+        ...opts,
+        ordered: true,
+        orderField: field,
+        orderDir: direction ?? 'asc',
+      }),
+    offset: (n: number) => makeCollectionRef(backing, { ...opts, offsetN: n }),
     startAfter: (cursor: DocSnap) =>
       makeCollectionRef(backing, { ...opts, afterId: cursor.id }),
     get: () => {
-      let rows = opts.ordered
-        ? [...backing].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+      // '__name__' (mocked FieldPath.documentId()) sorts by doc id, same as
+      // production. A real field name orders numerically on that field and —
+      // mirroring live Firestore — excludes docs where the field is absent.
+      const byRealField =
+        opts.ordered &&
+        opts.orderField !== undefined &&
+        opts.orderField !== '__name__';
+      let rows = byRealField
+        ? backing.filter((d) => d.data[opts.orderField as string] !== undefined)
         : [...backing];
+      if (opts.ordered) {
+        rows = rows.sort((a, b) => {
+          if (!byRealField) {
+            return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+          }
+          const field = opts.orderField as string;
+          const av = Number(a.data[field]);
+          const bv = Number(b.data[field]);
+          return opts.orderDir === 'desc' ? bv - av : av - bv;
+        });
+      }
       if (opts.afterId !== undefined) {
         const i = rows.findIndex((d) => d.id === opts.afterId);
         if (i >= 0) rows = rows.slice(i + 1);
+      }
+      if (opts.offsetN) {
+        rows = rows.slice(opts.offsetN);
       }
       const slice = rows.slice(
         0,
@@ -487,6 +524,105 @@ describe('runGcPlcOrphans — version overflow (category e)', () => {
 
     expect(counts.versionOverflow).toBe(0);
     expect(root.synced_quizzes[0].sub!.versions).toHaveLength(5);
+  });
+});
+
+describe('runGcPlcOrphans — version overflow is bounded per group (MAX_VERSIONS_SCAN_PER_GROUP)', () => {
+  // Before the fix, `sweepVersionOverflow` read the ENTIRE `versions`
+  // subcollection with a single un-bounded `.get()` and sorted it in memory —
+  // the one sweep in this file with no per-run ceiling. A group whose backlog
+  // has grown large (client prune stuck failing) could blow past the
+  // function's pinned 256MiB budget or simply dominate the run, and — since
+  // this sweep runs BEFORE the per-PLC loop with no try/catch around it — a
+  // single pathological group could abort the whole run before any PLC's
+  // activity/presence/tombstone sweep even starts. This proves the fix caps
+  // deletions at MAX_VERSIONS_SCAN_PER_GROUP per run and leaves the rest for
+  // next run, exactly like every other ceiling in this file.
+  it('caps deletions at MAX_VERSIONS_SCAN_PER_GROUP and leaves the remainder for next run', async () => {
+    const overflowBeyondCap = 50;
+    const totalOverflow = MAX_VERSIONS_SCAN_PER_GROUP + overflowBeyondCap;
+    const total = VERSION_HISTORY_LIMIT + totalOverflow;
+    const versions: StubDoc[] = Array.from({ length: total }, (_, i) => ({
+      id: String(i + 1),
+      data: { version: i + 1 },
+    }));
+    const { db, root } = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: { versions },
+        },
+      ],
+    });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    // Un-bounded (pre-fix) behaviour deletes ALL overflow in one run
+    // (totalOverflow); the fix must cap it at MAX_VERSIONS_SCAN_PER_GROUP.
+    expect(counts.versionOverflow).toBe(MAX_VERSIONS_SCAN_PER_GROUP);
+    const remaining = root.synced_quizzes[0].sub!.versions;
+    // The un-swept remainder (newest kept + leftover overflow) stays behind
+    // for the next run to pick up — nothing is lost, just deferred.
+    expect(remaining).toHaveLength(VERSION_HISTORY_LIMIT + overflowBeyondCap);
+    // The newest VERSION_HISTORY_LIMIT snapshots are never touched.
+    const newestIds = Array.from({ length: VERSION_HISTORY_LIMIT }, (_, i) =>
+      String(total - i)
+    );
+    const remainingIds = new Set(remaining.map((d) => d.id));
+    for (const id of newestIds) {
+      expect(remainingIds.has(id)).toBe(true);
+    }
+  });
+
+  it('warns when the per-group ceiling is hit', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const total = VERSION_HISTORY_LIMIT + MAX_VERSIONS_SCAN_PER_GROUP + 1;
+    const versions: StubDoc[] = Array.from({ length: total }, (_, i) => ({
+      id: String(i + 1),
+      data: { version: i + 1 },
+    }));
+    const { db } = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: { versions },
+        },
+      ],
+    });
+
+    await runGcPlcOrphans(db, NOW);
+
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes('MAX_VERSIONS_SCAN_PER_GROUP')
+      )
+    ).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('does not touch a group whose overflow is within the cap (unchanged behaviour)', async () => {
+    const versions: StubDoc[] = Array.from({ length: 13 }, (_, i) => ({
+      id: String(i + 1),
+      data: { version: i + 1 },
+    }));
+    const { db, root } = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: { versions },
+        },
+      ],
+    });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    expect(counts.versionOverflow).toBe(3);
+    expect(root.synced_quizzes[0].sub!.versions).toHaveLength(
+      VERSION_HISTORY_LIMIT
+    );
   });
 });
 

--- a/functions/src/gcPlcOrphans.test.ts
+++ b/functions/src/gcPlcOrphans.test.ts
@@ -624,6 +624,33 @@ describe('runGcPlcOrphans — version overflow is bounded per group (MAX_VERSION
       VERSION_HISTORY_LIMIT
     );
   });
+
+  it('pins the documented trade-off: a version doc missing the `version` field is left untouched (neither counted nor deleted)', async () => {
+    const versions: StubDoc[] = [
+      ...Array.from({ length: VERSION_HISTORY_LIMIT + 5 }, (_, i) => ({
+        id: String(i + 1),
+        data: { version: i + 1 },
+      })),
+      { id: 'malformed', data: {} },
+    ];
+    const { db, root } = makeStubDb({
+      synced_quizzes: [
+        {
+          id: 'g1',
+          data: { participants: { uidA: { joinedAt: 1 } } },
+          sub: { versions },
+        },
+      ],
+    });
+
+    const counts = await runGcPlcOrphans(db, NOW);
+
+    // Firestore's orderBy('version') excludes the fieldless doc from the
+    // query entirely — it's invisible to the sweep, not swept as overflow.
+    expect(counts.versionOverflow).toBe(5);
+    const remainingIds = root.synced_quizzes[0].sub!.versions.map((d) => d.id);
+    expect(remainingIds).toContain('malformed');
+  });
 });
 
 describe('runGcPlcOrphans — full sweep summary', () => {

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -119,6 +119,24 @@ export const MAX_CATEGORY_SCAN_PER_PLC = 5000;
 /** Page size for the paginated per-PLC category sweeps (startAfter cursor on document id). */
 export const CATEGORY_PAGE_SIZE = 500;
 
+/**
+ * Overall safety ceiling on version-overflow snapshots deleted PER GROUP PER
+ * RUN — same rationale as the other `MAX_*_PER_RUN` ceilings. Before this,
+ * `sweepVersionOverflow` read the ENTIRE `versions` subcollection into memory
+ * with an un-bounded `.get()` and sorted it client-side — the one sweep in
+ * this file with no ceiling at all. In steady state the client prunes to
+ * `VERSION_HISTORY_LIMIT` after every publish so this rarely matters, but a
+ * group whose prune has been failing (e.g. a long-broken client) can carry an
+ * unbounded backlog, and this sweep runs BEFORE the per-PLC loop with no
+ * try/catch around it — an unbounded read/sort on one pathological group can
+ * throw or exhaust the function's pinned 256MiB budget and abort the whole
+ * run before a single PLC's activity/presence/tombstone sweep even starts.
+ * Bounding the per-group delete keeps one bad group from starving every
+ * other group and PLC in the run; leftover overflow is picked up next run
+ * (the sweep is idempotent, same as every other ceiling in this file).
+ */
+export const MAX_VERSIONS_SCAN_PER_GROUP = 5000;
+
 /** Firestore caps a batch at 500 ops; chunk below that defensively. */
 const BATCH_CHUNK = 250;
 
@@ -300,28 +318,42 @@ async function sweepEmptyGroups(db: Firestore): Promise<number> {
 }
 
 /**
- * Trim version-history overflow under a single synced group. Keeps the newest
- * `VERSION_HISTORY_LIMIT` snapshots (by numeric doc id = version number) and
- * deletes the rest. Defensive: the client prunes after each publish, so this
- * usually finds nothing.
+ * Trim version-history overflow under a single synced group. Keeps the
+ * newest `VERSION_HISTORY_LIMIT` snapshots (by the numeric `version` field —
+ * every version doc is written with `version is int` per firestore.rules) and
+ * deletes the rest, bounded by `MAX_VERSIONS_SCAN_PER_GROUP` per run.
+ *
+ * Sorts and skips the kept head SERVER-SIDE via `orderBy('version',
+ * 'desc').offset(VERSION_HISTORY_LIMIT)` rather than fetching the whole
+ * subcollection and sorting in memory — the prior approach had no ceiling at
+ * all (see `MAX_VERSIONS_SCAN_PER_GROUP`). This intentionally does NOT mirror
+ * `fetchCategoryPaginated`'s doc-id `startAfter` cursor: doc ids here are
+ * stringified version numbers, so string-order pagination ("1","10","11",...)
+ * does not match numeric recency, and a capped doc-id page could delete the
+ * wrong (non-oldest) snapshots. Ordering by the real numeric field avoids
+ * that trap entirely. Defensive: the client prunes after each publish, so
+ * this usually finds nothing.
  */
 async function sweepVersionOverflow(
   db: Firestore,
   groupRef: admin.firestore.DocumentReference
 ): Promise<number> {
-  const versionsSnap = await groupRef.collection('versions').get();
-  if (versionsSnap.size <= VERSION_HISTORY_LIMIT) return 0;
-  // Newest-first by version number (doc id). Non-numeric ids sort last (NaN →
-  // treated as oldest) so malformed snapshots are pruned first.
-  const sorted = [...versionsSnap.docs].sort((a, b) => {
-    const av = Number(a.id);
-    const bv = Number(b.id);
-    const an = Number.isFinite(av) ? av : -Infinity;
-    const bn = Number.isFinite(bv) ? bv : -Infinity;
-    return bn - an;
-  });
-  const overflow = sorted.slice(VERSION_HISTORY_LIMIT).map((d) => d.ref);
-  return deleteRefs(db, overflow);
+  const overflowSnap = await groupRef
+    .collection('versions')
+    .orderBy('version', 'desc')
+    .offset(VERSION_HISTORY_LIMIT)
+    .limit(MAX_VERSIONS_SCAN_PER_GROUP)
+    .get();
+  if (overflowSnap.size === 0) return 0;
+  if (overflowSnap.size >= MAX_VERSIONS_SCAN_PER_GROUP) {
+    console.warn(
+      `[gcPlcOrphans] hit MAX_VERSIONS_SCAN_PER_GROUP ceiling (${MAX_VERSIONS_SCAN_PER_GROUP}) on ${groupRef.path}/versions — raise it or shard the sweep`
+    );
+  }
+  return deleteRefs(
+    db,
+    overflowSnap.docs.map((d) => d.ref)
+  );
 }
 
 /**

--- a/functions/src/gcPlcOrphans.ts
+++ b/functions/src/gcPlcOrphans.ts
@@ -333,6 +333,22 @@ async function sweepEmptyGroups(db: Firestore): Promise<number> {
  * wrong (non-oldest) snapshots. Ordering by the real numeric field avoids
  * that trap entirely. Defensive: the client prunes after each publish, so
  * this usually finds nothing.
+ *
+ * TRADE-OFF: `orderBy('version')` silently excludes any doc that lacks the
+ * `version` field entirely (Firestore's field-orderBy semantics, not a bug
+ * here) — such a doc would neither be counted nor deleted, and would
+ * accumulate forever instead of being pruned. The prior unbounded-`.get()`
+ * implementation handled this deliberately (non-numeric ids sorted as
+ * oldest, pruned first). This is an accepted, verified-unreachable trade:
+ * the sole writer (`useSyncedQuizGroups.ts`/`useSyncedVideoActivityGroups.ts`
+ * `writeVersionSnapshot`) always constructs a full `PlcVersionSnapshot`
+ * (`version: number` is non-optional in `types.ts`) and writes it via a
+ * full `setDoc` (never a partial `updateDoc`), so no code path can produce
+ * a fieldless version doc. `firestore.rules`' `version is int` constraint
+ * only covers this same client path — it's corroborating evidence, not the
+ * primary guarantee. If a future writer (e.g. a migration script or a new
+ * Admin-SDK caller) can create a version doc without this field, that
+ * writer must be fixed rather than this sweep re-widened to compensate.
  */
 async function sweepVersionOverflow(
   db: Firestore,


### PR DESCRIPTION
## Root cause

`gcPlcOrphans.ts`'s `sweepVersionOverflow()` read an entire synced group's `versions` subcollection into memory with an unbounded `.get()` and sorted it client-side — the only sweep in this file with no per-run ceiling (every sibling sweep already has one: `MAX_PLCS_PER_RUN`, `MAX_GROUPS_PER_RUN`, `fetchCategoryPaginated`'s `MAX_CATEGORY_SCAN_PER_PLC`).

In steady state this rarely fires (the client prunes to `VERSION_HISTORY_LIMIT` after every publish), but a group whose client-side prune has been silently failing accumulates an unbounded backlog. This sweep runs **before** the per-PLC loop with no `try/catch` anywhere in the file — a memory/time blowup on one pathological group's unbounded read+sort could abort the entire nightly GC run before a single PLC's activity/presence/tombstone sweep even starts, silently defeating GC network-wide.

## Fix

Replaced the in-memory read-everything-then-sort with a Firestore-side query: `orderBy('version', 'desc').offset(VERSION_HISTORY_LIMIT).limit(MAX_VERSIONS_SCAN_PER_GROUP)`, bounded by a new `MAX_VERSIONS_SCAN_PER_GROUP = 5000` ceiling (mirrors the file's established `MAX_*_PER_RUN` pattern), with a `console.warn` when the ceiling is hit.

**Band-aid rejected:** mirroring `fetchCategoryPaginated`'s `startAfter`-cursor-on-doc-id pagination (the pattern used by the other three sweeps) would have been actively wrong here — version doc IDs are stringified version numbers, so string-order pagination ("1","10","11",...,"2") doesn't match numeric recency, and a capped doc-id page could delete the wrong (non-oldest) snapshots. Ordering by the real numeric `version` field server-side avoids that trap.

## Regression test

`functions/src/gcPlcOrphans.test.ts` — 3 new tests: deletions capped at `MAX_VERSIONS_SCAN_PER_GROUP` per run (remainder deferred to next run), a warning is logged when the ceiling is hit, and unchanged behavior for a group whose overflow is within the cap. Also extended the in-memory stub Firestore to support `orderBy(field, direction)` on a real field (not just doc-id) and `.offset(n)`.

**Fail-before / pass-after** (independently re-verified by the orchestrator): 2/2 new tests fail against dev-paul (unfixed); 38/38 pass with the fix applied. Also independently type-checked clean.

## Evidence

- `pnpm run validate` — clean (type-check, lint, format, full root + functions suites, test:counts guard).
- `pnpm run build:all` — succeeds (Vite build + SSR prerender + functions `tsc` build).
- Independently re-verified by the orchestrator via a stash/apply-patch cycle against dev-paul, plus a standalone `tsc --noEmit` in `functions/`.

## Risk

**Architectural** (tag per the run's own guardrails: this closes a real "can abort the whole nightly GC run" failure mode, not just a cosmetic gap) but narrowly scoped — one function, one new bounded query, backward-compatible (idempotent, defers overflow to next run).

---
_Generated by [Claude Code](https://claude.ai/code/session_01EriKAPCtWWF9uLVRrM6ikw)_