### PR TITLE
fix(dock): use local time for screen-recording filenames, not UTC

### DIFF
--- a/components/layout/Dock.tsx
+++ b/components/layout/Dock.tsx
@@ -48,6 +48,7 @@ import { toLunchCountSchoolSite } from '@/config/buildings';
 import { matchesUserBuilding as matchesUserBuildingLevels } from '@/config/widgetGradeLevels';
 import { AddWidgetOverrides } from '@/types';
 import { getJoinUrl } from '@/utils/urlHelpers';
+import { getLocalTimestampForFilename } from '@/utils/localDate';
 import ClassRosterMenu from './ClassRosterMenu';
 import RemoteControlMenu from './RemoteControlMenu';
 import { CatalystSetPickerPopover } from '@/components/widgets/Catalyst/CatalystSetPickerPopover';
@@ -249,7 +250,8 @@ export const Dock: React.FC = () => {
 
   const handleRecordingComplete = useCallback(
     async (blob: Blob) => {
-      const fileName = `SPART-Board-Recording-${new Date().toISOString()}.webm`;
+      // Local time, not UTC — see utils/localDate.ts.
+      const fileName = `SPART-Board-Recording-${getLocalTimestampForFilename()}.webm`;
 
       if (driveService) {
         addToast(t('dock.uploadingToDrive'), 'info');

--- a/tests/components/layout/Dock.test.tsx
+++ b/tests/components/layout/Dock.test.tsx
@@ -14,7 +14,7 @@
  * at the top of the dock items render loop.
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Dock } from '@/components/layout/Dock';
 
@@ -88,6 +88,21 @@ vi.mock('@/utils/widgetDragFlag', () => ({
   beginWidgetDrag: vi.fn(),
   endWidgetDrag: vi.fn(),
 }));
+
+const { mockGetLocalTimestampForFilename } = vi.hoisted(() => ({
+  mockGetLocalTimestampForFilename: vi.fn<() => string>(),
+}));
+
+vi.mock('@/utils/localDate', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/localDate')>();
+  mockGetLocalTimestampForFilename.mockImplementation(
+    actual.getLocalTimestampForFilename
+  );
+  return {
+    ...actual,
+    getLocalTimestampForFilename: mockGetLocalTimestampForFilename,
+  };
+});
 
 // Mock heavy sub-components to keep the test focused on the permission logic
 vi.mock('@/components/layout/dock/WidgetLibrary', () => {
@@ -824,5 +839,77 @@ describe('Dock smart-paste – SELECT element is excluded from paste interceptio
 
     document.body.removeChild(selectEl);
     unmount();
+  });
+});
+
+// Regression: the recording download filename was built from
+// `new Date().toISOString()` — the UTC calendar date/time — instead of the
+// teacher's local time. For every timezone west of UTC (all of the
+// Americas), the last few hours of the local day fall on the *next* UTC
+// date, so a recording saved in the evening gets tomorrow's date baked into
+// the filename. Fix: use the shared `getLocalTimestampForFilename()` helper
+// (utils/localDate.ts), matching the DraggableWindow/AnnotationOverlay fixes.
+describe('Dock screen-record – recording filename uses local time, not UTC', () => {
+  const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+  const originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('names the downloaded recording using getLocalTimestampForFilename(), not a raw UTC ISO string', () => {
+    setupMocks();
+
+    // A sentinel local timestamp unrelated to the real current time — proves
+    // the filename comes from the mocked helper, not from Dock computing its
+    // own `new Date().toISOString()`.
+    mockGetLocalTimestampForFilename.mockReturnValue('2026-03-05T23-45-00');
+
+    // Capture the onSuccess callback useScreenRecord is wired with.
+    let capturedOnSuccess: ((blob: Blob) => void) | undefined;
+    vi.mocked(useScreenRecord).mockImplementation((opts = {}) => {
+      capturedOnSuccess = opts.onSuccess;
+      return {
+        isRecording: false,
+        duration: 0,
+        startRecording: vi.fn(),
+        stopRecording: vi.fn(),
+        error: null,
+      } as unknown as ReturnType<typeof useScreenRecord>;
+    });
+
+    const anchors: HTMLAnchorElement[] = [];
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = realCreateElement(tag);
+      if (tag === 'a') anchors.push(el as HTMLAnchorElement);
+      return el;
+    });
+
+    render(<Dock />);
+    expect(capturedOnSuccess).toBeDefined();
+
+    // driveService is null in setupMocks(), so this takes the local-download
+    // fallback path (URL.createObjectURL + a.click()), which is synchronous.
+    act(() => {
+      capturedOnSuccess?.(new Blob(['x'], { type: 'video/webm' }));
+    });
+
+    expect(anchors.length).toBeGreaterThan(0);
+    // BUG: toISOString-based code names the file after the real current UTC
+    // time, not the mocked local timestamp — this assertion fails on the
+    // pre-fix implementation and passes once the filename is sourced from
+    // getLocalTimestampForFilename().
+    expect(anchors[anchors.length - 1].download).toBe(
+      'SPART-Board-Recording-2026-03-05T23-45-00.webm'
+    );
   });
 });

--- a/utils/localDate.test.ts
+++ b/utils/localDate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   getLocalIsoDate,
+  getLocalTimestampForFilename,
   combineDateAndTime,
   splitDueAtToInputs,
   dueInputsToEpoch,
@@ -43,6 +44,36 @@ describe('getLocalIsoDate', () => {
     vi.setSystemTime(mockDate);
 
     expect(getLocalIsoDate()).toBe('2025-03-10');
+  });
+});
+
+describe('getLocalTimestampForFilename', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('formats as YYYY-MM-DDTHH-mm-ss using local getters', () => {
+    const date = new Date(2023, 4, 15, 9, 5, 3); // May 15, 2023, 09:05:03
+    expect(getLocalTimestampForFilename(date)).toBe('2023-05-15T09-05-03');
+  });
+
+  it('pads single-digit hours, minutes, and seconds', () => {
+    const date = new Date(2023, 0, 5, 1, 2, 3);
+    expect(getLocalTimestampForFilename(date)).toBe('2023-01-05T01-02-03');
+  });
+
+  it('contains no colons or periods (filename-safe on all OSes)', () => {
+    const date = new Date(2023, 4, 15, 23, 59, 59);
+    const result = getLocalTimestampForFilename(date);
+    expect(result).not.toMatch(/[:.]/);
+  });
+
+  it('uses the current time if no argument is provided', () => {
+    const mockDate = new Date(2025, 2, 10, 14, 30, 45);
+    vi.useFakeTimers();
+    vi.setSystemTime(mockDate);
+
+    expect(getLocalTimestampForFilename()).toBe('2025-03-10T14-30-45');
   });
 });
 

--- a/utils/localDate.ts
+++ b/utils/localDate.ts
@@ -13,6 +13,17 @@ export function getLocalIsoDate(now: Date = new Date()): string {
 }
 
 /**
+ * Returns a filename-safe local timestamp (`YYYY-MM-DDTHH-mm-ss`) using local
+ * getters (not `toISOString()`, which is UTC-based and shifts recordings made
+ * in the evening onto tomorrow's UTC date for every UTC-negative timezone —
+ * see `getLocalIsoDate` above for the same anti-pattern).
+ */
+export function getLocalTimestampForFilename(now: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${getLocalIsoDate(now)}T${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+}
+
+/**
  * Combine a `YYYY-MM-DD` date and `HH:MM` time into a millisecond timestamp
  * using local-time semantics. Returns null when either piece is missing,
  * malformed, or out of range.


### PR DESCRIPTION
## Root cause
`components/layout/Dock.tsx`'s `handleRecordingComplete` built the screen-recording download/upload filename with `new Date().toISOString()` — a UTC timestamp. In any UTC-negative timezone (all of the Americas), the last few hours of a teacher's local day fall on the *next* UTC calendar date, so a recording saved in the evening gets tomorrow's date baked into the filename. Same recurring anti-pattern already fixed in `DraggableWindow.tsx` (screenshots) and `AnnotationOverlay.tsx`'s download path.

## Fix
Added `getLocalTimestampForFilename()` to `utils/localDate.ts` (local-getter based, filename-safe `YYYY-MM-DDTHH-mm-ss`, no colons/periods that would be unsafe on Windows), and switched `Dock.tsx` to use it instead of `toISOString()`.

## Band-aid rejected
Just stripping colons from the existing `toISOString()` output (`.replace(/[:.]/g, '-')`, matching `AnnotationOverlay.tsx`'s still-open Drive-save path, flagged as a fresh backlog lead) would fix filename-safety but leave the actual UTC-vs-local date bug in place. Used the shared local-time helper instead, consistent with the established fix pattern.

## Regression test
`tests/components/layout/Dock.test.tsx` — renders `Dock`, triggers the recording-complete callback with a mocked local timestamp, asserts the downloaded filename uses it (not a raw UTC `toISOString()` value). Plus unit tests for the new `getLocalTimestampForFilename()` helper in `utils/localDate.test.ts`.

## Before/after evidence (independently re-verified by the orchestrator, not just the subagent)
Fail-before (`Dock.tsx` reverted to pre-fix `dev-paul` version):
```
AssertionError: expected 'SPART-Board-Recording-2026-08-20T04:3…' to be 'SPART-Board-Recording-2026-03-05T23-4…'
Tests  1 failed | 10 skipped (11)
```
Pass-after (fix restored):
```
Test Files  2 passed (2)
Tests  32 passed (32)
```
`pnpm run validate` and `pnpm run build` both green, independently re-run by the orchestrator after rebase-check against latest `dev-paul` (unchanged, still `c0eeb0a`).

## New backlog lead surfaced (not fixed here, logged for a future run)
`components/layout/AnnotationOverlay.tsx`'s `handleSaveToDrive` (line ~534) has the same UTC-timestamp anti-pattern for its Google Drive save filename — a very low-risk, high-precedent fix for a future run (its sibling `handleDownload` in the same file is already fixed, and `getLocalIsoDate` is already imported).

## Risk
**Contained** — one new pure-function helper, one call-site swap, no shared state or cross-component impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd296g9b7x6FpFNLkng2hY)_