### PR TITLE
fix(pii): scrub name-keyed assignments and jigsaw groups from Firestore

### DIFF
--- a/utils/dashboardPII.test.ts
+++ b/utils/dashboardPII.test.ts
@@ -95,6 +95,10 @@ describe('dashboardPII', () => {
           lockedNames: ['Alice Smith'],
           unassignedNames: ['Bob Jones'],
           doneNames: ['Carol Lee'],
+          // Jigsaw mode groups — RandomGroup[] whose `names` arrays are raw
+          // student names, same PII shape as the flat lists above.
+          jigsawHomeGroups: [{ id: 'g1', names: ['Alice Smith'] }],
+          jigsawExpertGroups: [{ id: 'g2', names: ['Bob Jones'] }],
         } as unknown as WidgetConfig,
       },
       {
@@ -108,9 +112,44 @@ describe('dashboardPII', () => {
         flipped: false,
         config: {
           stations: [],
-          assignments: {},
+          // Custom-list mode: keys are the raw student names typed into the
+          // roster, not roster ids — see Stations/Widget.tsx "custom-list
+          // mode: id IS the name".
+          assignments: { 'Dana White': 'station-1' },
           rosterMode: 'custom',
           customRoster: ['Dana White'],
+        } as unknown as WidgetConfig,
+      },
+      {
+        id: 'widget-6',
+        type: 'lunchCount',
+        x: 5,
+        y: 5,
+        w: 2,
+        h: 2,
+        z: 1,
+        flipped: false,
+        config: {
+          roster: ['Eve Adams'],
+          assignments: { 'Eve Adams': 'hot' },
+          rosterMode: 'custom',
+        } as unknown as WidgetConfig,
+      },
+      {
+        id: 'widget-7',
+        type: 'stations',
+        x: 6,
+        y: 6,
+        w: 2,
+        h: 2,
+        z: 1,
+        flipped: false,
+        config: {
+          stations: [],
+          // Class-roster mode: keys are opaque roster student ids, not PII —
+          // this field must NOT be scrubbed/extracted.
+          assignments: { 'roster-student-id-123': 'station-1' },
+          rosterMode: 'class',
         } as unknown as WidgetConfig,
       },
     ],
@@ -131,17 +170,32 @@ describe('dashboardPII', () => {
       expect(scrubbed.widgets[2].config).toEqual({ style: 'digital' });
     });
 
-    it('removes Random jigsaw/manual-edit name lists (lockedNames, unassignedNames, doneNames)', () => {
+    it('removes Random jigsaw/manual-edit name lists and jigsaw group name arrays', () => {
       const scrubbed = scrubDashboardPII(mockDashboardWithPii);
       expect(scrubbed.widgets[3].config).toEqual({ mode: 'shuffle' });
     });
 
-    it('removes Stations custom roster names', () => {
+    it('removes Stations custom roster names AND the name-keyed assignments map', () => {
       const scrubbed = scrubDashboardPII(mockDashboardWithPii);
       expect(scrubbed.widgets[4].config).toEqual({
         stations: [],
-        assignments: {},
         rosterMode: 'custom',
+      });
+    });
+
+    it('removes LunchCount custom roster names AND the name-keyed assignments map', () => {
+      const scrubbed = scrubDashboardPII(mockDashboardWithPii);
+      expect(scrubbed.widgets[5].config).toEqual({
+        rosterMode: 'custom',
+      });
+    });
+
+    it('keeps class-roster-mode assignments (keyed by roster id, not PII)', () => {
+      const scrubbed = scrubDashboardPII(mockDashboardWithPii);
+      expect(scrubbed.widgets[6].config).toEqual({
+        stations: [],
+        assignments: { 'roster-student-id-123': 'station-1' },
+        rosterMode: 'class',
       });
     });
 
@@ -177,13 +231,23 @@ describe('dashboardPII', () => {
           lockedNames: ['Alice Smith'],
           unassignedNames: ['Bob Jones'],
           doneNames: ['Carol Lee'],
+          jigsawHomeGroups: [{ id: 'g1', names: ['Alice Smith'] }],
+          jigsawExpertGroups: [{ id: 'g2', names: ['Bob Jones'] }],
         },
         'widget-5': {
           customRoster: ['Dana White'],
+          assignments: { 'Dana White': 'station-1' },
+        },
+        'widget-6': {
+          roster: ['Eve Adams'],
+          assignments: { 'Eve Adams': 'hot' },
         },
       });
       // widget-3 has no PII, so it should be omitted
       expect(supplement['widget-3']).toBeUndefined();
+      // widget-7 is class-roster mode — its assignments are non-PII ids, so
+      // it must never appear in the Drive-only supplement.
+      expect(supplement['widget-7']).toBeUndefined();
     });
   });
 

--- a/utils/dashboardPII.ts
+++ b/utils/dashboardPII.ts
@@ -30,9 +30,6 @@ export const PII_WIDGET_FIELDS = [
   'roster', // LunchCountConfig — student name array
   'customRoster', // StationsConfig — custom-mode roster name list
 ] as const;
-// NOTE: `assignments` (Stations/LunchCount/SeatingChart) is a further,
-// conditionally-PII field — see `isCustomModeAssignments` below. It isn't
-// listed here because it's only PII when `rosterMode === 'custom'`.
 
 export type PiiWidgetField = (typeof PII_WIDGET_FIELDS)[number] | 'assignments';
 
@@ -42,16 +39,7 @@ export type DashboardPiiSupplement = Record<
   Partial<Record<PiiWidgetField, unknown>>
 >;
 
-/**
- * Stations, LunchCount, and SeatingChart all persist an `assignments: Record<string, ...>`
- * map. In roster mode ('class') keys are opaque roster student ids — safe for
- * Firestore. In custom-list mode ('custom') there is no backing roster record,
- * so the widgets use the raw typed student name AS the key (see e.g.
- * `Stations/Widget.tsx`: "custom-list mode: id IS the name"). `assignments` is
- * therefore PII only when `rosterMode === 'custom'` — treating it as PII
- * unconditionally would strip the (non-PII, id-keyed) roster-mode map from
- * every save and break real-time sync for the common case.
- */
+// `assignments` is PII only in custom-list mode, where the map keys ARE the typed student names.
 function isCustomModeAssignments(config: Record<string, unknown>): boolean {
   return config.rosterMode === 'custom' && config.assignments !== undefined;
 }

--- a/utils/dashboardPII.ts
+++ b/utils/dashboardPII.ts
@@ -24,18 +24,37 @@ export const PII_WIDGET_FIELDS = [
   'lockedNames', // RandomWidget — manually pinned names (Jigsaw/manual edit)
   'unassignedNames', // RandomWidget — names parked in the Unassigned tray
   'doneNames', // RandomWidget — names marked "done" in Shuffle mode
+  'jigsawHomeGroups', // RandomWidget — Jigsaw mode home groups (RandomGroup[] with names[])
+  'jigsawExpertGroups', // RandomWidget — Jigsaw mode expert groups (RandomGroup[] with names[])
   'names', // SeatingChartWidget — custom roster name list
   'roster', // LunchCountConfig — student name array
   'customRoster', // StationsConfig — custom-mode roster name list
 ] as const;
+// NOTE: `assignments` (Stations/LunchCount/SeatingChart) is a further,
+// conditionally-PII field — see `isCustomModeAssignments` below. It isn't
+// listed here because it's only PII when `rosterMode === 'custom'`.
 
-export type PiiWidgetField = (typeof PII_WIDGET_FIELDS)[number];
+export type PiiWidgetField = (typeof PII_WIDGET_FIELDS)[number] | 'assignments';
 
 /** Maps widgetId → object containing only PII fields for that widget */
 export type DashboardPiiSupplement = Record<
   string,
   Partial<Record<PiiWidgetField, unknown>>
 >;
+
+/**
+ * Stations, LunchCount, and SeatingChart all persist an `assignments: Record<string, ...>`
+ * map. In roster mode ('class') keys are opaque roster student ids — safe for
+ * Firestore. In custom-list mode ('custom') there is no backing roster record,
+ * so the widgets use the raw typed student name AS the key (see e.g.
+ * `Stations/Widget.tsx`: "custom-list mode: id IS the name"). `assignments` is
+ * therefore PII only when `rosterMode === 'custom'` — treating it as PII
+ * unconditionally would strip the (non-PII, id-keyed) roster-mode map from
+ * every save and break real-time sync for the common case.
+ */
+function isCustomModeAssignments(config: Record<string, unknown>): boolean {
+  return config.rosterMode === 'custom' && config.assignments !== undefined;
+}
 
 /**
  * Returns a deep copy of `dashboard` with all PII fields removed from every
@@ -46,6 +65,9 @@ export function scrubDashboardPII(dashboard: Dashboard): Dashboard {
     ...dashboard,
     widgets: dashboard.widgets.map((widget) => {
       const config = { ...(widget.config as Record<string, unknown>) };
+      if (isCustomModeAssignments(config)) {
+        delete config.assignments;
+      }
       for (const field of PII_WIDGET_FIELDS) {
         delete config[field];
       }
@@ -74,6 +96,11 @@ export function extractDashboardPII(
         piiFields[field] = config[field];
         hasPii = true;
       }
+    }
+
+    if (isCustomModeAssignments(config)) {
+      piiFields.assignments = config.assignments;
+      hasPii = true;
     }
 
     if (hasPii) {
@@ -119,6 +146,7 @@ export function dashboardHasPII(dashboard: Dashboard): boolean {
     for (const field of PII_WIDGET_FIELDS) {
       if (field in config && config[field] !== undefined) return true;
     }
+    if (isCustomModeAssignments(config)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Root cause

`utils/dashboardPII.ts`'s `PII_WIDGET_FIELDS` allowlist — the list of widget-config keys stripped from every dashboard before it's written to Firestore (student PII instead goes to a Drive-only supplement file) — was incomplete in two reachable ways:

1. **`assignments` (Stations, LunchCount, SeatingChart) in custom-roster mode.** These widgets have no backing roster record in custom mode, so they use the raw typed student name as the object *key* of `config.assignments` (e.g. `{"Emma Smith": "station-1"}` — confirmed against `Stations/Widget.tsx`, `LunchCount/Widget.tsx`, and `SeatingChart/Widget.tsx`, all of which set `id = name` in custom mode). `assignments` was never in `PII_WIDGET_FIELDS`, so every save wrote those name keys straight to Firestore unscrubbed.
2. **`jigsawHomeGroups`/`jigsawExpertGroups` (RandomWidget Jigsaw mode)** — `RandomGroup[]` objects whose `names: string[]` are raw student names. A sibling utility (`utils/widgetConfigPersistence.ts`) already flagged these as PII when stripping saved *defaults*, but `dashboardPII.ts` never stripped them from the live dashboard write.

## Fix

- Added `jigsawHomeGroups`/`jigsawExpertGroups` to `PII_WIDGET_FIELDS` (unconditional).
- Added a conditional `isCustomModeAssignments(config)` check (keyed on `config.rosterMode === 'custom'`) for `assignments`, applied in `scrubDashboardPII`, `extractDashboardPII`, and `dashboardHasPII`.

## Band-aid rejected

Adding `assignments` unconditionally to `PII_WIDGET_FIELDS` — simpler, but would delete the (non-PII) id-keyed roster-mode assignments from every Firestore write, breaking real-time sync/multi-device display for the common (class-roster) case just to fix the minority (custom-list) leak.

## Regression test

`utils/dashboardPII.test.ts` — new cases for jigsaw group scrubbing, Stations/LunchCount custom-mode `assignments` scrubbing, and a negative case confirming class-roster-mode `assignments` (id-keyed) is preserved.

## Evidence

Fail-before (pre-fix `dashboardPII.ts` via `git show dev-paul:...`): 4 tests failed (assignments/jigsaw groups leaking into scrub/extract output). Pass-after: 20/20.

Independently re-verified by the orchestrator: full `pnpm run validate` (626 root test files/7460 tests, 41 functions files/822 tests, all green) + `pnpm run build` — both clean on a second, independent run.

## Risk

**Contained** — two-file diff (`utils/dashboardPII.ts` + its test), no widget-facing behavior change for the majority (class-roster) case.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXVWwoBL8m4Wh7PkrrXVMM)_