### PR TITLE
fix(a11y): pair 12 more orphaned SettingsLabel controls with htmlFor/id

### DIFF
--- a/components/admin/TimeToolConfigurationPanel.tsx
+++ b/components/admin/TimeToolConfigurationPanel.tsx
@@ -87,6 +87,7 @@ export const TimeToolConfigurationPanel: React.FC<
   const displayStyleLabelId = useId();
   const numberStyleLabelId = useId();
   const defaultAlertSoundLabelId = useId();
+  const defaultFontLabelId = useId();
 
   const buildingDefaults = config.buildingDefaults ?? {};
   const currentBuildingConfig: BuildingTimeToolDefaults = buildingDefaults[
@@ -350,8 +351,11 @@ export const TimeToolConfigurationPanel: React.FC<
 
         {/* Font Family */}
         <div>
-          <SettingsLabel className="mb-1">Default Font</SettingsLabel>
+          <SettingsLabel className="mb-1" htmlFor={defaultFontLabelId}>
+            Default Font
+          </SettingsLabel>
           <select
+            id={defaultFontLabelId}
             value={currentBuildingConfig.fontFamily ?? 'global'}
             onChange={(e) =>
               handleUpdateBuilding({

--- a/components/widgets/Checklist/Settings.tsx
+++ b/components/widgets/Checklist/Settings.tsx
@@ -276,10 +276,14 @@ export const ChecklistSettings: React.FC<{ widget: WidgetData }> = ({
 
       {mode === 'manual' && (
         <div className="animate-in fade-in slide-in-from-top-2 duration-300">
-          <SettingsLabel icon={ListPlus}>
+          <SettingsLabel
+            icon={ListPlus}
+            htmlFor={`checklist-task-list-${widget.id}`}
+          >
             Task List (One per line)
           </SettingsLabel>
           <textarea
+            id={`checklist-task-list-${widget.id}`}
             value={localText}
             onChange={(e) => handleBulkChange(e.target.value)}
             placeholder="Enter tasks here..."

--- a/components/widgets/DrawingWidget/Settings.tsx
+++ b/components/widgets/DrawingWidget/Settings.tsx
@@ -112,9 +112,15 @@ export const DrawingSettings: React.FC<{ widget: WidgetData }> = ({
       </div>
 
       <div>
-        <SettingsLabel icon={Pencil}>Brush Thickness</SettingsLabel>
+        <SettingsLabel
+          icon={Pencil}
+          htmlFor={`drawing-brush-thickness-${widget.id}`}
+        >
+          Brush Thickness
+        </SettingsLabel>
         <div className="flex items-center gap-4 px-2">
           <input
+            id={`drawing-brush-thickness-${widget.id}`}
             type="range"
             min="1"
             max="80"

--- a/components/widgets/Embed/Settings.tsx
+++ b/components/widgets/Embed/Settings.tsx
@@ -274,8 +274,11 @@ export const EmbedSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
       ) : (
         <div className="space-y-4 animate-in fade-in slide-in-from-bottom-2 duration-300">
           <div>
-            <SettingsLabel>HTML / CSS / JS</SettingsLabel>
+            <SettingsLabel htmlFor={`embed-html-content-${widget.id}`}>
+              HTML / CSS / JS
+            </SettingsLabel>
             <textarea
+              id={`embed-html-content-${widget.id}`}
               value={html}
               placeholder="<html>&#10;  <style>body { background: #f0f; }</style>&#10;  <body><h1>Hello Class!</h1></body>&#10;</html>"
               onChange={(e) =>

--- a/components/widgets/InstructionalRoutines/Settings.tsx
+++ b/components/widgets/InstructionalRoutines/Settings.tsx
@@ -212,8 +212,11 @@ export const InstructionalRoutinesAppearanceSettings: React.FC<{
 
   return (
     <div className="bg-slate-50 p-4 rounded-2xl">
-      <SettingsLabel>Text Zoom</SettingsLabel>
+      <SettingsLabel htmlFor={`instructional-routines-text-zoom-${widget.id}`}>
+        Text Zoom
+      </SettingsLabel>
       <input
+        id={`instructional-routines-text-zoom-${widget.id}`}
         type="range"
         min="0.5"
         max="2.0"

--- a/components/widgets/LunchCount/Settings.tsx
+++ b/components/widgets/LunchCount/Settings.tsx
@@ -65,6 +65,8 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
     gradeLevel = '',
   } = config;
   const gradeLevelLabelId = useId();
+  const schoolSiteLabelId = useId();
+  const customRosterLabelId = useId();
 
   // Legacy widget configs may contain a canonical short-form building ID
   // (e.g. `schumann`) instead of the long-form `schoolSite` this widget
@@ -93,8 +95,11 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
       <div className="p-4 bg-slate-50 rounded-2xl border border-slate-200 space-y-4">
         {/* School Site */}
         <div>
-          <SettingsLabel icon={School}>School Site</SettingsLabel>
+          <SettingsLabel icon={School} htmlFor={schoolSiteLabelId}>
+            School Site
+          </SettingsLabel>
           <select
+            id={schoolSiteLabelId}
             value={schoolSite}
             onChange={(e) =>
               handleSiteChange(e.target.value as LunchCountConfig['schoolSite'])
@@ -279,8 +284,11 @@ export const LunchCountSettings: React.FC<{ widget: WidgetData }> = ({
         <div>
           {rosterMode === 'custom' ? (
             <>
-              <SettingsLabel icon={Users}>Custom Roster</SettingsLabel>
+              <SettingsLabel icon={Users} htmlFor={customRosterLabelId}>
+                Custom Roster
+              </SettingsLabel>
               <textarea
+                id={customRosterLabelId}
                 value={roster.join('\n')}
                 onChange={(e) =>
                   updateWidget(widget.id, {

--- a/components/widgets/PollWidget/Settings.tsx
+++ b/components/widgets/PollWidget/Settings.tsx
@@ -265,8 +265,11 @@ export const PollSettings: React.FC<{ widget: WidgetData }> = ({ widget }) => {
 
       {/* Question Edit */}
       <div>
-        <SettingsLabel icon={Type}>Question</SettingsLabel>
+        <SettingsLabel icon={Type} htmlFor={`poll-question-${widget.id}`}>
+          Question
+        </SettingsLabel>
         <input
+          id={`poll-question-${widget.id}`}
           key={question} // Force reset when prop changes
           type="text"
           value={localQuestion}

--- a/components/widgets/QuizWidget/Settings.tsx
+++ b/components/widgets/QuizWidget/Settings.tsx
@@ -22,8 +22,11 @@ export const QuizWidgetSettings: React.FC<{ widget: WidgetData }> = ({
       </div>
 
       <div>
-        <SettingsLabel>Widget Label</SettingsLabel>
+        <SettingsLabel htmlFor={`quiz-widget-label-${widget.id}`}>
+          Widget Label
+        </SettingsLabel>
         <input
+          id={`quiz-widget-label-${widget.id}`}
           type="text"
           value={widget.customTitle ?? ''}
           onChange={(e) =>

--- a/components/widgets/RecessGear/Settings.tsx
+++ b/components/widgets/RecessGear/Settings.tsx
@@ -52,8 +52,14 @@ export const RecessGearSettings: React.FC<{ widget: WidgetData }> = ({
         </div>
 
         <div className="space-y-2">
-          <SettingsLabel className="px-1">Source Weather Widget</SettingsLabel>
+          <SettingsLabel
+            className="px-1"
+            htmlFor={`recessgear-source-weather-${widget.id}`}
+          >
+            Source Weather Widget
+          </SettingsLabel>
           <select
+            id={`recessgear-source-weather-${widget.id}`}
             value={config.linkedWeatherWidgetId ?? ''}
             onChange={(e) =>
               updateWidget(widget.id, {

--- a/components/widgets/SeatingChart/Settings.tsx
+++ b/components/widgets/SeatingChart/Settings.tsx
@@ -52,8 +52,11 @@ export const SeatingChartSettings: React.FC<{ widget: WidgetData }> = ({
 
       {rosterMode === 'custom' && (
         <div className="space-y-2">
-          <SettingsLabel>Custom Roster</SettingsLabel>
+          <SettingsLabel htmlFor={`seatingchart-custom-roster-${widget.id}`}>
+            Custom Roster
+          </SettingsLabel>
           <textarea
+            id={`seatingchart-custom-roster-${widget.id}`}
             value={names}
             onChange={(e) =>
               updateWidget(widget.id, {

--- a/components/widgets/SyntaxFramer/Settings.tsx
+++ b/components/widgets/SyntaxFramer/Settings.tsx
@@ -15,6 +15,7 @@ export const SyntaxFramerSettings: React.FC<SyntaxFramerSettingsProps> = ({
   const config = widget.config as SyntaxFramerConfig;
   const syntaxFramerModeLabelId = `syntaxframer-mode-label-${widget.id}`;
   const syntaxFramerAlignmentLabelId = `syntaxframer-alignment-label-${widget.id}`;
+  const syntaxFramerContentInputId = `syntaxframer-content-input-${widget.id}`;
 
   // Derive initial input from existing tokens
   const initialInput = config.tokens
@@ -81,9 +82,12 @@ export const SyntaxFramerSettings: React.FC<SyntaxFramerSettingsProps> = ({
   return (
     <div className="space-y-6">
       <div>
-        <SettingsLabel icon={Type}>Content</SettingsLabel>
+        <SettingsLabel icon={Type} htmlFor={syntaxFramerContentInputId}>
+          Content
+        </SettingsLabel>
         <div className="mb-4">
           <textarea
+            id={syntaxFramerContentInputId}
             className="w-full p-2 border border-slate-300 rounded-lg text-sm bg-white"
             rows={3}
             placeholder={


### PR DESCRIPTION
## Summary

Nightly consistency routine (D3 — Settings Panel Label Primitives). Continues the "1:1-pairing form" sweep formalized in the previous run (PR #2494): a `<SettingsLabel>` heading exactly one native form control with no `htmlFor`/`id` association, an orphaned-label accessibility gap distinct from the older "group-heading" retrofit series.

**Canonical form:** `<SettingsLabel htmlFor={id}>Label</SettingsLabel>` paired with a matching `id={id}` on the single control it heads.

**Instances unified** (12 labels across 11 files, none previously catalogued):

| File | Label | Control |
|---|---|---|
| `components/widgets/QuizWidget/Settings.tsx` | "Widget Label" | `<input>` |
| `components/widgets/SeatingChart/Settings.tsx` | "Custom Roster" | `<textarea>` |
| `components/widgets/InstructionalRoutines/Settings.tsx` | "Text Zoom" | `<input type="range">` |
| `components/widgets/Embed/Settings.tsx` | "HTML / CSS / JS" | `<textarea>` |
| `components/widgets/RecessGear/Settings.tsx` | "Source Weather Widget" | `<select>` |
| `components/widgets/Checklist/Settings.tsx` | "Task List (One per line)" | `<textarea>` |
| `components/widgets/DrawingWidget/Settings.tsx` | "Brush Thickness" | `<input type="range">` |
| `components/widgets/SyntaxFramer/Settings.tsx` | "Content" | `<textarea>` |
| `components/widgets/PollWidget/Settings.tsx` | "Question" | `<input>` |
| `components/widgets/LunchCount/Settings.tsx` | "School Site" | `<select>` |
| `components/widgets/LunchCount/Settings.tsx` | "Custom Roster" | `<textarea>` |
| `components/admin/TimeToolConfigurationPanel.tsx` | "Default Font" | `<select>` |

ID-naming convention matches each file's own pre-existing style: `useId()` for `LunchCount/Settings.tsx` and `TimeToolConfigurationPanel.tsx` (both already use `useId()` for sibling labels); `widget.id`-string-interpolation for the rest (matching each file's existing group-heading ids).

**Enforcement:** none added this run — this sweep closes out the remaining known 1:1-pairing instances found via a full manual audit of the ~84 non-`as="span"` `SettingsLabel` call sites; no automated `jsx-a11y` lint rule exists in this repo yet (noted as a possible future idea, out of scope for tonight).

**Behavior-preservation evidence:** Read `components/common/SettingsLabel.tsx` source directly — `combinedClasses` is computed once from `baseClasses`/`layoutClasses`/`className` only and is unaffected by `htmlFor`/`id`, which pass straight through to the DOM node. No `className` changed in any of the 12 edits — zero visual delta.

**Risk tag: mechanical** (pure accessibility wiring addition, no visual or behavioral change).

Deferred to the backlog (not touched this run):
- `components/widgets/Classes/RosterEditor.tsx` — same bug shape but the component is dead code (unreferenced by `WidgetRegistry.ts` or anywhere else in the app); flagged as a dead-code cleanup candidate for a different pass.
- `components/admin/TalkingToolConfigurationPanel.tsx` "Sentence Stems" — ambiguous between the 1:1 and group-heading shapes (heads a dynamic add/remove list), left for a human judgment call.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files> --max-warnings 0` — clean
- [x] `pnpm exec prettier --check <changed files>` — clean
- [x] `pnpm run validate` — green (root: 631/631 files, 7480/7480 tests; functions: 41/41 files, 822/822 tests) — run independently by both the subagent and the orchestrator
- [x] `pnpm run build` — green (client + SSR + prerender) — run independently by both the subagent and the orchestrator


---
_Generated by [Claude Code](https://claude.ai/code/session_014WpQe7Miq7g6soQwRxKkvz)_