### PR TITLE
fix(mini-app): use local date, not UTC, for library export filename

### DIFF
--- a/components/widgets/MiniApp/Widget.tsx
+++ b/components/widgets/MiniApp/Widget.tsx
@@ -27,6 +27,7 @@ import {
 import { Z_INDEX } from '@/config/zIndex';
 import { suggestDuplicateTitle } from '@/components/common/library/libraryDuplicate';
 import { logError } from '@/utils/logError';
+import { buildMiniAppExportFilename } from './exportFilename';
 import { WidgetLayout } from '../WidgetLayout';
 import { useAuth } from '@/context/useAuth';
 import { useMiniAppSessionTeacher } from '@/hooks/useMiniAppSession';
@@ -878,7 +879,7 @@ export const MiniAppWidget: React.FC<WidgetComponentProps> = ({
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `spartboard-apps-${new Date().toISOString().slice(0, 10)}.json`;
+    a.download = buildMiniAppExportFilename();
     a.click();
     URL.revokeObjectURL(url);
     addToast('Library exported successfully', 'success');

--- a/components/widgets/MiniApp/exportFilename.test.ts
+++ b/components/widgets/MiniApp/exportFilename.test.ts
@@ -3,9 +3,7 @@ import { buildMiniAppExportFilename } from './exportFilename';
 
 describe('buildMiniAppExportFilename', () => {
   it('REGRESSION: uses the local date, not the UTC date, for the export filename', () => {
-    // UTC+12 teacher at local midnight 2026-06-15 (= 2026-06-14T12:00:00Z).
-    // Old code: new Date().toISOString().slice(0, 10) -> "2026-06-14" (UTC date).
-    // Fixed code: getLocalIsoDate() reads local getters -> "2026-06-15".
+    // Getters stubbed (not a plain Date) because TZ is pinned to UTC in tests/setTz.ts, so a real offset can't otherwise be simulated.
     const now = new Date('2026-06-14T12:00:00.000Z');
     now.getFullYear = () => 2026;
     now.getMonth = () => 5;

--- a/components/widgets/MiniApp/exportFilename.test.ts
+++ b/components/widgets/MiniApp/exportFilename.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildMiniAppExportFilename } from './exportFilename';
+
+describe('buildMiniAppExportFilename', () => {
+  it('REGRESSION: uses the local date, not the UTC date, for the export filename', () => {
+    // UTC+12 teacher at local midnight 2026-06-15 (= 2026-06-14T12:00:00Z).
+    // Old code: new Date().toISOString().slice(0, 10) -> "2026-06-14" (UTC date).
+    // Fixed code: getLocalIsoDate() reads local getters -> "2026-06-15".
+    const now = new Date('2026-06-14T12:00:00.000Z');
+    now.getFullYear = () => 2026;
+    now.getMonth = () => 5;
+    now.getDate = () => 15;
+
+    expect(buildMiniAppExportFilename(now)).toBe(
+      'spartboard-apps-2026-06-15.json'
+    );
+  });
+
+  it('pads single-digit month and day', () => {
+    const now = new Date('2026-01-05T00:00:00.000Z');
+    now.getFullYear = () => 2026;
+    now.getMonth = () => 0;
+    now.getDate = () => 5;
+
+    expect(buildMiniAppExportFilename(now)).toBe(
+      'spartboard-apps-2026-01-05.json'
+    );
+  });
+});

--- a/components/widgets/MiniApp/exportFilename.ts
+++ b/components/widgets/MiniApp/exportFilename.ts
@@ -1,0 +1,6 @@
+import { getLocalIsoDate } from '@/utils/localDate';
+
+// Filename for the exported library JSON — local date, not UTC.
+export function buildMiniAppExportFilename(now: Date = new Date()): string {
+  return `spartboard-apps-${getLocalIsoDate(now)}.json`;
+}

--- a/components/widgets/Stations/Widget.tsx
+++ b/components/widgets/Stations/Widget.tsx
@@ -113,8 +113,8 @@ export const StationsWidget: React.FC<{ widget: WidgetData }> = ({
   // Group students by station id (for chip lists) plus an unassigned bucket.
   // Falls back to a legacy name-keyed entry when no id-keyed one exists, so
   // dashboards saved before assignments were id-keyed (and groups sent over
-  // from the Randomizer via nexus.ts, which are always name-keyed) still
-  // resolve correctly. Stale assignments (students no longer in roster)
+  // from the Randomizer via nexus.ts in custom-roster mode, which are still
+  // name-keyed) still resolve correctly. Stale assignments (students no longer in roster)
   // survive silently — we only render chips for roster members so
   // missing-from-roster keys don't appear, but they remain in `assignments`
   // until the next reset.


### PR DESCRIPTION
## Root cause
`components/widgets/MiniApp/Widget.tsx`'s library-export download built its filename with `new Date().toISOString().slice(0, 10)` — the UTC calendar date. For a teacher in a UTC+ timezone (e.g. any of this app's DE/ES/FR locales), the hours between local midnight and UTC midnight get exported under *yesterday's* date. This is the same UTC-vs-local anti-pattern already fixed in `Calendar/Widget.tsx`, `PollWidget/Settings.tsx`, and `ScheduleWidget.tsx` via the shared `getLocalIsoDate()` helper (`utils/localDate.ts`) — MiniApp's export was the one remaining holdout in `components/widgets/`.

## Fix
Extracted the filename builder to `components/widgets/MiniApp/exportFilename.ts` (`buildMiniAppExportFilename()`), using `getLocalIsoDate()` instead of `toISOString()`. Extracted to its own module rather than inlined so it's independently unit-testable without mounting the full `MiniAppWidget` (which needs heavy Firestore/Auth/Dashboard context).

## Band-aid rejected
Inlining the one-line fix directly in `Widget.tsx` — rejected because it can't be unit-tested in isolation without rendering the whole widget tree; extracting it matches this repo's established pattern for testable pure logic living next to a component.

## Regression test
`components/widgets/MiniApp/exportFilename.test.ts` — asserts a UTC+12 teacher at local midnight gets the local date, not the UTC (previous-day) date.

## Before/after evidence (independently re-verified by the orchestrator, not just the subagent)
Fail-before (buggy `toISOString().slice(0,10)` body restored):
```
AssertionError: expected 'spartboard-apps-2026-06-14.json' to be 'spartboard-apps-2026-06-15.json'
Tests  1 failed | 1 passed (2)
```
Pass-after (fix restored):
```
Test Files  1 passed (1)
Tests  2 passed (2)
```
`pnpm run validate` and `pnpm run build` both green (root: 632 files/7482 tests; functions: 41 files/822 tests), independently re-run by the orchestrator after rebase-check against latest `dev-paul` (unchanged, still `c0eeb0a`).

## Also included
A small drive-by comment fix in `components/widgets/Stations/Widget.tsx` correcting a stale comment about Randomizer-sent group keying (no longer accurate after a recent fix).

## Risk
**Contained** — single new pure-function module, one call-site swap, no shared state or cross-widget impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd296g9b7x6FpFNLkng2hY)_