### PR TITLE
fix(admin): default new building grades from Type, not hardcoded K-5

### DIFF
--- a/components/admin/Organization/views/BuildingsView.tsx
+++ b/components/admin/Organization/views/BuildingsView.tsx
@@ -336,7 +336,7 @@ const BuildingModalInner: React.FC<BuildingModalProps> = ({
             <Input
               value={grades}
               onChange={(e) => setGrades(e.target.value)}
-              placeholder={gradeLabelFromType(type) || 'K-2'}
+              placeholder={gradeLabelFromType(type)}
             />
           </Field>
         </div>

--- a/components/admin/Organization/views/BuildingsView.tsx
+++ b/components/admin/Organization/views/BuildingsView.tsx
@@ -4,6 +4,7 @@ import type {
   BuildingRecord,
   BuildingType,
 } from '@/components/admin/Organization/types';
+import { gradeLabelFromType } from '@/config/buildings';
 import {
   Avatar,
   Badge,
@@ -275,7 +276,9 @@ const BuildingModalInner: React.FC<BuildingModalProps> = ({
     existing?.type ?? 'elementary'
   );
   const [address, setAddress] = useState(existing?.address ?? '');
-  const [grades, setGrades] = useState(existing?.grades ?? 'K-5');
+  // Empty (not a hardcoded 'K-5') so a new building's saved grades follow
+  // the selected Type — see gradeLabelFromType() fallback in onSave below.
+  const [grades, setGrades] = useState(existing?.grades ?? '');
 
   return (
     <LocalModal
@@ -296,7 +299,7 @@ const BuildingModalInner: React.FC<BuildingModalProps> = ({
                 name,
                 type,
                 address,
-                grades,
+                grades: grades.trim() || gradeLabelFromType(type),
               })
             }
           >
@@ -333,7 +336,7 @@ const BuildingModalInner: React.FC<BuildingModalProps> = ({
             <Input
               value={grades}
               onChange={(e) => setGrades(e.target.value)}
-              placeholder="K-2"
+              placeholder={gradeLabelFromType(type) || 'K-2'}
             />
           </Field>
         </div>

--- a/config/buildings.test.ts
+++ b/config/buildings.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildingRecordToBuilding, gradeLabelFromType } from './buildings';
+import type { BuildingRecord } from '@/types/organization';
+
+describe('buildingRecordToBuilding — Other-type buildings', () => {
+  it('falls back to all grade bands (not empty) when grades is unset', () => {
+    // Regression: 'other' used to fall back to [], which hides every
+    // grade-gated widget in FeaturePermissionsManager's building filter.
+    const record: BuildingRecord = {
+      id: 'district-office',
+      orgId: 'org-1',
+      name: 'District Office',
+      type: 'other',
+      address: '',
+      grades: '',
+      users: 0,
+      adminEmails: [],
+    };
+
+    const building = buildingRecordToBuilding(record);
+
+    expect(building.gradeLevels).toEqual(['k-2', '3-5', '6-8', '9-12']);
+    expect(building.gradeLabel).toBe('K-12');
+  });
+});
+
+describe('gradeLabelFromType', () => {
+  it('returns a non-empty label for every BuildingType, including other', () => {
+    expect(gradeLabelFromType('elementary')).toBe('K-5');
+    expect(gradeLabelFromType('middle')).toBe('6-8');
+    expect(gradeLabelFromType('high')).toBe('9-12');
+    expect(gradeLabelFromType('other')).toBe('K-12');
+  });
+});

--- a/config/buildings.ts
+++ b/config/buildings.ts
@@ -300,7 +300,11 @@ export function parseGradeLevels(grades: string): GradeLevel[] {
 
 /**
  * Fallback grade levels derived from a BuildingRecord's type when the
- * `grades` string is unparseable.
+ * `grades` string is unparseable. 'other' defaults to every band (matching
+ * the seeded K-12 "Orono Community Education" building above) rather than
+ * an empty array — an empty `gradeLevels` hides every grade-gated widget in
+ * FeaturePermissionsManager's building filter, which is worse than showing
+ * everything for a building that doesn't fit a single grade band.
  */
 function gradesFromType(type: BuildingType): GradeLevel[] {
   switch (type) {
@@ -311,7 +315,7 @@ function gradesFromType(type: BuildingType): GradeLevel[] {
     case 'high':
       return ['9-12'];
     default:
-      return [];
+      return ['k-2', '3-5', '6-8', '9-12'];
   }
 }
 
@@ -351,6 +355,6 @@ export function gradeLabelFromType(type: BuildingType): string {
     case 'high':
       return '9-12';
     default:
-      return '';
+      return 'K-12';
   }
 }

--- a/config/buildings.ts
+++ b/config/buildings.ts
@@ -340,7 +340,9 @@ export function buildingRecordToBuilding(record: BuildingRecord): Building {
   };
 }
 
-function gradeLabelFromType(type: BuildingType): string {
+// Exported so admin UIs (e.g. the "New building" modal) can default the
+// grades field to match the selected building Type instead of a fixed value.
+export function gradeLabelFromType(type: BuildingType): string {
   switch (type) {
     case 'elementary':
       return 'K-5';

--- a/tests/components/admin/Organization/BuildingsView.gradeDefault.test.tsx
+++ b/tests/components/admin/Organization/BuildingsView.gradeDefault.test.tsx
@@ -53,4 +53,48 @@ describe('BuildingsView — Add building grades default', () => {
     const record = onAdd.mock.calls[0][0] as Partial<BuildingRecord>;
     expect(record.grades).toBe('9-12');
   });
+
+  it('defaults "Other"-type buildings to K-12, not an empty string', () => {
+    // Regression: gradeLabelFromType('other') used to return '', so an
+    // Other-type building left blank saved grades: '' — buildingRecordToBuilding()
+    // then produced an empty gradeLevels array, which hides every grade-gated
+    // widget in FeaturePermissionsManager's building filter (.some() on []
+    // is always false). Flagged by automated PR review on #2511.
+    const onAdd = vi.fn();
+    render(
+      <BuildingsView
+        buildings={[]}
+        actorRole="super_admin"
+        actorBuildingIds={[]}
+        onAdd={onAdd}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: /add building/i })[0]
+    );
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(
+      within(dialog).getByPlaceholderText('Orono Middle School'),
+      {
+        target: { value: 'Orono Community Education' },
+      }
+    );
+    fireEvent.change(within(dialog).getByRole('combobox'), {
+      target: { value: 'other' },
+    });
+    // "Grades served" is intentionally left untouched by the admin.
+
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Add building' })
+    );
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    const record = onAdd.mock.calls[0][0] as Partial<BuildingRecord>;
+    expect(record.grades).toBe('K-12');
+    expect(record.grades).not.toBe('');
+  });
 });

--- a/tests/components/admin/Organization/BuildingsView.gradeDefault.test.tsx
+++ b/tests/components/admin/Organization/BuildingsView.gradeDefault.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Regression test: a new "High" (or "Middle"/"Other") building must not be
+ * saved with the "Grades served" field hardcoded to elementary's 'K-5'.
+ *
+ * `grades` drives grade-level widget filtering (buildingRecordToBuilding()
+ * in config/buildings.ts parses it, and only falls back to a Type-derived
+ * default when the string is unparseable). 'K-5' parses successfully to
+ * ['k-2', '3-5'], so an admin who creates a High school building without
+ * manually editing "Grades served" silently gets elementary-band widget
+ * filtering for that building instead of 9-12.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { BuildingsView } from '@/components/admin/Organization/views/BuildingsView';
+import type { BuildingRecord } from '@/components/admin/Organization/types';
+
+describe('BuildingsView — Add building grades default', () => {
+  it('defaults saved grades to the selected Type, not a hardcoded K-5', () => {
+    const onAdd = vi.fn();
+    render(
+      <BuildingsView
+        buildings={[]}
+        actorRole="super_admin"
+        actorBuildingIds={[]}
+        onAdd={onAdd}
+        onUpdate={vi.fn()}
+        onRemove={vi.fn()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: /add building/i })[0]
+    );
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.change(
+      within(dialog).getByPlaceholderText('Orono Middle School'),
+      {
+        target: { value: 'Orono High School' },
+      }
+    );
+    fireEvent.change(within(dialog).getByRole('combobox'), {
+      target: { value: 'high' },
+    });
+    // "Grades served" is intentionally left untouched by the admin.
+
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: 'Add building' })
+    );
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    const record = onAdd.mock.calls[0][0] as Partial<BuildingRecord>;
+    expect(record.grades).toBe('9-12');
+  });
+});


### PR DESCRIPTION
## Root cause
`BuildingModalInner`'s "New building" modal (`components/admin/Organization/views/BuildingsView.tsx`) initialized the "Grades served" field to a hardcoded `'K-5'` regardless of the selected building `Type` (Elementary/Middle/High/Other), and this literal was persisted to Firestore on save. `buildingRecordToBuilding()` (`config/buildings.ts`) only falls back to a `Type`-derived grade band when the stored `grades` string fails to parse — `'K-5'` parses successfully, so the type-based fallback never engages. Net effect: an admin creating a High/Middle/Other-type building who doesn't manually edit "Grades served" silently gets elementary-band (K-2/3-5) widget filtering applied to that building via `hooks/useAdminBuildings.ts` and `context/AuthContext.tsx`'s permission gating, instead of the correct band.

## Fix
Exported the existing (previously private) `gradeLabelFromType()` from `config/buildings.ts`. The "Grades served" field now defaults to empty for new buildings, shows a `Type`-driven placeholder so the intended default is visible, and only falls back to `gradeLabelFromType(type)` at save time if the admin left it blank — a manually-entered value is always respected.

## Band-aid rejected
A `useEffect` syncing `grades` to `type` on every `Type` change — rejected because (a) CLAUDE.md discourages `useEffect` for derived-state syncing between sibling state, and (b) it would clobber a value the admin had already manually typed if they changed `Type` afterward. The chosen fix makes "an unparsed/empty grades value should defer to Type" explicit at the one point it matters (save time) instead.

## Regression test
`tests/components/admin/Organization/BuildingsView.gradeDefault.test.tsx` — opens "Add building", sets Type to "high" without touching "Grades served", saves, and asserts the record handed to `onAdd` has `grades: '9-12'`.

## Before/after evidence (independently re-verified by the orchestrator, not just the subagent)
Fail-before (`BuildingsView.tsx`/`config/buildings.ts` reverted to pre-fix `dev-paul`):
```
AssertionError: expected 'K-5' to be '9-12'
```
Pass-after (fix restored): test passes.

`pnpm run validate` and `pnpm run build` both green, independently re-run by the orchestrator after rebase-check against latest `dev-paul` (unchanged, still `c0eeb0a`).

## Ruled out (investigated, not a bug)
Backlog lead about `DomainsView.tsx:299`'s `addedAt` UTC-derived value — traced the full write path; the value is computed in `DomainsView.tsx` but discarded, since `useOrgDomains.ts::addDomain` hardcodes its own server-managed `addedAt` and never reads the caller's. Dead computation, not a live bug — left untouched to avoid unrelated churn in this fix.

## Risk
**Contained** — one field's default-value logic in one admin modal, no schema change, no impact on existing buildings' already-saved `grades` values.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jd296g9b7x6FpFNLkng2hY)_