### PR TITLE
fix(admin,widgets): poll CSV export filenames use local date, not UTC

### DIFF
--- a/components/admin/Announcements/Widget.tsx
+++ b/components/admin/Announcements/Widget.tsx
@@ -540,7 +540,7 @@ const AnnouncementPreview: React.FC<{
 // Poll responses panel — live vote tallies from announcement sub-collection
 // ---------------------------------------------------------------------------
 
-const PollResponsesPanel: React.FC<{
+export const PollResponsesPanel: React.FC<{
   announcement: Announcement;
   onClose: () => void;
 }> = ({ announcement, onClose }) => {
@@ -579,7 +579,7 @@ const PollResponsesPanel: React.FC<{
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = `Poll_${announcement.name.replace(/\s+/g, '_')}_${new Date().toISOString().split('T')[0]}.csv`;
+    link.download = `Poll_${announcement.name.replace(/\s+/g, '_')}_${getLocalIsoDate()}.csv`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/components/widgets/PollWidget/PollWidget.test.tsx
+++ b/components/widgets/PollWidget/PollWidget.test.tsx
@@ -549,6 +549,62 @@ describe('PollSettings', () => {
     );
   });
 
+  it('REGRESSION: exported CSV filename uses the local date, not the UTC date', () => {
+    // UTC+12 admin at local midnight 2026-06-15 (= 2026-06-14T12:00:00Z).
+    // Old code: toISOString() -> "2026-06-14T12:00:00.000Z" -> "2026-06-14".
+    // Fixed code: local getters -> "2026-06-15" via getLocalIsoDate().
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-06-14T12:00:00.000Z'));
+    vi.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2026);
+    vi.spyOn(Date.prototype, 'getMonth').mockReturnValue(5);
+    vi.spyOn(Date.prototype, 'getDate').mockReturnValue(15);
+
+    const mockWidget: WidgetData = {
+      id: 'poll-1',
+      type: 'poll',
+      w: 2,
+      h: 2,
+      x: 0,
+      y: 0,
+      z: 1,
+      flipped: false,
+      config: {
+        question: 'Test',
+        options: [{ id: 'opt-1', label: 'Option 1', votes: 5 }],
+      },
+    };
+
+    const originalCreateElement = document.createElement.bind(document);
+    const mockCreateElement = vi.spyOn(document, 'createElement');
+    vi.stubGlobal('URL', {
+      ...global.URL,
+      createObjectURL: vi.fn(() => 'blob:test-url'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    let mockAnchor: HTMLAnchorElement | undefined;
+    mockCreateElement.mockImplementation((tagName) => {
+      if (tagName === 'a') {
+        const a = originalCreateElement('a');
+        mockAnchor = a;
+        return a;
+      }
+      return originalCreateElement(tagName);
+    });
+
+    render(<PollSettings widget={mockWidget} />);
+    fireEvent.click(screen.getByRole('button', { name: /Export CSV/i }));
+
+    // BUG: toISOString-based code names the file after today's UTC date
+    // ("Poll_Results_2026-06-14.csv") — this assertion fails on the pre-fix
+    // implementation and passes once getLocalIsoDate() is used.
+    expect(mockAnchor?.getAttribute('download')).toBe(
+      'Poll_Results_2026-06-15.csv'
+    );
+
+    vi.useRealTimers();
+  });
+
   it('starts a fresh device-voting session when there is no prior session', async () => {
     const widget: WidgetData = {
       id: 'poll-1',

--- a/components/widgets/PollWidget/Settings.tsx
+++ b/components/widgets/PollWidget/Settings.tsx
@@ -3,6 +3,7 @@ import { useDashboard } from '@/context/useDashboard';
 import { useAuth } from '@/context/useAuth';
 import { WidgetData, PollConfig } from '@/types';
 import { useDialog } from '@/context/useDialog';
+import { getLocalIsoDate } from '@/utils/localDate';
 import {
   RotateCcw,
   Plus,
@@ -136,10 +137,7 @@ export const PollSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
     const link = document.createElement('a');
     link.setAttribute('href', url);
-    link.setAttribute(
-      'download',
-      `Poll_Results_${new Date().toISOString().split('T')[0]}.csv`
-    );
+    link.setAttribute('download', `Poll_Results_${getLocalIsoDate()}.csv`);
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/tests/components/admin/AnnouncementsPollExport.test.tsx
+++ b/tests/components/admin/AnnouncementsPollExport.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Regression guard: the poll-results CSV export filename must use the
+// admin's LOCAL today, not toISOString()'s UTC date (same bug class already
+// fixed in CalendarConfigurationModal.tsx, DraggableWindow.tsx and
+// AnnotationOverlay.tsx). TZ is pinned to UTC (tests/setTz.ts), so we spy on
+// the local-time Date.prototype getters to simulate an admin whose local
+// date is a day ahead of the UTC date.
+
+vi.mock('@/config/firebase', () => ({ db: {}, isAuthBypass: true }));
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(() => 'col'),
+  onSnapshot: vi.fn(() => vi.fn()),
+  doc: vi.fn(() => ({})),
+  setDoc: vi.fn().mockResolvedValue(undefined),
+  deleteDoc: vi.fn().mockResolvedValue(undefined),
+  updateDoc: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { PollResponsesPanel } from '@/components/admin/Announcements/Widget';
+import type { Announcement, PollConfig } from '@/types';
+
+function buildAnnouncement(config: PollConfig): Announcement {
+  return {
+    id: 'ann-1',
+    name: 'Lunch Choice',
+    widgetType: 'poll',
+    widgetConfig: config as unknown as Record<string, unknown>,
+    widgetSize: { w: 400, h: 300 },
+    maximized: false,
+    activationType: 'manual',
+    isActive: true,
+    activatedAt: null,
+    dismissalType: 'manual',
+    targetBuildings: [],
+    targetUsers: [],
+  } as unknown as Announcement;
+}
+
+describe('PollResponsesPanel — CSV export filename timezone', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('REGRESSION: exported CSV filename uses the local date, not the UTC date', () => {
+    // UTC+12 admin at local midnight 2026-06-15 (= 2026-06-14T12:00:00Z).
+    // Old code: toISOString() -> "2026-06-14T12:00:00.000Z" -> "2026-06-14".
+    // Fixed code: local getters -> "2026-06-15".
+    vi.setSystemTime(new Date('2026-06-14T12:00:00.000Z'));
+    vi.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2026);
+    vi.spyOn(Date.prototype, 'getMonth').mockReturnValue(5);
+    vi.spyOn(Date.prototype, 'getDate').mockReturnValue(15);
+
+    vi.stubGlobal('URL', {
+      ...global.URL,
+      createObjectURL: vi.fn(() => 'blob:test-url'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    const anchors: HTMLAnchorElement[] = [];
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') anchors.push(el as HTMLAnchorElement);
+      return el;
+    });
+
+    const announcement = buildAnnouncement({
+      question: 'Lunch?',
+      options: [{ id: 'opt-1', label: 'Pizza', votes: 0 }],
+    });
+
+    render(
+      <PollResponsesPanel
+        announcement={announcement}
+        onClose={() => undefined}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Export CSV/i }));
+
+    expect(anchors.length).toBeGreaterThan(0);
+    // BUG: toISOString-based code names the file after today's UTC date
+    // ("Poll_Lunch_Choice_2026-06-14.csv") — this assertion fails on the
+    // pre-fix implementation and passes once getLocalIsoDate() is used.
+    expect(anchors[0].download).toBe('Poll_Lunch_Choice_2026-06-15.csv');
+  });
+});


### PR DESCRIPTION
## Root cause

Both places that export a poll's results as a CSV built the filename with `new Date().toISOString().split('T')[0]` (UTC calendar date) instead of the teacher's local date:

- `components/admin/Announcements/Widget.tsx` — `PollResponsesPanel.exportCsv` (admin panel poll-preview export)
- `components/widgets/PollWidget/Settings.tsx` — `PollSettings.handleExport` (dashboard widget export)

This is the well-precedented UTC-vs-local-date anti-pattern already fixed elsewhere in the repo (`CalendarConfigurationModal.tsx`, `DraggableWindow.tsx`, `AnnotationOverlay.tsx`) — flagged as an open, untracked 2-instance backlog item in `docs/routines/debugger.md`. Fixed both instances together since they're the same bug class on the same poll-results feature.

## Fix

Routed both call sites through the existing, already-tested `getLocalIsoDate()` helper (`utils/localDate.ts`), matching the established fix pattern exactly.

## Band-aid rejected

Manually computing local Y/M/D inline at each call site (as a prior night's now-superseded PR did for a sibling bug) — rejected because it re-introduces a second, divergent implementation instead of closing the producer/consumer drift at the root via the shared helper.

## Regression test

New tests in `tests/components/admin/AnnouncementsPollExport.test.tsx` and `components/widgets/PollWidget/PollWidget.test.tsx`, using `Date.prototype` getter spies to simulate a UTC+12 admin at local midnight.

## Evidence

Fail-before (single-line revert): `expected 'Poll_Lunch_Choice_2026-06-14.csv' to be 'Poll_Lunch_Choice_2026-06-15.csv'` (admin panel) and the equivalent for the widget settings export. Pass-after: both green.

Independently re-verified by the orchestrator: full `pnpm run validate` (627 root test files/7460 tests, 41 functions files/822 tests, all green) + `pnpm run build` — both clean on a second, independent run.

## Risk

**Contained** — filename-only change (downloaded file naming), no data/business-logic impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXVWwoBL8m4Wh7PkrrXVMM)_