### PR TITLE
fix(library): stop Escape leaking from overflow menus to the global widget handler

### DIFF
--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -26,6 +26,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import { MoreHorizontal } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 import type {
   AssignmentArchiveCardProps,
   LibraryBadgeTone,
@@ -94,6 +95,23 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   // so `useClickOutside` doesn't re-subscribe DOM listeners every render.
   const ignoreRefs = useMemo(() => [menuRef], []);
   useClickOutside(wrapperRef, () => setOpen(false), ignoreRefs);
+
+  // Close on Escape and stop propagation — this menu is portalled to
+  // document.body, outside any `.widget` DraggableWindow ancestor, so an
+  // unhandled Escape here bubbles to DashboardView's global window-level
+  // handler, which falls back to minimizing the topmost widget.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      e.stopPropagation();
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
 
   // Measure trigger position when the menu opens so the portal renders
   // flush under it. `opacity-70` on archive cards creates a stacking

--- a/components/common/library/AssignmentArchiveCard.tsx
+++ b/components/common/library/AssignmentArchiveCard.tsx
@@ -96,10 +96,7 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const ignoreRefs = useMemo(() => [menuRef], []);
   useClickOutside(wrapperRef, () => setOpen(false), ignoreRefs);
 
-  // Close on Escape and stop propagation — this menu is portalled to
-  // document.body, outside any `.widget` DraggableWindow ancestor, so an
-  // unhandled Escape here bubbles to DashboardView's global window-level
-  // handler, which falls back to minimizing the topmost widget.
+  // stopPropagation prevents this portalled menu's Escape from also minimizing the topmost widget.
   useEffect(() => {
     if (!open) return undefined;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -29,6 +29,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Check, GripVertical, MoreHorizontal } from 'lucide-react';
 import { useClickOutside } from '@/hooks/useClickOutside';
+import { isEscapeFromWidgetInput } from '@/utils/domHelpers';
 import { Z_INDEX } from '@/config/zIndex';
 import { LibraryGridLockContext } from './LibraryGridLockContext';
 import type {
@@ -104,6 +105,23 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useClickOutside(ref, () => setOpen(false));
+
+  // Close on Escape and stop propagation — this menu is portalled to
+  // document.body, outside any `.widget` DraggableWindow ancestor, so an
+  // unhandled Escape here bubbles to DashboardView's global window-level
+  // handler, which falls back to minimizing the topmost widget.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (isEscapeFromWidgetInput(e)) return;
+      e.stopPropagation();
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
 
   useLayoutEffect(() => {
     if (!open || !buttonRef.current) return;

--- a/components/common/library/LibraryItemCard.tsx
+++ b/components/common/library/LibraryItemCard.tsx
@@ -106,10 +106,7 @@ const OverflowMenu: React.FC<OverflowMenuProps> = ({ actions }) => {
 
   useClickOutside(ref, () => setOpen(false));
 
-  // Close on Escape and stop propagation — this menu is portalled to
-  // document.body, outside any `.widget` DraggableWindow ancestor, so an
-  // unhandled Escape here bubbles to DashboardView's global window-level
-  // handler, which falls back to minimizing the topmost widget.
+  // stopPropagation prevents this portalled menu's Escape from also minimizing the topmost widget.
   useEffect(() => {
     if (!open) return undefined;
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/tests/components/common/library/AssignmentArchiveCard.escapePropagation.test.tsx
+++ b/tests/components/common/library/AssignmentArchiveCard.escapePropagation.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Regression test: AssignmentArchiveCard's overflow menu (kebab →
+ * OverflowMenu) is portalled to document.body, outside any `.widget`
+ * DraggableWindow ancestor, but never listened for Escape at all. Pressing
+ * Escape while the menu is open left it open AND let the keydown bubble to
+ * DashboardView's global window-level Escape handler, which — finding no
+ * typing field and no `.widget` ancestor for the portal — falls back to
+ * targeting the topmost z-index widget and minimizes it. Net effect:
+ * dismissing this menu (used by the Quiz / Video Activity / Mini App
+ * in-progress and archive rows) with Escape could silently minimize an
+ * unrelated widget on the live board.
+ *
+ * FIX: the menu now listens for Escape while open, calls
+ * event.stopPropagation() before closing, matching the same fix already
+ * applied to ToolDockItem, RemoteControlMenu, ClassRosterMenu, OverflowMenu,
+ * and FolderPickerPopover for this exact bug class.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  act,
+} from '@testing-library/react';
+import { AssignmentArchiveCard } from '@/components/common/library/AssignmentArchiveCard';
+import type {
+  AssignmentStatusBadge,
+  LibraryMenuAction,
+} from '@/components/common/library/types';
+
+interface Assignment {
+  id: string;
+  quizTitle: string;
+}
+
+const ASSIGNMENT: Assignment = { id: 'a1', quizTitle: 'My Quiz' };
+
+const LIVE_STATUS: AssignmentStatusBadge = {
+  label: 'Live',
+  tone: 'success',
+  dot: true,
+};
+
+afterEach(cleanup);
+
+describe('AssignmentArchiveCard overflow menu — Escape does not leak to window-level handlers', () => {
+  it('closes the menu on Escape and stops propagation before it reaches window listeners', () => {
+    const secondary: LibraryMenuAction[] = [
+      { id: 'delete', label: 'Delete', onClick: vi.fn() },
+    ];
+
+    render(
+      <AssignmentArchiveCard<Assignment>
+        assignment={ASSIGNMENT}
+        mode="active"
+        status={LIVE_STATUS}
+        title={ASSIGNMENT.quizTitle}
+        secondaryActions={secondary}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});

--- a/tests/components/common/library/LibraryItemCard.escapePropagation.test.tsx
+++ b/tests/components/common/library/LibraryItemCard.escapePropagation.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Regression test: LibraryItemCard's overflow menu (kebab → OverflowMenu)
+ * is portalled to document.body, outside any `.widget` DraggableWindow
+ * ancestor, but never listened for Escape at all. Pressing Escape while the
+ * menu is open left it open AND let the keydown bubble to DashboardView's
+ * global window-level Escape handler, which — finding no typing field and no
+ * `.widget` ancestor for the portal — falls back to targeting the topmost
+ * z-index widget and minimizes it. Net effect: dismissing this menu (used by
+ * the Quiz / Video Activity / Guided Learning / Mini App library managers)
+ * with Escape could silently minimize an unrelated widget on the live board.
+ *
+ * FIX: the menu now listens for Escape while open, calls
+ * event.stopPropagation() before closing, matching the same fix already
+ * applied to ToolDockItem, RemoteControlMenu, ClassRosterMenu, OverflowMenu,
+ * and FolderPickerPopover for this exact bug class.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  act,
+} from '@testing-library/react';
+import { LibraryItemCard } from '@/components/common/library/LibraryItemCard';
+
+afterEach(cleanup);
+
+describe('LibraryItemCard overflow menu — Escape does not leak to window-level handlers', () => {
+  it('closes the menu on Escape and stops propagation before it reaches window listeners', () => {
+    const onDelete = vi.fn();
+
+    render(
+      <LibraryItemCard
+        id="card-1"
+        title="Test card"
+        sortable={false}
+        secondaryActions={[
+          { id: 'delete', label: 'Delete', onClick: onDelete },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    const windowKeydownSpy = vi.fn();
+    window.addEventListener('keydown', windowKeydownSpy);
+
+    try {
+      act(() => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      });
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      // This is the crux of the regression: DashboardView's global Escape
+      // handler is a window-level `keydown` listener. If the menu's own
+      // handler doesn't stopPropagation, the event still reaches window
+      // and DashboardView falls back to minimizing the topmost widget.
+      expect(windowKeydownSpy).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('keydown', windowKeydownSpy);
+    }
+  });
+});


### PR DESCRIPTION
## Root cause

Following up on the recurring "portalled-popover Escape leak" bug class (previously fixed 10+ times across different components), two live instances were still missing the guard:

- `components/common/library/LibraryItemCard.tsx` — the card's kebab `OverflowMenu`
- `components/common/library/AssignmentArchiveCard.tsx` — its own `OverflowMenu`

Both menus are `createPortal`'d to `document.body`, outside any `.widget`/`[data-draggable-window]` DOM ancestor, and had no Escape handler at all. Pressing Escape while either menu was open left the menu open *and* let the keydown bubble to `DashboardView`'s global `window`-level Escape handler, which falls back to minimizing the topmost z-index widget. Both components are live: rendered inside `QuizManager`, `VideoActivityManager`, `MiniAppManager`, and `GuidedLearningManager` (confirmed via grep before committing to the fix).

## Fix

Added a `document`-level `keydown` listener (active only while `open`) in each `OverflowMenu`, guarded by `isEscapeFromWidgetInput(e)`, that calls `e.stopPropagation()` before closing — the established idiom already used by `ToolDockItem`/`FolderPickerPopover`/etc.

## Band-aid rejected

Patching `DashboardView`'s global handler to also treat "focus is inside `document.body`-portalled content" as a bail condition — would weaken the global handler for every future unguarded portal instead of fixing the actual missing listener, and would create a second, inconsistent mechanism alongside the established per-component idiom.

## Regression test

New files `tests/components/common/library/LibraryItemCard.escapePropagation.test.tsx` and `AssignmentArchiveCard.escapePropagation.test.tsx`.

## Evidence

Fail-before (pre-fix source via `git show dev-paul:...`, restored via `cp` — never `git stash`): both new tests failed (`expected document not to contain element, found <div role="menu">...` — menu never closed on Escape). Pass-after: 2/2.

Independently re-verified by the orchestrator via the same file-swap method: confirmed fail-before/pass-after matches the subagent's report exactly. Also trimmed a 4-line comment block in both files down to one line during review, per the repo's comment convention (`git show dev-paul:<path>` confirmed neither file has a pre-existing multi-line-comment convention to justify an exception).

Full `pnpm run validate` (628 root test files/7462 tests, 41 functions files/822 tests, all green) + `pnpm run build` — both clean on the orchestrator's independent run.

## Risk

**Contained** — two-file diff plus two new test files; same established idiom used 10+ times elsewhere in this codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXVWwoBL8m4Wh7PkrrXVMM)_